### PR TITLE
Optimize hidden park

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -6150,6 +6150,27 @@ boolean L11_hiddenCityZones()
 		{
 			set_property("choiceAdventure789", "2");
 		}
+
+		// Try to get the NC so that we can relocate Janitors and get items quickly
+                addToMaximize("-500combat");
+
+		asdonBuff($effect[Driving Stealthily]);
+		buffMaintain($effect[Smooth Movements], 0, 1, 1);
+		buffMaintain($effect[The Sonata of Sneakiness], 0, 1, 1);
+
+		if(0 >= have_effect($effect[Fresh Scent]))
+		{
+			if(item_amount($item[chunk of rock salt]) > 0)
+			{
+				use(1, $item[chunk of rock salt]);
+			}
+			else if(item_amount($item[deodorant]) > 0))
+			{
+				use(1, $item[deodorant]);
+			}		
+
+		}
+
 		autoAdv(1, $location[The Hidden Park]);
 		return true;
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -6152,24 +6152,7 @@ boolean L11_hiddenCityZones()
 		}
 
 		// Try to get the NC so that we can relocate Janitors and get items quickly
-                addToMaximize("-500combat");
-
-		asdonBuff($effect[Driving Stealthily]);
-		buffMaintain($effect[Smooth Movements], 0, 1, 1);
-		buffMaintain($effect[The Sonata of Sneakiness], 0, 1, 1);
-
-		if(0 >= have_effect($effect[Fresh Scent]))
-		{
-			if(item_amount($item[chunk of rock salt]) > 0)
-			{
-				use(1, $item[chunk of rock salt]);
-			}
-			else if(item_amount($item[deodorant]) > 0))
-			{
-				use(1, $item[deodorant]);
-			}		
-
-		}
+		providePlusNonCombat(25, true);
 
 		autoAdv(1, $location[The Hidden Park]);
 		return true;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2795,6 +2795,19 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		}
 	}
 
+	// We can get these during normal game, may as well use them!
+	if(0 >= have_effect($effect[Fresh Scent]))
+	{
+		if(item_amount($item[chunk of rock salt]) > 0)
+		{
+			use(1, $item[chunk of rock salt]);
+		}
+		else if(item_amount($item[deodorant]) > 0))
+		{
+			use(1, $item[deodorant]);
+		}
+	}
+
 	int equipDiff = 0;
 
 	if(doEquips)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2796,7 +2796,7 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 	}
 
 	// We can get these during normal game, may as well use them!
-	if(0 >= have_effect($effect[Fresh Scent]))
+	if(0 == have_effect($effect[Fresh Scent]))
 	{
 		if(item_amount($item[chunk of rock salt]) > 0)
 		{


### PR DESCRIPTION
# Description

Add prioritization for -combat to Hidden Park so that we relocate Janitors before we get the machete, and we can get the quest related items faster

## How Has This Been Tested?

Hasn't. :/

## Checklist:

- [X] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
