### PR TITLE
Bunch of changes to make no IotM Ed less terrible.

### DIFF
--- a/BUILD/monsters/banish.dat
+++ b/BUILD/monsters/banish.dat
@@ -2,28 +2,28 @@ A.M.C. Gremlin
 Animated Mahogany Nightstand
 Animated Possessions
 Animated Rustic Nightstand
-Bubblemint Twins
+Bubblemint Twins	!class:Ed
 Bullet Bill
 Burly Sidekick	item:Mohawk Wig>0
-Chatty Pirate
-Clingy Pirate (Female)
-Clingy Pirate (Male)
 Coaltergeist
-Crusty Pirate
 Doughbat
 Drunk Goat
+Eagle	class:Ed
 Evil Olive
+Empty suit of armor	class:Ed
 Flock Of Stab-Bats
 Gluttonous Ghuol	class:Vampyre
 Knob Goblin Harem Guard
 Knob Goblin Madam	item:Knob Goblin Perfume>0
-Mad Wino
+Mad Wino	!class:Ed
+MagiMechTech MechaMech	class:Ed
+Mob Penguin Capo	class:Ed
 Mismatched Twins
 Natural Spider
 Plaid Ghost
 Possessed Laundry Press
 Procrastination Giant
-Protagonist
+Protagonist	!class:Ed
 Pygmy Headhunter
 Pygmy Janitor	tavern:true
 Pygmy Orderlies
@@ -36,11 +36,14 @@ Senile Lihc	loc:The Defiled Niche
 Slick Lihc	loc:The Defiled Niche
 Skeletal Sommelier
 Snow Queen
+Spooky mummy	class:Ed
+Spooky vampire	class:Ed
 Steam Elemental
 Taco Cat
 Tan Gnat
 Tomb Asp
 Tomb Servant
+Triffid	class:Ed
 Wardr&ouml;b Nightstand
 Warehouse Janitor
 Upgraded Ram

--- a/BUILD/monsters/yellowray.dat
+++ b/BUILD/monsters/yellowray.dat
@@ -27,17 +27,18 @@ War Frat Wartender	!outfit:Frat Warrior Fatigues
 War Pledge	!outfit:Frat Warrior Fatigues
 # We also want to dress up like a filthy hippy to get frat warrior fatigues
 business hippy	!outfit:Filthy Hippy Disguise
-crusty hippy	!outfit:Filthy Hippy Disguise
-crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise
-crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise
-dirty hippy	!outfit:Filthy Hippy Disguise
-dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise
-dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise
-filthy hippy	!outfit:Filthy Hippy Disguise
-filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise
-filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise
+crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
 zombie hippy	!outfit:Filthy Hippy Disguise
 # And we want filthworm glands, but not if we're gonna hugpocket them
-larval filthworm	!familiar:XO Skeleton
-filthworm drone	!familiar:XO Skeleton
-filthworm royal guard	!familiar:XO Skeleton
+larval filthworm	!familiar:XO Skeleton;!class:Ed
+filthworm drone	!familiar:XO Skeleton;!class:Ed
+filthworm royal guard	!familiar:XO Skeleton;!class:Ed
+Knight (Snake)	class:Ed

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -6,28 +6,28 @@ banish	0	A.M.C. Gremlin
 banish	1	Animated Mahogany Nightstand
 banish	2	Animated Possessions
 banish	3	Animated Rustic Nightstand
-banish	4	Bubblemint Twins
+banish	4	Bubblemint Twins	!class:Ed
 banish	5	Bullet Bill
 banish	6	Burly Sidekick	item:Mohawk Wig>0
-banish	7	Chatty Pirate
-banish	8	Clingy Pirate (Female)
-banish	9	Clingy Pirate (Male)
-banish	10	Coaltergeist
-banish	11	Crusty Pirate
-banish	12	Doughbat
-banish	13	Drunk Goat
-banish	14	Evil Olive
-banish	15	Flock Of Stab-Bats
-banish	16	Gluttonous Ghuol	class:Vampyre
-banish	17	Knob Goblin Harem Guard
-banish	18	Knob Goblin Madam	item:Knob Goblin Perfume>0
-banish	19	Mad Wino
+banish	7	Coaltergeist
+banish	8	Doughbat
+banish	9	Drunk Goat
+banish	10	Eagle	class:Ed
+banish	11	Evil Olive
+banish	12	Empty suit of armor	class:Ed
+banish	13	Flock Of Stab-Bats
+banish	14	Gluttonous Ghuol	class:Vampyre
+banish	15	Knob Goblin Harem Guard
+banish	16	Knob Goblin Madam	item:Knob Goblin Perfume>0
+banish	17	Mad Wino	!class:Ed
+banish	18	MagiMechTech MechaMech	class:Ed
+banish	19	Mob Penguin Capo	class:Ed
 banish	20	Mismatched Twins
 banish	21	Natural Spider
 banish	22	Plaid Ghost
 banish	23	Possessed Laundry Press
 banish	24	Procrastination Giant
-banish	25	Protagonist
+banish	25	Protagonist	!class:Ed
 banish	26	Pygmy Headhunter
 banish	27	Pygmy Janitor	tavern:true
 banish	28	Pygmy Orderlies
@@ -40,14 +40,17 @@ banish	34	Senile Lihc	loc:The Defiled Niche
 banish	35	Slick Lihc	loc:The Defiled Niche
 banish	36	Skeletal Sommelier
 banish	37	Snow Queen
-banish	38	Steam Elemental
-banish	39	Taco Cat
-banish	40	Tan Gnat
-banish	41	Tomb Asp
-banish	42	Tomb Servant
-banish	43	Wardr&ouml;b Nightstand
-banish	44	Warehouse Janitor
-banish	45	Upgraded Ram
+banish	38	Spooky mummy	class:Ed
+banish	39	Spooky vampire	class:Ed
+banish	40	Steam Elemental
+banish	41	Taco Cat
+banish	42	Tan Gnat
+banish	43	Tomb Asp
+banish	44	Tomb Servant
+banish	45	Triffid	class:Ed
+banish	46	Wardr&ouml;b Nightstand
+banish	47	Warehouse Janitor
+banish	48	Upgraded Ram
 
 sniff	0	pygmy shaman	loc:The Hidden Apartment Building;sgeea:3;!effect:Thrice-Cursed
 sniff	1	Gurgle the Turgle
@@ -99,18 +102,19 @@ yellowray	19	War Frat Wartender	!outfit:Frat Warrior Fatigues
 yellowray	20	War Pledge	!outfit:Frat Warrior Fatigues
 # We also want to dress up like a filthy hippy to get frat warrior fatigues
 yellowray	21	business hippy	!outfit:Filthy Hippy Disguise
-yellowray	22	crusty hippy	!outfit:Filthy Hippy Disguise
-yellowray	23	crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise
-yellowray	24	crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise
-yellowray	25	dirty hippy	!outfit:Filthy Hippy Disguise
-yellowray	26	dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise
-yellowray	27	dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise
-yellowray	28	filthy hippy	!outfit:Filthy Hippy Disguise
-yellowray	29	filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise
-yellowray	30	filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise
+yellowray	22	crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	23	crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	24	crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	25	dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	26	dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	27	dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	28	filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	29	filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	30	filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
 yellowray	31	zombie hippy	!outfit:Filthy Hippy Disguise
 # And we want filthworm glands, but not if we're gonna hugpocket them
-yellowray	32	larval filthworm	!familiar:XO Skeleton
-yellowray	33	filthworm drone	!familiar:XO Skeleton
-yellowray	34	filthworm royal guard	!familiar:XO Skeleton
+yellowray	32	larval filthworm	!familiar:XO Skeleton;!class:Ed
+yellowray	33	filthworm drone	!familiar:XO Skeleton;!class:Ed
+yellowray	34	filthworm royal guard	!familiar:XO Skeleton;!class:Ed
+yellowray	35	Knight (Snake)	class:Ed
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -87,7 +87,6 @@ void initializeSettings()
 		use_familiar($familiar[none]);
 	}
 
-	set_property("chasmBridgeProgress", 0);
 	string pool = visit_url("questlog.php?which=3");
 	matcher my_pool = create_matcher("a skill level of (\\d+) at shooting pool", pool);
 	if(my_pool.find() && (my_turncount() == 0))
@@ -103,7 +102,6 @@ void initializeSettings()
 	}
 
 	set_property("auto_abooclover", true);
-	set_property("auto_aboocount", "0");
 	set_property("auto_aboopending", 0);
 	set_property("auto_aftercore", false);
 	set_property("auto_airship", "");
@@ -243,7 +241,6 @@ void initializeSettings()
 		auto_sourceTerminalRequest("enquiry protect.enq");
 	}
 
-	elementalPlanes_initializeSettings();
 	eudora_initializeSettings();
 	hr_initializeSettings();
 	picky_initializeSettings();
@@ -733,7 +730,7 @@ boolean LX_universeFrat()
 
 boolean LX_faxing()
 {
-	if((my_level() >= 9) && !get_property("_photocopyUsed").to_boolean() && (my_class() == $class[Ed]) && (my_daycount() < 3) && !is_unrestricted($item[Deluxe Fax Machine]))
+	if (my_level() >= 9 && !get_property("_photocopyUsed").to_boolean() && isActuallyEd() && my_daycount() < 3 && !is_unrestricted($item[Deluxe Fax Machine]))
 	{
 		auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 		if(handleFaxMonster($monster[Lobsterfrogman]))
@@ -767,7 +764,7 @@ boolean LX_chateauPainting()
 	{
 		paintingLevel = 9;
 	}
-	if((my_level() >= paintingLevel) && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && (my_class() == $class[Ed]) && (my_daycount() <= 3))
+	if (my_level() >= paintingLevel && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && isActuallyEd() && my_daycount() <= 3)
 	{
 		if(canYellowRay())
 		{
@@ -779,7 +776,7 @@ boolean LX_chateauPainting()
 		}
 	}
 
-	if(organsFull() && (my_adventures() < 10) && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && (my_daycount() == 1) && (my_class() != $class[Ed]))
+	if (organsFull() && my_adventures() < 10 && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && my_daycount() == 1 && !isActuallyEd())
 	{
 		auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 		if(chateaumantegna_usePainting())
@@ -787,7 +784,7 @@ boolean LX_chateauPainting()
 			return true;
 		}
 	}
-	if((my_level() >= 8) && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && (my_daycount() == 2) && (my_class() != $class[Ed]))
+	if (my_level() >= 8 && chateaumantegna_havePainting() && !get_property("chateauMonsterFought").to_boolean() && my_daycount() == 2 && !isActuallyEd())
 	{
 		auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 		if(chateaumantegna_usePainting())
@@ -985,7 +982,7 @@ int pullsNeeded(string data)
 	{
 		return 0;
 	}
-	if((my_class() == $class[Ed]) || (auto_my_path() == "Community Service"))
+	if (isActuallyEd() || auto_my_path() == "Community Service")
 	{
 		return 0;
 	}
@@ -1347,7 +1344,7 @@ boolean doThemtharHills()
 	autoEquip($item[Miracle Whip]);
 
 	shrugAT($effect[Polka of Plenty]);
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if(!have_skill($skill[Gift of the Maid]) && ($servant[Maid].experience >= 441))
 		{
@@ -1357,7 +1354,6 @@ boolean doThemtharHills()
 				print("Gift of the Maid not properly detected until charsheet refresh.", "red");
 			}
 		}
-		handleServant($servant[maid]);
 	}
 	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
 	songboomSetting("meat");
@@ -1457,7 +1453,7 @@ boolean doThemtharHills()
 
 	float meatDropHave = meat_drop_modifier();
 
-	if((my_class() == $class[Ed]) && have_skill($skill[Curse of Fortune]) && (item_amount($item[Ka Coin]) > 0))
+	if (isActuallyEd() && have_skill($skill[Curse of Fortune]) && item_amount($item[Ka Coin]) > 0)
 	{
 		meatDropHave = meatDropHave + 200;
 	}
@@ -1785,7 +1781,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[Replica Bat-oomerang], 1, 0);
 		}
 
-		if((!auto_have_familiar($familiar[Grim Brother])) && (my_class() != $class[Ed]) && glover_usable($item[Unconscious Collective Dream Jar]))
+		if (!auto_have_familiar($familiar[Grim Brother]) && !isActuallyEd() && glover_usable($item[Unconscious Collective Dream Jar]))
 		{
 			pullXWhenHaveY($item[Unconscious Collective Dream Jar], 1, 0);
 			if(item_amount($item[Unconscious Collective Dream Jar]) > 0)
@@ -1871,18 +1867,32 @@ boolean fortuneCookieEvent()
 			goal = $location[The Limerick Dungeon];
 		}
 
-		if((goal == $location[The Hidden Temple]) && ((item_amount($item[stone wool]) >= 2) || (get_property("auto_hiddenunlock") == "nose") || (get_property("auto_hiddenunlock") == "finished") || (internalQuestStatus("questL11Worship") >= 3) || (get_property("semirareLocation") == goal) || (get_property("lastTempleUnlock").to_int() < my_ascensions()) || (get_property("auto_spookysapling") != "finished")))
+		if (goal == $location[The Hidden Temple] && (get_property("semirareLocation") == goal || item_amount($item[stone wool]) >= 2 || get_property("auto_hiddenunlock") == "nose" || get_property("auto_hiddenunlock") == "finished" || internalQuestStatus("questL11Worship") >= 3 || get_property("lastTempleUnlock").to_int() < my_ascensions() || get_property("auto_spookysapling") != "finished"))
 		{
 			goal = $location[The Castle in the Clouds in the Sky (Top Floor)];
 		}
 
-		if((goal == $location[The Castle in the Clouds in the Sky (Top Floor)]) && ((item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0) || (get_property("auto_nuns") == "done") || (get_property("auto_nuns") == "finished") || (internalQuestStatus("questL10Garbage") < 9) || (get_property("semirareLocation") == goal) || (get_property("lastCastleTopUnlock").to_int() < my_ascensions()) || (get_property("auto_castleground") != "finished") || (get_property("sidequestNunsCompleted") != "none")))
+		if (goal == $location[The Castle in the Clouds in the Sky (Top Floor)] && (get_property("semirareLocation") == goal || item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || get_property("auto_nuns") == "done" || get_property("auto_nuns") == "finished" || internalQuestStatus("questL10Garbage") < 9 || get_property("lastCastleTopUnlock").to_int() < my_ascensions() || get_property("auto_castleground") != "finished" || get_property("sidequestNunsCompleted") != "none"))
 		{
 			goal = $location[The Limerick Dungeon];
 		}
 
