### PR TITLE
Pill Keeper and stench jelly usage

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3592,7 +3592,7 @@ boolean L11_aridDesert()
 	{
 		return false;
 	}
-	if((get_property("auto_hiddenapartment") != "finished") && (get_property("auto_hiddenapartment") != "0"))
+	if((get_property("auto_hiddenapartment") != "finished") && (0 < have_effect($effect[Once-Cursed]) + have_effect($effect[Twice-Cursed]) + have_effect($effect[Thrice-Cursed])))
 	{
 		return false;
 	}
@@ -5713,9 +5713,14 @@ boolean L11_hiddenTavernUnlock()
 
 boolean L11_hiddenTavernUnlock(boolean force)
 {
-	if(auto_my_path() == "G-Lover")
+	if(!auto_is_valid($item[Book of Matches]))
 	{
 		return false;
+	}
+
+	if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())
+	{
+		return true;
 	}
 
 	if(force)
@@ -5827,20 +5832,26 @@ boolean L11_hiddenCity()
 			int current = get_property("auto_hiddenapartment").to_int() + 1;
 			set_property("auto_hiddenapartment", current);
 
-			if(!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0))
+			if(auto_canForceNextNoncombat())
 			{
-				use(1, $item[Clara\'s Bell]);
+				L11_hiddenTavernUnlock(true);
 
-				if(auto_my_path() == "Pocket Familiars")
+				if(my_ascensions() == get_property("hiddenTavernUnlock").to_int()
+					|| (0 != have_effect($effect[Thrice-Cursed])) && current <= 3)
 				{
-					if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+					auto_forceNextNoncombat();
+
+					if(auto_my_path() == "Pocket Familiars")
 					{
-						set_property("choiceAdventure780", "3");
-						autoAdv(1, $location[The Hidden Apartment Building]);
-						return true;
+						if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+						{
+							set_property("choiceAdventure780", "3");
+							autoAdv(1, $location[The Hidden Apartment Building]);
+							return true;
+						}
 					}
+					current = 9;
 				}
-				current = 9;
 			}
 
 			if(current <= 8)
@@ -8614,7 +8625,10 @@ boolean L10_holeInTheSkyUnlock()
 	{
 		handleFamiliar($familiar[Puck Man]);
 	}
-	providePlusNonCombat(25);
+	if(!auto_forceNextNoncombat())
+	{
+		providePlusNonCombat(25);
+	}
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 	handleFamiliar("item");
 
@@ -8686,7 +8700,10 @@ boolean L10_topFloor()
 	}
 
 	handleFamiliar("initSuggest");
-	providePlusNonCombat(25);
+	if(!auto_forceNextNoncombat())
+	{
+		providePlusNonCombat(25);
+	}
 	autoEquip($item[mohawk wig]);
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 	handleFamiliar("item");
@@ -8830,7 +8847,10 @@ boolean L10_basement()
 	{
 		handleFamiliar($familiar[Puck Man]);
 	}
-	providePlusNonCombat(25);
+	if(!auto_forceNextNoncombat())
+	{
+		providePlusNonCombat(25);
+	}
 	if((my_class() == $class[Gelatinous Noob]) && auto_have_familiar($familiar[Robortender]))
 	{
 		if(!have_skill($skill[Bendable Knees]) && (item_amount($item[Bottle of Gregnadigne]) == 0))

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2289,6 +2289,8 @@ void initializeDay(int day)
 		cli_execute("garden pick");
 	}
 
+	set_property("auto_forceNonCombatSource", "");
+
 	set_property("auto_day_init", day);
 }
 
@@ -5836,8 +5838,8 @@ boolean L11_hiddenCity()
 			{
 				L11_hiddenTavernUnlock(true);
 
-				if(my_ascensions() == get_property("hiddenTavernUnlock").to_int()
-					|| (0 != have_effect($effect[Thrice-Cursed])) && current <= 3)
+				if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= 3*$item[Cursed Punch].inebriety) && !in_tcrs())
+					|| (0 != have_effect($effect[Thrice-Cursed]) && current <= 4))
 				{
 					auto_forceNextNoncombat();
 
@@ -5872,7 +5874,7 @@ boolean L11_hiddenCity()
 					L11_hiddenTavernUnlock(true);
 					while(have_effect($effect[Thrice-Cursed]) == 0)
 					{
-						if((inebriety_left() >= $item[Cursed Punch].inebriety) && canDrink($item[Cursed Punch]) && (my_ascensions() == get_property("hiddenTavernUnlock").to_int()) && !in_tcrs() && !in_koe())
+						if((inebriety_left() >= $item[Cursed Punch].inebriety) && canDrink($item[Cursed Punch]) && (my_ascensions() == get_property("hiddenTavernUnlock").to_int()) && !in_tcrs())
 						{
 							buyUpTo(1, $item[Cursed Punch]);
 							if(item_amount($item[Cursed Punch]) == 0)
@@ -6698,6 +6700,7 @@ boolean LX_spookyravenSecond()
 
 			auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
+			auto_forceNextNoncombat();
 			autoAdv(1, $location[The Haunted Bathroom]);
 
 			handleFamiliar("item");

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -103,6 +103,6 @@ boolean LX_koeInvaderHandler()
 			return ret;
 		}
 	}
-	abort("I'm not really sure how to kill this Invader guy. Do it manually?");
+	print("I don't think we're ready to kill the invader yet.", "blue");
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -689,7 +689,7 @@ int auto_pillKeeperUses()
 
 boolean auto_pillKeeperFreeUseAvailable()
 {
-	return get_property("_freePillKeeperUsed").to_boolean();
+	return !get_property("_freePillKeeperUsed").to_boolean();
 }
 
 boolean auto_pillKeeperAvailable()

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -676,3 +676,69 @@ boolean auto_campawayGrabBuffs()
 	}
 	return true;
 }
