### PR TITLE
setting hot tub to be 100% soft cap and hard cap of 2 since its relie…

### DIFF
--- a/RELEASE/data/autoscend_restoration.txt
+++ b/RELEASE/data/autoscend_restoration.txt
@@ -101,7 +101,7 @@
 104	Wint-O-Fresh mint	item	0	4	0	0	none	none
 105	magical mystery juice	item	0	scaling	0	0	none	none
 106	generic mana potion	item	0	scaling	0	0	none	none
-107	A Relaxing Hot Tub	clan	ALL	0	2	0	All Negative	none
+107	A Relaxing Hot Tub	clan	ALL	0	5	2	All Negative	none
 108	Psychokinetic Energy Blob	item	0	25	0	0	none	none
 109	Cloaca-Cola	item	0	12	0	0	none	none
 110	Holy Spring Water	item	0	50	0	0	none	Spiritually Awake


### PR DESCRIPTION
> Also, @macgregor this was before your recent changes to regen, but I noticed a hard stop in KoE when trying to kill the invader and being unable to uneffect Flared Nostrils (making it way too dangerous to fight the invader). Historically it's used the hot tub to uneffect Flared Nostrils, since it clear negative effects. It's possible the hot tub should be used generally less aggressively.
> Sure, we can set the soft limit to like all uses and a hard limit of 1 or 2 maybe. So literally any other method would out rank it (last resort option) until we hit the hard limit then it's off the table unless dohottub is called somewhere explicitly. Just update a couple fields in autoscend_restoration.txt