-		#(internalQuestStatus("questL10Garbage") < 9)
-		if((goal == $location[The Limerick Dungeon]) && ((item_amount($item[Cyclops Eyedrops]) > 0) || (get_property("auto_orchard") == "start") || (get_property("auto_orchard") == "done") || (get_property("auto_orchard") == "finished") || (get_property("semirareLocation") == goal) || (get_property("lastFilthClearance").to_int() >= my_ascensions()) || (get_property("sidequestOrchardCompleted") != "none") || (get_property("currentHippyStore") != "none")))
+		if (goal == $location[The Limerick Dungeon] && (get_property("semirareLocation") == goal || item_amount($item[Cyclops Eyedrops]) > 0 || get_property("auto_orchard") == "start" || get_property("auto_orchard") == "done" || get_property("auto_orchard") == "finished" || get_property("lastFilthClearance").to_int() >= my_ascensions() || get_property("sidequestOrchardCompleted") != "none" || get_property("currentHippyStore") != "none" || isActuallyEd()))
+		{
+			goal = $location[The Copperhead Club];
+		}
+
+		if (goal == $location[The Copperhead Club] && (get_property("semirareLocation") == goal || internalQuestStatus("questL11Shen") < 0 || internalQuestStatus("questL11Ron") >= 2))
+		{
+			goal = $location[The Haunted Kitchen];
+		}
+
+		if (goal == $location[The Haunted Kitchen] && (get_property("semirareLocation") == goal || get_property("chasmBridgeProgress").to_int() >= 30 || internalQuestStatus("questL09Topping") >= 1 || isActuallyEd()))
+		{
+			goal = $location[The Outskirts of Cobb\'s Knob];
+		}
+
+		if (goal == $location[The Outskirts of Cobb\'s Knob] && (get_property("semirareLocation") == goal || internalQuestStatus("questL05Goblin") > 1 || item_amount($item[Knob Goblin encryption key]) > 0 || $location[The Outskirts of Cobb\'s Knob].turns_spent >= 10))
 		{
 			goal = $location[The Haunted Pantry];
 		}
@@ -2229,7 +2239,7 @@ void initializeDay(int day)
 #				pullXWhenHaveY($item[milk of magnesium], 1, 0);
 #			}
 		}
-		if(chateaumantegna_havePainting() && (my_class() != $class[Ed]) && (auto_my_path() != "Community Service"))
+		if (chateaumantegna_havePainting() && !isActuallyEd() && auto_my_path() != "Community Service")
 		{
 			if(auto_have_familiar($familiar[Reanimated Reanimator]))
 			{
@@ -2969,7 +2979,7 @@ boolean doBedtime()
 		string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 	}
 
-	if((get_property("spookyAirportAlways").to_boolean()) && (my_class() != $class[Ed]) && !get_property("_controlPanelUsed").to_boolean())
+	if (get_property("spookyAirportAlways").to_boolean() && !isActuallyEd() && !get_property("_controlPanelUsed").to_boolean())
 	{
 		visit_url("place.php?whichplace=airport_spooky_bunker&action=si_controlpanel");
 		visit_url("choice.php?pwd=&whichchoice=986&option=8",true);
@@ -3489,7 +3499,7 @@ boolean questOverride()
 	{
 		print("Found completed Prism Recovery (13)");
 		set_property("auto_sorceress", "finished");
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			council();
 		}
@@ -4061,7 +4071,7 @@ boolean L11_palindome()
 			else if(item_amount($item[Stunt Nuts]) == 0)
 			{
 				print("We got no nuts!! :O", "Blue");
-				autoEquip($slot[acc3], $item[Talisman o' Namsilat]);
+				autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
 				autoAdv(1, $location[Inside the Palindome]);
 			}
 			else
@@ -4077,12 +4087,12 @@ boolean L11_palindome()
 		{
 			useILoveMeVolI();
 		}
-		if(equipped_amount($item[Talisman o' Namsilat]) == 0)
-			equip($slot[acc3], $item[Talisman o' Namsilat]);
+		if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
+			equip($slot[acc3], $item[Talisman o\' Namsilat]);
 		visit_url("place.php?whichplace=palindome&action=pal_drlabel");
 		visit_url("choice.php?pwd&whichchoice=872&option=1&photo1=2259&photo2=7264&photo3=7263&photo4=7265");
 
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			set_property("auto_palindome", "finished");
 			return true;
@@ -4099,8 +4109,8 @@ boolean L11_palindome()
 				doHottub();
 				bat_reallyPickSkills(20);
 			}
-			if(equipped_amount($item[Talisman o' Namsilat]) == 0)
-				equip($slot[acc3], $item[Talisman o' Namsilat]);
+			if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
+				equip($slot[acc3], $item[Talisman o\' Namsilat]);
 			visit_url("place.php?whichplace=palindome&action=pal_mrlabel");
 			if(!in_hardcore() && (item_amount($item[Wet Stunt Nut Stew]) == 0))
 			{
@@ -4131,8 +4141,8 @@ boolean L11_palindome()
 
 		if(!possessEquipment($item[Mega Gem]))
 		{
-			if(equipped_amount($item[Talisman o' Namsilat]) == 0)
-				equip($slot[acc3], $item[Talisman o' Namsilat]);
+			if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
+				equip($slot[acc3], $item[Talisman o\' Namsilat]);
 			visit_url("place.php?whichplace=palindome&action=pal_mrlabel");
 		}
 
@@ -4142,7 +4152,7 @@ boolean L11_palindome()
 			return false;
 		}
 		autoEquip($slot[acc2], $item[Mega Gem]);
-		autoEquip($slot[acc3], $item[Talisman o' Namsilat]);
+		autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
 		int palinChoice = random(3) + 1;
 		set_property("choiceAdventure131", palinChoice);
 
@@ -4190,7 +4200,7 @@ boolean L11_palindome()
 			}
 		}
 
-		autoEquip($slot[acc3], $item[Talisman o' Namsilat]);
+		autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
 		autoAdv(1, $location[Inside the Palindome]);
 		if(($location[Inside the Palindome].turns_spent > 30) && (auto_my_path() != "Pocket Familiars") && (auto_my_path() != "G-Lover") && !in_koe())
 		{
@@ -4441,7 +4451,7 @@ boolean L13_towerNSTower()
 		{
 			// nothing, just for else
 		}
-		else if(autoEquip($item[Unfortunato's foolscap]))
+		else if (autoEquip($item[Unfortunato\'s foolscap]))
 		{
 			// nothing, just for else
 		}
@@ -5647,50 +5657,61 @@ boolean LX_attemptPowerLevel()
 	{
 		autoAdv(1, $location[Sloppy Seconds Diner]);
 	}
-#	else if(elementalPlanes_access($element[stench]))
-#	{
-#		autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
-#	}
 	else if(elementalPlanes_access($element[sleaze]))
 	{
 		autoAdv(1, $location[Sloppy Seconds Diner]);
 	}
 	else
 	{
-		if((my_level() >= 11) && (get_property("auto_hiddenzones") == "finished"))
+		// burn all spare clovers after level 12 if we need to powerlevel.
+		if (my_level() >= 12 && get_property("questL12War") == "finished" && cloversAvailable() > 0)
 		{
-			autoAdv($location[The Hidden Hospital]);
-			return true;
-		}
-		if((my_level() >= 10) && zone_isAvailable($location[The Hole In The Sky]))
-		{
-			autoAdv($location[The Hole In The Sky]);
-			return true;
-		}
-		if((my_level() >= 9) && ((get_property("auto_highlandlord") == "start") || (get_property("auto_highlandlord") == "finished")))
-		{
-			if((monster_level_adjustment() < 60) && (get_property("oilPeakProgress").to_float() > 0.0))
+			//Determine where to go for clover stats, do not worry about clover failures
+			location whereTo = $location[none];
+			switch (my_primestat())
 			{
-				autoEquip($slot[Pants], $item[Dress Pants]);
+				case $stat[Muscle]:
+					whereTo = $location[The Haunted Gallery];
+					break;
+				case $stat[Mysticality]:
+					whereTo = $location[The Haunted Bathroom];			
+					break;
+				case $stat[Moxie]:
+					whereTo = $location[The Haunted Ballroom];
+					break;
 			}
-			autoAdv($location[Oil Peak]);
-			return true;
+
+			cloverUsageInit();
+			boolean retval = autoAdv(1, whereTo);
+			cloverUsageFinish();
+			return retval;
 		}
-		if((my_level() >= 8) && (get_property("auto_trapper") == "finished"))
+
+		// optimal levelling if you have no IotMs.
+		if (get_property("questM21Dance") == "finished")
 		{
-			float elemDamage = numeric_modifier("Hot Damage");
-			elemDamage += numeric_modifier("Sleaze Damage");
-			elemDamage += numeric_modifier("Spooky Damage");
-			elemDamage += numeric_modifier("Stench Damage");
-			if(elemDamage > 20)
+			switch (my_primestat())
 			{
-				autoAdv($location[The Icy Peak]);
+				case $stat[Muscle]:
+					set_property("louvreDesiredGoal", "4"); // get Muscle stats
+					break;
+				case $stat[Mysticality]:
+					set_property("louvreDesiredGoal", "5"); // get Myst stats
+					break;
+				case $stat[Moxie]:
+					set_property("louvreDesiredGoal", "6"); // get Moxie stats
+					break;
+			}
+			if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield])))
+			{
+				set_property("choiceAdventure89", "2"); // fight the snake knight (as Ed)
 			}
 			else
 			{
-				autoAdv($location[The Extreme Slope]);
+				set_property("choiceAdventure89", "6"); // ignore the NC & banish it for 10 adv
 			}
-			return true;
+			providePlusNonCombat(25);
+			return autoAdv($location[The Haunted Gallery]);
 		}
 		return false;
 	}
@@ -5746,7 +5767,7 @@ boolean L11_hiddenCity()
 		set_property("auto_hiddencity", "finished");
 		return true;
 	}
-	else if((item_amount($item[[7963]Ancient Amulet]) == 0) && (my_class() == $class[Ed]))
+	else if (item_amount($item[[7963]Ancient Amulet]) == 0 && isActuallyEd())
 	{
 		set_property("auto_hiddencity", "finished");
 		return true;
@@ -6587,7 +6608,6 @@ boolean LX_spookyravenSecond()
 		{
 			set_property("choiceAdventure106", "3");
 		}
-		visit_url("place.php?whichplace=manor3&action=manor3_ladys");
 		return true;
 	}
 
@@ -6783,7 +6803,7 @@ boolean L11_mauriceSpookyraven()
 
 
 		# The autoAdvBypass case is probably suitable for Ed but we'd need to verify it.
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			visit_url("place.php?whichplace=manor4&action=manor4_chamberboss");
 		}
@@ -7113,7 +7133,7 @@ boolean L11_unlockEd()
 		return false;
 	}
 
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		set_property("auto_mcmuffin", "finished");
 		return true;
@@ -7223,7 +7243,7 @@ boolean L11_unlockPyramid()
 	{
 		return false;
 	}
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		return false;
 	}
@@ -7670,7 +7690,7 @@ boolean L12_sonofaBeach()
 		}
 	}
 
-	if((my_class() == $class[Ed]) && (item_amount($item[Talisman of Horus]) == 0))
+	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0)
 	{
 		return false;
 	}
@@ -7735,7 +7755,7 @@ boolean L12_sonofaBeach()
 	set_property("auto_doCombatCopy", "no");
 	handleFamiliar("item");
 
-	if((my_class() == $class[Ed]) && (my_hp() == 0))
+	if (isActuallyEd() && my_hp() == 0)
 	{
 		use(1, $item[Linen Bandages]);
 	}
@@ -7823,7 +7843,7 @@ boolean L12_sonofaPrefix()
 		return false;
 	}
 
-	if((my_class() == $class[Ed]) && (item_amount($item[Talisman of Horus]) == 0))
+	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0)
 	{
 		return false;
 	}
@@ -7915,7 +7935,7 @@ boolean L12_sonofaPrefix()
 	set_property("auto_doCombatCopy", "no");
 	handleFamiliar("item");
 
-	if((my_class() == $class[Ed]) && (my_hp() == 0))
+	if (isActuallyEd() && my_hp() == 0)
 	{
 		use(1, $item[Linen Bandages]);
 	}
@@ -8084,32 +8104,39 @@ boolean L12_finalizeWar()
 	if(have_outfit("War Hippy Fatigues"))
 	{
 		print("Getting dimes.", "blue");
-		sell($item[padl phone].buyer, item_amount($item[padl phone]), $item[padl phone]);
-		sell($item[red class ring].buyer, item_amount($item[red class ring]), $item[red class ring]);
-		sell($item[blue class ring].buyer, item_amount($item[blue class ring]), $item[blue class ring]);
-		sell($item[white class ring].buyer, item_amount($item[white class ring]), $item[white class ring]);
+		foreach it in $items[padl phone, red class ring, blue class ring, white class ring]
+		{
+			sell(it.buyer, item_amount(it), it);
+		}
+		foreach it in $items[beer helmet, distressed denim pants, bejeweled pledge pin]
+		{
+			sell(it.buyer, item_amount(it) - 1, it);
+		}
+		if (isActuallyEd())
+		{
+			foreach it in $items[kick-ass kicks, perforated battle paddle, bottle opener belt buckle, keg shield, giant foam finger, war tongs, energy drink IV, Elmley shades, beer bong]
+			{
+				sell(it.buyer, item_amount(it), it);
+			}
+		}
 	}
 	if(have_outfit("Frat Warrior Fatigues"))
 	{
 		print("Getting quarters.", "blue");
-		sell($item[pink clay bead].buyer, item_amount($item[pink clay bead]), $item[pink clay bead]);
-		sell($item[purple clay bead].buyer, item_amount($item[purple clay bead]), $item[purple clay bead]);
-		sell($item[green clay bead].buyer, item_amount($item[green clay bead]), $item[green clay bead]);
-		sell($item[communications windchimes].buyer, item_amount($item[communications windchimes]), $item[communications windchimes]);
-	}
-
-	if(!get_property("auto_hippyInstead").to_boolean())
-	{
-		if($coinmaster[Dimemaster].available_tokens >= 2)
+		foreach it in $items[pink clay bead, purple clay bead, green clay bead, communications windchimes]
 		{
-			cli_execute("make " + ($coinmaster[Dimemaster].available_tokens/2) + " filthy poultice");
+			sell(it.buyer, item_amount(it), it);
 		}
-	}
-	else
-	{
-		if($coinmaster[Quartersmaster].available_tokens >= 2)
+		foreach it in $items[bullet-proof corduroys, round purple sunglasses, reinforced beaded headband]
 		{
-			cli_execute("make " + ($coinmaster[Quartersmaster].available_tokens/2) + " gauze garter");
+			sell(it.buyer, item_amount(it) - 1, it);
+		}
+		if (isActuallyEd())
+		{
+			foreach it in $items[hippy protest button, Lockenstock&trade; sandals, didgeridooka, wicker shield, oversized pipe, fire poi, Gaia beads, hippy medical kit, flowing hippy skirt, round green sunglasses]
+			{
+				sell(it.buyer, item_amount(it), it);
+			}
 		}
 	}
 
@@ -8134,7 +8161,7 @@ boolean L12_finalizeWar()
 	}
 
 	int have = item_amount($item[filthy poultice]) + item_amount($item[gauze garter]);
-	if(have < 10)
+	if (have < 10 && !isActuallyEd())
 	{
 		int need = 10 - have;
 		if(!get_property("auto_hippyInstead").to_boolean())
@@ -8148,7 +8175,6 @@ boolean L12_finalizeWar()
 			cli_execute("make " + need + " filthy poultice");
 		}
 	}
-
 
 	if(have_outfit("War Hippy Fatigues"))
 	{
@@ -8512,7 +8538,7 @@ boolean L10_plantThatBean()
 		set_property("auto_bean", true);
 		return true;
 	}
-	else if(my_class() == $class[Ed])
+	else if (isActuallyEd())
 	{
 		set_property("auto_bean", true);
 		return true;
@@ -8629,7 +8655,7 @@ boolean L10_topFloor()
 		set_property("choiceAdventure678", 1);
 	}
 
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		set_property("choiceAdventure679", 2);
 	}
@@ -8687,7 +8713,7 @@ boolean L10_ground()
 	set_property("choiceAdventure672", 3);
 	set_property("choiceAdventure673", 3);
 	set_property("choiceAdventure674", 3);
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		set_property("choiceAdventure1026", 3);
 	}
@@ -9385,7 +9411,7 @@ boolean L7_crypt()
 	buffMaintain($effect[Rosewater Mark], 0, 1, 1);
 
 	boolean edAlcove = true;
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		edAlcove = have_skill($skill[More Legs]);
 	}
@@ -9965,47 +9991,6 @@ boolean LX_steelOrgan()
 	return false;
 }
 
-boolean L6_friarsHotWing()
-{
-	if(get_property("auto_friars") != "done")
-	{
-		return false;
-	}
-	if((get_property("auto_pirateoutfit") == "almost") || (get_property("auto_pirateoutfit") == "finished") )
-	{
-		set_property("auto_friars", "finished");
-		return false;
-	}
-
-	if(internalQuestStatus("questM12Pirate") >= 3)
-	{
-		set_property("auto_friars", "finished");
-		return false;
-	}
-
-	if((item_amount($item[Hot Wing]) >= 3) || (auto_my_path() == "Pocket Familiars"))
-	{
-		set_property("auto_friars", "finished");
-		return true;
-	}
-
-	if(considerGrimstoneGolem(true))
-	{
-		handleBjornify($familiar[Grimstone Golem]);
-	}
-	print("Need more Hot Wings", "blue");
-	if(my_class() == $class[Ed])
-	{
-		if(!autoAdv(1, $location[Pandamonium]))
-		{
-			print("Was unable to go to Pandamonium (438) in Ed. Uh oh. If we did, run me again and report this to the script writer", "blue");
-		}
-		return true;
-	}
-	autoAdv(1, $location[Pandamonium Slums]);
-	return true;
-}
-
 boolean LX_fancyOilPainting()
 {
 	if(get_property("chasmBridgeProgress").to_int() >= 30)
@@ -10063,11 +10048,7 @@ boolean L9_leafletQuest()
 	{
 		return false;
 	}
-	if(my_class() == $class[Ed])
-	{
-		return false;
-	}
-	if(in_koe())
+	if (isActuallyEd() || in_koe())
 	{
 		return false;
 	}
@@ -10310,7 +10291,7 @@ boolean L5_goblinKing()
 	{
 		return false;
 	}
-	if((my_level() < 8) && (get_property("auto_powerLevelAdvCount").to_int() < 9))
+	if (my_level() < 8 && get_property("auto_powerLevelAdvCount").to_int() < 9 && !isActuallyEd())
 	{
 		return false;
 	}
@@ -10400,7 +10381,7 @@ boolean L4_batCave()
 
 	if(batStatus >= 4)
 	{
-		if((item_amount($item[Enchanted Bean]) == 0) && !get_property("auto_bean").to_boolean() && (my_class() != $class[Ed]))
+		if (item_amount($item[Enchanted Bean]) == 0 && !get_property("auto_bean").to_boolean() && !isActuallyEd())
 		{
 			autoAdv(1, $location[The Beanbat Chamber]);
 			return true;
@@ -10427,7 +10408,7 @@ boolean L4_batCave()
 	if(batStatus >= 2)
 	{
 		bat_formBats();
-		if((item_amount($item[Enchanted Bean]) == 0) && !get_property("auto_bean").to_boolean() && (my_class() != $class[Ed]))
+		if (item_amount($item[Enchanted Bean]) == 0 && !get_property("auto_bean").to_boolean() && !isActuallyEd())
 		{
 			autoAdv(1, $location[The Beanbat Chamber]);
 			return true;
@@ -10485,7 +10466,7 @@ boolean L4_batCave()
 		}
 	}
 
-	if((my_class() == $class[Ed]) && (cloversAvailable() > 0) && (batStatus <= 1))
+	if (isActuallyEd() && cloversAvailable() > 0 && batStatus <= 1)
 	{
 		cloverUsageInit();
 		autoAdvBypass(31, $location[Guano Junction]);
@@ -10762,16 +10743,7 @@ boolean councilMaintenance()
 	if(my_level() > get_property("lastCouncilVisit").to_int())
 	{
 		council();
-		if(is_unrestricted($item[Order Of The Green Thumb Order Form]) && !florist_available() && contains_text(visit_url("place.php?whichplace=forestvillage"), "The Florist Friar's Cottage"))
-		{
-			print("Mafia does not think you have a Florist Friar but one seems to live in your forest.", "red");
-			trickMafiaAboutFlorist();
-			if(florist_available())
-			{
-				print("Deception successful, Mafia now realizes you have a Florist Friar.", "blue");
-			}
-		}
-		if((my_class() == $class[Ed]) && (my_level() == 11) && (item_amount($item[7961]) > 0))
+		if (isActuallyEd() && my_level() == 11 && item_amount($item[7961]) > 0)
 		{
 			cli_execute("refresh inv");
 		}
@@ -10785,7 +10757,7 @@ boolean adventureFailureHandler()
 	if(my_location().turns_spent > 52)
 	{
 		boolean tooManyAdventures = false;
-		if(($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Deep Dark Jungle, Hippy Camp, The Neverending Party, Noob Cave, Oil Peak, Pirates of the Garbage Barges, The Secret Government Laboratory, Sloppy Seconds Diner, The SMOOCH Army HQ, Super Villain\'s Lair, Uncle Gator\'s Country Fun-Time Liquid Waste Sluice, VYKEA, The X-32-F Combat Training Snowman, The Exploaded Battlefield] contains my_location()) == false)
+		if (($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Deep Dark Jungle, The Neverending Party, Noob Cave, Pirates of the Garbage Barges, The Secret Government Laboratory, Sloppy Seconds Diner, The SMOOCH Army HQ, Super Villain\'s Lair, Uncle Gator\'s Country Fun-Time Liquid Waste Sluice, VYKEA, The X-32-F Combat Training Snowman, The Exploaded Battlefield] contains my_location()) == false)
 		{
 			tooManyAdventures = true;
 		}
@@ -10798,18 +10770,17 @@ boolean adventureFailureHandler()
 			}
 		}
 
-		if(tooManyAdventures && (my_class() == $class[Ed]))
+		if(tooManyAdventures && isActuallyEd())
 		{
-			if($locations[The Neverending Party, The Secret Government Laboratory] contains my_location())
+			if ($location[Hippy Camp] == my_location())
 			{
 				tooManyAdventures = false;
 			}
 		}
 
-		int plCount = get_property("auto_powerLevelAdvCount").to_int();
-		if((plCount > 20) && (my_level() < 13))
+		if (get_property("auto_powerLevelAdvCount").to_int() > 20 && my_level() < 13)
 		{
-			if($locations[The EXtreme Slope, The Hidden Hospital, The Hole In The Sky, Oil Peak] contains my_location())
+			if ($location[The Haunted Gallery] == my_location())
 			{
 				tooManyAdventures = false;
 			}
@@ -11552,7 +11523,7 @@ boolean LX_handleSpookyravenFirstFloor()
 		}
 		if(!haveRes)
 		{
-			if(my_class() == $class[Ed])
+			if (isActuallyEd())
 			{
 				// this should be false if we have the 3rd resist upgrade (max available for Ed) and true if we don't!
 				delayKitchen = !have_skill($skill[Even More Elemental Wards]);
@@ -11863,6 +11834,11 @@ boolean L12_startWar()
 		return false;
 	}
 
+	if (my_level() < 12)
+	{
+		return false;
+	}
+
 	if((my_basestat($stat[Muscle]) < 70) || (my_basestat($stat[Mysticality]) < 70) || (my_basestat($stat[Moxie]) < 70))
 	{
 		return false;
@@ -12013,7 +11989,7 @@ boolean L12_preOutfit()
 		return true;
 	}
 
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if(!canYellowRay() && (my_level() < 12))
 		{
@@ -12102,7 +12078,7 @@ boolean L9_highLandlord()
 		return false;
 	}
 
-	if((my_class() == $class[Ed]) && !get_property("auto_chasmBusted").to_boolean())
+	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
 		return false;
 	}
@@ -12110,7 +12086,6 @@ boolean L9_highLandlord()
 	if(get_property("auto_highlandlord") == "")
 	{
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");
-		set_property("auto_aboocount", "0");
 		set_property("choiceAdventure296", "1");
 		set_property("auto_highlandlord", "start");
 		set_property("auto_grimstoneFancyOilPainting", false);
@@ -12122,9 +12097,9 @@ boolean L9_highLandlord()
 		set_property("auto_boopeak", "finished");
 	}
 
+	if(L9_twinPeak())			return true;
 	if(L9_aBooPeak())			return true;
 	if(L9_oilPeak())			return true;
-	if(L9_twinPeak())			return true;
 
 	if((get_property("twinPeakProgress").to_int() == 15) && (get_property("auto_oilpeak") == "finished") && (get_property("auto_boopeak") == "finished"))
 	{
@@ -12156,12 +12131,11 @@ boolean L9_aBooPeak()
 	}
 	int clueAmt = item_amount(clue);
 
-	if(get_property("auto_aboocount").to_int() < 5)
+	if (get_property("booPeakProgress").to_int() > 90)
 	{
 		print("A-Boo Peak (initial): " + get_property("booPeakProgress"), "blue");
-		set_property("auto_aboocount", get_property("auto_aboocount").to_int() + 1);
 
-		if(clueAmt < 3)
+		if (clueAmt < 3 && item_amount($item[January\'s Garbage Tote]) > 0)
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
 			if(!useMaximizeToEquip())
@@ -12200,7 +12174,7 @@ boolean L9_aBooPeak()
 	{
 		boolean doThisBoo = false;
 
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			if(item_amount($item[Linen Bandages]) == 0)
 			{
@@ -12210,7 +12184,7 @@ boolean L9_aBooPeak()
 		familiar priorBjorn = my_bjorned_familiar();
 
 		string lihcface = "";
-		if((my_class() == $class[Ed]) && possessEquipment($item[The Crown of Ed the Undying]))
+		if (isActuallyEd() && possessEquipment($item[The Crown of Ed the Undying]))
 		{
 			lihcface = "-equip lihc face";
 		}
@@ -12275,7 +12249,7 @@ boolean L9_aBooPeak()
 		if(auto_canBeachCombHead("cold")) {
 			coldResist = coldResist + 3;
 		}
-		if(auto_canBeachCombHead("cold")) {
+		if (auto_canBeachCombHead("spooky")) {
 			spookyResist = spookyResist + 3;
 		}
 
@@ -12407,11 +12381,11 @@ boolean L9_aBooPeak()
 				}
 			}
 			useCocoon();
-			if((my_class() == $class[Ed]) && (my_hp() == 0))
+			if (isActuallyEd() && my_hp() == 0)
 			{
 				use(1, $item[Linen Bandages]);
 			}
-			if(((my_hp() * 4) < my_maxhp()) && (item_amount($item[Scroll of Drastic Healing]) > 0) && (my_class() != $class[Ed] && my_class() != $class[Vampyre]))
+			if ((my_hp() * 4) < my_maxhp() && item_amount($item[Scroll of Drastic Healing]) > 0 && (!isActuallyEd() || my_class() != $class[Vampyre]))
 			{
 				use(1, $item[Scroll of Drastic Healing]);
 			}
@@ -12419,10 +12393,7 @@ boolean L9_aBooPeak()
 			handleBjornify(priorBjorn);
 			return true;
 		}
-		else if(auto_my_path() != "Picky")
-		{
-			#abort("Could not handle HP/MP situation for a-boo peak");
-		}
+
 		print("Nevermind, that peak is too scary!", "green");
 		equipBaseline();
 		handleFamiliar("item");
@@ -12440,7 +12411,7 @@ boolean L9_aBooPeak()
 	}
 	else
 	{
-		if($location[A-Boo Peak].turns_spent < 10)
+		if ($location[A-Boo Peak].turns_spent < 10 && item_amount($item[January\'s Garbage Tote]) > 0)
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
 			if(!useMaximizeToEquip())
@@ -12468,10 +12439,6 @@ boolean L9_aBooPeak()
 boolean L9_twinPeak()
 {
 	if(get_property("twinPeakProgress").to_int() >= 15)
-	{
-		return false;
-	}
-	if(get_property("auto_oilpeak") != "finished")
 	{
 		return false;
 	}
@@ -12606,7 +12573,7 @@ boolean L9_twinPeak()
 				}
 				if(auto_have_familiar($familiar[Trick-Or-Treating Tot]))
 				{
-					if(possessEquipment($item[li'l candy corn costume]) && auto_is_valid($item[li'l candy corn costume]))
+					if (possessEquipment($item[li\'l candy corn costume]) && auto_is_valid($item[li\'l candy corn costume]))
 					{
 						resist = $familiar[Trick-Or-Treating Tot];
 					}
@@ -12616,7 +12583,7 @@ boolean L9_twinPeak()
 					handleFamiliar(resist);
 					if(resist == $familiar[Trick-Or-Treating Tot])
 					{
-						autoEquip($slot[familiar], $item[li'l candy corn costume]);
+						autoEquip($slot[familiar], $item[li\'l candy corn costume]);
 					}
 				}
 			}
@@ -12750,8 +12717,8 @@ boolean L9_twinPeak()
 	}
 	else
 	{
+		handleFamiliar("item"); // should probably call this before adventuring no?
 		autoAdv(1, $location[Twin Peak]);
-		handleFamiliar("item");
 	}
 	return true;
 }
@@ -12824,7 +12791,7 @@ boolean L9_oilPeak()
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 	handleFamiliar("initSuggest");
 
-	if((my_class() == $class[Ed]) && get_property("auto_dickstab").to_boolean())
+	if (isActuallyEd() && get_property("auto_dickstab").to_boolean())
 	{
 		buffMaintain($effect[The Dinsey Look], 0, 1, 1);
 	}
@@ -12943,21 +12910,14 @@ void L9_chasmMaximizeForNoncombat()
 }
 boolean L9_chasmBuild()
 {
-	if((my_level() < 9) || (get_property("chasmBridgeProgress").to_int() >= 30))
+	if (my_level() < 9 || get_property("chasmBridgeProgress").to_int() >= 30 || internalQuestStatus("questL09Topping") >= 1)
 	{
 		return false;
 	}
-#	if(LX_getDictionary() || LX_dictionary())
-#	{
-#		return true;
-#	}
+
 	print("Chasm time", "blue");
 
 	if(item_amount($item[fancy oil painting]) > 0)
-	{
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-	}
-	if(item_amount($item[bridge]) > 0)
 	{
 		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 	}
@@ -13099,45 +13059,6 @@ boolean L9_chasmBuild()
 	}
 	visit_url("place.php?whichplace=highlands&action=highlands_dude");
 	return true;
-}
-
-boolean LX_dictionary()
-{
-	if(item_amount($item[abridged dictionary]) > 1)
-	{
-		print("Inventory defective... refreshing", "red");
-		cli_execute("refresh inv");
-	}
-
-	if(item_amount($item[abridged dictionary]) > 0)
-	{
-		print("Got this dictionary I need to deal with, boo words!", "green");
-		if(knoll_available() || (get_property("questM01Untinker") == "finished"))
-		{
-			print("Untinkering dictionary", "blue");
-			cli_execute("untinker abridged dictionary");
-		}
-		else
-		{
-			if(get_property("questM01Untinker") == "unstarted")
-			{
-				visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
-			}
-			if((item_amount($item[Rusty Screwdriver]) == 0) && (get_property("questM01Untinker") != "finished"))
-			{
-				if(!autoAdv(1, $location[The Degrassi Knoll Garage]))
-				{
-					abort("Can't automatically do the Screwdriver quest, sorry....");
-				}
-				return true;
-			}
-			if(item_amount($item[Rusty Screwdriver]) > 0)
-			{
-				cli_execute("untinker abridged dictionary");
-			}
-		}
-	}
-	return false;
 }
 
 boolean L9_chasmStart()
@@ -13367,37 +13288,55 @@ boolean L11_shenCopperhead()
 
 	set_property("choiceAdventure1074", 1);
 
-	if((internalQuestStatus("questL11Shen") == 0) || (internalQuestStatus("questL11Shen") == 2) || (internalQuestStatus("questL11Shen") == 4) || (internalQuestStatus("questL11Shen") == 6))
+	if (internalQuestStatus("questL11Shen") == 0 || internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)
 	{
-		if((item_amount($item[Crappy Waiter Disguise]) > 0) && (have_effect($effect[Crappily Disguised as a Waiter]) == 0) && !in_tcrs())
+		if (item_amount($item[Crappy Waiter Disguise]) > 0 && have_effect($effect[Crappily Disguised as a Waiter]) == 0 && !in_tcrs())
 		{
 			use(1, $item[Crappy Waiter Disguise]);
-			switch(get_property("auto_copperhead").to_int())
+
+			// default to getting unnamed cocktails to turn into Flamin' Whatsisnames.
+			int behindtheStacheOption = 4;
+			if (item_amount($item[priceless diamond]) > 0 || item_amount($item[Red Zeppelin Ticket]) > 0 || (internalQuestStatus("questL11Shen") == 6 && item_amount($item[unnamed cocktail]) > 0))
 			{
-			case 0:		set_property("choiceAdventure855", 2);		break;
-			case 1:		set_property("choiceAdventure855", 2);		break;
-			case 2:		set_property("choiceAdventure855", 3);		break;
-			case 3:		set_property("choiceAdventure855", 2);		break;
-			case 4:		set_property("choiceAdventure855", 2);		break;
-			case 5:		set_property("choiceAdventure855", 2);		break;
-			case 6:		set_property("choiceAdventure855", 1);		break;
-			case 7:		set_property("choiceAdventure855", 4);		break;
+				if (get_property("auto_copperhead").to_int() != 3)
+				{
+					// got priceless diamond or zeppelin ticket so lets burn the place down (and make Flamin' Whatsisnames)
+					behindtheStacheOption = 3;
+				}
 			}
+			else
+			{
+				if (get_property("auto_copperhead").to_int() != 2)
+				{
+					// knock over the ice bucket & try for the priceless diamond.
+					behindtheStacheOption = 2;
+				}
+			}
+			set_property("choiceAdventure855", behindtheStacheOption);
 		}
 
-		boolean retval = autoAdv($location[The Copperhead Club]);
-		if(get_property("lastEncounter") == "Behind the 'Stache")
+		if (!maximizeContains("-10ml"))
 		{
-			switch(get_property("choiceAdventure855").to_int())
+			addToMaximize("-10ml");
+		}
+		boolean retval = autoAdv($location[The Copperhead Club]);
+		if (maximizeContains("-10ml"))
+		{
+			removeFromMaximize("-10ml");
+		}
+		if (get_property("lastEncounter") == "Behind the 'Stache")
+		{
+			// store which of the 3 zone changing options we have active so we don't waste Crappy Waiter Disguises
+			switch (get_property("choiceAdventure855").to_int())
 			{
 			case 1:
-				set_property("auto_copperhead", get_property("auto_copperhead").to_int() | 1);
+				set_property("auto_copperhead", 1);
 				break;
 			case 2:
-				set_property("auto_copperhead", get_property("auto_copperhead").to_int() | 2);
+				set_property("auto_copperhead", 2);
 				break;
 			case 3:
-				set_property("auto_copperhead", get_property("auto_copperhead").to_int() | 4);
+				set_property("auto_copperhead", 3);
 				break;
 			}
 		}
@@ -13407,7 +13346,7 @@ boolean L11_shenCopperhead()
 	if((internalQuestStatus("questL11Shen") == 1) || (internalQuestStatus("questL11Shen") == 3) || (internalQuestStatus("questL11Shen") == 5))
 	{
 		item it = to_item(get_property("shenQuestItem"));
-		if (it == $item[none] && my_class() == $class[Ed])
+		if (it == $item[none] && isActuallyEd())
 		{
 			// temp workaround until mafia bug is fixed - https://kolmafia.us/showthread.php?23742
 			cli_execute("refresh quests");
@@ -13791,6 +13730,11 @@ boolean L5_haremOutfit()
 
 boolean L8_trapperGroar()
 {
+	if(my_level() < 8)
+	{
+		return false;
+	}
+  
 	if(get_property("auto_trapper") == "finished")
 	{
 		return false;
@@ -13865,7 +13809,7 @@ boolean L8_trapperGroar()
 			}
 		}
 		string lihcface = "";
-		if((my_class() == $class[Ed]) && possessEquipment($item[The Crown of Ed the Undying]))
+		if (isActuallyEd() && possessEquipment($item[The Crown of Ed the Undying]))
 		{
 			lihcface = "-equip lihc face";
 		}
@@ -13939,9 +13883,9 @@ boolean L8_trapperExtreme()
 	//Lucky Pill:	"Look in the side Pocket"
 	//set_property("choiceAdventure575", "2");
 
-	if(have_outfit("eXtreme Cold-Weather Gear"))
+	if (possessEquipment($item[extreme mittens]) && possessEquipment($item[extreme scarf]) && possessEquipment($item[snowboarder pants]))	
 	{
-		if(autoOutfit("eXtreme Cold-Weather Gear"))
+		if (my_basestat($stat[moxie]) >= 35 && my_basestat($stat[mysticality]) >= 35 && autoOutfit("eXtreme Cold-Weather Gear"))
 		{
 			set_property("choiceAdventure575", "3");
 			autoAdv(1, $location[The eXtreme Slope]);
@@ -14012,6 +13956,11 @@ boolean L8_trapperYeti()
 		return true;
 	}
 
+	if (internalQuestStatus("questL08Trapper") >= 3)
+	{
+		return false;
+	}
+
 	if(!have_skill($skill[Rain Man]) && (pulls_remaining() >= 3) && (internalQuestStatus("questL08Trapper") < 3))
 	{
 		foreach it in $items[Ninja Carabiner, Ninja Crampons, Ninja Rope]
@@ -14040,7 +13989,7 @@ boolean L8_trapperYeti()
 		{
 			set_property("questL08Trapper", "step2");
 		}
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			if(item_amount($item[Talisman of Horus]) == 0)
 			{
@@ -14064,7 +14013,7 @@ boolean L8_trapperYeti()
 			return false;
 		}
 
-		if((my_class() == $class[Ed]) && (!elementalPlanes_access($element[spooky])))
+		if (isActuallyEd() && !elementalPlanes_access($element[spooky]))
 		{
 			adjustEdHat("myst");
 		}
@@ -14130,7 +14079,7 @@ boolean auto_tavern()
 		{
 			autoEquip($item[17-Ball]);
 		}
-		if(possessEquipment($item[Kremlin's Greatest Briefcase]))
+		if (possessEquipment($item[Kremlin\'s Greatest Briefcase]))
 		{
 			string mod = string_modifier($item[Kremlin\'s Greatest Briefcase], "Modifiers");
 			if(contains_text(mod, "Weapon Damage Percent"))
@@ -14312,7 +14261,7 @@ boolean L3_tavern()
 
 	boolean delayTavern = false;
 
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		set_property("choiceAdventure1000", "1");
 		set_property("choiceAdventure1001", "2");
@@ -14382,7 +14331,7 @@ boolean LX_setBallroomSong()
 		set_property("auto_ballroomsong", "finished");
 		return false;
 	}
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		return false;
 	}
@@ -14416,7 +14365,7 @@ boolean LX_setBallroomSong()
 	if(contains_text(get_property("lastEncounter"), "We\'ll All Be Flat"))
 	{
 		set_property("auto_ballroomflat", "finished");
-		if(my_class() == $class[Ed])
+		if (isActuallyEd())
 		{
 			set_property("auto_ballroomsong", "finished");
 		}
@@ -14517,7 +14466,7 @@ void print_header()
 	{
 		print("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		print("Ka Coins: " + item_amount($item[Ka Coin]) + " Lashes used: " + get_property("_edLashCount"), "green");
 	}
@@ -14624,7 +14573,7 @@ boolean doTasks()
 		cheeseWarMachine(0, 0, 0, 0);
 
 		int turnGoal = 0;
-		if((my_class() == $class[Ed]) && !possessEquipment($item[The Crown Of Ed The Undying]))
+		if (isActuallyEd() && !possessEquipment($item[The Crown Of Ed The Undying]))
 		{
 			turnGoal = 15;
 		}
@@ -14674,7 +14623,7 @@ boolean doTasks()
 		// Once we've started the war, we want to be able to micromanage songs
 		// for Gremlins and Nuns. Don't break this for them.
 	}
-	else if((my_class() != $class[Ed]) && (get_property("auto_crypt") != "finished") && (get_property("_boomBoxFights").to_int() == 10) && (get_property("_boomBoxSongsLeft").to_int() > 3))
+	else if (!isActuallyEd() && get_property("auto_crypt") != "finished" && get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
 	{
 		songboomSetting("nightmare");
 	}
@@ -14751,14 +14700,12 @@ boolean doTasks()
 	if(LX_chateauPainting())			return true;
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;
-#	if(LX_dictionary())					return true;
 	if(L5_findKnob())					return true;
 	if(LM_edTheUndying())				return true;
-
 	if(L12_sonofaPrefix())				return true;
 	if(LX_burnDelay())					return true;
 
-	if((my_class() != $class[Ed]) && (my_level() >= 9) && (my_daycount() == 1))
+	if (!isActuallyEd() && my_level() >= 9 && my_daycount() == 1)
 	{
 		if((get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available() && (auto_my_path() != "The Source"))
 		{
@@ -14857,14 +14804,9 @@ boolean doTasks()
 	if(L10_airship())					return true;
 	if(L10_basement())					return true;
 	if(L10_ground())					return true;
-
 	if(L11_blackMarket())				return true;
 	if(L11_forgedDocuments())			return true;
 	if(L11_mcmuffinDiary())				return true;
-	if(L11_shenCopperhead())			return true;
-	if(L11_redZeppelin())				return true;
-	if(L11_ronCopperhead())				return true;
-
 	if(L10_topFloor())					return true;
 	if(L10_holeInTheSkyUnlock())		return true;
 	if(L10_holeInTheSky())				return true;
@@ -14873,11 +14815,7 @@ boolean doTasks()
 	if(L9_highLandlord())				return true;
 	if(L12_flyerBackup())				return true;
 	if(Lsc_flyerSeals())				return true;
-	if(L11_blackMarket())				return true;
-	if(L11_forgedDocuments())			return true;
-	if(L11_mcmuffinDiary())				return true;
 	if(L11_mauriceSpookyraven())		return true;
-	if(L11_talismanOfNam())				return true;
 	if(L11_nostrilOfTheSerpent())		return true;
 	if(L11_unlockHiddenCity())			return true;
 	if(L11_hiddenCityZones())			return true;
@@ -14893,8 +14831,8 @@ boolean doTasks()
 		}
 	}
 
-
 	if(L11_hiddenCity())				return true;
+	if(L11_talismanOfNam())				return true;
 	if(L11_palindome())					return true;
 	if(L11_unlockPyramid())				return true;
 	if(L11_unlockEd())					return true;
@@ -14942,7 +14880,7 @@ boolean doTasks()
 				warOutfit(false);
 			}
 
-			item warKillDoubler = get_property("auto_hippyInstead").to_boolean() ? $item[Jacob's rung] : $item[Haunted paddle-ball];
+			item warKillDoubler = get_property("auto_hippyInstead").to_boolean() ? $item[Jacob\'s rung] : $item[Haunted paddle-ball];
 			pullXWhenHaveY(warKillDoubler, 1, 0);
 			if(possessEquipment(warKillDoubler))
 			{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -13842,9 +13842,9 @@ boolean L8_trapperGroar()
 			}
 
 			print("Time to take out Gargle, sure, Gargle (Groar)", "blue");
-			if((item_amount($item[Groar\'s Fur]) == 0) && (item_amount($item[Winged Yeti Fur]) == 0))
+			if (item_amount($item[Groar\'s Fur]) == 0 && item_amount($item[Winged Yeti Fur]) == 0)
 			{
-				addToMaximize("5meat");
+				addToMaximize("5meat 2000cold res 5 max");
 				//If this returns false, we might have finished already, can we check this?
 				autoAdv(1, $location[Mist-shrouded Peak]);
 			}
@@ -14680,6 +14680,10 @@ boolean doTasks()
 	{
 		if((my_adventures() < 10) && (my_level() >= 7) && (my_hp() > 0))
 		{
+			if (!handleServant($servant[Scribe]))
+			{
+				handleServant($servant[Cat]);
+			}
 			fightScienceTentacle();
 			if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))
 			{
@@ -14689,6 +14693,7 @@ boolean doTasks()
 	}
 	else if((my_level() >= 9) && (my_hp() > 0))
 	{
+		handleServant($servant[Scribe]);
 		fightScienceTentacle();
 		if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))
 		{

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2494,9 +2494,9 @@ string auto_edCombatHandler(int round, string opp, string text)
 		{
 			foreach it in $items[Holy Spring Water, Spirit Beer, Sacramental Wine]
 			{
-				if(item_amount(it) > 0)
+				if (canUse(it))
 				{
-					return "item " + it;
+					return useItem(it);
 				}
 			}
 		}
@@ -2720,7 +2720,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if(!contains_text(combatState, "flyers") && (my_location() != $location[The Battlefield (Frat Uniform)]) && (my_location() != $location[The Battlefield (Hippy Uniform)]) && !get_property("auto_ignoreFlyer").to_boolean())
 	{
-		if((item_amount($item[Rock Band Flyers]) > 0) && (get_property("flyeredML").to_int() < 10000))
+		if (canUse($item[Rock Band Flyers]) && get_property("flyeredML").to_int() < 10000)
 		{
 			set_property("auto_combatHandler", combatState + "(flyers)");
 			if (get_property("_edDefeats").to_int() < 3 && get_property("auto_edStatus") == "dying")
@@ -2728,9 +2728,9 @@ string auto_edCombatHandler(int round, string opp, string text)
 				set_property("auto_edStatus", "UNDYING!");
 				// abuse the ability to flyer the same monster multiple times (optimal!)
 			}
-			return "item " + $item[Rock Band Flyers];
+			return useItem($item[Rock Band Flyers]);
 		}
-		if((item_amount($item[Jam Band Flyers]) > 0) && (get_property("flyeredML").to_int() < 10000))
+		if (canUse($item[Jam Band Flyers]) && get_property("flyeredML").to_int() < 10000)
 		{
 			set_property("auto_combatHandler", combatState + "(flyers)");
 			if (get_property("_edDefeats").to_int() < 3 && get_property("auto_edStatus") == "dying")
@@ -2738,7 +2738,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 				set_property("auto_edStatus", "UNDYING!");
 				// abuse the ability to flyer the same monster multiple times (optimal!)
 			}
-			return "item " + $item[Jam Band Flyers];
+			return useItem($item[Jam Band Flyers]);
 		}
 	}
 
@@ -2860,7 +2860,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if(auto_have_skill($skill[Curse Of Vacation]) && (my_mp() >= mp_cost($skill[Curse Of Vacation])))
+	if (auto_have_skill($skill[Curse Of Vacation]) && my_mp() >= mp_cost($skill[Curse Of Vacation]) && get_property("auto_edStatus") == "dying")
 	{
 		if (auto_wantToBanish(enemy, my_location()) && !(auto_banishesUsedAt(my_location()) contains "curse of vacation"))
 		{
@@ -2870,16 +2870,13 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if(item_amount($item[Disposable Instant Camera]) > 0)
+	if (canUse($item[Disposable Instant Camera]) && $monsters[Bob Racecar, Racecar Bob] contains enemy)
 	{
-		if($monsters[Bob Racecar, Racecar Bob] contains enemy)
-		{
-			set_property("auto_combatHandler", combatState + "(disposable instant camera)");
-			return "item " + $item[Disposable Instant Camera];
-		}
+		set_property("auto_combatHandler", combatState + "(disposable instant camera)");
+		return useItem($item[Disposable Instant Camera]);
 	}
 
-	if((my_location() == $location[Oil Peak]) && (item_amount($item[Duskwalker Syringe]) > 0))
+	if (my_location() == $location[Oil Peak] && canUse($item[Duskwalker Syringe]))
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean wantCrude = ((oilProgress & 4) == 0);
@@ -2890,19 +2887,23 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 		if(wantCrude)
 		{
-			return "item " + $item[Duskwalker Syringe];
+			return useItem($item[Duskwalker Syringe]);
 		}
 	}
 
-	if(my_location() == $location[A Mob Of Zeppelin Protesters] && item_amount($item[cigarette lighter]) > 0)
+	if (canUse($item[Cigarette Lighter]) && my_location() == $location[A Mob Of Zeppelin Protesters] && get_property("questL11Ron") == "step1" && get_property("auto_edStatus") == "dying")
 	{
-		string res = "item " + $item[cigarette lighter];
-		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
-		{
-			res += ", none";
-		}
-		return res;
+		return useItem($item[Cigarette Lighter]);
 		// insta-kills protestors and removes an additional 5-7 (optimal!)
+	}
+
+	if (canUse($item[Glark Cable]) && my_location() == $location[The Red Zeppelin] && get_property("questL11Ron") == "step3" && get_property("_glarkCableUses").to_int() < 5 && get_property("auto_edStatus") == "dying")
+	{
+		if($monsters[Man With The Red Buttons, Red Butler, Red Fox, Red Skeleton] contains enemy)
+		{
+			return useItem($item[Glark Cable]);
+			// free insta-kill (optimal!)
+		}
 	}
 
 	if (!get_property("edUsedLash").to_boolean() && auto_have_skill($skill[Lash of the Cobra]) && my_mp() >= mp_cost($skill[Lash of the Cobra]))
@@ -3054,16 +3055,16 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if((item_amount($item[Tattered Scrap of Paper]) > 0) && !contains_text(combatState, "tatters"))
+	if(canUse($item[Tattered Scrap of Paper]) && !contains_text(combatState, "tatters"))
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
 			set_property("auto_combatHandler", combatState + "(tatters)");
-			return "item " + $item[Tattered Scrap Of Paper];
+			return useItem($item[Tattered Scrap Of Paper]);
 		}
 	}
 
-	if(!contains_text(edCombatState, "talismanofrenenutet") && (item_amount($item[Talisman of Renenutet]) > 0))
+	if (!contains_text(edCombatState, "talismanofrenenutet") && canUse($item[Talisman of Renenutet]))
 	{
 		boolean doRenenutet = false;
 		if((enemy == $monster[Cabinet of Dr. Limpieza]) && ($location[The Haunted Laundry Room].turns_spent > 2))
@@ -3114,13 +3115,13 @@ string auto_edCombatHandler(int round, string opp, string text)
 			set_property("auto_edCombatHandler", edCombatState + "(talismanofrenenutet)");
 			handleTracker(enemy, "auto_renenutet");
 			set_property("auto_edStatus", "dying");
-			return "item " + $item[Talisman Of Renenutet];
+			return useItem($item[Talisman Of Renenutet]);
 		}
 	}
 
-	if((enemy == $monster[Pygmy Orderlies]) && (item_amount($item[Short Writ of Habeas Corpus]) > 0))
+	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus]))
 	{
-		return "item short writ of habeas corpus";
+		return useItem($item[Short Writ of Habeas Corpus]);
 	}
 
 	if(get_property("auto_edStatus") == "UNDYING!")

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -340,19 +340,6 @@ boolean adjustEdHat(string goal)
 	return false;
 }
 
-float edMeatBonus()
-{
-	if (!isActuallyEd())
-	{
-		return 0.0;
-	}
-	if(have_skill($skill[Curse of Fortune]) && (item_amount($item[Ka Coin]) > 0))
-	{
-		return 200.0;
-	}
-	return 0.0;
-}
-
 boolean handleServant(servant who)
 {
 	if (!isActuallyEd())
@@ -767,7 +754,7 @@ boolean ed_eatStuff()
 
 	if (!contains_text(get_counters("Fortune Cookie", 0, 200), "Fortune Cookie"))
 	{
-		if (item_amount($item[Clan VIP Lounge Key]) > 0 && my_meat() >= 500 && inebriety_limit() == 4 && (my_inebriety() == 0 || my_inebriety() == 3) && auto_get_clan_lounge() contains $item[Clan Speakeasy])
+		if((item_amount($item[Clan VIP Lounge Key]) > 0) && (my_meat() >= 500) && (inebriety_limit() == 4) && ((my_inebriety() == 0) || (my_inebriety() == 3)) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]))
 		{
 			autoDrink(1, $item[Lucky Lindy]);
 		}
@@ -782,11 +769,6 @@ boolean ed_eatStuff()
 
 skill ed_nextUpgrade()
 {
-	if (!isActuallyEd())
-	{
-		return $skill[none];
-	}
-
 	int coins = item_amount($item[Ka Coin]);
 	int canEat = (spleen_limit() - my_spleen_use()) / 5;
 
@@ -883,124 +865,34 @@ skill ed_nextUpgrade()
 
 int ed_KaCost(skill upgrade)
 {
-	if (!isActuallyEd())
+	static int[skill] kaNeeded = {
+		$skill[Extra Spleen]: 5,
+   	$skill[Another Extra Spleen]: 10,
+		$skill[Upgraded Legs]: 10,
+		$skill[Tougher Skin]: 10,
+		$skill[Armor Plating]: 10,
+ 		$skill[Healing Scarabs]: 10,
+ 		$skill[Elemental Wards]: 10,
+ 		$skill[Yet Another Extra Spleen]: 15,
+ 		$skill[Still Another Extra Spleen]: 20,
+ 		$skill[More Legs]: 20,
+		$skill[Upgraded Arms]: 20,
+ 		$skill[Upgraded Spine]: 20,
+ 		$skill[Bone Spikes]: 20,
+ 		$skill[Arm Blade]: 20,
+ 		$skill[More Elemental Wards]: 20,
+ 		$skill[Just One More Extra Spleen]: 25,
+ 		$skill[Replacement Stomach]: 30,
+ 		$skill[Replacement Liver]: 30,
+		$skill[Okay Seriously, This is the Last Spleen]: 30,
+ 		$skill[Even More Elemental Wards]: 30
+		};
+  if (kaNeeded contains upgrade)
 	{
+		return kaNeeded[upgrade];
+	} else {
 		return -1;
 	}
-
-	int returnCost = -1;
-	switch (upgrade)
-	{
-  case $skill[Extra Spleen]:
-		returnCost = 5;
-  	break;
-  case $skill[Another Extra Spleen]:
-  case $skill[Upgraded Legs]:
-	case $skill[Tougher Skin]:
-	case $skill[Armor Plating]:
-  case $skill[Healing Scarabs]:
-  case $skill[Elemental Wards]:
-		returnCost = 10;
-    break;
-  case $skill[Yet Another Extra Spleen]:
-		returnCost = 15;
-    break;
-  case $skill[Still Another Extra Spleen]:
-  case $skill[More Legs]:
-	case $skill[Upgraded Arms]:
-  case $skill[Upgraded Spine]:
-  case $skill[Bone Spikes]:
-  case $skill[Arm Blade]:
-  case $skill[More Elemental Wards]:
-		returnCost = 20;
-    break;
-  case $skill[Just One More Extra Spleen]:
-		returnCost = 25;
-    break;
-  case $skill[Replacement Stomach]:
-  case $skill[Replacement Liver]:
-	case $skill[Okay Seriously, This is the Last Spleen]:
-  case $skill[Even More Elemental Wards]:
-		returnCost = 30;
-    break;
-  default:
-	}
-	return returnCost;
-}
-
-int ed_skillID(skill upgrade)
-{
-	if (!isActuallyEd())
-	{
-		return -1;
-	}
-
-	int skillID = -1;
-	switch (upgrade)
-	{
-  case $skill[Replacement Stomach]:
-		skillID = 28;
-  	break;
-  case $skill[Replacement Liver]:
-		skillID = 29;
-  	break;
-  case $skill[Extra Spleen]:
-		skillID = 30;
-  	break;
-  case $skill[Another Extra Spleen]:
-		skillID = 31;
-  	break;
-  case $skill[Yet Another Extra Spleen]:
-		skillID = 32;
-    break;
-  case $skill[Still Another Extra Spleen]:
-		skillID = 33;
-  	break;
-  case $skill[Just One More Extra Spleen]:
-		skillID = 34;
-    break;
-	case $skill[Okay Seriously, This is the Last Spleen]:
-		skillID = 35;
-  	break;
-  case $skill[Upgraded Legs]:
-		skillID = 36;
-  	break;
-	case $skill[Upgraded Arms]:
-		skillID = 37;
-  	break;
-  case $skill[Upgraded Spine]:
-		skillID = 38;
-  	break;
-	case $skill[Tougher Skin]:
-		skillID = 39;
-  	break;
-	case $skill[Armor Plating]:
-		skillID = 40;
-  	break;
-  case $skill[Bone Spikes]:
-		skillID = 41;
-  	break;
-  case $skill[Arm Blade]:
-		skillID = 42;
-  	break;
-  case $skill[Healing Scarabs]:
-		skillID = 43;
-  	break;
-  case $skill[Elemental Wards]:
-		skillID = 44;
-    break;
-  case $skill[More Elemental Wards]:
-		skillID = 45;
-    break;
-  case $skill[Even More Elemental Wards]:
-		skillID = 46;
-    break;
-  case $skill[More Legs]:
-		skillID = 48;
-  	break;
-  default:
-	}
-	return skillID;
 }
 
 boolean ed_needShop()
@@ -1083,6 +975,39 @@ boolean ed_needShop()
 
 boolean ed_shopping()
 {
+
+	int ed_skillID(skill upgrade)
+	{
+		static int[skill] skillIDs = {
+  		$skill[Replacement Stomach]: 28, 
+  		$skill[Replacement Liver]: 29, 
+  		$skill[Extra Spleen]: 30,
+  		$skill[Another Extra Spleen]: 31,
+  		$skill[Yet Another Extra Spleen]: 32,
+  		$skill[Still Another Extra Spleen]: 33,
+  		$skill[Just One More Extra Spleen]: 34,
+			$skill[Okay Seriously, This is the Last Spleen]: 35,
+  		$skill[Upgraded Legs]: 36,
+			$skill[Upgraded Arms]: 37,
+  		$skill[Upgraded Spine]: 38,
+			$skill[Tougher Skin]:  39,
+			$skill[Armor Plating]: 40,
+  		$skill[Bone Spikes]: 41,
+  		$skill[Arm Blade]: 42,
+  		$skill[Healing Scarabs]: 43,
+  		$skill[Elemental Wards]: 44,
+  		$skill[More Elemental Wards]: 45,
+  		$skill[Even More Elemental Wards]: 46,
+  		$skill[More Legs]: 48
+			};
+  	if (skillIDs contains upgrade)
+		{
+			return skillIDs[upgrade];
+		} else {
+			return -1;
+		}
+	}
+
 	if (!isActuallyEd())
 	{
 		return false;
@@ -1146,7 +1071,7 @@ boolean ed_shopping()
 		if (requiredKa != -1 && coins >= requiredKa)
 		{
 			print("Buying " + nextUpgrade.to_string() + " (" + requiredKa.to_string() + " Ka).", "green");
-			int skillBuy = ed_SkillID(nextUpgrade);
+			int skillBuy = ed_skillID(nextUpgrade);
 			if (skillBuy != 0)
 			{
 				visit_url("place.php?whichplace=edunder&action=edunder_bodyshop");
@@ -1408,7 +1333,7 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 
 		if(get_property("_edDefeats").to_int() > get_property("edDefeatAbort").to_int())
 		{
-			auto_abort("Manually forcing edDefeatAborts. We can't handle the battle.");
+			abort("Manually forcing edDefeatAborts. We can't handle the battle.");
 		}
 
 		cli_execute("auto_post_adv.ash");
@@ -1632,31 +1557,14 @@ boolean L1_ed_islandFallback()
 
 	if (have_skill($skill[Upgraded Legs]) || item_amount($item[Ka coin]) >= 10)
 	{
-		if(have_outfit("Filthy Hippy Disguise") && is_wearing_outfit("Filthy Hippy Disguise"))
-		{
-			equip($slot[Pants], $item[None]);
-			put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
-			equipBaseline();
-		}
 		buffMaintain($effect[Wisdom Of Thoth], 20, 1, 1);
 		if (have_skill($skill[More Legs]) && maximizeContains("-10ml"))
 		{
 			removeFromMaximize("-10ml");
 		}
 		auto_change_mcd(11);
-		boolean retVal = autoAdv(1, $location[Hippy Camp]);
-		if (item_amount($item[Filthy Corduroys]) > 0)
-		{
-			if (closet_amount($item[Filthy Corduroys]) > 0)
-			{
-				autosell(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
-			}
-			else
-			{
-				put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
-			}
-		}
-		return retVal;
+		addToMaximize("-outfit Filthy Hippy Disguise");
+		return autoAdv(1, $location[Hippy Camp]);
 	}
 	set_property("auto_needLegs", true);
 	if (!maximizeContains("-10ml"))

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1660,7 +1660,7 @@ boolean LM_edTheUndying()
 		}
 	}
 
-	if(L1_ed_island() || l1_ed_islandFallback())
+	if(L1_ed_island() || L1_ed_islandFallback())
 	{
 		return true;
 	}
@@ -1675,9 +1675,9 @@ boolean LM_edTheUndying()
 		return true;
 	}
 
-	if (closet_amount($item[Filthy Corduroys]) > 0)
+	if (maximizeContains("-outfit Filthy Hippy Disguise"))
 	{
-		take_closet(closet_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+		removeFromMaximize("-outfit Filthy Hippy Disguise");
 	}
 
 	if (!get_property("breakfastCompleted").to_boolean())

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1,5 +1,10 @@
 script "auto_edTheUndying.ash"
 
+boolean isActuallyEd()
+{
+	return (my_class() == $class[Ed] || my_path() == "Actually Ed the Undying");
+}
+
 int ed_spleen_limit()
 {
 	int limit = 5;
@@ -10,20 +15,12 @@ int ed_spleen_limit()
 			limit += 5;
 		}
 	}
-	if(spleen_limit() == limit)
-	{
-		print("Correct spleen limit obtained", "green");
-	}
-	else
-	{
-		print("Incorrect spleen limit (" + spleen_limit() + ") but actually: " + limit + " overriding.", "red");
-	}
 	return limit;
 }
 
 void ed_initializeSettings()
 {
-	if(my_path() == "Actually Ed the Undying")
+	if (isActuallyEd())
 	{
 		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_crackpotjar", "done");
@@ -52,12 +49,13 @@ void ed_initializeSettings()
 		set_property("choiceAdventure1023", "");
 		set_property("desertExploration", 100);
 		set_property("nsTowerDoorKeysUsed", "Boris's key,Jarlsberg's key,Sneaky Pete's key,Richard's star key,skeleton key,digital key");
+		set_property("auto_delayHauntedKitchen", true);
 	}
 }
 
 void ed_initializeSession()
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if(get_property("hpAutoRecoveryItems") != "linen bandages")
 		{
@@ -66,14 +64,14 @@ void ed_initializeSession()
 			set_property("auto_hpAutoRecoveryTarget", get_property("hpAutoRecoveryTarget"));
 			set_property("hpAutoRecoveryItems", "linen bandages");
 			set_property("hpAutoRecovery", 0.0);
-			set_property("hpAutoRecoveryTarget", 0.0);
+			set_property("hpAutoRecoveryTarget", 0.1);
 		}
 	}
 }
 
 void ed_terminateSession()
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if(get_property("hpAutoRecoveryItems") == "linen bandages")
 		{
@@ -89,15 +87,22 @@ void ed_terminateSession()
 
 void ed_initializeDay(int day)
 {
-	if(my_path() != "Actually Ed the Undying")
+	if (!isActuallyEd())
 	{
 		return;
 	}
+
+	set_property("auto_renenutetBought", 0);
+  
+	if (!get_property("breakfastCompleted").to_boolean() && day != 1)
+	{
+		cli_execute("breakfast");
+	}
+
 	if(day == 1)
 	{
 		if(get_property("auto_day_init").to_int() < 1)
 		{
-			set_property("auto_renenutetBought", 0);
 			if(item_amount($item[transmission from planet Xi]) > 0)
 			{
 				use(1, $item[transmission from planet xi]);
@@ -122,7 +127,6 @@ void ed_initializeDay(int day)
 
 		if(get_property("auto_day_init").to_int() < 2)
 		{
-
 			if(get_property("auto_dickstab").to_boolean() && chateaumantegna_available())
 			{
 				boolean[item] furniture = chateaumantegna_decorations();
@@ -132,7 +136,6 @@ void ed_initializeDay(int day)
 				}
 			}
 
-			set_property("auto_renenutetBought", 0);
 			if(item_amount($item[gym membership card]) > 0)
 			{
 				use(1, $item[gym membership card]);
@@ -142,26 +145,9 @@ void ed_initializeDay(int day)
 			{
 				acquireHermitItem($item[Seal Tooth]);
 			}
-			while(acquireHermitItem($item[Ten-leaf Clover]));
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
 			pullXWhenHaveY(whatHiMein(), 1, 0);
-		}
-	}
-	else if(day == 3)
-	{
-		if(get_property("auto_day_init").to_int() < 3)
-		{
-			set_property("auto_renenutetBought", 0);
-			while(acquireHermitItem($item[Ten-leaf Clover]));
-		}
-	}
-	else if(day == 4)
-	{
-		if(get_property("auto_day_init").to_int() < 4)
-		{
-			set_property("auto_renenutetBought", 0);
-			while(acquireHermitItem($item[Ten-leaf Clover]));
 		}
 	}
 
@@ -171,7 +157,7 @@ void ed_initializeDay(int day)
 
 boolean L13_ed_towerHandler()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -263,7 +249,7 @@ boolean L13_ed_towerHandler()
 
 boolean L13_ed_councilWarehouse()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -272,7 +258,6 @@ boolean L13_ed_councilWarehouse()
 		return false;
 	}
 
-#	if(item_amount($item[Holy MacGuffin]) == 0)
 	if(item_amount($item[7965]) == 0)
 	{
 		autoAdv(1, $location[The Secret Council Warehouse]);
@@ -285,7 +270,6 @@ boolean L13_ed_councilWarehouse()
 	}
 	while((item_amount($item[Warehouse Map Page]) > 0) && (item_amount($item[Warehouse Inventory Page]) > 0))
 	{
-		#use(item_amount($item[Warehouse Map Page]), $item[Warehouse Map Page]);
 		use(item_amount($item[Warehouse Inventory Page]), $item[Warehouse Inventory Page]);
 	}
 	if(get_property("lastEncounter") == "You Found It!")
@@ -358,7 +342,7 @@ boolean adjustEdHat(string goal)
 
 float edMeatBonus()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return 0.0;
 	}
@@ -371,7 +355,7 @@ float edMeatBonus()
 
 boolean handleServant(servant who)
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -393,7 +377,7 @@ boolean handleServant(servant who)
 
 boolean handleServant(string name)
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -432,9 +416,10 @@ boolean handleServant(string name)
 	}
 	return false;
 }
+
 boolean ed_doResting()
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		int maxBuff = 675 - my_turncount();
 		while((get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
@@ -454,7 +439,7 @@ boolean ed_doResting()
 
 boolean ed_buySkills()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -563,10 +548,6 @@ boolean ed_buySkills()
 			visit_url("choice.php?pwd&skillid=" + skillid + "&option=1&whichchoice=1051");
 		}
 	}
-
-	#adding this after skill purchase, is mafia not detecting our skills?
-	//visit_url("charsheet.php");
-
 
 	page = visit_url("place.php?whichplace=edbase&action=edbase_door");
 	matcher my_imbuePoints = create_matcher("Impart Wisdom unto Current Servant ..100xp, (\\d\+) remain.", page);
@@ -722,7 +703,7 @@ boolean ed_buySkills()
 
 boolean ed_eatStuff()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -733,25 +714,6 @@ boolean ed_eatStuff()
 		autoChew(canEat, $item[Mummified Beef Haunch]);
 	}
 	xiblaxian_makeStuff();
-#	if((my_daycount() == 2) && (eudora_current() == $item[Xi Receiver Unit]) && possessEquipment($item[Xiblaxian holo-wrist-puter]) && ((my_fullness() + 4) <= fullness_limit()) && (item_amount($item[Xiblaxian Circuitry]) >= 1) && (item_amount($item[Xiblaxian Polymer]) >= 1) && (item_amount($item[Xiblaxian Alloy]) >= 3))
-#	{
-#		if(item_amount($item[Xiblaxian 5D Printer]) == 0)
-#		{
-#			if(item_amount($item[transmission from planet Xi]) > 0)
-#			{
-#				use(1, $item[transmission from planet xi]);
-#				use(1, $item[Xiblaxian Cache Locator Simcode]);
-#			}
-#		}
-#		if(item_amount($item[Xiblaxian 5D Printer]) > 0)
-#		{
-#			int[item] canMake = eudora_xiblaxian();
-#			if((canMake contains $item[Xiblaxian Ultraburrito]) && (canMake[$item[Xiblaxian Ultraburrito]] > 0))
-#			{
-#				visit_url("shop.php?pwd=&whichshop=5dprinter&action=buyitem&quantity=1&whichrow=339", true);
-#			}
-#		}
-#	}
 
 	if((item_amount($item[Limp Broccoli]) > 0) && (my_level() >= 5) && ((my_fullness() == 0) || (my_fullness() == 3)) && (fullness_limit() >= 2))
 	{
@@ -777,13 +739,10 @@ boolean ed_eatStuff()
 	{
 		eatFancyDog("video games hot dog");
 	}
-
 	if(get_property("auto_dickstab").to_boolean() && !get_property("_fancyHotDogEaten").to_boolean() && (my_daycount() == 1) && ((my_fullness() + 2) <= fullness_limit()) && (item_amount($item[Astral Hot Dog]) == 0) && (item_amount($item[Clan VIP Lounge Key]) > 0) && chateaumantegna_available())
 	{
 		eatFancyDog("sleeping dog");
 	}
-
-
 	if((my_daycount() >= 3) && (my_inebriety() == 0) && (inebriety_limit() == 4) && (item_amount($item[Xiblaxian Space-Whiskey]) > 0) && (my_adventures() < 10))
 	{
 		autoDrink(1, $item[Xiblaxian Space-Whiskey]);
@@ -806,13 +765,13 @@ boolean ed_eatStuff()
 		autoDrink(1, $item[Highest Bitter]);
 	}
 
-	if((!contains_text(get_counters("Fortune Cookie", 0, 200), "Fortune Cookie")) && (get_property("semirareLocation") != $location[The Castle in the Clouds in the Sky (Top Floor)]))
+	if (!contains_text(get_counters("Fortune Cookie", 0, 200), "Fortune Cookie"))
 	{
-		if((item_amount($item[Clan VIP Lounge Key]) > 0) && (my_meat() >= 500) && (inebriety_limit() == 4) && ((my_inebriety() == 0) || (my_inebriety() == 3)) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]))
+		if (item_amount($item[Clan VIP Lounge Key]) > 0 && my_meat() >= 500 && inebriety_limit() == 4 && (my_inebriety() == 0 || my_inebriety() == 3) && auto_get_clan_lounge() contains $item[Clan Speakeasy])
 		{
 			autoDrink(1, $item[Lucky Lindy]);
 		}
-		else if((my_meat() >= npc_price($item[Fortune Cookie])) && (fullness_left() > 0))
+		else if (my_meat() >= npc_price($item[Fortune Cookie]) && fullness_left() > 0 && my_level() < 12)
 		{
 			buyUpTo(1, $item[Fortune Cookie], npc_price($item[Fortune Cookie]));
 			autoEat(1, $item[Fortune Cookie]);
@@ -821,79 +780,318 @@ boolean ed_eatStuff()
 	return true;
 }
 
+skill ed_nextUpgrade()
+{
+	if (!isActuallyEd())
+	{
+		return $skill[none];
+	}
+
+	int coins = item_amount($item[Ka Coin]);
+	int canEat = (spleen_limit() - my_spleen_use()) / 5;
+
+	if (!have_skill($skill[Upgraded Legs]) && get_property("auto_needLegs").to_boolean())
+	{
+		return $skill[Upgraded Legs]; // 10 Ka
+	}
+	else if (!have_skill($skill[Extra Spleen]) && canEat < 1)
+	{
+		return $skill[Extra Spleen]; // 5 Ka
+	}
+	else if (!have_skill($skill[Another Extra Spleen]) && canEat < 1)
+	{
+		return $skill[Another Extra Spleen]; // 10 Ka
+	}
+	else if (!have_skill($skill[Replacement Stomach]))
+	{
+		return $skill[Replacement Stomach]; // 30 Ka
+	}
+	else if (!have_skill($skill[Upgraded Legs]))
+	{
+		return $skill[Upgraded Legs]; // 10 Ka
+	}
+	else if (!have_skill($skill[More Legs]))
+	{
+		return $skill[More Legs]; // 20 Ka
+	}
+	else if (!have_skill($skill[Yet Another Extra Spleen]) && have_skill($skill[Another Extra Spleen]))
+	{
+		return $skill[Yet Another Extra Spleen]; // 15 Ka
+	}
+	else if (!have_skill($skill[Still Another Extra Spleen]))
+	{
+		return $skill[Still Another Extra Spleen]; // 20 Ka
+	}
+	else if (!have_skill($skill[Just One More Extra Spleen]))
+	{
+		return $skill[Just One More Extra Spleen]; // 25 Ka
+	}
+	else if (!have_skill($skill[Replacement Liver]))
+	{
+		return $skill[Replacement Liver]; // 30 Ka
+	}
+	else if (!have_skill($skill[Elemental Wards]))
+	{
+		return $skill[Elemental Wards]; // 10 Ka
+	}
+	else if (!have_skill($skill[Okay Seriously, This is the Last Spleen]))
+	{
+		return $skill[Okay Seriously, This is the Last Spleen];  // 30 Ka
+	}
+	else if (!possessEquipment($item[The Crown of Ed the Undying]) && !have_skill($skill[Tougher Skin]))
+	{
+		return $skill[Tougher Skin];  // 10 Ka
+	}
+	else if (!have_skill($skill[More Elemental Wards]))
+	{
+		return $skill[More Elemental Wards]; // 20 Ka
+	}
+	else if (!have_skill($skill[Even More Elemental Wards]))
+	{
+		return $skill[Even More Elemental Wards]; // 30 Ka
+	}
+	else if (!have_skill($skill[Healing Scarabs]) && my_daycount() >= 2)
+	{
+		return $skill[Healing Scarabs]; // 10 Ka
+	}
+	else if (!have_skill($skill[Tougher Skin]) && my_daycount() >= 2 && coins >= 50)
+	{
+		return $skill[Tougher Skin]; // 10 Ka
+	}
+	else if (!have_skill($skill[Armor Plating]) && my_daycount() >= 2 && coins >= 50)
+	{
+		return $skill[Armor Plating]; // 10 Ka
+	}
+	else if (!have_skill($skill[Upgraded Spine]) && my_daycount() >= 2 && coins >= 50)
+	{
+		return $skill[Upgraded Spine]; // 20 Ka
+	}
+	else if (!have_skill($skill[Upgraded Arms]) && my_daycount() >= 2 && coins >= 50)
+	{
+		return $skill[Upgraded Arms]; // 20 Ka
+	}
+	else if (!have_skill($skill[Arm Blade]) && my_daycount() >= 4 && coins >= 100)
+	{
+		return $skill[Arm Blade]; // 20 Ka
+	}
+	else if (!have_skill($skill[Bone Spikes]) && my_daycount() >= 4 && coins >= 100)
+	{
+		return $skill[Bone Spikes]; // 20 Ka
+	}
+	return $skill[none];
+}
+
+int ed_KaCost(skill upgrade)
+{
+	if (!isActuallyEd())
+	{
+		return -1;
+	}
+
+	int returnCost = -1;
+	switch (upgrade)
+	{
+  case $skill[Extra Spleen]:
+		returnCost = 5;
+  	break;
+  case $skill[Another Extra Spleen]:
+  case $skill[Upgraded Legs]:
+	case $skill[Tougher Skin]:
+	case $skill[Armor Plating]:
+  case $skill[Healing Scarabs]:
+  case $skill[Elemental Wards]:
+		returnCost = 10;
+    break;
+  case $skill[Yet Another Extra Spleen]:
+		returnCost = 15;
+    break;
+  case $skill[Still Another Extra Spleen]:
+  case $skill[More Legs]:
+	case $skill[Upgraded Arms]:
+  case $skill[Upgraded Spine]:
+  case $skill[Bone Spikes]:
+  case $skill[Arm Blade]:
+  case $skill[More Elemental Wards]:
+		returnCost = 20;
+    break;
+  case $skill[Just One More Extra Spleen]:
+		returnCost = 25;
+    break;
+  case $skill[Replacement Stomach]:
+  case $skill[Replacement Liver]:
+	case $skill[Okay Seriously, This is the Last Spleen]:
+  case $skill[Even More Elemental Wards]:
+		returnCost = 30;
+    break;
+  default:
+	}
+	return returnCost;
+}
+
+int ed_skillID(skill upgrade)
+{
+	if (!isActuallyEd())
+	{
+		return -1;
+	}
+
+	int skillID = -1;
+	switch (upgrade)
+	{
+  case $skill[Replacement Stomach]:
+		skillID = 28;
+  	break;
+  case $skill[Replacement Liver]:
+		skillID = 29;
+  	break;
+  case $skill[Extra Spleen]:
+		skillID = 30;
+  	break;
+  case $skill[Another Extra Spleen]:
+		skillID = 31;
+  	break;
+  case $skill[Yet Another Extra Spleen]:
+		skillID = 32;
+    break;
+  case $skill[Still Another Extra Spleen]:
+		skillID = 33;
+  	break;
+  case $skill[Just One More Extra Spleen]:
+		skillID = 34;
+    break;
+	case $skill[Okay Seriously, This is the Last Spleen]:
+		skillID = 35;
+  	break;
+  case $skill[Upgraded Legs]:
+		skillID = 36;
+  	break;
+	case $skill[Upgraded Arms]:
+		skillID = 37;
+  	break;
+  case $skill[Upgraded Spine]:
+		skillID = 38;
+  	break;
+	case $skill[Tougher Skin]:
+		skillID = 39;
+  	break;
+	case $skill[Armor Plating]:
+		skillID = 40;
+  	break;
+  case $skill[Bone Spikes]:
+		skillID = 41;
+  	break;
+  case $skill[Arm Blade]:
+		skillID = 42;
+  	break;
+  case $skill[Healing Scarabs]:
+		skillID = 43;
+  	break;
+  case $skill[Elemental Wards]:
+		skillID = 44;
+    break;
+  case $skill[More Elemental Wards]:
+		skillID = 45;
+    break;
+  case $skill[Even More Elemental Wards]:
+		skillID = 46;
+    break;
+  case $skill[More Legs]:
+		skillID = 48;
+  	break;
+  default:
+	}
+	return skillID;
+}
+
 boolean ed_needShop()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
 
-	if(have_skill($skill[Upgraded Legs]) && get_property("auto_needLegs").to_boolean())
+	if (have_skill($skill[Upgraded Legs]) && get_property("auto_needLegs").to_boolean())
 	{
 		set_property("auto_needLegs", false);
 	}
 
-	if(get_property("auto_needLegs").to_boolean() && (item_amount($item[Ka Coin]) >= 10))
+	int coins = item_amount($item[Ka Coin]);
+
+	if (get_property("auto_needLegs").to_boolean() && coins >= ed_KaCost($skill[Upgraded Legs]))
+	{
+		return true;
+	}
+ 
+	// check if we need mummified beef haunches
+	int canEat = (spleen_limit() - my_spleen_use()) / 5;
+	canEat = max(0, canEat - item_amount($item[Mummified Beef Haunch]));
+	if (canEat > 0 && coins >= 15)
 	{
 		return true;
 	}
 
-	if(item_amount($item[Ka Coin]) < 15)
+	// check if we need emergency MP
+	if (coins >= 1 && my_mp() < mp_cost($skill[Storm Of The Scarab]))
 	{
-		return false;
-	}
-  
-	int canEat = (spleen_limit() - my_spleen_use()) / 5;
-	canEat = max(0, canEat - item_amount($item[Mummified Beef Haunch]));
-
-	skill limiter = $skill[Even More Elemental Wards];
-	if(my_daycount() >= 2)
-	{
-		limiter = $skill[Healing Scarabs];
+		if (item_amount($item[Holy Spring Water]) < 1 && item_amount($item[Spirit Beer]) < 1 && item_amount($item[Sacramental Wine]) < 1)
+		{
+			return true;
+		}
 	}
 
-	if((canEat == 0) && have_skill(limiter) && (item_amount($item[Linen Bandages]) >= 4) && (get_property("auto_renenutetBought").to_int() >= 7) && (item_amount($item[Holy Spring Water]) >= 1) && (item_amount($item[Talisman of Horus]) >= 2))
+	// check if we have skills or consumables to buy
+	skill nextUpgrade = ed_nextUpgrade();
+	int requiredKa = ed_KaCost(nextUpgrade);
+	if (canEat < 1 && requiredKa != -1 && coins >= requiredKa)
 	{
-		if((item_amount($item[Ka Coin]) > 30) && (item_amount($item[Spirit Beer]) == 0))
-		{
-			return true;
-		}
-		if((item_amount($item[Ka Coin]) > 35) && !have_skill($skill[Upgraded Spine]))
-		{
-			return true;
-		}
-		if(((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 2) && (item_amount($item[Ka Coin]) > 30))
-		{
-			return true;
-		}
-		return false;
+		return true;
 	}
-	return true;
+	else if (have_skill($skill[Okay Seriously, This is the Last Spleen]) && canEat < 1)
+	{
+		if (item_amount($item[Talisman of Renenutet]) < 1 && get_property("auto_renenutetBought").to_int() < 7 && coins >= (7 - get_property("auto_renenutetBought").to_int()))
+		{
+			return true;
+		}
+		else if (item_amount($item[Linen Bandages]) < 1 && coins >= 4)
+		{
+			return true;
+		}
+		else if (item_amount($item[Holy Spring Water]) < 1 && coins >= 1 && (my_maxmp() - my_mp() < 50))
+		{
+			return true;
+		}
+		else if (item_amount($item[Talisman of Horus]) < 1 && coins >= 5)
+		{
+			return true;
+		}
+		else if (item_amount($item[Spirit Beer]) < 1 && coins >= 30)
+		{
+			return true;
+		}
+		else if ((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 1 && coins >= 30)
+		{
+			return true;
+		}
+		else if (item_amount($item[Sacramental Wine]) < 1 && coins >= 30)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
-
 
 boolean ed_shopping()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
-	}
-	if(!ed_needShop())
-	{
-		if((my_mp() < 8) && (item_amount($item[Ka Coin]) > 0) && (item_amount($item[Holy Spring Water]) == 0))
-		{
-		}
-		else
-		{
-			return false;
-		}
 	}
 	print("Time to shop!", "red");
 	wait(1);
 	visit_url("choice.php?pwd=&whichchoice=1023&option=1", true);
 
-
-	if(get_property("auto_breakstone").to_boolean())
+	if (get_property("auto_breakstone").to_boolean())
 	{
 		string temp = visit_url("peevpee.php?action=smashstone&pwd&confirm=on", true);
 		temp = visit_url("place.php?whichplace=edunder&action=edunder_hippy");
@@ -901,412 +1099,207 @@ boolean ed_shopping()
 		set_property("auto_breakstone", false);
 	}
 
-	int skillBuy = 0;
 	int coins = item_amount($item[Ka Coin]);
 	//Handler for low-powered accounts
-	if(!have_skill($skill[Upgraded Legs]) && get_property("auto_needLegs").to_boolean())
+	if (!have_skill($skill[Upgraded Legs]) && get_property("auto_needLegs").to_boolean())
 	{
-		if(coins >= 10)
+		if (coins >= 10)
 		{
 			print("Buying Upgraded Legs", "green");
 			set_property("auto_needLegs", false);
-			skillBuy = 36;
+			visit_url("place.php?whichplace=edunder&action=edunder_bodyshop");
+			visit_url("choice.php?pwd&skillid=36&option=1&whichchoice=1052", true);
+			visit_url("choice.php?pwd&option=2&whichchoice=1052", true);
+			coins -= 10;
 		}
-		//Prevent other purchases from interrupting us.
-		coins = 0;
+		else
+		{
+			//Prevent other purchases from interrupting us.
+			coins = 0;
+		}
 	}
 
-	//Limit mode: edunder
+	// fill spleen with mummified beef haunches.
 	int canEat = (ed_spleen_limit() - my_spleen_use()) / 5;
 	canEat -= item_amount($item[Mummified Beef Haunch]);
-	while((coins >= 15) && (canEat > 0))
+	while (coins >= 15 && canEat > 0)
 	{
 		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=428", true);
 		print("Buying a mummified beef haunch!", "green");
-		coins = coins - 15;
-		canEat = canEat - 1;
+		coins -= 15;
+		canEat--;
 	}
-
-	if(!get_property("lovebugsUnlocked").to_boolean() && (coins >= 2) && (item_amount($item[Holy Spring Water]) == 0) && (my_mp() < 15))
+	
+	// buy emergency MP restores.
+	if (!get_property("lovebugsUnlocked").to_boolean() && coins >= 1 && item_amount($item[Holy Spring Water]) == 0 && my_mp() < mp_cost($skill[Storm Of The Scarab]))
 	{
 		print("Buying Holy Spring Water", "green");
 		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
 		coins -= 1;
 	}
 
-	if(!have_skill($skill[Extra Spleen]) && (canEat < 1))
+	// buy skills
+	if (canEat < 1)
 	{
-		if(coins >= 5)
+		skill nextUpgrade = ed_nextUpgrade();
+		int requiredKa = ed_KaCost(nextUpgrade);
+		if (requiredKa != -1 && coins >= requiredKa)
 		{
-			print("Buying Extra Spleen", "green");
-			skillBuy = 30;
+			print("Buying " + nextUpgrade.to_string() + " (" + requiredKa.to_string() + " Ka).", "green");
+			int skillBuy = ed_SkillID(nextUpgrade);
+			if (skillBuy != 0)
+			{
+				visit_url("place.php?whichplace=edunder&action=edunder_bodyshop");
+				visit_url("choice.php?pwd&skillid=" + skillBuy + "&option=1&whichchoice=1052", true);
+				visit_url("choice.php?pwd&option=2&whichchoice=1052", true);
+				coins -= requiredKa;
+			}
 		}
-	}
-	else if(!have_skill($skill[Another Extra Spleen]) && (canEat < 1))
-	{
-		if(coins >= 10)
+		else if (have_skill($skill[Okay Seriously, This is the Last Spleen]) && canEat < 1)
 		{
-			print("Buying Another Extra Spleen", "green");
-			skillBuy = 31;
-		}
-	}
-	else if(!have_skill($skill[Replacement Stomach]))
-	{
-		if(coins >= 30)
-		{
-			print("Buying Replacement Stomach", "green");
-			skillBuy = 28;
-		}
-	}
-	else if(!have_skill($skill[Upgraded Legs]) && !get_property("auto_dickstab").to_boolean())
-	{
-		if(coins >= 10)
-		{
-			print("Buying Upgraded Legs", "green");
-			skillBuy = 36;
-		}
-	}
-	else if(!have_skill($skill[More Legs]) && !get_property("auto_dickstab").to_boolean())
-	{
-		if(coins >= 20)
-		{
-			print("Buying More Legs", "green");
-			skillBuy = 48;
-		}
-	}
-	else if(!have_skill($skill[Yet Another Extra Spleen]) && have_skill($skill[Another Extra Spleen]))
-	{
-		if(coins >= 15)
-		{
-			print("Buying Yet Another Extra Spleen", "green");
-			skillBuy = 32;
-		}
-	}
-	else if(!have_skill($skill[Replacement Liver]) && get_property("auto_dickstab").to_boolean())
-	{
-		if(coins >= 30)
-		{
-			print("Buying Replacement Liver", "green");
-			skillBuy = 29;
-		}
-	}
-	else if(!have_skill($skill[Still Another Extra Spleen]))
-	{
-		if(coins >= 20)
-		{
-			print("Buying Still Another Extra Spleen", "green");
-			skillBuy = 33;
-		}
-	}
-	else if(!have_skill($skill[Just One More Extra Spleen]))
-	{
-		if(coins >= 25)
-		{
-			print("Buying Just One More Extra Spleen", "green");
-			skillBuy = 34;
-		}
-	}
-	else if(!have_skill($skill[Replacement Liver]))
-	{
-		if(coins >= 30)
-		{
-			print("Buying Replacement Liver", "green");
-			skillBuy = 29;
-		}
-	}
-	else if(!have_skill($skill[Elemental Wards]) && !get_property("auto_dickstab").to_boolean())
-	{
-		if(coins >= 10)
-		{
-			print("Buying Elemental Wards", "green");
-			skillBuy = 44;
-		}
-	}
-	else if(!have_skill($skill[Okay Seriously, This is the Last Spleen]))
-	{
-		if(coins >= 30)
-		{
-			print("Buying Okay Seriously, This is the Last Spleen", "green");
-			skillBuy = 35;
-		}
-	}
-	else if((get_property("auto_renenutetBought").to_int() < 7) && (coins > 1))
-	{
-		while((get_property("auto_renenutetBought").to_int() < 7) && (coins > 1))
+			while (item_amount($item[Talisman of Renenutet]) < 7 && get_property("auto_renenutetBought").to_int() < 7 && coins >= 1)
 		{
 			print("Buying Talisman of Renenutet", "green");
 			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=439", true);
 			set_property("auto_renenutetBought", 1 + get_property("auto_renenutetBought").to_int());
-			coins = coins - 1;
-			if(!have_skill($skill[Okay Seriously, This is the Last Spleen]))
+				coins -= 1;
+			}
+			while (item_amount($item[Linen Bandages]) < 4 && coins >= 1)
 			{
-				break;
+				print("Buying Linen Bandages", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=429", true);
+				coins -= 1;
+			}
+			if (item_amount($item[Holy Spring Water]) == 0 && coins >= 1)
+			{
+				print("Buying Holy Spring Water", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
+				coins -= 1;
+			}
+			while (item_amount($item[Talisman of Horus]) < 2 && coins >= 5)
+			{
+				print("Buying Talisman of Horus", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=693", true);
+				coins -= 5;
+			}
+			if (item_amount($item[Spirit Beer]) == 0 && coins >= 30)
+			{
+				print("Buying Spirit Beer", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=432", true);
+				coins -= 2;
+			}
+			if ((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 2 && coins >= 30)
+			{
+				print("Buying Ancient Cure-all", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=435", true);
+				coins -= 3;
+			}
+			if (item_amount($item[Sacramental Wine]) == 0 && coins >= 30)
+			{
+				print("Buying Sacramental Wine", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=433", true);
+				coins -= 3;
 			}
 		}
 	}
-	else if(!have_skill($skill[Upgraded Legs]))
-	{
-		if(coins >= 10)
-		{
-			print("Buying Upgraded Legs", "green");
-			skillBuy = 36;
-		}
-	}
-	else if(!possessEquipment($item[The Crown of Ed the Undying]) && !have_skill($skill[Tougher Skin]) && (coins >= 10))
-	{
-		print("Buying Tougher Skin (10)", "green");
-		skillBuy = 39;
-	}
-	else if(!have_skill($skill[More Legs]))
-	{
-		if(coins >= 20)
-		{
-			print("Buying More Legs", "green");
-			skillBuy = 48;
-		}
-	}
-	else if(!have_skill($skill[Elemental Wards]))
-	{
-		if(coins >= 10)
-		{
-			print("Buying Elemental Wards", "green");
-			skillBuy = 44;
-		}
-	}
-	else if(!have_skill($skill[More Elemental Wards]))
-	{
-		if(coins >= 20)
-		{
-			print("Buying More Elemental Wards", "green");
-			skillBuy = 45;
-		}
-	}
-	else if(!have_skill($skill[Even More Elemental Wards]))
-	{
-		if(coins >= 30)
-		{
-			print("Buying Even More Elemental Wards", "green");
-			skillBuy = 46;
-		}
-	}
-	else if((!have_skill($skill[Healing Scarabs])) && (my_daycount() >= 2))
-	{
-		if(coins >= 10)
-		{
-			print("Buying Healing Scarabs", "green");
-			skillBuy = 43;
-		}
-	}
-	else if((!have_skill($skill[Arm Blade])) && (my_daycount() >= 2) && (coins >= 100))
-	{
-		print("Buying Arm Blade (20)", "green");
-		skillBuy = 42;
-	}
-	else if(!have_skill($skill[Upgraded Arms]) && (my_daycount() >= 2) && (coins >= 100))
-	{
-		print("Buying Upgraded Arms (20)", "green");
-		skillBuy = 37;
-	}
-	else if(!have_skill($skill[Tougher Skin]) && (my_daycount() >= 2) && (coins >= 50))
-	{
-		print("Buying Tougher Skin (10)", "green");
-		skillBuy = 39;
-	}
-	else if(!have_skill($skill[Armor Plating]) && (my_daycount() >= 2) && (coins >= 50))
-	{
-		print("Buying Armor Plating (10)", "green");
-		skillBuy = 40;
-	}
-	else if(!have_skill($skill[Upgraded Spine]) && (my_daycount() >= 2) && (coins >= 50))
-	{
-		print("Buying Upgraded Spine (20)", "green");
-		skillBuy = 38;
-	}
-	else if(!have_skill($skill[Bone Spikes]) && (my_daycount() >= 4) && (coins >= 100))
-	{
-		print("Buying Bone Spikes (20)", "green");
-		skillBuy = 41;
-	}
-	else if(have_skill($skill[Okay Seriously, This is the Last Spleen]) && (canEat < 1))
-	{	//437 438?
-		while((coins >= 1) && (get_property("auto_renenutetBought").to_int() < 7))
-		{
-			print("Buying Talisman of Renenutet", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=439", true);
-			set_property("auto_renenutetBought", 1 + get_property("auto_renenutetBought").to_int());
-			coins = coins - 1;
-		}
-		while((item_amount($item[Linen Bandages]) < 4) && (coins >= 4))
-		{
-			print("Buying Linen Bandages", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=429", true);
-			coins -= 1;
-		}
-		while((item_amount($item[Holy Spring Water]) < 1) && (coins >= 2))
-		{
-			print("Buying Holy Spring Water", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
-			coins -= 1;
-		}
-		while((item_amount($item[Talisman of Horus]) < 3) && (coins >= 5))
-		{
-			print("Buying Talisman of Horus", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=693", true);
-			coins -= 5;
-		}
-		while((item_amount($item[Spirit Beer]) == 0) && (coins >= 30))
-		{
-			print("Buying Spirit Beer", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=432", true);
-			coins -= 2;
-		}
-		if(((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 2) && (coins >= 30))
-		{
-			print("Buying Ancient Cure-all", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=435", true);
-			coins -= 3;
-		}
-		while((item_amount($item[Holy Spring Water]) < 1) && (coins >= 1) && (my_mp() < 8))
-		{
-			print("Buying Holy Spring Water", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
-			coins -= 1;
-		}
-	}
 
-
-	if(skillBuy != 0)
-	{
-		visit_url("place.php?whichplace=edunder&action=edunder_bodyshop");
-		visit_url("choice.php?pwd&skillid=" + skillBuy + "&option=1&whichchoice=1052", true);
-		visit_url("choice.php?pwd&option=2&whichchoice=1052", true);
-	}
 	visit_url("place.php?whichplace=edunder&action=edunder_leave");
 	visit_url("choice.php?pwd=&whichchoice=1024&option=1", true);
 	return true;
 }
 
-boolean ed_handleAdventureServant(int num, location loc, string option)
+void ed_handleAdventureServant(location loc)
 {
-	handleServant($servant[Priest]);
-	boolean reassign = false;
-	if((!ed_needShop() && (my_spleen_use() == 35)) && (item_amount($item[Ka Coin]) > 15))
+	// the order servants are unlocked is
+	// level 3 - Priest (extra Ka)
+	// level 6 - Cat (item drops)
+	// level 9 - Scribe (stats)
+	// level 12 - Maid (meat drops)
+
+	// Default to the Priest as we need Ka to get upgrades and fill spleen (and other miscellanea)
+	servant myServant = $servant[Priest];
+	
+	if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]) && my_level() < 13 && have_servant($servant[Scribe]))
 	{
-		reassign = true;
+		// Ka is less important when we have a full spleen and all the skills we need
+		// so default to getting stats if we're not level 13 yet.
+		myServant = $servant[Scribe];
 	}
-	if((my_daycount() >= 3) && (my_adventures() >= 20) && (my_level() >= 12))
+	else if (my_level() > 12)
 	{
-		reassign = true;
+		if (!have_skill($skill[Gift of the Maid]) && have_servant($servant[Maid]) && get_property("sidequestNunsCompleted") == "none")
+		{
+			myServant = $servant[Maid];
+		}
+		else if (!have_skill($skill[Gift of the Cat]) && have_servant($servant[Cat]))
+		{
+			myServant = $servant[Cat];
+		}
 	}
 
-	if(reassign)
+	// Initial Ka farming to get Spleen & Legs upgrades.
+	if ($locations[Hippy Camp, The Neverending Party, The Secret Government Laboratory, The SMOOCH Army HQ, VYKEA] contains loc && my_daycount() == 1)
 	{
-		if(!have_skill($skill[Gift of the Maid]) && have_servant($servant[Maid]) && (get_property("auto_nuns") != "finished") && (get_property("auto_nuns") != "done"))
+		myServant = $servant[Priest];
+	}
+
+	// Locations where item drop is required for quest furthering purposes but we don't want to miss out on Ka if needed.
+	if ($locations[The eXtreme Slope, The Batrat and Ratbat Burrow, Cobb's Knob Harem, Twin Peak, The Black Forest, The Hidden Bowling Alley, The Copperhead Club, A Mob of Zeppelin Protesters, The Red Zeppelin] contains loc)
+	{
+		if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]))
 		{
-			handleServant($servant[Maid]);
+			myServant = $servant[Cat];
 		}
-		else if((!have_skill($skill[Gift of the Scribe]) || (my_level() < 13)) && have_servant($servant[Scribe]))
+	}
+
+	// Locations where item drop is required for quest furthering purposes and we won't get Ka regardless
+	if ($locations[The Defiled Nook, Oil Peak, A-Boo Peak, The Haunted Laundry Room, The Haunted Wine Cellar] contains loc)
+	{
+		myServant = $servant[Cat];
+	}
+
+	// Locations where we won't get Ka and don't need item drop.
+	if ($locations[The Dark Neck of the Woods, The Dark Heart of the Woods, The Dark Elbow of the Woods, The Defiled Alcove, The Defiled Cranny, The Defiled Niche, The Haunted Kitchen, The Haunted Billiards Room, The Haunted Library, The Haunted Bedroom, The Haunted Ballroom, The Haunted Bathroom, The Haunted Boiler Room] contains loc)
+	{
+		if (have_servant($servant[Scribe]))
 		{
-			handleServant($servant[Scribe]);
-		}
-		else if(!have_skill($skill[Gift of the Cat]) && have_servant($servant[Cat]))
-		{
-			handleServant($servant[Cat]);
-		}
-		else if((my_mp() < 20) && have_servant($servant[Belly-Dancer]))
-		{
-			handleServant($servant[Belly-Dancer]);
+			myServant = $servant[Scribe];
 		}
 		else
 		{
-			if(my_level() >= 13)
+			if (have_servant($servant[Cat]))
 			{
-				if(!handleServant($servant[Cat]))
-				{
-					if(!handleServant($servant[Maid]))
-					{
-						handleServant($servant[Scribe]);
-					}
-				}
-			}
-			else
-			{
-				if(!handleServant($servant[Scribe]))
-				{
-					if(!handleServant($servant[Cat]))
-					{
-						handleServant($servant[Maid]);
-					}
-				}
+				myServant = $servant[Cat];
 			}
 		}
 	}
-	if(($locations[Hippy Camp, The Neverending Party, The Secret Government Laboratory, The SMOOCH Army HQ, VYKEA] contains loc) && (my_daycount() == 1))
+
+	// Locations where meat drop is required for quest furthering purposes
+	if (loc == $location[The Themthar Hills] && have_servant($servant[Maid]))
 	{
-		handleServant($servant[Priest]);
+		myServant = $servant[Maid];
 	}
 
-	if($locations[A-Boo Peak, The Defiled Nook, The Haunted Laundry Room, The Haunted Library, The Haunted Wine Cellar, The Hidden Bowling Alley, Oil Peak] contains loc)
+	// Special case for The Penultimate Fantasy Airship as we want to farm some items for quest furthering purposes
+	// but it's also an excellent Ka farming zone and we have to spend a bunch of adventures there
+	if (loc == $location[The Penultimate Fantasy Airship])
 	{
-		if(!handleServant($servant[Cat]))
+		if (!possessEquipment($item[Mohawk wig]) || !possessEquipment($item[amulet of extreme plot significance]) || !possessEquipment($item[titanium assault umbrella]))
 		{
-			if(!handleServant($servant[Scribe]))
-			{
-				handleServant($servant[Maid]);
-			}
+			myServant = $servant[Cat];
 		}
-	}
-
-	if((loc == $location[The Dark Neck of the Woods]) ||
-		(loc == $location[The Dark Heart of the Woods]) ||
-		(loc == $location[The Dark Elbow of the Woods]))
-	{
-		if(!handleServant($servant[Scribe]))
+		else if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]) && my_level() < 13 && have_servant($servant[Scribe]))
 		{
-			if(!handleServant($servant[Cat]))
-			{
-				handleServant($servant[Maid]);
-			}
+			myServant = $servant[Scribe];
 		}
 	}
-
-	if((loc == $location[The Defiled Alcove]) ||
-		(loc == $location[The Defiled Cranny]) ||
-		(loc == $location[The Defiled Niche]) ||
-		(loc == $location[The Haunted Bedroom]) ||
-		(loc == $location[The Haunted Ballroom]) ||
-		(loc == $location[The Haunted Billiards Room]) ||
-		(loc == $location[The Haunted Kitchen]) ||
-		(loc == $location[The Haunted Bathroom]))
-	{
-		if(!have_skill($skill[Gift of the Maid]) && !handleServant($servant[Maid]))
-		{
-			if(!handleServant($servant[Scribe]))
-			{
-				handleServant($servant[Cat]);
-			}
-		}
-	}
-
-	if(loc == $location[The Themthar Hills])
-	{
-		handleServant($servant[Maid]);
-	}
-
-	if((loc == $location[Next To That Barrel With Something Burning In It]) ||
-		(loc == $location[Out By That Rusted-Out Car]) ||
-		(loc == $location[Over Where The Old Tires Are]) ||
-		(loc == $location[Near an Abandoned Refrigerator]))
-	{
-		handleServant($servant[Cat]);
-	}
-
-	return false;
+	
+	handleServant(myServant);
 }
 
 boolean ed_preAdv(int num, location loc, string option)
 {
-	ed_handleAdventureServant(num, loc, option);
+	ed_handleAdventureServant(loc);
 	return preAdvXiblaxian(loc);
 }
 
@@ -1343,7 +1336,6 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 
 		if(!skipFirstLife)
 		{
-			set_property("auto_edCombatStage", 0);
 			print("Starting Ed Battle at " + loc, "blue");
 			status = adv1(loc, 0, option);
 			if(!status && (get_property("lastEncounter") == "Like a Bat Into Hell"))
@@ -1366,13 +1358,11 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 				#If this visit_url results in the enemy dying, we don't want to continue
 				visit_url("choice.php?pwd=&whichchoice=1023&option=2", true);
 			}
-			set_property("auto_edCombatStage", 1);
 			print("Ed returning to battle Stage 1", "blue");
 
 			if(get_property("_edDefeats").to_int() == 0)
 			{
 				print("Monster defeated in initialization, aborting attempt.", "red");
-				set_property("auto_edCombatStage", 0);
 				set_property("auto_disableAdventureHandling", false);
 				cli_execute("auto_post_adv.ash");
 				return true;
@@ -1397,13 +1387,11 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 					#If this visit_url results in the enemy dying, we don't want to continue
 					visit_url("choice.php?pwd=&whichchoice=1023&option=2", true);
 				}
-				set_property("auto_edCombatStage", 2);
 				print("Ed returning to battle Stage 2", "blue");
 
 				if(get_property("_edDefeats").to_int() == 0)
 				{
 					print("Monster defeated in initialization, aborting attempt.", "red");
-					set_property("auto_edCombatStage", 0);
 					set_property("auto_disableAdventureHandling", false);
 					cli_execute("auto_post_adv.ash");
 					return true;
@@ -1416,12 +1404,11 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 				}
 			}
 		}
-		set_property("auto_edCombatStage", 0);
 		set_property("auto_disableAdventureHandling", false);
 
 		if(get_property("_edDefeats").to_int() > get_property("edDefeatAbort").to_int())
 		{
-			abort("Manually forcing edDefeatAborts. We can't handle the battle.");
+			auto_abort("Manually forcing edDefeatAborts. We can't handle the battle.");
 		}
 
 		cli_execute("auto_post_adv.ash");
@@ -1434,7 +1421,6 @@ boolean ed_autoAdv(int num, location loc, string option)
 	return ed_autoAdv(num, loc, option, false);
 }
 
-
 boolean L1_ed_island()
 {
 	return L1_ed_island(0);
@@ -1442,7 +1428,7 @@ boolean L1_ed_island()
 
 boolean L1_ed_dinsey()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -1468,7 +1454,7 @@ boolean L1_ed_dinsey()
 
 boolean L1_ed_island(int dickstabOverride)
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -1548,7 +1534,7 @@ boolean L1_ed_island(int dickstabOverride)
 
 boolean L1_ed_islandFallback()
 {
-	if(my_class() != $class[Ed])
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -1563,10 +1549,6 @@ boolean L1_ed_islandFallback()
 		{
 			return false;
 		}
-#		if((my_daycount() > 2) || (my_spleen_use() > 20))
-#		{
-#			return false;
-#		}
 	}
 
 	if(!get_property("lovebugsUnlocked").to_boolean())
@@ -1643,17 +1625,12 @@ boolean L1_ed_islandFallback()
 		return true;
 	}
 
-
 	if(LX_islandAccess())
 	{
 		return true;
 	}
 
-	boolean haveLegs = have_skill($skill[Upgraded Legs]);
-	#Consider trying to get Upgraded legs first
-
-	auto_change_mcd(max(2, my_level()-1));
-	if(haveLegs || item_amount($item[Ka coin]) >= 10)
+	if (have_skill($skill[Upgraded Legs]) || item_amount($item[Ka coin]) >= 10)
 	{
 		if(have_outfit("Filthy Hippy Disguise") && is_wearing_outfit("Filthy Hippy Disguise"))
 		{
@@ -1662,15 +1639,37 @@ boolean L1_ed_islandFallback()
 			equipBaseline();
 		}
 		buffMaintain($effect[Wisdom Of Thoth], 20, 1, 1);
-		return autoAdv(1, $location[Hippy Camp]);
+		if (have_skill($skill[More Legs]) && maximizeContains("-10ml"))
+		{
+			removeFromMaximize("-10ml");
+		}
+		auto_change_mcd(11);
+		boolean retVal = autoAdv(1, $location[Hippy Camp]);
+		if (item_amount($item[Filthy Corduroys]) > 0)
+		{
+			if (closet_amount($item[Filthy Corduroys]) > 0)
+			{
+				autosell(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+			}
+			else
+			{
+				put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+			}
+		}
+		return retVal;
 	}
 	set_property("auto_needLegs", true);
+	if (!maximizeContains("-10ml"))
+	{
+		addToMaximize("-10ml");
+		auto_change_mcd(0);
+	}
 	return autoAdv(1, $location[The Outskirts of Cobb\'s Knob]);
 }
 
 boolean L9_ed_chasmStart()
 {
-	if((my_class() == $class[Ed]) && !get_property("auto_chasmBusted").to_boolean())
+	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
 		print("It's a troll on a bridge!!!!", "blue");
 
@@ -1678,7 +1677,6 @@ boolean L9_ed_chasmStart()
 		autoAdvBypass("place.php?whichplace=orc_chasm&action=bridge_done", $location[The Smut Orc Logging Camp]);
 
 		set_property("auto_chasmBusted", true);
-		set_property("chasmBridgeProgress", 0);
 		return true;
 	}
 	return false;
@@ -1686,7 +1684,7 @@ boolean L9_ed_chasmStart()
 
 boolean L9_ed_chasmBuild()
 {
-	if((my_class() == $class[Ed]) && !get_property("auto_chasmBusted").to_boolean())
+	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
 		print("What a nice bridge over here...." , "green");
 
@@ -1694,7 +1692,6 @@ boolean L9_ed_chasmBuild()
 		autoAdvBypass("place.php?whichplace=orc_chasm&action=bridge_done", $location[The Smut Orc Logging Camp]);
 
 		set_property("auto_chasmBusted", true);
-		set_property("chasmBridgeProgress", 0);
 		return true;
 	}
 	return false;
@@ -1702,7 +1699,7 @@ boolean L9_ed_chasmBuild()
 
 boolean L9_ed_chasmBuildClover(int need)
 {
-	if((my_class() == $class[Ed]) && (need > 3) && (item_amount($item[Disassembled Clover]) > 2))
+	if (isActuallyEd() && (need > 3) && (item_amount($item[Disassembled Clover]) > 2))
 	{
 		use(1, $item[disassembled clover]);
 		backupSetting("cloverProtectActive", false);
@@ -1723,7 +1720,7 @@ boolean L9_ed_chasmBuildClover(int need)
 
 boolean L11_ed_mauriceSpookyraven()
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if(item_amount($item[7962]) == 0)
 		{
@@ -1736,7 +1733,7 @@ boolean L11_ed_mauriceSpookyraven()
 
 boolean LM_edTheUndying()
 {
-	if(my_path() != "Actually Ed the Undying")
+	if (!isActuallyEd())
 	{
 		return false;
 	}
@@ -1754,6 +1751,7 @@ boolean LM_edTheUndying()
 			adjustEdHat("myst");
 		}
 	}
+
 	if(L1_ed_island() || l1_ed_islandFallback())
 	{
 		return true;
@@ -1768,12 +1766,23 @@ boolean LM_edTheUndying()
 	{
 		return true;
 	}
-	if(item_amount($item[Seal Tooth]) == 0)
+
+	if (closet_amount($item[Filthy Corduroys]) > 0)
+	{
+		take_closet(closet_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+	}
+
+	if (!get_property("breakfastCompleted").to_boolean())
+	{
+		cli_execute("breakfast");
+	}
+
+	if (item_amount($item[Seal Tooth]) == 0)
 	{
 		acquireHermitItem($item[Seal Tooth]);
 	}
 
-	if(my_level() >= 9)
+	if (my_level() >= 9)
 	{
 		if((get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
 		{
@@ -1783,141 +1792,63 @@ boolean LM_edTheUndying()
 		}
 	}
 
-	if(L10_plantThatBean() || L10_airship() || L10_basement() || L10_ground() || L10_topFloor())
+	// as we do hippy side, the war is a 2 Ka quest (excluding sidequests but that shouldn't matter)
+	// once the war is no longer a complete mess of spaghetti code, change this to do the whole war.
+	if (L12_getOutfit() || L12_startWar())
 	{
 		return true;
 	}
-
-	if(L12_preOutfit())
+	// start the macguffin quest, conveniently the black forest is a 1.4 Ka zone.
+	if (L11_blackMarket() || L11_forgedDocuments() || L11_mcmuffinDiary())
 	{
 		return true;
 	}
-
-	if(get_property("auto_dickstab").to_boolean())
-	{
-		if((my_level() >= 5) && (chateaumantegna_havePainting()) && (my_daycount() <= 2) && (my_class() != $class[Ed]))
-		{
-			if(chateaumantegna_usePainting())
-			{
-				autoAdv(1, $location[Noob Cave]);
-				return true;
-			}
-		}
-		if(L1_ed_dinsey())
-		{
-			return true;
-		}
-		if(L2_mosquito() || L2_treeCoin() || L2_spookyMap() || L2_spookyFertilizer() || L2_spookySapling())
-		{
-			return true;
-		}
-		if(L8_trapperStart() || L8_trapperGround() || L8_trapperYeti())
-		{
-			return true;
-		}
-		if(L4_batCave())
-		{
-			return true;
-		}
-		if(L5_getEncryptionKey())
-		{
-			return true;
-		}
-		if(L5_goblinKing())
-		{
-			return true;
-		}
-		if(L9_chasmStart() || L9_chasmBuild())
-		{
-			return true;
-		}
-		if(LX_dinseylandfillFunbucks())
-		{
-			return true;
-		}
-
-		if(my_level() < 9)
-		{
-			if((get_property("timesRested").to_int() < total_free_rests()) && chateaumantegna_available())
-			{
-				doRest();
-				cli_execute("scripts/autoscend/auto_post_adv.ash");
-				return true;
-			}
-		}
-
-		if(L1_ed_island(10))
-		{
-			return true;
-		}
-
-		buffMaintain($effect[The Dinsey Look], 0, 1, 1);
-
-		if(L7_crypt())
-		{
-			if(item_amount($item[FunFunds&trade;]) > 4)
-			{
-				buyUpTo(1, $item[Dinsey Face Paint]);
-			}
-			return true;
-		}
-
-
-	}
-
-
-	if(L2_mosquito() || L2_treeCoin() || L2_spookyMap() || L2_spookyFertilizer() || L2_spookySapling())
+	// The hidden city is mostly 2 Ka monsters so do it ASAP.
+	if (L11_nostrilOfTheSerpent() || L11_unlockHiddenCity() || L11_hiddenCityZones() || L11_hiddenCity())
 	{
 		return true;
 	}
-	if(L8_trapperStart() || L8_trapperGround() || L8_trapperYeti())
+	// Airship is 1.5 Ka or 1.8 Ka with the construct banished so third highest priorty after the war
+	// Castle zones are all 1 Ka so may as well finish it off
+	if (L10_plantThatBean() || L10_airship() || L10_basement() || L10_ground() || L10_topFloor())
 	{
 		return true;
 	}
-	if(L4_batCave())
+	// L8 quest is all 1 Ka zones for Ed (unlikely to survive Ninja Snowmen Assassins so they don't count)
+	if (L8_trapperStart() || L8_trapperGround() || L8_trapperGroar())
 	{
 		return true;
 	}
-	if(L5_goblinKing())
+	// Bats are 1 Ka and the rewards are useful
+	if (L4_batCave())
 	{
 		return true;
 	}
-	if(!get_property("auto_dickstab").to_boolean() || (my_daycount() >= 2))
-	{
-		if(L3_tavern())
-		{
-			return true;
-		}
-	}
-
-	if(L9_chasmStart() || L9_chasmBuild())
+	// Goblins are 1 Ka and the rewards are useful
+	if (L5_haremOutfit() || L5_goblinKing())
 	{
 		return true;
 	}
-
-	if(L6_friarsGetParts() || L6_friarsHotWing())
+	// need to do L2 quest to unlock the L3. 0.83 Ka zone or 1/1.25/1.67 with 1/2/3 banishes
+	if (L2_mosquito() || L2_treeCoin() || L2_spookyMap() || L2_spookyFertilizer() || L2_spookySapling())
 	{
 		return true;
 	}
-	if(L11_blackMarket() || L11_forgedDocuments() || L11_mcmuffinDiary() || L11_talismanOfNam())
+	// should probably complete the tavern for drinking purposes (and rats are 1 Ka).
+	if (L3_tavern())
 	{
 		return true;
 	}
-
-	if(my_spleen_use() == 35)
+	// Smut Orcs are 1 Ka so build the bridge.
+	if (L9_chasmStart() || L9_chasmBuild())
 	{
-		if(my_daycount() >= 2)
-		{
-			if(my_mp() < 40)
-			{
-				buffMaintain($effect[Spiritually Awake], 0, 1, 1);
-				buffMaintain($effect[Spiritually Aware], 0, 1, 1);
-				buffMaintain($effect[Spiritually Awash], 0, 1, 1);
-			}
-		}
+		return true;
 	}
-
-
+	// Copperhead Club & Mob of Zeppelin Protestors are 2 Ka zones (with a banish use) but we want to delay them so we can semi-rare Copperhead
+	if (L11_mauriceSpookyraven() || L11_talismanOfNam() || L11_palindome())
+	{
+		return true;
+	}
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -138,7 +138,7 @@ string defaultMaximizeStatement()
 		else
 		{
 			res += ",0.4hp,0.2mp 1000max";
-			res += (my_class() == $class[Ed]) ? ",6mp regen" : ",3mp regen";
+			res += isActuallyEd() ? ",6mp regen" : ",3mp regen";
 		}
 
 		if(my_primestat() == $stat[Mysticality])
@@ -177,13 +177,16 @@ void resetMaximize()
 	}
 	foreach it in $items[hewn moon-rune spoon, makeshift garbage shirt, broken champagne bottle, snow suit]
 	{
-		if(res != "")
+		if (possessEquipment(it))
 		{
-			res += ",";
+			if(res != "")
+			{
+				res += ",";
+			}
+			// don't want to equip these items automatically
+			// spoon breaks mafia, and the others have limited charges
+			res += "-equip " + it;
 		}
-		// don't want to equip these items automatically
-		// spoon breaks mafia, and the others have limited charges
-		res += "-equip " + it;
 	}
 	set_property("auto_maximize_current", res);
 	auto_debug_print("Resetting auto_maximize_current to " + res, "gold");
@@ -541,6 +544,11 @@ int equipmentAmount(item equipment)
 	}
 
 	int amount = item_amount(equipment) + equipped_amount(equipment);
+
+	if (get_related($item[broken champagne bottle], "fold") contains equipment)
+	{
+		amount = item_amount($item[January\'s Garbage Tote]);
+	}
 
 	if(item_type(equipment) == "familiar equipment")
 	{

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -282,7 +282,7 @@ boolean auto_saberChoice(string choice)
 
 boolean auto_saberDailyUpgrade(int day)
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		return auto_saberChoice("mp");
 	}
@@ -610,6 +610,10 @@ int auto_beachCombHeadNumFrom(string name)
 }
 
 boolean auto_canBeachCombHead(string name) {
+	if (!auto_beachCombAvailable())
+	{
+	   return false;
+	}
 	int head = auto_beachCombHeadNumFrom(name);
 	foreach _, usedHead in (get_property("_beachHeadsUsed").split_string(","))
 	{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -202,35 +202,38 @@ void handlePostAdventure()
 			maxBuff = 5;
 		}
 
-		if (my_servant() != $servant[none] && my_servant().experience < 196)
+		if ($location[The Shore\, Inc. Travel Agency] != my_location())
 		{
-			buffMaintain($effect[Purr of the Feline], 20, 1, 10);
-		}
-
-		if (my_level() < 13)
-		{
-			buffMaintain($effect[Prayer of Seshat], 5, 1, 10);
-		}
-
-		buffMaintain($effect[Wisdom of Thoth], 20, 1, 10);
-		buffMaintain($effect[Power of Heka], 20, 1, 10);
-		buffMaintain($effect[Hide of Sobek], 20, 1, 10);
-
-		if(!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, Pirates of the Garbage Barges, The Secret Government Laboratory] contains my_location()))
-		{
-			buffMaintain($effect[Bounty of Renenutet], 20, 1, 10);
-		}
-
-		if (my_level() < 13 && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && (!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()) || have_skill($skill[More Legs])))
-		{
-			buffMaintain($effect[Blessing of Serqet], 20, 1, 10);
-		}
-
-		foreach ef in $effects[Prayer Of Seshat, Wisdom Of Thoth, Power of Heka, Hide Of Sobek, Bounty Of Renenutet]
-		{
-			if(my_mp() > 100)
+			if (my_servant() != $servant[none] && my_servant().experience < 196)
 			{
-				buffMaintain(ef, 20, 1, 20);
+				buffMaintain($effect[Purr of the Feline], 20, 1, 10);
+			}
+
+			if (my_level() < 13)
+			{
+				buffMaintain($effect[Prayer of Seshat], 5, 1, 10);
+			}
+
+			buffMaintain($effect[Wisdom of Thoth], 20, 1, 10);
+			buffMaintain($effect[Power of Heka], 20, 1, 10);
+			buffMaintain($effect[Hide of Sobek], 20, 1, 10);
+
+			if(!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, Pirates of the Garbage Barges, The Secret Government Laboratory] contains my_location()))
+			{
+				buffMaintain($effect[Bounty of Renenutet], 20, 1, 10);
+			}
+
+			if (my_level() < 13 && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && (!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()) || have_skill($skill[More Legs])))
+			{
+				buffMaintain($effect[Blessing of Serqet], 20, 1, 10);
+			}
+
+			foreach ef in $effects[Prayer Of Seshat, Wisdom Of Thoth, Power of Heka, Hide Of Sobek, Bounty Of Renenutet]
+			{
+				if(my_mp() > 100)
+				{
+					buffMaintain(ef, 20, 1, 20);
+				}
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -190,7 +190,7 @@ void handlePostAdventure()
 		}
 	}
 
-	if(my_path() == "Actually Ed the Undying")
+	if (isActuallyEd())
 	{
 		int maxBuff = max(5, 660 - my_turncount());
 		if(spleen_limit() < 35)
@@ -201,62 +201,37 @@ void handlePostAdventure()
 		{
 			maxBuff = 5;
 		}
-		if(my_level() < 13)
+
+		if (my_servant() != $servant[none] && my_servant().experience < 196)
 		{
-			buffMaintain($effect[Prayer of Seshat], 5, 1, maxBuff);
-		}
-		if(my_location() == $location[The Secret Government Laboratory])
-		{
-			buffMaintain($effect[Wisdom of Thoth], 5, 1, maxBuff);
-			buffMaintain($effect[Power of Heka], 10, 1, maxBuff);
-		}
-		else
-		{
-			buffMaintain($effect[Wisdom of Thoth], 150, 1, maxBuff);
-			buffMaintain($effect[Power of Heka], 100, 1, maxBuff);
+			buffMaintain($effect[Purr of the Feline], 20, 1, 10);
 		}
 
-		if(get_property("edPoints").to_int() <= 6)
+		if (my_level() < 13)
 		{
-			buffMaintain($effect[Wisdom of Thoth], 5, 1, 10);
-			buffMaintain($effect[Power of Heka], 10, 1, 10);
+			buffMaintain($effect[Prayer of Seshat], 5, 1, 10);
 		}
 
-		buffMaintain($effect[Hide of Sobek], 200, 1, maxBuff);
-		if(my_location() == $location[Hippy Camp])
-		{
-			buffMaintain($effect[Hide of Sobek], 20, 1, maxBuff);
-		}
+		buffMaintain($effect[Wisdom of Thoth], 20, 1, 10);
+		buffMaintain($effect[Power of Heka], 20, 1, 10);
+		buffMaintain($effect[Hide of Sobek], 20, 1, 10);
 
 		if(!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, Pirates of the Garbage Barges, The Secret Government Laboratory] contains my_location()))
 		{
-			buffMaintain($effect[Bounty of Renenutet], 20, 1, maxBuff);
+			buffMaintain($effect[Bounty of Renenutet], 20, 1, 10);
 		}
 
-		if((my_servant() == $servant[Priest]) && ($servant[Priest].experience < 196) && ($servant[Priest].experience >= 81))
+		if (my_level() < 13 && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && (!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()) || have_skill($skill[More Legs])))
 		{
-			buffMaintain($effect[Purr of the Feline], 10, 1, maxBuff);
-		}
-		if(my_servant() == $servant[Cat])
-		{
-			buffMaintain($effect[Purr of the Feline], 10, 1, maxBuff);
-		}
-		if((my_servant() == $servant[Belly-Dancer]) && ($servant[Belly-Dancer].experience < 196) && ($servant[Belly-Dancer].experience >= 81))
-		{
-			buffMaintain($effect[Purr of the Feline], 10, 1, maxBuff);
+			buffMaintain($effect[Blessing of Serqet], 20, 1, 10);
 		}
 
-		foreach ef in $effects[Prayer Of Seshat, Wisdom Of Thoth, Hide Of Sobek, Bounty Of Renenutet]
+		foreach ef in $effects[Prayer Of Seshat, Wisdom Of Thoth, Power of Heka, Hide Of Sobek, Bounty Of Renenutet]
 		{
 			if(my_mp() > 100)
 			{
-				buffMaintain(ef, 20, 1, maxBuff);
+				buffMaintain(ef, 20, 1, 20);
 			}
-		}
-
-		if((my_level() < 13) && (my_level() > 3) && !get_property("auto_needLegs").to_boolean() && (get_property("edPoints").to_int() > 15) && !($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()))
-		{
-			buffMaintain($effect[Blessing of Serqet], 50, 1, 1);
 		}
 
 		if((my_mp() + 100) < my_maxmp())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -165,16 +165,16 @@ void handlePreAdventure(location place)
 		}
 	}
 
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		if((zone_combatMod(place)._int < combat_rate_modifier()) && (have_effect($effect[Shelter Of Shed]) == 0) && auto_have_skill($skill[Shelter Of Shed]))
 		{
 			acquireMP(25, false);
 		}
-		acquireMP(20, false);
+		acquireMP(40, false);
 		if(my_meat() > 1000)
 		{
-			acquireMP(20, true);
+			acquireMP(40, true);
 		}
 	}
 
@@ -187,7 +187,7 @@ void handlePreAdventure(location place)
 				buyUpTo(1, $item[hair spray]);
 				use(1, $item[hair spray]);
 			}
-			if (0 == have_effect($effect[Minerva's Zen]))
+			if (0 == have_effect($effect[Minerva\'s Zen]))
 			{
 				buyUpTo(1, $item[glittery mascara]);
 				use(1, $item[glittery mascara]);
@@ -250,7 +250,7 @@ void handlePreAdventure(location place)
 	if(auto_latteDropWanted(place))
 	{
 		print('We want to get the "' + auto_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
-		autoEquip($item[latte lovers member's mug]);
+		autoEquip($item[latte lovers member\'s mug]);
 	}
 
 	equipOverrides();
@@ -306,11 +306,11 @@ void handlePreAdventure(location place)
 		}
 		if(itemDrop < itemNeed._float)
 		{
-			if(buffMaintain($effect[Fat Leon's Phat Loot Lyric], 20, 1, 10))
+			if (buffMaintain($effect[Fat Leon\'s Phat Loot Lyric], 20, 1, 10))
 			{
 				itemDrop += 20.0;
 			}
-			if(buffMaintain($effect[Singer's Faithful Ocelot], 35, 1, 10))
+			if (buffMaintain($effect[Singer\'s Faithful Ocelot], 35, 1, 10))
 			{
 				itemDrop += 10.0;
 			}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5710,12 +5710,6 @@ void auto_interruptCheck()
 	}
 }
 
-void auto_abort(string message)
-{
-	restoreAllSettings();
-	abort(message);
-}
-
 element currentFlavour()
 {
 	if(have_effect($effect[Spirit of Peppermint]) != 0)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1755,7 +1755,7 @@ boolean isGuildClass()
 float elemental_resist_value(int resistance)
 {
 	float bonus = 0;
-	if((my_class() == $class[Pastamancer]) || (my_class() == $class[Sauceror]) || (my_class() == $class[Ed]))
+	if (my_class() == $class[Pastamancer] || my_class() == $class[Sauceror] || isActuallyEd())
 	{
 		bonus = 5;
 	}
@@ -2078,7 +2078,7 @@ boolean ovenHandle()
 {
 	if((auto_get_campground() contains $item[Dramatic&trade; range]) && !get_property("auto_haveoven").to_boolean())
 	{
-		if((auto_get_campground() contains $item[Certificate of Participation]) && (my_class() == $class[Ed]))
+		if (auto_get_campground() contains $item[Certificate of Participation] && isActuallyEd())
 		{
 			print("Mafia reports we have an oven but we do not. Logging back in will resolve this.", "red");
 		}
@@ -2253,6 +2253,7 @@ boolean cloverUsageInit()
 		abort("Called cloverUsageInit but have no clovers");
 	}
 
+	backupSetting("cloverProtectActive", false); // maybe set this before we return?
 	if(item_amount($item[Ten-Leaf Clover]) > 0)
 	{
 		return true;
@@ -2286,7 +2287,6 @@ boolean cloverUsageInit()
 		return true;
 	}
 	abort("We tried to initialize clover usage but do not appear to have a Ten-Leaf Clover");
-	backupSetting("cloverProtectActive", false);
 	return false;
 }
 
@@ -3327,7 +3327,7 @@ int towerKeyCount()
 
 int towerKeyCount(boolean effective)
 {
-	if(my_class() == $class[Ed])
+	if (isActuallyEd())
 	{
 		return 3;
 	}
@@ -4034,13 +4034,13 @@ boolean useCocoon()
 		return true;
 	}
 
-	print("Considering using Cocoon at " + my_hp() + "/" + my_maxhp() + " HP with " + my_mp() + "/" + my_maxmp() + " MP", "blue");
-
 	int mpCost = 0;
 	int casts = 1;
 	skill cocoon = $skill[none];
 	if(have_skill($skill[Cannelloni Cocoon]))
 	{
+		print("Considering using Cocoon at " + my_hp() + "/" + my_maxhp() + " HP with " + my_mp() + "/" + my_maxmp() + " MP", "blue");
+
 		boolean canUseFamiliars = have_familiar($familiar[Mosquito]);
 		skill blood_skill = $skill[none];
 		if(auto_have_skill($skill[Blood Bubble]) && auto_have_skill($skill[Blood Bond]))
@@ -5578,7 +5578,7 @@ boolean auto_check_conditions(string conds)
 			// data: Doesn't matter, but put something so I don't have to support dataless conditions
 			// True if the hidden tavern has been unlocked this ascension
 			case "tavern":
-				return get_property("hiddenTavernUnlock").to_int() < my_ascensions();
+				return get_property("hiddenTavernUnlock").to_int() >= my_ascensions();
 			// data: The number of sgeeas you want to have
 			// True if you have at least that many sgeeas at your disposal
 			case "sgeea":
@@ -5708,6 +5708,12 @@ void auto_interruptCheck()
 		restoreAllSettings();
 		abort("auto_interrupt detected and aborting, auto_interrupt disabled.");
 	}
+}
+
+void auto_abort(string message)
+{
+	restoreAllSettings();
+	abort(message);
 }
 
 element currentFlavour()

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -530,8 +530,6 @@ boolean eatFancyDog(string dog);							//Defined in autoscend/auto_clan.ash
 boolean zataraClanmate(string who);							//Defined in autoscend/auto_clan.ash
 boolean zataraSeaside(string who);							//Defined in autoscend/auto_clan.ash
 boolean isActuallyEd();										//Defined in auto_ascend/auto_edTheUndying.ash
-float edMeatBonus();										//Defined in autoscend/auto_edTheUndying.ash
-boolean ed_buySkills();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_autoAdv(int num, location loc, string option);		//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife);//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_doResting();										//Defined in autoscend/auto_edTheUndying.ash
@@ -540,13 +538,8 @@ void ed_handleAdventureServant(location loc);//Defined in auto_ascend/auto_edThe
 void ed_initializeDay(int day);								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSession();								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSettings();								//Defined in autoscend/auto_edTheUndying.ash
-skill ed_nextUpgrade();										//Defined in auto_ascend/auto_edTheUndying.ash
-int ed_KaCost(skill upgrade);										//Defined in auto_ascend/auto_edTheUndying.ash
-int ed_skillID(skill upgrade);										//Defined in auto_ascend/auto_edTheUndying.ash
 boolean ed_needShop();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_preAdv(int num, location loc, string option);	//Defined in autoscend/auto_edTheUndying.ash
-boolean ed_shopping();										//Defined in autoscend/auto_edTheUndying.ash
-int ed_spleen_limit();										//Defined in autoscend/auto_edTheUndying.ash
 void ed_terminateSession();									//Defined in autoscend/auto_edTheUndying.ash
 effect[int] effectList();									//Defined in autoscend/auto_list.ash
 boolean elementalPlanes_access(element ele);				//Defined in autoscend/auto_elementalPlanes.ash
@@ -943,7 +936,6 @@ boolean zoneNonCombat(location loc);						//Defined in autoscend/auto_util.ash
 boolean declineTrades();									//Defined in autoscend/auto_util.ash
 boolean auto_beta(); //Defined in autoscend/auto_util.ash
 void auto_interruptCheck(); //Defined in autoscend/auto_util.ash
-void auto_abort(string message); //Defined in auto_ascend/auto_util.ash
 
 //From Zlib Stuff
 record kmailObject {

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -25,8 +25,6 @@ boolean LX_fancyOilPainting();
 boolean LX_setBallroomSong();
 boolean LX_fcle();
 boolean LX_ornateDowsingRod();
-boolean LX_getDictionary();
-boolean LX_dictionary();
 boolean LX_nastyBooty();
 boolean LX_spookyravenSecond();
 boolean LX_spookyBedroomCombat();
@@ -80,7 +78,6 @@ boolean L5_goblinKing();
 boolean L5_getEncryptionKey();
 boolean L6_dakotaFanning();
 boolean L6_friarsGetParts();
-boolean L6_friarsHotWing();
 boolean L8_trapperStart();
 boolean L7_crypt();
 boolean L8_trapperGround();
@@ -532,16 +529,20 @@ boolean drinkSpeakeasyDrink(string drink);					//Defined in autoscend/auto_clan.
 boolean eatFancyDog(string dog);							//Defined in autoscend/auto_clan.ash
 boolean zataraClanmate(string who);							//Defined in autoscend/auto_clan.ash
 boolean zataraSeaside(string who);							//Defined in autoscend/auto_clan.ash
+boolean isActuallyEd();										//Defined in auto_ascend/auto_edTheUndying.ash
 float edMeatBonus();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_buySkills();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_autoAdv(int num, location loc, string option);		//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife);//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_doResting();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_eatStuff();										//Defined in autoscend/auto_edTheUndying.ash
-boolean ed_handleAdventureServant(int num, location loc, string option);//Defined in autoscend/auto_edTheUndying.ash
+void ed_handleAdventureServant(location loc);//Defined in auto_ascend/auto_edTheUndying.ash
 void ed_initializeDay(int day);								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSession();								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSettings();								//Defined in autoscend/auto_edTheUndying.ash
+skill ed_nextUpgrade();										//Defined in auto_ascend/auto_edTheUndying.ash
+int ed_KaCost(skill upgrade);										//Defined in auto_ascend/auto_edTheUndying.ash
+int ed_skillID(skill upgrade);										//Defined in auto_ascend/auto_edTheUndying.ash
 boolean ed_needShop();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_preAdv(int num, location loc, string option);	//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_shopping();										//Defined in autoscend/auto_edTheUndying.ash
@@ -942,6 +943,7 @@ boolean zoneNonCombat(location loc);						//Defined in autoscend/auto_util.ash
 boolean declineTrades();									//Defined in autoscend/auto_util.ash
 boolean auto_beta(); //Defined in autoscend/auto_util.ash
 void auto_interruptCheck(); //Defined in autoscend/auto_util.ash
+void auto_abort(string message); //Defined in auto_ascend/auto_util.ash
 
 //From Zlib Stuff
 record kmailObject {


### PR DESCRIPTION
Long list of things I've been working on a testing for a while to make Actually Ed with no IotMs less bad.
There are a handful of bugfixes in here too which I didn't get around to extracting to submit individually (had been doing that in the past on sl_ascend). The main highlights are thus:
- Ed: no longer dies twice unnecessarily. This should mean your runs go faster and encounter fewer aborts. It can and will still die when it loses initiative 3 times in a row but since it now (mostly) gets 3 attempts at each combat for free, there's more chance of it killing the monster. Note: doesn't apply when flyering as we can abuse the UNDYING mechanic to flyer the same monster multiple times and by level 12 you're generally able to take a hit from full HP so it matters less.
- Ed: no longer switches servants in and out unnecessarily before combat. Makes runs faster. Also tweaked the choice of servants in a few places when it's a good idea.
- Ed: better choices about what to banish and what to yellow ray. As Ka is important early on in a run & not all monsters drop Ka & Ed has both a banish and a yellow ray we now use them in slightly better ways.
- Everyone: more semi-rare locations. Will attempt to get Flamin' Whatsisnames from Copperhead (cuts turns at the Zeppelin), Freezerburned Ice Cube from The Haunted Kitchen (cuts turns at the Smut Orcs) and a Knob Goblin Lunchbox (if delay hasn't been burned at the Outskirts).
- Everyone: better powerlevelling if you don't have scaling IotMs. At level 12 if we need to powerlevel we will use all the clovers we have left in the appropriate Spookyraven 2nd floor zone. Otherwise we will spend adventures in The Haunted Gallery with -combat to get Louvre it or Leave it as it gives non-muscle classes up to 200 substats and muscle classes up to 300.
- Everyone: Better choices about the NCs in Copperhead. Will try to get a priceless diamond since it saves 5k meat unless we have unnamed cocktails we want to turn into Flamin' Whatsisnames. Will attempt to acquire unnamed cocktails from the NC too.

Have tested this a bunch on sl_ascend and am in the middle of a run using this code. Unfortunately I can't get it to do less than 4 days but them's the breaks.