### PR TITLE
fix to new restoration NPC store purchase logic

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -671,7 +671,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
       item i = to_item(metadata.name);
       boolean npc_buyable = npc_price(i) > 0 || (i.seller != $coinmaster[none] && is_accessible(i.seller) && get_property("autoSatisfyWithCoinmasters").to_boolean());
       boolean mall_buyable = can_interact() && auto_mall_price(i) > 0;
-      boolean can_buy = meat_reserve > my_meat() && (npc_buyable || mall_buyable);
+      boolean can_buy = meat_reserve < my_meat() && (npc_buyable || mall_buyable);
       return (available_amount(i) > 0 || can_buy);
     }
     if(metadata.type == "skill"){


### PR DESCRIPTION
# Description

new restoration logic will now buy restorers from NPC stores if appropriate.
Was previously checking `meat_reserve > my_meat()` which doesn't make much sense (only use the source when we have less than the amount of meat we want to keep on hand?).
Now checks for `meat_reserve < my_meat()`

Single character change.

Fixes #140 

## How Has This Been Tested?

Running HC Ed with this change right now. Also tested using `ash import <autoscend.ash> acquireMP(40, 1000);` in the cli.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
