### PR TITLE
BugFix: Save a clover when powerlevelling at 12 if in a path that needs a Wand of Nagamar

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5664,7 +5664,8 @@ boolean LX_attemptPowerLevel()
 	else
 	{
 		// burn all spare clovers after level 12 if we need to powerlevel.
-		if (my_level() >= 12 && get_property("questL12War") == "finished" && cloversAvailable() > 0)
+		int cloverLimit = get_property("auto_wandOfNagamar").to_boolean() ? 1 : 0;
+		if (my_level() >= 12 && get_property("questL12War") == "finished" && cloversAvailable() > cloverLimit)
 		{
 			//Determine where to go for clover stats, do not worry about clover failures
 			location whereTo = $location[none];


### PR DESCRIPTION
# Description

as title. Single line change to hotfix something I didn't consider on the beta branch.

## How Has This Been Tested?

It hasn't yet. I realised I wouldn't see this as a problem in Ed since Ed doesn't fight the NS but any paths that do would fail to make the Wand before fighting the NS if they have no clovers when they reach level 13.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.