### PR TITLE
Outfit acc normalization

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -80,6 +80,7 @@ boolean autoOutfit(string toWear)
 		boolean pass = true;
 		foreach i,it in outfit_pieces(toWear)
 		{
+			// Keep required accessories in acc3 slot to preserve our format
 			if(CommonOutfitAccessories contains $item(it))
 			{
 				pass = pass && autoEquip(acc3, it);

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -73,10 +73,21 @@ boolean autoOutfit(string toWear)
 	{
 		// yes I could use +outfit instead here but this makes it simpler to avoid failed maximize calls
 		auto_debug_print('Adding outfit "' + toWear + '" to maximizer statement', "gold");
+
+		// Accessory items from outfits we commonly wear
+		boolean[item] CommonOutfitAccessories = $items[eXtreme mittens, bejeweled pledge pin, round purple sunglasses];
+
 		boolean pass = true;
 		foreach i,it in outfit_pieces(toWear)
 		{
-			pass = pass && autoEquip(it);
+			if(CommonOutfitAccessories contains $item(it))
+			{
+				pass = pass && autoEquip(acc3, it);
+			}
+			else
+			{
+				pass = pass && autoEquip(it);
+			}
 		}
 		return pass;
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -67,7 +67,9 @@ boolean autoForceEquip(item it)
 boolean autoOutfit(string toWear)
 {
 	if(!have_outfit(toWear))
+	{
 		return false;
+	}
 
 	if(useMaximizeToEquip())
 	{
@@ -75,7 +77,7 @@ boolean autoOutfit(string toWear)
 		auto_debug_print('Adding outfit "' + toWear + '" to maximizer statement', "gold");
 
 		// Accessory items from outfits we commonly wear
-		boolean[item] CommonOutfitAccessories = $items[eXtreme mittens, bejeweled pledge pin, round purple sunglasses];
+		boolean[item] CommonOutfitAccessories = $items[eXtreme mittens, bejeweled pledge pin, round purple sunglasses, Oscus\'s pelt, Stuffed Shoulder Parrot];
 
 		boolean pass = true;
 		foreach i,it in outfit_pieces(toWear)

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -24,6 +24,24 @@ boolean autoEquip(slot s, item it)
 		return false;
 	}
 
+	// This logic lets us force the equipping of multiple accessories with minimal conflict
+	if(item_type($item[it]) == "accessory") && (s == $slot[acc3]) && (contains_text(get_property("auto_maximize_current"), "acc3")))
+	{
+		if(!contains_text(get_property("auto_maximize_current"), "acc2"))
+		{
+			slot s = $slot[acc2];
+		}
+		else if(!contains_text(get_property("auto_maximize_current"), "acc1"))
+		{
+			slot s = $slot[acc1];
+		}
+		else
+		{
+			print("We can not equip " + it + " because our slots are all full.", "red");
+			return false;
+		}
+	}
+
 	auto_debug_print("Equipping " + it + " to slot " + s, "gold");
 
 	if(useMaximizeToEquip())

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -634,7 +634,7 @@ void handlePostAdventure()
 			#Not sure if the ASH command actually handles it properly, we'll see.
 			#cli_execute("outfit Vile Vagrant Vestments");
 			#outfit does not... damn it.
-			if(!outfit("Vile Vagrant Vestments"))
+			if(!autoOutfit("Vile Vagrant Vestments"))
 			{
 				print("Could not wear Vile Vagrant Outfit for some raisin", "red");
 			}


### PR DESCRIPTION
# Description

Keeps accessories required by outfits (War outfits and eXtreme) in our reserved slot acc3

Fixes # (issue)
 Issues reported on Discord

## How Has This Been Tested?
Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
