### PR TITLE
Fix KoE keys, delay nook, use exploding cigar on astronauts

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -9504,7 +9504,17 @@ boolean L7_crypt()
 		return true;
 	}
 
-	if((get_property("cyrptNookEvilness").to_int() > 0) && canGroundhog($location[The Defiled Nook]))
+	// In KoE, skeleton astronauts are random encounters that drop Evil Eyes.
+	// We might be able to reach the Nook boss without adventuring.
+
+	while((item_amount($item[Evil Eye]) > 0) && auto_is_valid($item[Evil Eye]) && (get_property("cyrptNookEvilness").to_int() > 25))
+	{
+		use(1, $item[Evil Eye]);
+	}
+
+	boolean skip_in_koe = in_koe() && (get_property("cyrptNookEvilness").to_int() > 25) && get_property("questL12War") == "finished";
+
+	if((get_property("cyrptNookEvilness").to_int() > 0) && canGroundhog($location[The Defiled Nook]) && !skip_in_koe)
 	{
 		print("The Nook!", "blue");
 		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
@@ -9512,8 +9522,9 @@ boolean L7_crypt()
 		autoEquip($item[Gravy Boat]);
 
 		bat_formBats();
+
 		januaryToteAcquire($item[broken champagne bottle]);
-		if(useMaximizeToEquip())
+		if(useMaximizeToEquip() && (get_property("cyrptNookEvilness").to_int() > 26))
 		{
 			removeFromMaximize("-equip " + $item[broken champagne bottle]);
 		}
@@ -9528,10 +9539,6 @@ boolean L7_crypt()
 		}
 
 		autoAdv(1, $location[The Defiled Nook]);
-		while((item_amount($item[Evil Eye]) > 0) && auto_is_valid($item[Evil Eye]) && (get_property("cyrptNookEvilness").to_int() > 25))
-		{
-			use(1, $item[Evil Eye]);
-		}
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -7037,7 +7037,7 @@ boolean L13_sorceressDoor()
 		}
 	}
 
-	if((item_amount($item[white pixel]) >= 30) && (item_amount($item[Digital Key]) == 0))
+	if((item_amount($item[white pixel]) >= 30) && (item_amount($item[Digital Key]) == 0) && !in_koe())
 	{
 		cli_execute("make digital key");
 		set_property("auto_crackpotjar", "finished");
@@ -7070,7 +7070,12 @@ boolean L13_sorceressDoor()
 	{
 		if(item_amount($item[Boris\'s Key]) == 0)
 		{
-			boolean temp = cli_execute("make Boris's Key");
+			if(in_koe() && item_amount($item[fat loot token]) > 0) {
+				visit_url("shop.php?whichshop=exploathing&action=buyitem&quantity=1&whichrow=1093&pwd", true);
+			}
+			else {
+				cli_execute("make Boris's Key");
+			}
 		}
 		if(item_amount($item[Boris\'s Key]) == 0)
 		{
@@ -7082,7 +7087,12 @@ boolean L13_sorceressDoor()
 	{
 		if(item_amount($item[Jarlsberg\'s Key]) == 0)
 		{
-			boolean temp = cli_execute("make Jarlsberg's Key");
+			if(in_koe() && item_amount($item[fat loot token]) > 0) {
+				visit_url("shop.php?whichshop=exploathing&action=buyitem&quantity=1&whichrow=1094&pwd", true);
+			}
+			else {
+				cli_execute("make Jarlsberg's Key");
+			}
 		}
 		if(item_amount($item[Jarlsberg\'s Key]) == 0)
 		{
@@ -7094,7 +7104,12 @@ boolean L13_sorceressDoor()
 	{
 		if(item_amount($item[Sneaky Pete\'s Key]) == 0)
 		{
-			boolean temp = cli_execute("make Sneaky Pete's Key");
+			if(in_koe() && item_amount($item[fat loot token]) > 0) {
+				visit_url("shop.php?whichshop=exploathing&action=buyitem&quantity=1&whichrow=1095&pwd", true);
+			}
+			else {
+				cli_execute("make Sneaky Pete's Key");
+			}
 		}
 		if(item_amount($item[Sneaky Pete\'s Key]) == 0)
 		{
@@ -7120,7 +7135,21 @@ boolean L13_sorceressDoor()
 	{
 		if(item_amount($item[Digital Key]) == 0)
 		{
-			boolean temp = cli_execute("make digital key");
+			if(item_amount($item[white pixel]) < 30)
+			{
+				int pulls_needed = 30 - item_amount($item[white pixel]);
+				// Save 5 pulls for later, just in case.
+				if(pulls_remaining() - pulls_needed >= 5)
+				{
+					pullXWhenHaveY($item[white pixel], pulls_needed, item_amount($item[white pixel]));
+				}
+			}
+			if(in_koe() && item_amount($item[white pixel]) >= 30) {
+				visit_url("shop.php?whichshop=exploathing&action=buyitem&quantity=1&whichrow=1090&pwd", true);
+			}
+			else {
+				cli_execute("make digital key");
+			}
 		}
 		if(item_amount($item[Digital Key]) == 0)
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -9541,7 +9541,7 @@ boolean L7_crypt()
 		use(1, $item[Evil Eye]);
 	}
 
-	boolean skip_in_koe = in_koe() && (get_property("cyrptNookEvilness").to_int() > 25) && get_property("questL12War") == "finished";
+	boolean skip_in_koe = in_koe() && (get_property("cyrptNookEvilness").to_int() > 25) && get_property("questL12War") != "finished";
 
 	if((get_property("cyrptNookEvilness").to_int() > 0) && canGroundhog($location[The Defiled Nook]) && !skip_in_koe)
 	{
@@ -9569,6 +9569,10 @@ boolean L7_crypt()
 
 		autoAdv(1, $location[The Defiled Nook]);
 		return true;
+	}
+	else if(skip_in_koe)
+	{
+		auto_debug_print("In Exploathing, skipping Defiled Nook until we get more evil eyes.");
 	}
 
 	if((get_property("cyrptNicheEvilness").to_int() > 0) && canGroundhog($location[The Defiled Niche]))

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -590,13 +590,20 @@ string auto_combatHandler(int round, string opp, string text)
 
 	if(enemy.to_string() == "skeleton astronaut")
 	{
+		if(my_daycount() == 1 && item_amount($item[Exploding cigar]) > 0){
+			return "item " + $item[Exploding cigar];
+		}
 		int dmg = 0;
 		foreach el in $elements[hot, cold, sleaze, spooky, stench]
 		{
 			dmg += min(10, numeric_modifier(el.to_string() + " Damage"));
 		}
+		// 10 physical + 10 prismatic is enough to be better than Saucestorm.
+		// Otherwise, saucestorm deals 20 damage/round.
 		if(dmg >= 10 && buffed_hit_stat() >= 120 + monster_level_adjustment())
+		{
 			return "attack with weapon";
+		}
 		else if(canUse($skill[Saucestorm], false))
 		{
 			return useSkill($skill[Saucestorm], false);


### PR DESCRIPTION
# Description

Fixes #94 
Fixes #107 

Relevant to #93 (delays the Nook)

## How Has This Been Tested?

Ran through two softcore KoE runs. Confirmed it:

* Delayed nook
* Used evil eyes when available
* Used exploding cigar against skeleton astronauts on day 1
* Opened and finished tower

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
