### PR TITLE
Added: Optimization for +ML zones and grouping Tavern with other +ML …

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -145,6 +145,7 @@ void initializeSettings()
 	set_property("auto_eaten", "");
 	set_property("auto_familiarChoice", $familiar[none]);
 	set_property("auto_fcle", "");
+	set_property("auto_forceTavern", false);
 	set_property("auto_friars", "");
 	set_property("auto_funTracker", "");
 	set_property("auto_getBoningKnife", false);
@@ -6977,7 +6978,13 @@ boolean L11_mauriceSpookyraven()
 			buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
 		}
 
-		addToMaximize("100ml 82max");
+		// Maximize Asdon usage
+		if(monster_level_adjustment() <= 81)
+		{
+			asdonBuff($effect[Driving Recklessly]);
+		}
+
+		addToMaximize("500ml 82max");
 
 		autoAdv(1, $location[The Haunted Boiler Room]);
 
@@ -7142,6 +7149,10 @@ boolean L11_unlockEd()
 	if(get_property("auto_tavern") != "finished")
 	{
 		print("Uh oh, didn\'t do the tavern and we are at the pyramid....", "red");
+
+		// Forcing Tavern.
+		set_property("auto_forceTavern", true);
+		if (L3_Tavern()) return true;
 	}
 
 	print("In the pyramid (W:" + item_amount($item[crumbling wooden wheel]) + ") (R:" + item_amount($item[tomb ratchet]) + ") (U:" + get_property("controlRoomUnlock") + ")", "blue");
@@ -12753,8 +12764,6 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
-
 	if(contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
@@ -12790,6 +12799,19 @@ boolean L9_oilPeak()
 	buffMaintain($effect[Tortious], 0, 1, 1);
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 	handleFamiliar("initSuggest");
+
+	// Force MCD usage
+	auto_change_mcd(11);
+
+	// Maximize Asdon usage
+	if(((monster_level_adjustment() >= 75) && (monster_level_adjustment() <= 99)) || ((monster_level_adjustment() >= 25) && (monster_level_adjustment() <= 49)) || (monster_level_adjustment() <= 11))
+	{
+		asdonBuff($effect[Driving Recklessly]);
+	}
+	else
+	{
+		asdonBuff($effect[Driving Wastefully]);
+	}
 
 	if (isActuallyEd() && get_property("auto_dickstab").to_boolean())
 	{
@@ -12827,10 +12849,22 @@ boolean L9_oilPeak()
 		}
 	}
 	addToMaximize("1000ml 100max");
+
+	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
+
 	autoAdv(1, $location[Oil Peak]);
-	if(get_property("lastAdventure") == "Unimpressed with Pressure")
+	if(get_property("lastEncounter") == "Unimpressed with Pressure")
 	{
 		set_property("oilPeakProgress", 0.0);
+
+		// Brute Force grouping with tavern (if not done) to maximize tangles while we have a high ML.
+		print("Checking to see if we should do the tavern while we are running high ML.", "green");
+		set_property("auto_forceTavern", true);
+		// Remove Driving Wastefully if we had it
+		if (0 < have_effect($effect[Driving Wastefully]))
+		{
+			uneffect($effect[Driving Wastefully]);
+		}
 	}
 	handleFamiliar("item");
 	return true;
@@ -14069,6 +14103,10 @@ boolean auto_tavern()
 	}
 	print("In the tavern! Layout: " + tavern, "blue");
 	boolean [int] locations = $ints[3, 2, 1, 0, 5, 10, 15, 20, 16, 21];
+
+	// Infrequent compunding issue, reset maximizer
+	resetMaximize()
+
 	boolean maximized = false;
 	foreach loc in locations
 	{
@@ -14131,6 +14169,19 @@ boolean auto_tavern()
 			}
 		}
 
+		if((my_path() != "Actually Ed the Undying") && (monster_level_adjustment() <= 299))
+		{
+			// Maximize ML First by using equipment
+			// Asdon usage increases Rat King chance by 8.3%
+			if(monster_level_adjustment() <= 299)
+			{
+				asdonBuff($effect[Driving Recklessly]);
+			}
+		}
+
+		//Turn up the MCD
+		auto_change_mcd(11);
+
 		foreach element_type in $strings[Hot, Cold, Stench, Sleaze, Spooky]
 		{
 			if(numeric_modifier(element_type + " Damage") < 20.0)
@@ -14141,7 +14192,8 @@ boolean auto_tavern()
 
 		if(!maximized)
 		{
-			addToMaximize("200cold damage 20max,200hot damage 20max,200spooky damage 20max,200stench damage 20max,100ml 149max");
+			// Tails are a better time saving investment
+			addToMaximize("80cold damage 20max,80hot damage 20max,80spooky damage 20max,80stench damage 20max,500ml 150max");
 			simMaximize();
 			maximized = true;
 		}
@@ -14238,7 +14290,7 @@ boolean L3_tavern()
 	{
 		return false;
 	}
-	if(my_adventures() < 5)
+	if(my_adventures() < 10)
 	{
 		return false;
 	}
@@ -14278,6 +14330,11 @@ boolean L3_tavern()
 		}
 	}
 	if(my_level() == get_property("auto_powerLevelLastLevel").to_int())
+	{
+		delayTavern = false;
+	}
+
+	if(get_property("auto_forceTavern").to_boolean())
 	{
 		delayTavern = false;
 	}


### PR DESCRIPTION
…zones

# Description

Added optimization for +ML zones. (Oil Peak, Tavern, Boiler Room)
Added Grouping for Pyramid+Tavern and Oil Peak+Tavern


Fixes #55 #43 #20 

## How Has This Been Tested?
:(
Am not currently in-run where I can test. I C&P with minor modifications from my local copy of sl_ascend which I have made many runs with.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