+
+int auto_pillKeeperUses()
+{
+	if (0 == item_amount($item[Eight Days a Week Pill Keeper])
+		|| (!is_unrestricted($item[Unopened Eight Days a Week Pill Keeper])))
+	{
+		return 0;
+	}
+	return spleen_left()/3 + 1 - get_property("_freePillKeeperUsed").to_boolean().to_int();
+}
+
+boolean auto_pillKeeperFreeUseAvailable()
+{
+	return get_property("_freePillKeeperUsed").to_boolean();
+}
+
+boolean auto_pillKeeperAvailable()
+{
+	return auto_pillKeeperUses() > 0;
+}
+
+boolean auto_pillKeeper(int pill)
+{
+	if(auto_pillKeeperUses() == 0) return false;
+	print("Using pill keeper: consuming pill #" + pill, "blue");
+	string page = visit_url("main.php?eowkeeper=1", false);
+	page = visit_url("choice.php?pwd=&whichchoice=1395&pwd&option=" + pill, true);
+	return true;
+}
+
+/* How to use this?
+	 * Drink 3x cursed punch + pill in Haunted Apartment
+	 * 
+	 * [other] Battlefield NC
+ */
+
+boolean auto_pillKeeper(string pill)
+{
+	int pillId;
+	switch(pill.to_lower_case())
+	{
+	case "yr":
+	case "yellow ray":
+		pillID = 1; break;
+	case "potion":
+		pillID = 2; break;
+	case "noncombat":
+	case "bell":
+		pillID = 3; break;
+	case "resistance":
+		pillID = 4; break;
+	case "stat":
+		pillID = 5; break;
+	case "weight":
+	case "fam weight":
+		pillID = 6; break;
+	case "semirare":
+		pillID = 7; break;
+	case "random":
+		pillID = 8; break;
+	default:
+		abort("invalid argument to auto_pillKeeper: \"" + pill + "\"");
+	}
+
+	return auto_pillKeeper(pillId);
+}

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -679,7 +679,7 @@ boolean auto_campawayGrabBuffs()
 
 int auto_pillKeeperUses()
 {
-	if (0 == item_amount($item[Eight Days a Week Pill Keeper])
+	if (0 == equipmentAmount($item[Eight Days a Week Pill Keeper])
 		|| (!is_unrestricted($item[Unopened Eight Days a Week Pill Keeper])))
 	{
 		return 0;

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -706,12 +706,6 @@ boolean auto_pillKeeper(int pill)
 	return true;
 }
 
-/* How to use this?
-	 * Drink 3x cursed punch + pill in Haunted Apartment
-	 * 
-	 * [other] Battlefield NC
- */
-
 boolean auto_pillKeeper(string pill)
 {
 	int pillId;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5805,7 +5805,7 @@ boolean auto_canForceNextNoncombat()
 	|| (item_amount($item[stench jelly]) > 0 && auto_is_valid($item[stench jelly]) && spleen_left() < $item[stench jelly].spleen);
 }
 
-boolean auto_forceNextNoncombat()
+boolean _auto_forceNextNoncombat()
 {
 	// Use stench jelly or other item to set the combat rate to zero until the next noncombat.
 	// There's no way of knowing if we've already used one, so the caller needs to be careful.
@@ -5816,7 +5816,7 @@ boolean auto_forceNextNoncombat()
 	}
 	if(!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0))
 	{
-		use(1, $item[Clara\'s Bell]);
+		return use(1, $item[Clara\'s Bell]);
 	}
 	else if(item_amount($item[stench jelly]) > 0 && auto_is_valid($item[stench jelly]))
 	{
@@ -5825,6 +5825,15 @@ boolean auto_forceNextNoncombat()
 	else if(auto_pillKeeperAvailable())
 	{
 		return auto_pillKeeper("noncombat");
+	}
+	return false;
+}
+
+boolean auto_forceNextNoncombat() {
+	if (_auto_forceNextNoncombat())
+	{
+		print("Next noncombat adventure has been forced...", "blue");
+		return true;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5792,3 +5792,39 @@ int auto_reserveCraftAmount(item orig_it)
 	}
 	return inner(orig_it);
 }
+
+float mp_regen()
+{
+	return 0.5 * (numeric_modifier("MP Regen Min") + numeric_modifier("MP Regen Max"));
+}
+
+boolean auto_canForceNextNoncombat()
+{
+	return auto_pillKeeperAvailable()
+	|| (!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0))
+	|| (item_amount($item[stench jelly]) > 0 && auto_is_valid($item[stench jelly]) && spleen_left() < $item[stench jelly].spleen);
+}
+
+boolean auto_forceNextNoncombat()
+{
+	// Use stench jelly or other item to set the combat rate to zero until the next noncombat.
+	// There's no way of knowing if we've already used one, so the caller needs to be careful.
+
+	if(auto_pillKeeperFreeUseAvailable())
+	{
+		return auto_pillKeeper("noncombat");
+	}
+	if(!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0))
+	{
+		use(1, $item[Clara\'s Bell]);
+	}
+	else if(item_amount($item[stench jelly]) > 0 && auto_is_valid($item[stench jelly]))
+	{
+		return autoChew(1, $item[stench jelly]);
+	}
+	else if(auto_pillKeeperAvailable())
+	{
+		return auto_pillKeeper("noncombat");
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -692,7 +692,12 @@ int auto_beachCombFreeUsesLeft();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_beachUseFreeCombs();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayAvailable();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayGrabBuffs();	// Defined in autoscend/auto_mr2019.ash
-boolean getSpaceJelly();									//Defined in autoscend/auto_mr2017.ash
+int auto_pillKeeperUses();						//Defined in autoscend/auto_mr2019.ash
+boolean auto_pillKeeperFreeUseAvailable();	//Defined in autoscend/auto_mr2019.ash
+boolean auto_pillKeeperAvailable();			//Defined in autoscend/auto_mr2019.ash
+boolean auto_pillKeeper(int pill);			//Defined in autoscend/auto_mr2019.ash
+boolean auto_pillKeeper(string pill);		//Defined in autoscend/auto_mr2019.ash
+boolean getSpaceJelly();					//Defined in autoscend/auto_mr2017.ash
 int horseCost();											//Defined in autoscend/auto_mr2017.ash
 string horseNormalize(string horseText); // Defined in autoscend/auto_mr2017.ash
 boolean getHorse(string type);								//Defined in autoscend/auto_mr2017.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1100,9 +1100,10 @@ boolean executeFlavour(); // Defined in autoscend/auto_util.ash
 boolean autoFlavour(location place); // Defined in autoscend/auto_util.ash
 int auto_reserveAmount(item it); // Defined in autoscend/auto_util.ash
 int auto_reserveCraftAmount(item it); // Defined in autoscend/auto_util.ash
-float mp_regen(); // Defined in autoscend/auto_util.ash
 boolean auto_canForceNextNoncombat();  // Defined in autoscend/auto_util.ash
 boolean auto_forceNextNoncombat(); // Defined in autoscend/auto_util.ash
+boolean auto_haveQueuedForcedNonCombat(); // Defined in autoscend/auto_util.ash
+boolean is_superlikely(string encounterName); // Defined in autoscend/auto_util.ash
 
 //Record from autoscend/auto_zone.ash
 record generic_t

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1100,6 +1100,9 @@ boolean executeFlavour(); // Defined in autoscend/auto_util.ash
 boolean autoFlavour(location place); // Defined in autoscend/auto_util.ash
 int auto_reserveAmount(item it); // Defined in autoscend/auto_util.ash
 int auto_reserveCraftAmount(item it); // Defined in autoscend/auto_util.ash
+float mp_regen(); // Defined in autoscend/auto_util.ash
+boolean auto_canForceNextNoncombat();  // Defined in autoscend/auto_util.ash
+boolean auto_forceNextNoncombat(); // Defined in autoscend/auto_util.ash
 
 //Record from autoscend/auto_zone.ash
 record generic_t


### PR DESCRIPTION
# Description

* Adds utility functions for the Pill Keeper
* Adds utility functions for forcing the next adventure to be a noncombat (delegating to Pill Keeper/Clara's Bell/stench jelly as required)
* Use noncombat-forcing functionality in:
  * Castle basement (1 use)
  * Castle top floor (2 uses)
  * Hidden Apartment Building (1 use - along with using the hidden tavern to drink 3x Cursed Punch, saving 9 turns)

Also a one-off fix to close #113 (aborting in KoE when out of quests).

## How Has This Been Tested?

Has gone through a KoE SC run. Looks good to me:
![image](https://user-images.githubusercontent.com/55042506/66878448-edc14300-ef87-11e9-8d65-4518ddd924f7.png)

Note that there are some implications for nonstandard paths where spleen can be converted into turns and it might be a bad idea to save 3 turns for 3 spleen. I haven't thought about how to address those issues and would be pleased for rampant speculation to take place in the comments on this pull request, but for now am planning to just push this through.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
