### PR TITLE
BugFix for Maximizer and forcing required equipment.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -262,6 +262,7 @@ void handlePreAdventure(location place)
 			abort("Tried to be retro but lacking the Continuum Transfunctioner.");
 		}
 		autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
+		addToMaximize("+equip " + $item[Continuum Transfunctioner]);
 	}
 
 	if((place == $location[Inside The Palindome]) && (my_turncount() != 0))
@@ -271,6 +272,7 @@ void handlePreAdventure(location place)
 			abort("Tried to go to The Palindome but don't have the Namsilat");
 		}
 		autoEquip($slot[acc3], $item[Talisman O\' Namsilat]);
+		addToMaximize("+equip " + $item[Talisman O\' Namsilat]);
 	}
 
 	if((place == $location[The Haunted Wine Cellar]) && (my_turncount() != 0) && (get_property("auto_winebomb") == "partial"))
@@ -280,11 +282,19 @@ void handlePreAdventure(location place)
 			abort("Tried to charge a WineBomb but don't have one.");
 		}
 		autoEquip($slot[off-hand], $item[Unstable Fulminate]);
+		addToMaximize("+equip " + $item[Unstable Fulminate]);
 	}
 
-	if(place == $location[The Black Forest])
+	if((place == $location[The Black Forest]) && (my_turncount() != 0)
 	{
 		autoEquip($slot[acc3], $item[Blackberry Galoshes]);
+		addToMaximize("+equip " + $item[Blackberry Galoshes]);
+	}
+
+	if((place == $location[The Arid\, Extra-Dry Desert]) && (my_turncount() != 0)
+	{
+		autoEquip($slot[acc3], $item[UV-resistant compass]);
+		addToMaximize("+equip " + $item[UV-resistant compass]);
 	}
 
 	bat_formPreAdventure();


### PR DESCRIPTION
# Description

Forcing required equips into maximizer message so they override any other equip attempts (latte seems to override fulminate)


If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

Issue reported by Ares on discord

## How Has This Been Tested?

Haven't tested in script, tested by manually running commands in GCLI

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
