### PR TITLE
WIP having CS path try to get +10 lb pokefam item using fertilizer

### DIFF
--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -3212,9 +3212,12 @@ void cs_initializeDay(int day)
 				acquireHermitItem($item[Seal Tooth]);
 			}
 
-			if(!(auto_get_campground() contains $item[Packet Of Tall Grass Seeds]))
-			{
-				cli_execute("garden pick");
+			cli_execute("garden pick");
+			if(auto_get_campground() contains $item[Packet Of Tall Grass Seeds]){
+				// get +10 lb familiar equipment if we need it
+				while(isPokeFertilizerAvailable() && !haveAnyPokeFamiliarEquipment() && equipmentAmount($item[astral pet sweater]) == 0){
+					pokeFertilizeAndHarvest();
+				}
 			}
 
 			if(!possessEquipment($item[Saucepan]))

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -358,7 +358,6 @@ boolean songboomSetting(string goal)
 	return songboomSetting(option);
 }
 
-
 boolean songboomSetting(int option)
 {
 	if(!is_unrestricted($item[SongBoom&trade; BoomBox]))
@@ -711,7 +710,6 @@ boolean neverendingPartyAvailable()
 	return true;
 
 }
-
 
 boolean neverendingPartyCombat(effect eff, boolean hardmode, string option, boolean powerlevelling)
 {
@@ -1222,8 +1220,6 @@ boolean fightClubNap()
 	return true;
 }
 
-
-
 boolean fightClubSpa()
 {
 	int option = 4;
@@ -1235,7 +1231,6 @@ boolean fightClubSpa()
 	}
 	return fightClubSpa(option);
 }
-
 
 boolean fightClubSpa(effect eff)
 {
@@ -1255,7 +1250,6 @@ boolean fightClubSpa(effect eff)
 	}
 	return fightClubSpa(option);
 }
-
 
 boolean fightClubSpa(int option)
 {
@@ -1328,4 +1322,40 @@ boolean fightClubStats()
 	page = visit_url("choice.php?pwd=&whichchoice=1334&option=4");
 
 	return true;
+}
+
+static boolean[item] __poke_fam_equipment = $items[amulet coin, luck incense, muscle band, razor fang, shell bell, smoke ball];
+static item __fertilizer = $item[Pok&eacute;-Gro fertilizer];
+static item __tallGrass = $item[Packet Of Tall Grass Seeds];
+
+boolean isTallGrassAvailable(){
+	return auto_is_valid(__tallGrass) && auto_get_campground()[__tallGrass] > 0;
+}
+
+int pokeFertilizerAmountAvailable(){
+	if(!auto_is_valid(__fertilizer)){
+		return 0;
+	}
+	return item_amount(__fertilizer);
+}
+
+boolean isPokeFertilizerAvailable(){
+	return isTallGrassAvailable() && pokeFertilizerAmountAvailable() > 0;
+}
+
+boolean haveAnyPokeFamiliarEquipment(){
+	foreach i, _ in __poke_fam_equipment{
+		if(equipmentAmount(i) > 0){
+			return true;
+		}
+	}
+	return false;
+}
+
+boolean pokeFertilizeAndHarvest(){
+	if(!isPokeFertilizerAvailable()){
+		return false;
+	}
+
+	return use(1, __fertilizer) && cli_execute("garden pick");
 }

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -1324,19 +1324,17 @@ boolean fightClubStats()
 	return true;
 }
 
-static boolean[item] __poke_fam_equipment = $items[amulet coin, luck incense, muscle band, razor fang, shell bell, smoke ball];
-static item __fertilizer = $item[Pok&eacute;-Gro fertilizer];
-static item __tallGrass = $item[Packet Of Tall Grass Seeds];
-
 boolean isTallGrassAvailable(){
-	return auto_is_valid(__tallGrass) && auto_get_campground()[__tallGrass] > 0;
+	static item tallGrass = $item[Packet Of Tall Grass Seeds];
+	return auto_is_valid(tallGrass) && auto_get_campground()[tallGrass] > 0;
 }
 
 int pokeFertilizerAmountAvailable(){
-	if(!auto_is_valid(__fertilizer)){
+	static item fertilizer = $item[Pok&eacute;-Gro fertilizer];
+	if(!auto_is_valid(fertilizer)){
 		return 0;
 	}
-	return item_amount(__fertilizer);
+	return item_amount(fertilizer);
 }
 
 boolean isPokeFertilizerAvailable(){
@@ -1344,7 +1342,8 @@ boolean isPokeFertilizerAvailable(){
 }
 
 boolean haveAnyPokeFamiliarEquipment(){
-	foreach i, _ in __poke_fam_equipment{
+	static boolean[item] poke_fam_equipment = $items[amulet coin, luck incense, muscle band, razor fang, shell bell, smoke ball];
+	foreach i, _ in poke_fam_equipment{
 		if(equipmentAmount(i) > 0){
 			return true;
 		}
@@ -1357,5 +1356,5 @@ boolean pokeFertilizeAndHarvest(){
 		return false;
 	}
 
-	return use(1, __fertilizer) && cli_execute("garden pick");
+	return use(1, $item[Pok&eacute;-Gro fertilizer]) && cli_execute("garden pick");
 }


### PR DESCRIPTION
# Description

On day 2 of community service, use fertilizer dropped on day 1 to get the +10 lb familiar equipment from tall grass. Wont do this if it already has one of the poke fam items or the astral pet sweater. Can add other fam equipment if needed.

Fixes #98 

## How Has This Been Tested?

I havent tested this yet since I already used my turns but I've written something like this before and lost it. Will remove WIP tag after tested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
