### PR TITLE
adding auto_log functions as wrapper around print

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -57,3 +57,4 @@ auto_beta_test	boolean	Occasionally I might need to make big changes, but not wa
 auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
 auto_legacyConsumeStuff	boolean	When true, use the old heuristic-based consumption strategy instead of the new solver that tries to pack as many adventures into your organs as possible. Not used in CS or Ed.
 auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -98,8 +98,8 @@ void initializeSettings()
 		int sharkCountMax = ceil((curSkill + 1) * (curSkill + 1) / 4);
 		if(get_property("poolSharkCount").to_int() < sharkCountMin || get_property("poolSharkCount").to_int() >= sharkCountMax)
 		{
-			print("poolSharkCount set to incorrect value.", "red");
-			print("You can \"set poolSharkCount="+sharkCountMin+"\" to use the least optimistic value consistent with your pool skill.", "blue");
+			auto_log_warning("poolSharkCount set to incorrect value.", "red");
+			auto_log_info("You can \"set poolSharkCount="+sharkCountMin+"\" to use the least optimistic value consistent with your pool skill.", "blue");
 		}
 	}
 
@@ -306,14 +306,14 @@ boolean handleFamiliar(string type)
 
 		string [string,int,string] familiars_text;
 		if(!file_to_map("autoscend_familiars.txt", familiars_text))
-			print("Could not load autoscend_familiars.txt. This is bad!", "red");
+			auto_log_critical("Could not load autoscend_familiars.txt. This is bad!", "red");
 		foreach i,name,conds in familiars_text[type]
 		{
 			familiar thisFamiliar = name.to_familiar();
 			if(thisFamiliar == $familiar[none] && name != "none")
 			{
-				print('"' + name + '" does not convert to a familiar properly!', "red");
-				print(type + "; " + i + "; " + conds, "red");
+				auto_log_error('"' + name + '" does not convert to a familiar properly!', "red");
+				auto_log_error(type + "; " + i + "; " + conds, "red");
 				continue;
 			}
 			if(!auto_check_conditions(conds))
@@ -428,13 +428,9 @@ boolean handleFamiliar(string type)
 
 		int index = 0;
 		while(index < count(fams))
-#		foreach fam in $familiars[Rockin\' Robin, Grimstone Golem, Angry Jung Man, Intergnat, Bloovian Groose, Fist Turkey, Slimeling, Jumpsuited Hound Dog, Adventurous Spelunker, Gelatinous Cubeling, Baby Gravy Fairy, Obtuse Angel, Pair of Stomping Boots, Jack-in-the-Box, Syncopated Turtle]
 		{
-			#if(auto_have_familiar(fam) && !(blacklist contains fam))
-			#print("Looking for " + fams[index] + " at: " + index, "blue");
 			if(auto_have_familiar(fams[index]) && !(blacklist contains fams[index]))
 			{
-#				return handleFamiliar(fam);
 				return handleFamiliar(fams[index]);
 			}
 			index = index + 1;
@@ -682,7 +678,7 @@ boolean LX_burnDelay()
 	{
 		if(auto_voteMonster(true))
 		{
-			print("Burn some delay somewhere (voting), if we found a place!", "green");
+			auto_log_info("Burn some delay somewhere (voting), if we found a place!", "green");
 			if(auto_voteMonster(true, burnZone, ""))
 			{
 				return true;
@@ -690,7 +686,7 @@ boolean LX_burnDelay()
 		}
 		if(isOverdueDigitize())
 		{
-			print("Burn some delay somewhere (digitize), if we found a place!", "green");
+			auto_log_info("Burn some delay somewhere (digitize), if we found a place!", "green");
 			if(autoAdv(burnZone))
 			{
 				return true;
@@ -698,7 +694,7 @@ boolean LX_burnDelay()
 		}
 		if(auto_sausageGoblin())
 		{
-			print("Burn some delay somewhere (sausage goblin), if we found a place!", "green");
+			auto_log_info("Burn some delay somewhere (sausage goblin), if we found a place!", "green");
 			if(auto_sausageGoblin(burnZone, ""))
 			{
 				return true;
@@ -707,9 +703,9 @@ boolean LX_burnDelay()
 	}
 	else if(wannaVote || wannaDigitize || wannaSausage)
 	{
-		if(wannaVote) print("Had overdue voting monster but couldn't find a zone to burn delay", "red");
-		if(wannaDigitize) print("Had overdue digitize but couldn't find a zone to burn delay", "red");
-		if(wannaSausage) print("Had overdue sausage but couldn't find a zone to burn delay", "red");
+		if(wannaVote) auto_log_warning("Had overdue voting monster but couldn't find a zone to burn delay", "red");
+		if(wannaDigitize) auto_log_warning("Had overdue digitize but couldn't find a zone to burn delay", "red");
+		if(wannaSausage) auto_log_warning("Had overdue sausage but couldn't find a zone to burn delay", "red");
 	}
 	return false;
 }
@@ -912,10 +908,6 @@ item[monster] catBurglarHeistDesires()
 			wannaHeists[$monster[Burly Sidekick]] = $item[Mohawk wig];
 	}
 
-	// foreach mon, it in wannaHeists
-	// {
-	//	auto_debug_print("catBurglarHeistDesires(): Want to heist a " + it + " from a " + mon);
-	// }
 	return wannaHeists;
 }
 
@@ -1051,7 +1043,7 @@ int pullsNeeded(string data)
 		ns_hedge2();
 		ns_hedge3();
 
-		print("Hedge time of 4 adventures. (Up to 10 without Elemental Resistances)", "red");
+		auto_log_warning("Hedge time of 4 adventures. (Up to 10 without Elemental Resistances)", "red");
 		adv = adv + 4;
 	}
 
@@ -1059,10 +1051,10 @@ int pullsNeeded(string data)
 	{
 		if((item_amount($item[Richard\'s Star Key]) == 0) && (item_amount($item[Star Chart]) == 0))
 		{
-			print("Need star chart", "red");
+			auto_log_warning("Need star chart", "red");
 			if((auto_my_path() == "Heavy Rains") && (my_rain() >= 50))
 			{
-				print("You should rain man a star chart", "blue");
+				auto_log_info("You should rain man a star chart", "blue");
 			}
 			else
 			{
@@ -1077,19 +1069,19 @@ int pullsNeeded(string data)
 
 			if(stars < 8)
 			{
-				print("Need " + (8-stars) + " stars.", "red");
+				auto_log_warning("Need " + (8-stars) + " stars.", "red");
 				count = count + (8-stars);
 			}
 			if(lines < 7)
 			{
-				print("Need " + (7-lines) + " lines.", "red");
+				auto_log_warning("Need " + (7-lines) + " lines.", "red");
 				count = count + (7-lines);
 			}
 		}
 
 		if((item_amount($item[Digital Key]) == 0) && (item_amount($item[White Pixel]) < 30))
 		{
-			print("Need " + (30-item_amount($item[white pixel])) + " white pixels.", "red");
+			auto_log_warning("Need " + (30-item_amount($item[white pixel])) + " white pixels.", "red");
 			count = count + (30 - item_amount($item[white pixel]));
 		}
 
@@ -1102,7 +1094,7 @@ int pullsNeeded(string data)
 		}
 		if(item_amount($item[skeleton key]) == 0)
 		{
-			print("Need a skeleton key or the ingredients (skeleton bone, loose teeth) for it.");
+			auto_log_warning("Need a skeleton key or the ingredients (skeleton bone, loose teeth) for it.");
 		}
 	}
 
@@ -1111,22 +1103,22 @@ int pullsNeeded(string data)
 		adv = adv + 6;
 		if(get_property("auto_wandOfNagamar").to_boolean() && (item_amount($item[Wand Of Nagamar]) == 0) && (cloversAvailable() == 0))
 		{
-			print("Need a wand of nagamar (can be clovered).", "red");
+			auto_log_warning("Need a wand of nagamar (can be clovered).", "red");
 			count = count + 1;
 		}
 	}
 
 	if(adv > 0)
 	{
-		print("Estimated adventure need (tower) is: " + adv + ".", "orange");
+		auto_log_info("Estimated adventure need (tower) is: " + adv + ".", "orange");
 		if(!in_hardcore())
 		{
-			print("You need " + count + " pulls.", "orange");
+			auto_log_info("You need " + count + " pulls.", "orange");
 		}
 	}
 	if(pulls_remaining() > 0)
 	{
-		print("You have " + pulls_remaining() + " pulls.", "orange");
+		auto_log_info("You have " + pulls_remaining() + " pulls.", "orange");
 	}
 	return count;
 }
@@ -1189,7 +1181,7 @@ boolean tophatMaker()
 		return false;
 	}
 
-	print("Mark Steam-Hat upgraded!", "blue");
+	auto_log_info("Mark Steam-Hat upgraded!", "blue");
 	if(reEquip != $item[none])
 	{
 		equip($slot[hat], reEquip);
@@ -1321,7 +1313,7 @@ boolean doThemtharHills()
 
 	if(get_property("auto_hippyInstead").to_boolean() || (get_property("hippiesDefeated").to_int() >= 192))
 	{
-		print("Themthar Nuns!", "blue");
+		auto_log_info("Themthar Nuns!", "blue");
 	}
 
 	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
@@ -1352,7 +1344,7 @@ boolean doThemtharHills()
 			visit_url("charsheet.php");
 			if(have_skill($skill[Gift of the Maid]))
 			{
-				print("Gift of the Maid not properly detected until charsheet refresh.", "red");
+				auto_log_warning("Gift of the Maid not properly detected until charsheet refresh.", "red");
 			}
 		}
 	}
@@ -1460,11 +1452,11 @@ boolean doThemtharHills()
 	}
 	if(meatDropHave < meat_need)
 	{
-		print("Meat drop (" + meatDropHave+ ") is pretty low, (we want: " + meat_need + ") probably not worth it to try this.", "red");
+		auto_log_warning("Meat drop (" + meatDropHave+ ") is pretty low, (we want: " + meat_need + ") probably not worth it to try this.", "red");
 
 		float minget = 800.00 * (meatDropHave / 100.0);
 		int meatneed = 100000 - get_property("currentNunneryMeat").to_int();
-		print("The min we expect is: " + minget + " and we need: " + meatneed, "blue");
+		auto_log_info("The min we expect is: " + minget + " and we need: " + meatneed, "blue");
 
 		if(minget < meatneed)
 		{
@@ -1479,7 +1471,7 @@ boolean doThemtharHills()
 				float needPerAdv = needMeat / advLeft;
 				if(minget > needPerAdv)
 				{
-					print("We don't have the desired +meat but should be able to complete the nuns to our advantage", "green");
+					auto_log_info("We don't have the desired +meat but should be able to complete the nuns to our advantage", "green");
 					failNuns = false;
 				}
 			}
@@ -1493,7 +1485,7 @@ boolean doThemtharHills()
 		}
 		else
 		{
-			print("The min should be enough! Doing it!!", "purple");
+			auto_log_info("The min should be enough! Doing it!!", "purple");
 		}
 	}
 
@@ -1518,7 +1510,7 @@ boolean doThemtharHills()
 
 		int lastMeat = get_property("currentNunneryMeat").to_int();
 		int myLastMeat = my_meat();
-		print("Meat drop to start: " + meat_drop_modifier(), "blue");
+		auto_log_info("Meat drop to start: " + meat_drop_modifier(), "blue");
 		if(!autoAdv(1, $location[The Themthar Hills]))
 		{
 			//Maybe we passed it!
@@ -1545,7 +1537,7 @@ boolean doThemtharHills()
 		int diffMeat = curMeat - lastMeat;
 		int needMeat = 100000 - curMeat;
 		int average = curMeat / advs;
-		print("Cur Meat: " + curMeat + " Average: " + average, "blue");
+		auto_log_info("Cur Meat: " + curMeat + " Average: " + average, "blue");
 
 		diffMeat = diffMeat * 1.2;
 		average = average * 1.2;
@@ -1583,7 +1575,7 @@ int handlePulls(int day)
 		# Do starting pulls:
 		if((pulls_remaining() != 20) && !in_hardcore() && (my_turncount() > 0))
 		{
-			print("I assume you've handled your pulls yourself... who knows.");
+			auto_log_info("I assume you've handled your pulls yourself... who knows.");
 			return 0;
 		}
 
@@ -1794,7 +1786,7 @@ int handlePulls(int day)
 
 		if(my_class() == $class[Vampyre])
 		{
-			print("You are a powerful vampire who is doing a softcore run. Turngen is busted in this path, so let's see how much we can get.", "blue");
+			auto_log_info("You are a powerful vampire who is doing a softcore run. Turngen is busted in this path, so let's see how much we can get.", "blue");
 			if((storage_amount($item[mime army shotglass]) > 0) && is_unrestricted($item[mime army shotglass]))
 			{
 				pullXWhenHaveY($item[mime army shotglass], 1, 0);
@@ -1857,7 +1849,7 @@ boolean fortuneCookieEvent()
 {
 	if(get_counters("Fortune Cookie", 0, 0) == "Fortune Cookie")
 	{
-		print("Semi rare time!", "blue");
+		auto_log_info("Semi rare time!", "blue");
 		cli_execute("counters");
 		cli_execute("counters clear");
 
@@ -1910,7 +1902,7 @@ boolean fortuneCookieEvent()
 
 		if((goal == $location[The Outskirts of Cobb\'s Knob]) && (get_property("semirareLocation") == goal))
 		{
-			print("Do we not have access to either The Haunted Pantry or The Sleazy Back Alley?", "red");
+			auto_log_warning("Do we not have access to either The Haunted Pantry or The Sleazy Back Alley?", "red");
 			goal = $location[The Haunted Pantry];
 		}
 
@@ -1955,7 +1947,7 @@ void initializeDay(int day)
 
 	if(item_amount($item[Telegram From Lady Spookyraven]) > 0)
 	{
-		print("Lady Spookyraven quest not detected as started should have been auto-started. Starting it. If you are not in an Ed run, report this. Otherwise, it is expected.", "red");
+		auto_log_warning("Lady Spookyraven quest not detected as started should have been auto-started. Starting it. If you are not in an Ed run, report this. Otherwise, it is expected.", "red");
 		use(1, $item[Telegram From Lady Spookyraven]);
 		set_property("questM20Necklace", "started");
 	}
@@ -1964,12 +1956,12 @@ void initializeDay(int day)
 	{
 		if(item_amount($item[Telegram From Lady Spookyraven]) > 0)
 		{
-			print("Lady Spookyraven quest not started and we have a Telegram so let us use it.", "red");
+			auto_log_warning("Lady Spookyraven quest not started and we have a Telegram so let us use it.", "red");
 			boolean temp = use(1, $item[Telegram From Lady Spookyraven]);
 		}
 		else
 		{
-			print("Lady Spookyraven quest not detected as started but we don't have the telegram, assuming it is... If you are not in an Ed run, report this. Otherwise, it is expected.", "red");
+			auto_log_warning("Lady Spookyraven quest not detected as started but we don't have the telegram, assuming it is... If you are not in an Ed run, report this. Otherwise, it is expected.", "red");
 			set_property("questM20Necklace", "started");
 		}
 	}
@@ -2423,7 +2415,7 @@ boolean dailyEvents()
 
 boolean doBedtime()
 {
-	print("Starting bedtime: Pulls Left: " + pulls_remaining(), "blue");
+	auto_log_info("Starting bedtime: Pulls Left: " + pulls_remaining(), "blue");
 
 	if(get_property("lastEncounter") == "Like a Bat Into Hell")
 	{
@@ -2526,7 +2518,7 @@ boolean doBedtime()
 
 	if(get_property("auto_priorCharpaneMode").to_int() == 1)
 	{
-		print("Resuming Compact Character Mode.");
+		auto_log_info("Resuming Compact Character Mode.");
 		set_property("auto_priorCharpaneMode", 0);
 		visit_url("account.php?am=1&pwd=&action=flag_compactchar&value=1&ajax=0", true);
 	}
@@ -2542,30 +2534,30 @@ boolean doBedtime()
 		{
 			if(item_amount($item[Rain-Doh Indigo Cup]) > 0)
 			{
-				print("Copies left: " + (5 - get_property("_raindohCopiesMade").to_int()), "olive");
+				auto_log_info("Copies left: " + (5 - get_property("_raindohCopiesMade").to_int()), "olive");
 			}
 			if(!in_hardcore())
 			{
-				print("Pulls remaining: " + pulls_remaining(), "olive");
+				auto_log_info("Pulls remaining: " + pulls_remaining(), "olive");
 			}
 			if(item_amount($item[beer helmet]) == 0)
 			{
-				print("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
+				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 				if(canYellowRay())
 				{
-					print("Make sure to Ball Lightning the spy!!", "red");
+					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
 				}
 			}
 			else
 			{
-				print("If you have the Frat Warrior Fatigues, rain man an Astronomer? Skinflute?", "blue");
+				auto_log_info("If you have the Frat Warrior Fatigues, rain man an Astronomer? Skinflute?", "blue");
 			}
 		}
 		if(auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (inebriety_left() >= 0) && (my_adventures() > 0))
 		{
-			print("You have " + (5 - get_property("_machineTunnelsAdv").to_int()) + " fights in The Deep Machine Tunnels that you should use!", "blue");
+			auto_log_info("You have " + (5 - get_property("_machineTunnelsAdv").to_int()) + " fights in The Deep Machine Tunnels that you should use!", "blue");
 		}
-		print("You have a rain man to cast, please do so before overdrinking and run me again.", "red");
+		auto_log_info("You have a rain man to cast, please do so before overdrinking and run me again.", "red");
 		return false;
 	}
 
@@ -2584,7 +2576,7 @@ boolean doBedtime()
 	}
 	if(canGenieCombat() && item_amount($item[beer helmet]) == 0)
 	{
-		print("Please consider genie wishing for an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
+		auto_log_info("Please consider genie wishing for an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 	}
 
 	if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
@@ -2696,8 +2688,8 @@ boolean doBedtime()
 	// If in TCRS skip using freecrafts but alert user of how many they can manually use.
 	if((in_tcrs()) && (freeCrafts() > 0))
 	{
-		print("In TCRS: Items are variable, skipping End Of Day crafting", "red");
-		print("Consider manually using your "+freeCrafts()+" free crafts", "red");
+		auto_log_warning("In TCRS: Items are variable, skipping End Of Day crafting", "red");
+		auto_log_warning("Consider manually using your "+freeCrafts()+" free crafts", "red");
 	}
 	else if((my_daycount() <= 2) && (freeCrafts() > 0) && my_adventures() > 0)
 	{
@@ -2889,42 +2881,42 @@ boolean doBedtime()
 		int extrudeLeft = 3 - get_property("_sourceTerminalExtrudes").to_int();
 		if((extrudeLeft > 0) && (auto_my_path() != "Pocket Familiars") && (item_amount($item[Source Essence]) >= 10))
 		{
-			print("You still have " + extrudeLeft + " Source Extrusions left", "blue");
+			auto_log_info("You still have " + extrudeLeft + " Source Extrusions left", "blue");
 		}
 	}
 
 	if(item_amount($item[Rain-Doh Indigo Cup]) > 0)
 	{
-		print("Copies left: " + (5 - get_property("_raindohCopiesMade").to_int()), "olive");
+		auto_log_info("Copies left: " + (5 - get_property("_raindohCopiesMade").to_int()), "olive");
 	}
 	if(!in_hardcore())
 	{
-		print("Pulls remaining: " + pulls_remaining(), "olive");
+		auto_log_info("Pulls remaining: " + pulls_remaining(), "olive");
 	}
 
 	if(have_skill($skill[Inigo\'s Incantation of Inspiration]))
 	{
 		int craftingLeft = 5 - get_property("_inigosCasts").to_int();
-		print("Free Inigo\'s craftings left: " + craftingLeft, "blue");
+		auto_log_info("Free Inigo\'s craftings left: " + craftingLeft, "blue");
 	}
 	if(item_amount($item[Loathing Legion Jackhammer]) > 0)
 	{
 		int craftingLeft = 3 - get_property("_legionJackhammerCrafting").to_int();
-		print("Free Loathing Legion Jackhammer craftings left: " + craftingLeft, "blue");
+		auto_log_info("Free Loathing Legion Jackhammer craftings left: " + craftingLeft, "blue");
 	}
 	if(item_amount($item[Thor\'s Pliers]) > 0)
 	{
 		int craftingLeft = 10 - get_property("_thorsPliersCrafting").to_int();
-		print("Free Thor's Pliers craftings left: " + craftingLeft, "blue");
+		auto_log_info("Free Thor's Pliers craftings left: " + craftingLeft, "blue");
 	}
 	if(freeCrafts() > 0)
 	{
-		print("Free craftings left: " + freeCrafts(), "blue");
+		auto_log_info("Free craftings left: " + freeCrafts(), "blue");
 	}
 	if(get_property("timesRested").to_int() < total_free_rests())
 	{
 		cs_spendRests();
-		print("You have " + (total_free_rests() - get_property("timesRested").to_int()) + " free rests remaining.", "blue");
+		auto_log_info("You have " + (total_free_rests() - get_property("timesRested").to_int()) + " free rests remaining.", "blue");
 	}
 	if(possessEquipment($item[Kremlin\'s Greatest Briefcase]) && (get_property("_kgbClicksUsed").to_int() < 24))
 	{
@@ -2932,16 +2924,16 @@ boolean doBedtime()
 		int clicks = 22 - get_property("_kgbClicksUsed").to_int();
 		if(clicks > 0)
 		{
-			print("You have some KGB clicks (" + clicks + ") left!", "green");
+			auto_log_info("You have some KGB clicks (" + clicks + ") left!", "green");
 		}
 	}
 	if((get_property("sidequestNunsCompleted") == "fratboy") && (get_property("nunsVisits").to_int() < 3))
 	{
-		print("You have " + (3 - get_property("nunsVisits").to_int()) + " nuns visits left.", "blue");
+		auto_log_info("You have " + (3 - get_property("nunsVisits").to_int()) + " nuns visits left.", "blue");
 	}
 	if(get_property("libramSummons").to_int() > 0)
 	{
-		print("Total Libram Summons: " + get_property("libramSummons"), "blue");
+		auto_log_info("Total Libram Summons: " + get_property("libramSummons"), "blue");
 	}
 
 	int smiles = (5 * (item_amount($item[Golden Mr. Accessory]) + storage_amount($item[Golden Mr. Accessory]) + closet_amount($item[Golden Mr. Accessory]))) - get_property("_smilesOfMrA").to_int();
@@ -2957,21 +2949,21 @@ boolean doBedtime()
 		}
 		else
 		{
-			print("You have " + smiles + " smiles of Mr. A remaining.", "blue");
+			auto_log_info("You have " + smiles + " smiles of Mr. A remaining.", "blue");
 		}
 	}
 
 	if((item_amount($item[CSA Fire-Starting Kit]) > 0) && (!get_property("_fireStartingKitUsed").to_boolean()))
 	{
-		print("Still have a CSA Fire-Starting Kit you can use!", "blue");
+		auto_log_info("Still have a CSA Fire-Starting Kit you can use!", "blue");
 	}
 	if((item_amount($item[Glenn\'s Golden Dice]) > 0) && (!get_property("_glennGoldenDiceUsed").to_boolean()))
 	{
-		print("Still have some of Glenn's Golden Dice that you can use!", "blue");
+		auto_log_info("Still have some of Glenn's Golden Dice that you can use!", "blue");
 	}
 	if((item_amount($item[License to Chill]) > 0) && (!get_property("_licenseToChillUsed").to_boolean()))
 	{
-		print("You are still licensed enough to be able to chill.", "blue");
+		auto_log_info("You are still licensed enough to be able to chill.", "blue");
 	}
 
 	if((item_amount($item[School of Hard Knocks Diploma]) > 0) && (!get_property("_hardKnocksDiplomaUsed").to_boolean()))
@@ -3019,35 +3011,35 @@ boolean doBedtime()
 	}
 	if(!done)
 	{
-		print("Goodnight done, please make sure to handle your overdrinking, then you can run me again.", "blue");
+		auto_log_info("Goodnight done, please make sure to handle your overdrinking, then you can run me again.", "blue");
 		if(auto_have_familiar($familiar[Stooper]) && (inebriety_left() == 0) && (my_familiar() != $familiar[Stooper]) && (auto_my_path() != "Pocket Familiars"))
 		{
-			print("You have a Stooper, you can increase liver by 1!", "blue");
+			auto_log_info("You have a Stooper, you can increase liver by 1!", "blue");
 			use_familiar($familiar[Stooper]);
 		}
 		if(auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5))
 		{
-			print("You have " + (5 - get_property("_machineTunnelsAdv").to_int()) + " fights in The Deep Machine Tunnels that you should use!", "blue");
+			auto_log_info("You have " + (5 - get_property("_machineTunnelsAdv").to_int()) + " fights in The Deep Machine Tunnels that you should use!", "blue");
 		}
 		if((my_inebriety() <= inebriety_limit()) && (my_rain() >= 50) && (my_adventures() >= 1))
 		{
 			if(item_amount($item[beer helmet]) == 0)
 			{
-				print("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
+				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 				if(canYellowRay())
 				{
-					print("Make sure to Ball Lightning the spy!!", "red");
+					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
 				}
 			}
 			else
 			{
-				print("If you have the Frat Warrior Fatigues, rain man an Astronomer? Skinflute?", "blue");
+				auto_log_info("If you have the Frat Warrior Fatigues, rain man an Astronomer? Skinflute?", "blue");
 			}
-			print("You have a rain man to cast, please do so before overdrinking and then run me again.", "red");
+			auto_log_info("You have a rain man to cast, please do so before overdrinking and then run me again.", "red");
 			return false;
 		}
 		auto_autoDrinkNightcap(true); // simulate;
-		print("You need to overdrink and then run me again. Beep.", "red");
+		auto_log_warning("You need to overdrink and then run me again. Beep.", "red");
 		if(have_skill($skill[The Ode to Booze]))
 		{
 			shrugAT($effect[Ode to Booze]);
@@ -3059,12 +3051,12 @@ boolean doBedtime()
 	{
 		if(!get_property("kingLiberated").to_boolean())
 		{
-			print(get_property("auto_banishes_day" + my_daycount()));
-			print(get_property("auto_yellowRay_day" + my_daycount()));
+			auto_log_info(get_property("auto_banishes_day" + my_daycount()));
+			auto_log_info(get_property("auto_yellowRay_day" + my_daycount()));
 			pullsNeeded("evaluate");
 			if(!get_property("_photocopyUsed").to_boolean() && (is_unrestricted($item[Deluxe Fax Machine])) && (my_adventures() > 0) && !($classes[Avatar of Boris, Avatar of Sneaky Pete] contains my_class()) && (item_amount($item[Clan VIP Lounge Key]) > 0))
 			{
-				print("You may have a fax that you can use. Check it out!", "blue");
+				auto_log_info("You may have a fax that you can use. Check it out!", "blue");
 			}
 			if((pulls_remaining() > 0) && (my_daycount() == 1))
 			{
@@ -3089,33 +3081,33 @@ boolean doBedtime()
 						}
 					}
 				}
-				print("You still have pulls, consider: " + consider + "?", "red");
+				auto_log_warning("You still have pulls, consider: " + consider + "?", "red");
 			}
 		}
 
 		if(have_skill($skill[Calculate the Universe]) && (get_property("_universeCalculated").to_int() < get_property("skillLevel144").to_int()))
 		{
-			print("You can still Calculate the Universe!", "blue");
+			auto_log_info("You can still Calculate the Universe!", "blue");
 		}
 
 		if(is_unrestricted($item[Deck of Every Card]) && (item_amount($item[Deck of Every Card]) > 0) && (get_property("_deckCardsDrawn").to_int() < 15))
 		{
-			print("You have a Deck of Every Card and " + (15 - get_property("_deckCardsDrawn").to_int()) + " draws remaining!", "blue");
+			auto_log_info("You have a Deck of Every Card and " + (15 - get_property("_deckCardsDrawn").to_int()) + " draws remaining!", "blue");
 		}
 
 		if(is_unrestricted($item[Time-Spinner]) && (item_amount($item[Time-Spinner]) > 0) && (get_property("_timeSpinnerMinutesUsed").to_int() < 10) && glover_usable($item[Time-Spinner]))
 		{
-			print("You have " + (10 - get_property("_timeSpinnerMinutesUsed").to_int()) + " minutes left to Time-Spinner!", "blue");
+			auto_log_info("You have " + (10 - get_property("_timeSpinnerMinutesUsed").to_int()) + " minutes left to Time-Spinner!", "blue");
 		}
 
 		if(is_unrestricted($item[Chateau Mantegna Room Key]) && !get_property("_chateauMonsterFought").to_boolean() && get_property("chateauAvailable").to_boolean())
 		{
-			print("You can still fight a Chateau Mangtegna Painting today.", "blue");
+			auto_log_info("You can still fight a Chateau Mangtegna Painting today.", "blue");
 		}
 
 		if(stills_available() > 0)
 		{
-			print("You have " + stills_available() + " uses of Nash Crosby's Still left.", "blue");
+			auto_log_info("You have " + stills_available() + " uses of Nash Crosby's Still left.", "blue");
 		}
 
 		if(!get_property("_streamsCrossed").to_boolean() && possessEquipment($item[Protonic Accelerator Pack]))
@@ -3125,28 +3117,28 @@ boolean doBedtime()
 
 		if(is_unrestricted($item[shrine to the Barrel God]) && !get_property("_barrelPrayer").to_boolean() && get_property("barrelShrineUnlocked").to_boolean())
 		{
-			print("You can still worship the barrel god today.", "blue");
+			auto_log_info("You can still worship the barrel god today.", "blue");
 		}
 		if(is_unrestricted($item[Airplane Charter: Dinseylandfill]) && !get_property("_dinseyGarbageDisposed").to_boolean() && elementalPlanes_access($element[stench]))
 		{
 			if((item_amount($item[bag of park garbage]) > 0) || (pulls_remaining() > 0))
 			{
-				print("You can still dispose of Garbage in Dinseyland.", "blue");
+				auto_log_info("You can still dispose of Garbage in Dinseyland.", "blue");
 			}
 		}
 		if(is_unrestricted($item[Airplane Charter: That 70s Volcano]) && !get_property("_infernoDiscoVisited").to_boolean() && elementalPlanes_access($element[hot]))
 		{
 			if((item_amount($item[Smooth Velvet Hat]) > 0) || (item_amount($item[Smooth Velvet Shirt]) > 0) || (item_amount($item[Smooth Velvet Pants]) > 0) || (item_amount($item[Smooth Velvet Hanky]) > 0) || (item_amount($item[Smooth Velvet Pocket Square]) > 0) || (item_amount($item[Smooth Velvet Socks]) > 0))
 			{
-				print("You can still disco inferno at the Inferno Disco.", "blue");
+				auto_log_info("You can still disco inferno at the Inferno Disco.", "blue");
 			}
 		}
 		if(is_unrestricted($item[Potted Tea Tree]) && !get_property("_pottedTeaTreeUsed").to_boolean() && (auto_get_campground() contains $item[Potted Tea Tree]))
 		{
-			print("You have a tea tree to shake!", "blue");
+			auto_log_info("You have a tea tree to shake!", "blue");
 		}
 
-		print("You are probably done for today, beep.", "blue");
+		auto_log_info("You are probably done for today, beep.", "blue");
 		return true;
 	}
 	return false;
@@ -3167,80 +3159,72 @@ boolean questOverride()
 	// Visiting the campground doesn\'t work.... grrr...
 	//	visit_url("campground.php");
 
-#	if(!get_property("auto_haveoven").to_boolean())
-#	{
-#		if(auto_get_campground() contains $item[Dramatic&trade; range])
-#		{
-#			set_property("auto_haveoven", true);
-#		}
-#	}
-
 	if((get_property("lastTempleUnlock").to_int() == my_ascensions()) && (get_property("auto_treecoin") != "finished"))
 	{
-		print("Found Unlocked Hidden Temple but unaware of tree-holed coin (2)");
+		auto_log_info("Found Unlocked Hidden Temple but unaware of tree-holed coin (2)");
 		set_property("auto_treecoin", "finished");
 	}
 	if((get_property("lastTempleUnlock").to_int() == my_ascensions()) && (get_property("auto_spookymap") != "finished"))
 	{
-		print("Found Unlocked Hidden Temple but unaware of spooky map (2)");
+		auto_log_info("Found Unlocked Hidden Temple but unaware of spooky map (2)");
 		set_property("auto_spookymap", "finished");
 	}
 	if((get_property("lastTempleUnlock").to_int() == my_ascensions()) && (get_property("auto_spookyfertilizer") != "finished"))
 	{
-		print("Found Unlocked Hidden Temple but unaware of spooky fertilizer (2)");
+		auto_log_info("Found Unlocked Hidden Temple but unaware of spooky fertilizer (2)");
 		set_property("auto_spookyfertilizer", "finished");
 	}
 	if((get_property("lastTempleUnlock").to_int() == my_ascensions()) && (get_property("auto_spookysapling") != "finished"))
 	{
-		print("Found Unlocked Hidden Temple but unaware of spooky sapling (2)");
+		auto_log_info("Found Unlocked Hidden Temple but unaware of spooky sapling (2)");
 		set_property("auto_spookysapling", "finished");
 	}
 
 	if((get_property("questL02Larva") == "finished") && (get_property("auto_mosquito") != "finished"))
 	{
-		print("Found completed Mosquito Larva (2)");
+		auto_log_info("Found completed Mosquito Larva (2)");
 		set_property("auto_mosquito", "finished");
 	}
 	if((get_property("questL03Rat") == "finished") && (get_property("auto_tavern") != "finished"))
 	{
-		print("Found completed Tavern (3)");
+		auto_log_info("Found completed Tavern (3)");
 		set_property("auto_tavern", "finished");
 	}
 	if((get_property("questL04Bat") == "finished") && (get_property("auto_bat") != "finished"))
 	{
-		print("Found completed Bat Cave (4)");
+		auto_log_info("Found completed Bat Cave (4)");
 		set_property("auto_bat", "finished");
 	}
 	if((get_property("questL05Goblin") == "finished") && (get_property("auto_goblinking") != "finished"))
 	{
-		print("Found completed Goblin King (5)");
+		auto_log_info("Found completed Goblin King (5)");
 		set_property("auto_day1_cobb", "finished");
 		set_property("auto_goblinking", "finished");
 	}
 	if((get_property("questL06Friar") == "finished") && (get_property("auto_friars") != "done") && (get_property("auto_friars") != "finished"))
 	{
-		print("Found completed Friars (6)");
+		auto_log_info("Found completed Friars (6)");
 		set_property("auto_friars", "done");
 	}
 	if((get_property("questL07Cyrptic") == "finished") && (get_property("auto_crypt") != "finished"))
 	{
-		print("Found completed Cyrpt (7)");
+		auto_log_info("Found completed Cyrpt (7)");
 		set_property("auto_crypt", "finished");
 	}
 	if((get_property("questL08Trapper") == "step2") && (get_property("auto_trapper") != "yeti"))
 	{
-		print("Found Trapper partially completed (8: Ores/Cheese)");
+		auto_log_info("Found Trapper partially completed (8: Ores/Cheese)");
 		set_property("auto_trapper", "yeti");
 	}
 	if((get_property("questL08Trapper") == "finished") && (get_property("auto_trapper") != "finished"))
 	{
-		print("Found completed Trapper (8)");
+		auto_log_info("Found completed Trapper (8)");
 		set_property("auto_trapper", "finished");
 	}
 
 	if((get_property("questL09Topping") == "finished") && (get_property("auto_highlandlord") != "finished"))
 	{
-		print("Found completed Highland Lord (9)");
+		auto_log_info("Found completed Highland Lord (9)");
 		set_property("auto_highlandlord", "finished");
 		set_property("auto_boopeak", "finished");
 		set_property("auto_oilpeak", "finished");
@@ -3248,7 +3232,7 @@ boolean questOverride()
 	}
 	if((get_property("questL10Garbage") == "finished") && (get_property("auto_castletop") != "finished"))
 	{
-		print("Found completed Castle in the Clouds in the Sky with some Pie (10)");
+		auto_log_info("Found completed Castle in the Clouds in the Sky with some Pie (10)");
 		set_property("auto_castletop", "finished");
 		set_property("auto_castleground", "finished");
 		set_property("auto_castlebasement", "finished");
@@ -3257,34 +3241,28 @@ boolean questOverride()
 	}
 	if((internalQuestStatus("questL10Garbage") >= 9) && (get_property("auto_castleground") != "finished"))
 	{
-		print("Found completed Castle Ground Floor (10)");
+		auto_log_info("Found completed Castle Ground Floor (10)");
 		set_property("auto_castleground", "finished");
 	}
 	if((internalQuestStatus("questL10Garbage") >= 8) && (get_property("auto_castlebasement") != "finished"))
 	{
-		print("Found completed Castle Basement (10)");
+		auto_log_info("Found completed Castle Basement (10)");
 		set_property("auto_castlebasement", "finished");
 	}
 	if((internalQuestStatus("questL10Garbage") >= 7) && (get_property("auto_airship") != "finished"))
 	{
-		print("Found completed Airship (10)");
+		auto_log_info("Found completed Airship (10)");
 		set_property("auto_airship", "finished");
 	}
 	if((internalQuestStatus("questL10Garbage") >= 2) && !get_property("auto_bean").to_boolean())
 	{
-		print("Found completed Planted Beanstalk (10)");
+		auto_log_info("Found completed Planted Beanstalk (10)");
 		set_property("auto_bean", true);
 	}
 
-#	if((get_property("lastSecondFloorUnlock").to_int() >= my_ascensions()) && (get_property("auto_spookyravennecklace") != "done"))
-#	{
-#		print("Found completed Spookyraven Necklace Sequence (M20)");
-#		set_property("auto_spookyravennecklace", "done");
-#	}
-
 	if((internalQuestStatus("questL11Manor") >= 11) && (get_property("auto_ballroom") != "finished"))
 	{
-		print("Found completed Spookyraven Manor (11)");
+		auto_log_info("Found completed Spookyraven Manor (11)");
 		set_property("auto_ballroom", "finished");
 		set_property("auto_winebomb", "finished");
 		set_property("auto_ballroomflat", "finished");
@@ -3292,7 +3270,7 @@ boolean questOverride()
 
 	if((internalQuestStatus("questL11Manor") >= 3) && (get_property("auto_winebomb") != "finished"))
 	{
-		print("Found completed Spookyraven Manor Organ Music (11)");
+		auto_log_info("Found completed Spookyraven Manor Organ Music (11)");
 		set_property("auto_winebomb", "finished");
 		set_property("auto_masonryWall", true);
 		set_property("auto_ballroomflat", "finished");
@@ -3300,71 +3278,66 @@ boolean questOverride()
 
 	if((internalQuestStatus("questL11Manor") >= 1) && (get_property("auto_ballroomflat") != "finished"))
 	{
-		print("Found completed Spookyraven Manor Organ Music (11)");
+		auto_log_info("Found completed Spookyraven Manor Organ Music (11)");
 		set_property("auto_ballroomflat", "finished");
 	}
 
 	if((internalQuestStatus("questL11Worship") >= 3) && (get_property("auto_hiddenunlock") != "finished"))
 	{
-		print("Found unlocked Hidden City (11)");
+		auto_log_info("Found unlocked Hidden City (11)");
 		set_property("auto_hiddenunlock", "finished");
 	}
 
 	if((internalQuestStatus("questL11Black") >= 2) && (get_property("auto_blackmap") == ""))
 	{
-		print("Found an unexpected Black Market (11 - via questL11Black)");
+		auto_log_info("Found an unexpected Black Market (11 - via questL11Black)");
 		set_property("auto_blackmap", "document");
 	}
 	if((get_property("blackForestProgress") >= 5) && (get_property("auto_blackmap") == ""))
 	{
-		print("Found an unexpected Black Market (11 - via blackForestProgress)");
+		auto_log_info("Found an unexpected Black Market (11 - via blackForestProgress)");
 		set_property("auto_blackmap", "document");
 	}
 
 	if((get_property("questL11Black") == "finished") && (get_property("auto_blackmap") != "finished"))
 	{
-		print("Found completed Black Market (11 - via questL11Black)");
+		auto_log_info("Found completed Black Market (11 - via questL11Black)");
 		set_property("auto_blackmap", "finished");
 	}
 	if((internalQuestStatus("questL11MacGuffin") >= 2) && (get_property("auto_blackmap") != "finished"))
 	{
-		print("Found completed Black Market (11 - via questL11MacGuffin)");
+		auto_log_info("Found completed Black Market (11 - via questL11MacGuffin)");
 		set_property("auto_blackmap", "finished");
 	}
 
 	if((internalQuestStatus("questL11MacGuffin") >= 2) && (get_property("auto_mcmuffin") == ""))
 	{
-		print("Found started McMuffin quest (11)");
+		auto_log_info("Found started McMuffin quest (11)");
 		set_property("auto_mcmuffin", "start");
 	}
 
 	if((get_property("questL11Palindome") == "finished") && (get_property("auto_palindome") != "finished"))
 	{
-		print("Found completed Palindome (11)");
+		auto_log_info("Found completed Palindome (11)");
 		set_property("auto_palindome", "finished");
 	}
 
 	if(get_property("pyramidBombUsed").to_boolean() && (get_property("auto_mcmuffin") == "pyramid"))
 	{
-		print("Found Ed in the Pyramid (11)");
+		auto_log_info("Found Ed in the Pyramid (11)");
 		set_property("auto_mcmuffin", "ed");
 	}
 
-//	if((get_property("questL11Pyramid") == "finished") && (get_property("auto_mcmuffin") != "finished"))
-//	{
-//		print("Found completed Pyramid (11)");
-//		set_property("auto_mcmuffin", "finished");
-//	}
 	if((get_property("questL11MacGuffin") == "finished") && (get_property("auto_mcmuffin") != "finished"))
 	{
-		print("Found completed McMuffin (11)");
+		auto_log_info("Found completed McMuffin (11)");
 		visit_url("diary.php?whichpage=1");
 		set_property("auto_mcmuffin", "finished");
 	}
 
 	if((get_property("questL11Business") == "finished") && (get_property("auto_hiddenoffice") != "finished"))
 	{
-		print("Found completed Hidden Office Building (11)");
+		auto_log_info("Found completed Hidden Office Building (11)");
 		set_property("auto_hiddenoffice", "finished");
 		if((get_property("auto_hiddenzones") != "finished") && (get_property("auto_hiddenzones").to_int() < 3))
 		{
@@ -3373,7 +3346,7 @@ boolean questOverride()
 	}
 	if((get_property("questL11Curses") == "finished") && (get_property("auto_hiddenapartment") != "finished"))
 	{
-		print("Found completed Hidden Apartment Building (11)");
+		auto_log_info("Found completed Hidden Apartment Building (11)");
 		set_property("auto_hiddenapartment", "finished");
 		if((get_property("auto_hiddenzones") != "finished") && (get_property("auto_hiddenzones").to_int() < 2))
 		{
@@ -3382,7 +3355,7 @@ boolean questOverride()
 	}
 	if((get_property("questL11Spare") == "finished") && (get_property("auto_hiddenbowling") != "finished"))
 	{
-		print("Found completed Hidden Bowling Alley (11)");
+		auto_log_info("Found completed Hidden Bowling Alley (11)");
 		set_property("auto_hiddenbowling", "finished");
 		if((get_property("auto_hiddenzones") != "finished") && (get_property("auto_hiddenzones").to_int() < 5))
 		{
@@ -3391,7 +3364,7 @@ boolean questOverride()
 	}
 	if((get_property("questL11Doctor") == "finished") && (get_property("auto_hiddenhospital") != "finished"))
 	{
-		print("Found completed Hidden Hopickle (11)");
+		auto_log_info("Found completed Hidden Hopickle (11)");
 		set_property("auto_hiddenhospital", "finished");
 		if((get_property("auto_hiddenzones") != "finished") && (get_property("auto_hiddenzones").to_int() < 4))
 		{
@@ -3400,14 +3373,14 @@ boolean questOverride()
 	}
 	if((get_property("questL11Worship") == "finished") && (get_property("auto_hiddencity") != "finished"))
 	{
-		print("Found completed Hidden City (11)");
+		auto_log_info("Found completed Hidden City (11)");
 		set_property("auto_hiddencity", "finished");
 		set_property("auto_hiddenzones", "finished");
 		set_property("auto_hiddenunlock", "finished");
 	}
 	if((internalQuestStatus("questL11Worship") >= 3) && (get_property("auto_hiddenunlock") != "finished"))
 	{
-		print("Found completed unlocked Hidden City (11)");
+		auto_log_info("Found completed unlocked Hidden City (11)");
 		set_property("auto_hiddenunlock", "finished");
 	}
 
@@ -3415,7 +3388,7 @@ boolean questOverride()
 	{
 		if(get_property("flyeredML").to_int() < 10000)
 		{
-			print("Found completed Island War Arena but flyeredML does not match (12)");
+			auto_log_info("Found completed Island War Arena but flyeredML does not match (12)");
 			set_property("flyeredML", 10000);
 		}
 	}
@@ -3424,19 +3397,19 @@ boolean questOverride()
 	{
 		if(get_property("auto_orchard") != "finished")
 		{
-			print("Found completed Orchard (12)");
+			auto_log_info("Found completed Orchard (12)");
 			set_property("auto_orchard", "finished");
 		}
 	}
 
 	if((get_property("sidequestLighthouseCompleted") != "none") && (get_property("auto_sonofa") != "finished"))
 	{
-		print("Found completed Lighthouse (12)");
+		auto_log_info("Found completed Lighthouse (12)");
 		set_property("auto_sonofa", "finished");
 	}
 	if((get_property("sidequestJunkyardCompleted") != "none") && (get_property("auto_gremlins") != "finished"))
 	{
-		print("Found completed Junkyard (12)");
+		auto_log_info("Found completed Junkyard (12)");
 		set_property("auto_gremlins", "finished");
 	}
 
@@ -3444,65 +3417,65 @@ boolean questOverride()
 	{
 		if(get_property("auto_gremlins") != "finished")
 		{
-			print("Found completed Junkyard (12)");
+			auto_log_info("Found completed Junkyard (12)");
 			set_property("auto_gremlins", "finished");
 		}
 
 		if(get_property("auto_sonofa") != "finished")
 		{
-			print("Found completed Lighthouse (12)");
+			auto_log_info("Found completed Lighthouse (12)");
 			set_property("auto_sonofa", "finished");
 		}
 
 		if(get_property("auto_orchard") != "finished")
 		{
-			print("Found completed Orchard (12)");
+			auto_log_info("Found completed Orchard (12)");
 			set_property("auto_orchard", "finished");
 		}
 
 		if((get_property("auto_nuns") != "done") && (get_property("auto_nuns") != "finished"))
 		{
-			print("Found completed Nuns (12)");
+			auto_log_info("Found completed Nuns (12)");
 			set_property("auto_nuns", "finished");
 		}
 	}
 
 	if((get_property("sidequestOrchardCompleted") != "none") && (get_property("auto_orchard") != "finished"))
 	{
-		print("Found completed Orchard (12)");
+		auto_log_info("Found completed Orchard (12)");
 		set_property("auto_orchard", "finished");
 	}
 
 
 	if((get_property("sidequestNunsCompleted") != "none") && (get_property("auto_nuns") != "done") && (get_property("auto_nuns") != "finished"))
 	{
-		print("Found completed Nuns (12)");
+		auto_log_info("Found completed Nuns (12)");
 		set_property("auto_nuns", "finished");
 	}
 
 	if((get_property("sideDefeated") != "neither") && (get_property("auto_war") != "finished"))
 	{
-		print("Found completed Island War (12)");
+		auto_log_info("Found completed Island War (12)");
 		set_property("auto_war", "finished");
 		council();
 	}
 
 	if((internalQuestStatus("questL12War") >= 1)  && (get_property("auto_prewar") != "started"))
 	{
-		print("Found Started Island War (12)");
+		auto_log_info("Found Started Island War (12)");
 		set_property("auto_prewar", "started");
 	}
 
 	if((internalQuestStatus("questL12War") >= 2)  && (get_property("auto_war") != "finished"))
 	{
-		print("Found completed Island War (12)");
+		auto_log_info("Found completed Island War (12)");
 		set_property("auto_war", "finished");
 		council();
 	}
 
 	if((internalQuestStatus("questL13Final") >= 13) && (get_property("auto_sorceress") != "finished"))
 	{
-		print("Found completed Prism Recovery (13)");
+		auto_log_info("Found completed Prism Recovery (13)");
 		set_property("auto_sorceress", "finished");
 		if (isActuallyEd())
 		{
@@ -3514,7 +3487,7 @@ boolean questOverride()
 	{
 		if(get_property("auto_pirateoutfit") == "")
 		{
-			print("Pirate Quest already started but we don't know that, fixing...");
+			auto_log_info("Pirate Quest already started but we don't know that, fixing...");
 			set_property("auto_pirateoutfit", "insults");
 		}
 	}
@@ -3523,7 +3496,7 @@ boolean questOverride()
 	{
 		if((get_property("auto_pirateoutfit") == "insults") || (get_property("auto_pirateoutfit") == "blueprint"))
 		{
-			print("Pirate Quest got enough insults and did the blueprint, fixing...");
+			auto_log_info("Pirate Quest got enough insults and did the blueprint, fixing...");
 			set_property("auto_pirateoutfit", "almost");
 		}
 	}
@@ -3532,7 +3505,7 @@ boolean questOverride()
 	{
 		if(get_property("auto_pirateoutfit") != "finished")
 		{
-			print("Completed Beer Pong but we were not aware, fixing...");
+			auto_log_info("Completed Beer Pong but we were not aware, fixing...");
 			set_property("auto_pirateoutfit", "finished");
 		}
 	}
@@ -3541,19 +3514,19 @@ boolean questOverride()
 	{
 		if(get_property("auto_pirateoutfit") != "finished")
 		{
-			print("Found Pirate Fledges and incomplete pirate outfit, fixing...");
+			auto_log_info("Found Pirate Fledges and incomplete pirate outfit, fixing...");
 			set_property("auto_pirateoutfit", "finished");
 		}
 		if(get_property("auto_fcle") != "finished")
 		{
-			print("Found Pirate Fledges and incomplete F\'C\'le, fixing...");
+			auto_log_info("Found Pirate Fledges and incomplete F\'C\'le, fixing...");
 			set_property("auto_fcle", "finished");
 		}
 	}
 
 	if((get_property("lastQuartetAscension").to_int() >= my_ascensions()) && (get_property("auto_ballroomsong") != "finished"))
 	{
-		print("Found Ballroom Quarter Song set (X).");
+		auto_log_info("Found Ballroom Quarter Song set (X).");
 		set_property("auto_ballroomsong", "finished");
 	}
 
@@ -3642,7 +3615,7 @@ boolean L11_aridDesert()
 	{
 		if((my_level() >= 12) && !in_hardcore())
 		{
-			print("Do you actually have a UV-resistant compass? Try 'refresh inv' in the CLI! If possible, pull a Grimstone mask and rerun, we may have missed that somehow.", "green");
+			auto_log_warning("Do you actually have a UV-resistant compass? Try 'refresh inv' in the CLI! If possible, pull a Grimstone mask and rerun, we may have missed that somehow.", "green");
 			if(is_unrestricted($item[Hibernating Grimstone Golem]) && have_familiar($familiar[Grimstone Golem]))
 			{
 				abort("I can't do the Oasis without an Ornate Dowsing Rod. You can manually get a UV-resistant compass and I'll use that if you really hate me that much.");
@@ -3676,7 +3649,7 @@ boolean L11_aridDesert()
 		}
 		else
 		{
-			print("Skipping desert, don't have a rod or a compass.");
+			auto_log_warning("Skipping desert, don't have a rod or a compass.");
 			set_property("auto_skipDesert", my_turncount());
 		}
 		return false;
@@ -3684,7 +3657,7 @@ boolean L11_aridDesert()
 
 	if((have_effect($effect[Ultrahydrated]) > 0) || (get_property("desertExploration").to_int() == 0))
 	{
-		print("Searching for the pyramid", "blue");
+		auto_log_info("Searching for the pyramid", "blue");
 		if(auto_my_path() == "Heavy Rains")
 		{
 			autoEquip($item[Thor\'s Pliers]);
@@ -3717,17 +3690,16 @@ boolean L11_aridDesert()
 			acquireHP();
 		}
 
-#		if(in_hardcore() && isGuildClass() && (item_amount($item[Worm-Riding Hooks]) > 0) && (get_property("desertExploration").to_int() <= (100 - (5 * progress))) && ((get_property("gnasirProgress").to_int() & 16) != 16))
 		if((in_hardcore() || (pulls_remaining() == 0)) && (item_amount($item[Worm-Riding Hooks]) > 0) && (get_property("desertExploration").to_int() <= (100 - (5 * progress))) && ((get_property("gnasirProgress").to_int() & 16) != 16) && (item_amount($item[Stone Rose]) == 0))
 		{
 			if(item_amount($item[Drum Machine]) > 0)
 			{
-				print("Found the drums, now we use them!", "blue");
+				auto_log_info("Found the drums, now we use them!", "blue");
 				use(1, $item[Drum Machine]);
 			}
 			else
 			{
-				print("Off to find the drums!", "blue");
+				auto_log_info("Off to find the drums!", "blue");
 				autoAdv(1, $location[The Oasis]);
 			}
 			return true;
@@ -3738,12 +3710,12 @@ boolean L11_aridDesert()
 			int expectedOasisTurns = 8 - $location[The Oasis].turns_spent;
 			int equivProgress = expectedOasisTurns * progress;
 			int need = 100 - get_property("desertExploration").to_int();
-			print("expectedOasis: " + expectedOasisTurns, "brown");
-			print("equivProgress: " + equivProgress, "brown");
-			print("need: " + need, "brown");
+			auto_log_info("expectedOasis: " + expectedOasisTurns, "brown");
+			auto_log_info("equivProgress: " + equivProgress, "brown");
+			auto_log_info("need: " + need, "brown");
 			if((need <= 15) && (15 >= equivProgress) && (item_amount($item[Stone Rose]) == 0))
 			{
-				print("It seems raisinable to hunt a Stone Rose. Beep", "blue");
+				auto_log_info("It seems raisinable to hunt a Stone Rose. Beep", "blue");
 				autoAdv(1, $location[The Oasis]);
 				return true;
 			}
@@ -3756,18 +3728,18 @@ boolean L11_aridDesert()
 		handleFamiliar("initSuggest");
 		set_property("choiceAdventure805", 1);
 		int need = 100 - get_property("desertExploration").to_int();
-		print("Need for desert: " + need, "blue");
-		print("Worm riding: " + item_amount($item[Worm-Riding Manual Page]), "blue");
+		auto_log_info("Need for desert: " + need, "blue");
+		auto_log_info("Worm riding: " + item_amount($item[Worm-Riding Manual Page]), "blue");
 
 		if(!get_property("auto_gnasirUnlocked").to_boolean() && ($location[The Arid\, Extra-Dry Desert].turns_spent > 10) && (get_property("desertExploration").to_int() > 10))
 		{
-			print("Did not appear to notice that Gnasir unlocked, assuming so at this point.", "green");
+			auto_log_info("Did not appear to notice that Gnasir unlocked, assuming so at this point.", "green");
 			set_property("auto_gnasirUnlocked", true);
 		}
 
 		if(get_property("auto_gnasirUnlocked").to_boolean() && (item_amount($item[Stone Rose]) > 0) && ((get_property("gnasirProgress").to_int() & 1) != 1))
 		{
-			print("Returning the stone rose", "blue");
+			auto_log_info("Returning the stone rose", "blue");
 			auto_visit_gnasir();
 			visit_url("choice.php?whichchoice=805&option=1&pwd=");
 			visit_url("choice.php?whichchoice=805&option=2&pwd=");
@@ -3783,7 +3755,7 @@ boolean L11_aridDesert()
 				{
 					if((get_property("gnasirProgress").to_int() & 1) != 1)
 					{
-						print("Mafia did not track gnasir Stone Rose (0x1). Fixing.", "red");
+						auto_log_warning("Mafia did not track gnasir Stone Rose (0x1). Fixing.", "red");
 						set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 1);
 					}
 				}
@@ -3803,7 +3775,7 @@ boolean L11_aridDesert()
 			if((item_amount($item[Can of Black Paint]) > 0) || ((my_meat() >= 1000) && canBuyPaint))
 			{
 				buyUpTo(1, $item[Can of Black Paint]);
-				print("Returning the Can of Black Paint", "blue");
+				auto_log_info("Returning the Can of Black Paint", "blue");
 				auto_visit_gnasir();
 				visit_url("choice.php?whichchoice=805&option=1&pwd=");
 				visit_url("choice.php?whichchoice=805&option=2&pwd=");
@@ -3815,7 +3787,7 @@ boolean L11_aridDesert()
 					{
 						if(item_amount($item[Can Of Black Paint]) == 0)
 						{
-							print("Mafia did not track gnasir Can of Black Paint (0x2). Fixing.", "red");
+							auto_log_warning("Mafia did not track gnasir Can of Black Paint (0x2). Fixing.", "red");
 							set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 2);
 							return true;
 						}
@@ -3828,7 +3800,7 @@ boolean L11_aridDesert()
 					{
 						if((get_property("gnasirProgress").to_int() & 2) != 2)
 						{
-							print("Mafia did not track gnasir Can of Black Paint (0x2). Fixing.", "red");
+							auto_log_warning("Mafia did not track gnasir Can of Black Paint (0x2). Fixing.", "red");
 							set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 2);
 						}
 					}
@@ -3840,7 +3812,7 @@ boolean L11_aridDesert()
 
 		if(get_property("auto_gnasirUnlocked").to_boolean() && (item_amount($item[Killing Jar]) > 0) && ((get_property("gnasirProgress").to_int() & 4) != 4))
 		{
-			print("Returning the killing jar", "blue");
+			auto_log_info("Returning the killing jar", "blue");
 			auto_visit_gnasir();
 			visit_url("choice.php?whichchoice=805&option=1&pwd=");
 			visit_url("choice.php?whichchoice=805&option=2&pwd=");
@@ -3856,7 +3828,7 @@ boolean L11_aridDesert()
 				{
 					if((get_property("gnasirProgress").to_int() & 4) != 4)
 					{
-						print("Mafia did not track gnasir Killing Jar (0x4). Fixing.", "red");
+						auto_log_warning("Mafia did not track gnasir Killing Jar (0x4). Fixing.", "red");
 						set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 4);
 					}
 				}
@@ -3867,22 +3839,23 @@ boolean L11_aridDesert()
 
 		if((item_amount($item[Worm-Riding Manual Page]) >= 15) && ((get_property("gnasirProgress").to_int() & 8) != 8))
 		{
-			print("Returning the worm-riding manual pages", "blue");
+			auto_log_info("Returning the worm-riding manual pages", "blue");
 			auto_visit_gnasir();
 			visit_url("choice.php?whichchoice=805&option=1&pwd=");
 			visit_url("choice.php?whichchoice=805&option=2&pwd=");
 			visit_url("choice.php?whichchoice=805&option=1&pwd=");
 			if(item_amount($item[Worm-Riding Hooks]) == 0)
 			{
+				auto_log_critical("We messed up in the Desert, get the Worm-Riding Hooks and use them please.");
 				abort("We messed up in the Desert, get the Worm-Riding Hooks and use them please.");
 			}
 			if(item_amount($item[Worm-Riding Manual Page]) >= 15)
 			{
-				print("Mafia doesn't realize that we've returned the worm-riding manual pages... fixing", "red");
+				auto_log_warning("Mafia doesn't realize that we've returned the worm-riding manual pages... fixing", "red");
 				cli_execute("refresh all");
 				if((get_property("gnasirProgress").to_int() & 8) != 8)
 				{
-					print("Mafia did not track gnasir Worm-Riding Manual Pages (0x8). Fixing.", "red");
+					auto_log_warning("Mafia did not track gnasir Worm-Riding Manual Pages (0x8). Fixing.", "red");
 					set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 8);
 				}
 			}
@@ -3895,7 +3868,7 @@ boolean L11_aridDesert()
 			pullXWhenHaveY($item[Drum Machine], 1, 0);
 			if(item_amount($item[Drum Machine]) > 0)
 			{
-				print("Drum machine desert time!", "blue");
+				auto_log_info("Drum machine desert time!", "blue");
 				use(1, $item[Drum Machine]);
 				return true;
 			}
@@ -3908,7 +3881,7 @@ boolean L11_aridDesert()
 			pullXWhenHaveY($item[Killing Jar], 1, 0);
 			if(item_amount($item[Killing Jar]) > 0)
 			{
-				print("Secondary killing jar handler", "blue");
+				auto_log_info("Secondary killing jar handler", "blue");
 				auto_visit_gnasir();
 				visit_url("choice.php?whichchoice=805&option=1&pwd=");
 				visit_url("choice.php?whichchoice=805&option=2&pwd=");
@@ -3924,7 +3897,7 @@ boolean L11_aridDesert()
 					{
 						if((get_property("gnasirProgress").to_int() & 4) != 4)
 						{
-							print("Mafia did not track gnasir Killing Jar (0x4). Fixing.", "red");
+							auto_log_warning("Mafia did not track gnasir Killing Jar (0x4). Fixing.", "red");
 							set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 4);
 						}
 					}
@@ -3939,7 +3912,7 @@ boolean L11_aridDesert()
 
 		if(contains_text(get_property("lastEncounter"), "A Sietch in Time"))
 		{
-			print("We've found the gnome!! Sightseeing pamphlets for everyone!", "green");
+			auto_log_info("We've found the gnome!! Sightseeing pamphlets for everyone!", "green");
 			set_property("auto_gnasirUnlocked", true);
 		}
 
@@ -3953,11 +3926,11 @@ boolean L11_aridDesert()
 	else
 	{
 		int need = 100 - get_property("desertExploration").to_int();
-		print("Getting some ultrahydrated, I suppose. Desert left: " + need, "blue");
+		auto_log_info("Getting some ultrahydrated, I suppose. Desert left: " + need, "blue");
 
 		if((need > (5 * progress)) && (cloversAvailable() > 2) && !get_property("lovebugsUnlocked").to_boolean())
 		{
-			print("Gonna clover this, yeah, it only saves 2 adventures. So?", "green");
+			auto_log_info("Gonna clover this, yeah, it only saves 2 adventures. So?", "green");
 			cloverUsageInit();
 			autoAdvBypass("adventure.php?snarfblat=122", $location[The Oasis]);
 			cloverUsageFinish();
@@ -3966,7 +3939,7 @@ boolean L11_aridDesert()
 		{
 			if(!autoAdv(1, $location[The Oasis]))
 			{
-				print("Could not visit the Oasis for some raisin, assuming desertExploration is incorrect.", "red");
+				auto_log_warning("Could not visit the Oasis for some raisin, assuming desertExploration is incorrect.", "red");
 				set_property("desertExploration", 0);
 			}
 		}
@@ -4018,7 +3991,7 @@ boolean L11_palindome()
 		lovemeDone = lovemeDone || contains_text(palindomeCheck, "pal_drlabel");
 	}
 
-	print("In the palindome : emodnilap eht nI", "blue");
+	auto_log_info("In the palindome : emodnilap eht nI", "blue");
 	#
 	#	In hardcore, guild-class, the right side of the or doesn't happen properly due us farming the
 	#	Mega Gem within the if, with pulls, it works fine. Need to fix this. This is bad.
@@ -4057,8 +4030,8 @@ boolean L11_palindome()
 
 					if(get_property("lastGuildStoreOpen").to_int() < my_ascensions())
 					{
-						print("This is probably no longer needed as of r16907. Please remove me", "blue");
-						print("Going to pretend we have unlocked the Guild because Mafia will assume we need to do that before going to Whitey's Grove and screw up us. We'll fix it afterwards.", "red");
+						auto_log_warning("This is probably no longer needed as of r16907. Please remove me", "blue");
+						auto_log_warning("Going to pretend we have unlocked the Guild because Mafia will assume we need to do that before going to Whitey's Grove and screw up us. We'll fix it afterwards.", "red");
 					}
 					backupSetting("lastGuildStoreOpen", my_ascensions());
 					string[int] pages;
@@ -4070,12 +4043,12 @@ boolean L11_palindome()
 				}
 				// +item is nice to get that food
 				bat_formBats();
-				print("Off to the grove for some doofy food!", "blue");
+				auto_log_info("Off to the grove for some doofy food!", "blue");
 				autoAdv(1, $location[Whitey\'s Grove]);
 			}
 			else if(item_amount($item[Stunt Nuts]) == 0)
 			{
-				print("We got no nuts!! :O", "Blue");
+				auto_log_info("We got no nuts!! :O", "Blue");
 				autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
 				autoAdv(1, $location[Inside the Palindome]);
 			}
@@ -4110,7 +4083,7 @@ boolean L11_palindome()
 			if(item_amount($item[&quot;2 Love Me\, Vol. 2&quot;]) > 0)
 			{
 				use(1, $item[&quot;2 Love Me\, Vol. 2&quot;]);
-				print("Oh no, we died from reading a book. I'm going to take a nap.", "blue");
+				auto_log_info("Oh no, we died from reading a book. I'm going to take a nap.", "blue");
 				acquireHP();
 				bat_reallyPickSkills(20);
 			}
@@ -4153,7 +4126,7 @@ boolean L11_palindome()
 
 		if(!possessEquipment($item[Mega Gem]))
 		{
-			print("No mega gem for us. Well, no raisin to go further here....", "red");
+			auto_log_warning("No mega gem for us. Well, no raisin to go further here....", "red");
 			return false;
 		}
 		autoEquip($slot[acc2], $item[Mega Gem]);
@@ -4161,7 +4134,7 @@ boolean L11_palindome()
 		int palinChoice = random(3) + 1;
 		set_property("choiceAdventure131", palinChoice);
 
-		print("War sir is raw!!", "blue");
+		auto_log_info("War sir is raw!!", "blue");
 
 		string[int] pages;
 		pages[0] = "place.php?whichplace=palindome&action=pal_drlabel";
@@ -4184,15 +4157,15 @@ boolean L11_palindome()
 		{
 			if(!get_property("auto_bruteForcePalindome").to_boolean())
 			{
-				print("Palindome failure:", "red");
-				print("You probably just need to get a Mega Gem to fix this.", "red");
+				auto_log_critical("Palindome failure:", "red");
+				auto_log_critical("You probably just need to get a Mega Gem to fix this.", "red");
 				abort("We have made too much progress in the Palindome and should not be here.");
 			}
 			else
 			{
-				print("We need wet stunt nut stew to get the Mega Gem, but I've been told to get it via the mercy adventure.", "red");
-				print("Set auto_bruteForcePalindome=false to try to get a stunt nut stew", "red");
-				print("(We typically only set this option in hardcore Kingdom of Exploathing, in which the White Forest isn't available)", "red");
+				auto_log_critical("We need wet stunt nut stew to get the Mega Gem, but I've been told to get it via the mercy adventure.", "red");
+				auto_log_critical("Set auto_bruteForcePalindome=false to try to get a stunt nut stew", "red");
+				auto_log_critical("(We typically only set this option in hardcore Kingdom of Exploathing, in which the White Forest isn't available)", "red");
 			}
 		}
 
@@ -4200,7 +4173,7 @@ boolean L11_palindome()
 		{
 			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
 			{
-				print("Gotta hunt down them Naskar boys.", "blue");
+				auto_log_info("Gotta hunt down them Naskar boys.", "blue");
 				uneffect($effect[On The Trail]);
 			}
 		}
@@ -4288,7 +4261,7 @@ boolean L13_towerNSFinal()
 	}
 	if(get_property("auto_wandOfNagamar").to_boolean())
 	{
-		print("We do not have a Wand of Nagamar but appear to need one. We must lose to the Sausage first...", "red");
+		auto_log_warning("We do not have a Wand of Nagamar but appear to need one. We must lose to the Sausage first...", "red");
 	}
 
 	//Only if the final boss does not unbuff us...
@@ -4356,7 +4329,7 @@ boolean L13_towerNSFinal()
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_10_sorcfight", $location[Noob Cave]);
 		if(have_effect($effect[Beaten Up]) > 0)
 		{
-			print("Sorceress beat us up. Wahhh.", "red");
+			auto_log_warning("Sorceress beat us up. Wahhh.", "red");
 			set_property("auto_disableAdventureHandling", false);
 			return true;
 		}
@@ -4365,7 +4338,7 @@ boolean L13_towerNSFinal()
 			autoAdv(1, $location[Noob Cave]);
 			if(have_effect($effect[Beaten Up]) > 0)
 			{
-				print("Blobbage Sorceress beat us up. Wahhh.", "red");
+				auto_log_warning("Blobbage Sorceress beat us up. Wahhh.", "red");
 				set_property("auto_disableAdventureHandling", true);
 				return true;
 			}
@@ -4386,7 +4359,7 @@ boolean L13_towerNSFinal()
 					}
 					return true;
 				}
-				print("We got beat up by a sausage....", "red");
+				auto_log_warning("We got beat up by a sausage....", "red");
 				set_property("auto_disableAdventureHandling", false);
 				return true;
 			}
@@ -4443,11 +4416,11 @@ boolean L13_towerNSTower()
 		return false;
 	}
 
-	print("Scaling the mighty NStower...", "green");
+	auto_log_info("Scaling the mighty NStower...", "green");
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_05_monster1"))
 	{
-		print("Time to fight the Wall of Skins!", "blue");
+		auto_log_info("Time to fight the Wall of Skins!", "blue");
 		auto_change_mcd(0);
 		acquireMP(120, 0);
 
@@ -4582,7 +4555,7 @@ boolean L13_towerNSTower()
 		{
 			sourceNeed -= 2;
 		}
-		print("I think I have " + sources + " sources of damage, let's do this!", "blue");
+		auto_log_info("I think I have " + sources + " sources of damage, let's do this!", "blue");
 		if(auto_my_path() == "Pocket Familiars")
 		{
 			sources = 9999;
@@ -4597,7 +4570,7 @@ boolean L13_towerNSTower()
 			if(internalQuestStatus("questL13Final") < 7)
 			{
 				set_property("auto_getBeehive", true);
-				print("I probably failed the Wall of Skin, I assume that I tried without a beehive. Well, I'm going back to get it.", "red");
+				auto_log_warning("I probably failed the Wall of Skin, I assume that I tried without a beehive. Well, I'm going back to get it.", "red");
 			}
 			else
 			{
@@ -4607,7 +4580,7 @@ boolean L13_towerNSTower()
 		else
 		{
 			set_property("auto_getBeehive", true);
-			print("Need a beehive, buzz buzz. Only have " + sources + " damage sources and we want " + sourceNeed, "red");
+			auto_log_warning("Need a beehive, buzz buzz. Only have " + sources + " damage sources and we want " + sourceNeed, "red");
 		}
 		return true;
 	}
@@ -4717,7 +4690,7 @@ boolean L13_towerNSTower()
 			autoAdvBypass("place.php?whichplace=nstower&action=ns_07_monster3", $location[Noob Cave]);
 			if(internalQuestStatus("questL13Final") < 9)
 			{
-				print("Could not towerkill Wall of Bones, reverting to Boning Knife", "red");
+				auto_log_warning("Could not towerkill Wall of Bones, reverting to Boning Knife", "red");
 				acquireHP();
 				set_property("auto_getBoningKnife", true);
 			}
@@ -4732,7 +4705,7 @@ boolean L13_towerNSTower()
 		}
 		else if(canGroundhog($location[The Castle in the Clouds in the Sky (Ground Floor)]))
 		{
-			print("Backfarming an Electric Boning Knife", "green");
+			auto_log_info("Backfarming an Electric Boning Knife", "green");
 			set_property("choiceAdventure1026", "2");
 			autoAdv(1, $location[The Castle in the Clouds in the Sky (Ground Floor)]);
 		}
@@ -4801,13 +4774,13 @@ boolean L13_towerNSHedge()
 		set_property("questL13Final", "step4");
 		if((have_effect($effect[Beaten Up]) > 0) || (my_hp() < 150))
 		{
-			print("Hedge maze not solved, the mysteries are still there (correcting step5 -> step4)", "red");
+			auto_log_critical("Hedge maze not solved, the mysteries are still there (correcting step5 -> step4)", "red");
 			abort("Heal yourself and try again...");
 		}
 	}
 	if(internalQuestStatus("questL13Final") >= 5)
 	{
-		print("Should already be past the hedge maze but did not see the door", "red");
+		auto_log_warning("Should already be past the hedge maze but did not see the door", "red");
 		set_property("auto_sorceress", "door");
 		return false;
 	}
@@ -4883,20 +4856,20 @@ boolean L13_towerNSContests()
 		ns_hedge3();
 		if(get_property("auto_trytower") == "stop")
 		{
-			print("Manual handling for the start of challenges still required. Then run me again. Beep", "blue");
+			auto_log_critical("Manual handling for the start of challenges still required. Then run me again. Beep", "blue");
 			set_property("choiceAdventure1003", 3);
 			abort("Can't handle this optimally just yet, damn it");
 		}
 		else if(get_property("auto_trytower") == "pause")
 		{
 			set_property("auto_trytower", "");
-			print("Start the tower challenges and then run me again and I'll take care of the rest");
+			auto_log_critical("Start the tower challenges and then run me again and I'll take care of the rest");
 			abort("Run again once all three challenges have been started. We will assume they have been");
 			set_property("choiceAdventure1003", 3);
 		}
 		else
 		{
-			print("Manual handling for the start of challenges still required. Then run me again. Beep");
+			auto_log_critical("Manual handling for the start of challenges still required. Then run me again. Beep");
 			set_property("choiceAdventure1003", 3);
 			abort("Can't handle this optimally just yet, damn it");
 		}
@@ -4992,7 +4965,7 @@ boolean L13_towerNSContests()
 					if(get_property("auto_secondPlaceOrBust").to_boolean())
 						abort("Not enough initiative for the initiative test, aborting since auto_secondPlaceOrBust=true");
 					else
-						print("Not enough initiative for the initiative test, but continuing since auto_secondPlaceOrBust=false", "red");
+						auto_log_warning("Not enough initiative for the initiative test, but continuing since auto_secondPlaceOrBust=false", "red");
 				}
 				break;
 			}
@@ -5015,7 +4988,7 @@ boolean L13_towerNSContests()
 				{
 					boolean[skill] requirements;
 					requirements[$skill[Preternatural Strength]] = true;
-					print("Torporing, since we want to get Preternatural Strength.", "blue");
+					auto_log_info("Torporing, since we want to get Preternatural Strength.", "blue");
 					bat_reallyPickSkills(20, requirements);
 				}
 				// This could be generalized for stat equalizer potions, but that seems marginal
@@ -5095,7 +5068,7 @@ boolean L13_towerNSContests()
 				if(get_property("auto_secondPlaceOrBust").to_boolean())
 					abort("Not enough " + crowd_stat + " for the stat test, aborting since auto_secondPlaceOrBust=true");
 				else
-					print("Not enough " + crowd_stat + " for the stat test, but continuing since auto_secondPlaceOrBust=false", "red");
+					auto_log_warning("Not enough " + crowd_stat + " for the stat test, but continuing since auto_secondPlaceOrBust=false", "red");
 			}
 			visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
 			visit_url("choice.php?pwd=&whichchoice=1003&option=2", true);
@@ -5187,7 +5160,7 @@ boolean L13_towerNSContests()
 				if(get_property("auto_secondPlaceOrBust").to_boolean())
 					abort("Not enough " + challenge + " for the elemental test, aborting since auto_secondPlaceOrBust=true");
 				else
-					print("Not enough " + challenge + " for the elemental test, but continuing since auto_secondPlaceOrBust=false", "red");
+					auto_log_warning("Not enough " + challenge + " for the elemental test, but continuing since auto_secondPlaceOrBust=false", "red");
 			}
 
 			visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
@@ -5198,7 +5171,7 @@ boolean L13_towerNSContests()
 		set_property("choiceAdventure1003",  4);
 		if((get_property("nsContestants1").to_int() == 0) && (get_property("nsContestants2").to_int() == 0) && (get_property("nsContestants3").to_int() == 0))
 		{
-			print("The NS Challenges are over! Victory is ours!", "blue");
+			auto_log_info("The NS Challenges are over! Victory is ours!", "blue");
 			visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
 			visit_url("choice.php?pwd=&whichchoice=1003&option=4", true);
 			visit_url("main.php");
@@ -5210,18 +5183,18 @@ boolean L13_towerNSContests()
 					{
 						//As of r17048, encountering a Source Agent on the Challenge line results in nsContestants being decremented twice.
 						//Since we were using Mafia\'s tracking here, we have to compensate for when it fails...
-						print("Probably encountered a Source Agent during the NS Contestants and Mafia's tracking fails on this. Let's try to correct it...", "red");
+						auto_log_warning("Probably encountered a Source Agent during the NS Contestants and Mafia's tracking fails on this. Let's try to correct it...", "red");
 						set_property("questL13Final", "step1");
 					}
 					else
 					{
-						print("Error not recoverable (as not antipicipated) outside of The Source (Source Agents during NS Challenges), aborting.", "red");
+						auto_log_critical("Error not recoverable (as not antipicipated) outside of The Source (Source Agents during NS Challenges), aborting.", "red");
 						abort("questL13Final error in unexpected path.");
 					}
 				}
 				else
 				{
-					print("Unresolvable error: Mafia thinks the NS challenges are complete but something is very wrong.", "red");
+					auto_log_critical("Unresolvable error: Mafia thinks the NS challenges are complete but something is very wrong.", "red");
 					abort("Unknown questL13Final/auto_sorceress state.");
 				}
 			}
@@ -5273,7 +5246,7 @@ boolean L13_towerNSContests()
 		autoAdv(1, toCompete);
 		return true;
 	}
-	print("No challenges left!", "green");
+	auto_log_info("No challenges left!", "green");
 	if(auto_my_path() == "Pocket Familiars")
 	{
 		if(get_property("nsContestants1").to_int() == 0)
@@ -5309,7 +5282,7 @@ boolean L13_towerNSEntrance()
 	{
 		if(my_level() < 13)
 		{
-			print("I seem to need to power level, or something... waaaa.", "red");
+			auto_log_warning("I seem to need to power level, or something... waaaa.", "red");
 			# lx_attemptPowerLevel is before. We need to merge all of this into that....
 			set_property("auto_newbieOverride", true);
 
@@ -5369,7 +5342,7 @@ boolean L13_towerNSEntrance()
 			{
 				if(get_property("auto_powerLevelAdvCount").to_int() >= 10)
 				{
-					print("The following error message is probably wrong, you just need to powerlevel to 13 most likely.", "red");
+					auto_log_warning("The following error message is probably wrong, you just need to powerlevel to 13 most likely.", "red");
 					if((item_amount($item[Rock Band Flyers]) > 0) || (item_amount($item[Jam Band Flyers]) > 0))
 					{
 						abort("Need more flyer ML but don't know where to go :(");
@@ -5387,7 +5360,7 @@ boolean L13_towerNSEntrance()
 			#need a wand (or substitute a key lime for food earlier)
 			if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
 			{
-				print("Hmmm, we need to stop being so feisty about quests...", "red");
+				auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
 				set_property("auto_powerLevelLastLevel", my_level());
 				return true;
 			}
@@ -5425,7 +5398,7 @@ boolean L12_lastDitchFlyer()
 		return false;
 	}
 
-	print("Not enough flyer ML but we are ready for the war... uh oh", "blue");
+	auto_log_info("Not enough flyer ML but we are ready for the war... uh oh", "blue");
 	boolean doHoleInTheSky = needStarKey();
 
 	if(doHoleInTheSky)
@@ -5454,7 +5427,7 @@ boolean L12_lastDitchFlyer()
 	}
 	else
 	{
-		print("Should not have so little flyer ML at this point", "red");
+		auto_log_warning("Should not have so little flyer ML at this point", "red");
 		wait(1);
 		if(!LX_attemptFlyering())
 		{
@@ -5789,7 +5762,7 @@ boolean L11_hiddenCity()
 			{
 				if(item_amount($item[soft green echo eyedrop antidote]) > 0)
 				{
-					print("They stink so much!", "blue");
+					auto_log_info("They stink so much!", "blue");
 					uneffect($effect[On The Trail]);
 				}
 			}
@@ -5801,7 +5774,7 @@ boolean L11_hiddenCity()
 			{
 				if(item_amount($item[soft green echo eyedrop antidote]) > 0)
 				{
-					print("No more accountants to hunt!", "blue");
+					auto_log_info("No more accountants to hunt!", "blue");
 					uneffect($effect[On The Trail]);
 				}
 			}
@@ -5813,7 +5786,7 @@ boolean L11_hiddenCity()
 			{
 				if(item_amount($item[soft green echo eyedrop antidote]) > 0)
 				{
-					print("No more stinky bowling shoes to worry about!", "blue");
+					auto_log_info("No more stinky bowling shoes to worry about!", "blue");
 					uneffect($effect[On The Trail]);
 				}
 			}
@@ -5829,7 +5802,7 @@ boolean L11_hiddenCity()
 	}
 	if((get_property("auto_hiddenapartment") != "finished") && (get_counters("Fortune Cookie", 0, 9) != "Fortune Cookie") && (my_adventures() >= (9 - get_property("auto_hiddenapartment").to_int())) && (have_effect($effect[Ancient Fortitude]) == 0))
 		{
-			print("The idden [sic] apartment!", "blue");
+			auto_log_info("The idden [sic] apartment!", "blue");
 
 			int current = get_property("auto_hiddenapartment").to_int() + 1;
 			set_property("auto_hiddenapartment", current);
@@ -5858,7 +5831,7 @@ boolean L11_hiddenCity()
 
 			if(current <= 8)
 			{
-				print("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");
+				auto_log_info("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");
 				autoAdv(1, $location[The Hidden Apartment Building]);
 				if(lastAdventureSpecialNC())
 				{
@@ -5890,14 +5863,14 @@ boolean L11_hiddenCity()
 						}
 					}
 				}
-				print("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");
+				auto_log_info("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");
 				autoAdv(1, $location[The Hidden Apartment Building]);
 				return true;
 			}
 		}
 		if((get_property("auto_hiddenoffice") != "finished") && (my_adventures() >= 11))
 		{
-			print("The idden [sic] office!", "blue");
+			auto_log_info("The idden [sic] office!", "blue");
 
 			if((item_amount($item[Boring Binder Clip]) == 1) && (item_amount($item[McClusky File (Page 5)]) == 1))
 			{
@@ -5919,7 +5892,7 @@ boolean L11_hiddenCity()
 				set_property("choiceAdventure786", "3");
 			}
 
-			print("Hidden Office Progress: " + get_property("hiddenOfficeProgress"), "blue");
+			auto_log_info("Hidden Office Progress: " + get_property("hiddenOfficeProgress"), "blue");
 			if(considerGrimstoneGolem(true))
 			{
 				handleBjornify($familiar[Grimstone Golem]);
@@ -5933,7 +5906,7 @@ boolean L11_hiddenCity()
 
 		if(get_property("auto_hiddenbowling") != "finished")
 		{
-			print("The idden [sic] bowling alley!", "blue");
+			auto_log_info("The idden [sic] bowling alley!", "blue");
 			L11_hiddenTavernUnlock(true);
 			if(my_ascensions() == get_property("hiddenTavernUnlock").to_int() && !in_koe())
 			{
@@ -5954,16 +5927,8 @@ boolean L11_hiddenCity()
 			}
 
 			buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
-			print("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
-//			if(have_familiar($familiar[Cat Burglar]))
-//			{
-//				handleFamiliar($familiar[Cat Burglar]);
-//			}
+			auto_log_info("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
 			autoAdv(1, $location[The Hidden Bowling Alley]);
-//			if(last_monster() == $monster[Pygmy Bowler])
-//			{
-//				abort("Pygmy!");
-//			}
 
 			return true;
 		}
@@ -5975,7 +5940,7 @@ boolean L11_hiddenCity()
 				set_property("auto_hiddenhospital", "finished");
 				return true;
 			}
-			print("The idden osptial!! [sic]", "blue");
+			auto_log_info("The idden osptial!! [sic]", "blue");
 			set_property("choiceAdventure784", "1");
 
 			autoEquip($item[bloodied surgical dungarees]);
@@ -5983,7 +5948,7 @@ boolean L11_hiddenCity()
 			autoEquip($item[surgical apron]);
 			autoEquip($slot[acc3], $item[head mirror]);
 			autoEquip($slot[acc2], $item[surgical mask]);
-			print("Hidden Hospital Progress: " + get_property("hiddenHospitalProgress"), "blue");
+			auto_log_info("Hidden Hospital Progress: " + get_property("hiddenHospitalProgress"), "blue");
 			if((my_mp() > 60) || considerGrimstoneGolem(true))
 			{
 				handleBjornify($familiar[Grimstone Golem]);
@@ -5994,7 +5959,7 @@ boolean L11_hiddenCity()
 		}
 		if((get_property("auto_hiddenapartment") == "finished") && (get_property("auto_hiddenoffice") == "finished") && (get_property("auto_hiddenbowling") == "finished") && (get_property("auto_hiddenhospital") == "finished"))
 		{
-			print("Getting the stone triangles", "blue");
+			auto_log_info("Getting the stone triangles", "blue");
 			set_property("choiceAdventure791", "1");
 			while(item_amount($item[stone triangle]) < 1)
 			{
@@ -6013,7 +5978,7 @@ boolean L11_hiddenCity()
 				autoAdv(1, $location[An Overgrown Shrine (Southeast)]);
 			}
 
-			print("Fighting the out-of-work spirit", "blue");
+			auto_log_info("Fighting the out-of-work spirit", "blue");
 			acquireHP();
 
 			try
@@ -6027,7 +5992,7 @@ boolean L11_hiddenCity()
 			}
 			finally
 			{
-				print("If I stopped, just run me again, beep!", "red");
+				auto_log_warning("If I stopped, just run me again, beep!", "red");
 			}
 
 			if(item_amount($item[2180]) == 1)
@@ -6065,7 +6030,7 @@ boolean L11_hiddenCityZones()
 
 	if(get_property("auto_hiddenzones") == "")
 	{
-		print("Machete the hidden zones!", "blue");
+		auto_log_info("Machete the hidden zones!", "blue");
 		set_property("choiceAdventure791", "6");
 		set_property("auto_hiddenzones", "0");
 	}
@@ -6331,24 +6296,24 @@ boolean L11_wishForBaaBaaBuran()
 {
 	if(!get_property("auto_useWishes").to_boolean() && canGenieCombat())
 	{
-		print("Skipping wishing for Baa'baa'bu'ran because auto_useWishes=false", "red");
+		auto_log_warning("Skipping wishing for Baa'baa'bu'ran because auto_useWishes=false", "red");
 	}
 	if (get_property("auto_useWishes").to_boolean() && canGenieCombat())
 	{
-		print("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
+		auto_log_info("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
 		handleFamiliar("item");
 		if((numeric_modifier("item drop") >= 100))
 		{
 			if (!makeGenieCombat($monster[Baa\'baa\'bu\'ran]) || item_amount($item[Stone Wool]) == 0)
 			{
-				print("Wishing for stone wool failed.", "red");
+				auto_log_warning("Wishing for stone wool failed.", "red");
 				return false;
 			}
 			return true;
 		}
 		else
 		{
-			print("Never mind, we couldn't get a mere +100% item for the Baa'baa'bu'ran wish.", "red");
+			auto_log_warning("Never mind, we couldn't get a mere +100% item for the Baa'baa'bu'ran wish.", "red");
 		}
 	}
 	return false;
@@ -6387,7 +6352,7 @@ boolean L11_unlockHiddenCity()
 		backupSetting("choiceAdventure579", 3);
 	}
 
-	print("Searching for the Hidden City", "blue");
+	auto_log_info("Searching for the Hidden City", "blue");
 	if(useStoneWool)
 	{
 		if((item_amount($item[Stone Wool]) == 0) && (have_effect($effect[Stone-Faced]) == 0))
@@ -6417,7 +6382,7 @@ boolean L11_unlockHiddenCity()
 	{
 		if(bypassResult)
 		{
-			print("Wandering monster interrupted our attempt at the Hidden City", "red");
+			auto_log_warning("Wandering monster interrupted our attempt at the Hidden City", "red");
 			return true;
 		}
 		if(get_property("lastEncounter") != "Fitting In")
@@ -6438,7 +6403,7 @@ boolean L11_unlockHiddenCity()
 	visit_url("choice.php");
 	cli_execute("dvorak");
 	visit_url("choice.php?whichchoice=125&option=3&pwd");
-	print("Hidden Temple Unlocked");
+	auto_log_info("Hidden Temple Unlocked");
 	set_property("auto_hiddenunlock", "finished");
 	if(!possessEquipment($item[Antique Machete]) && !in_hardcore())
 	{
@@ -6474,7 +6439,7 @@ boolean L11_nostrilOfTheSerpent()
 		return false;
 	}
 
-	print("Must get a snake nose.", "blue");
+	auto_log_info("Must get a snake nose.", "blue");
 	boolean useStoneWool = true;
 
 	if(auto_my_path() == "G-Lover" || auto_my_path() == "Two Crazy Random Summer")
@@ -6517,7 +6482,7 @@ boolean L11_nostrilOfTheSerpent()
 					visit_url("choice.php");
 					cli_execute("dvorak");
 					visit_url("choice.php?whichchoice=125&option=3&pwd");
-					print("Hidden Temple Unlocked");
+					auto_log_info("Hidden Temple Unlocked");
 					set_property("auto_hiddenunlock", "finished");
 				}
 				else
@@ -6553,12 +6518,12 @@ boolean LX_spookyBedroomCombat()
 	autoAdv(1, $location[The Haunted Bedroom]);
 	if(contains_text(visit_url("main.php"), "choice.php"))
 	{
-		print("Bedroom choice adventure get!", "green");
+		auto_log_info("Bedroom choice adventure get!", "green");
 		autoAdv(1, $location[The Haunted Bedroom]);
 	}
 	else if(contains_text(visit_url("main.php"), "Combat"))
 	{
-		print("Bedroom post-combat super combat get!", "green");
+		auto_log_info("Bedroom post-combat super combat get!", "green");
 		autoAdv(1, $location[The Haunted Bedroom]);
 	}
 	set_property("auto_disableAdventureHandling", false);
@@ -6582,13 +6547,13 @@ boolean LX_spookyravenSecond()
 
 	if(internalQuestStatus("questM21Dance") < 1)
 	{
-		print("Invalid questM21Dance detected. Trying to override", "red");
+		auto_log_warning("Invalid questM21Dance detected. Trying to override", "red");
 		set_property("questM21Dance", "step1");
 	}
 
 	if((item_amount($item[Lady Spookyraven\'s Powder Puff]) == 1) && (item_amount($item[Lady Spookyraven\'s Dancing Shoes]) == 1) && (item_amount($item[Lady Spookyraven\'s Finest Gown]) == 1))
 	{
-		print("Finished Spookyraven, just dancing with the lady.", "blue");
+		auto_log_info("Finished Spookyraven, just dancing with the lady.", "blue");
 		visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 		visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 		set_property("auto_ballroomopen", "open");
@@ -6653,15 +6618,15 @@ boolean LX_spookyravenSecond()
 	{
 		if(needSpectacles)
 		{
-			print("Need Spectacles, damn it.", "blue");
+			auto_log_info("Need Spectacles, damn it.", "blue");
 			LX_spookyBedroomCombat();
-			print("Finished 1 Spookyraven Bedroom Spectacle Sequence", "blue");
+			auto_log_info("Finished 1 Spookyraven Bedroom Spectacle Sequence", "blue");
 		}
 		else if(needCamera)
 		{
-			print("Need Disposable Instant Camera, damn it.", "blue");
+			auto_log_info("Need Disposable Instant Camera, damn it.", "blue");
 			LX_spookyBedroomCombat();
-			print("Finished 1 Spookyraven Bedroom Disposable Instant Camera Sequence", "blue");
+			auto_log_info("Finished 1 Spookyraven Bedroom Disposable Instant Camera Sequence", "blue");
 		}
 		else
 		{
@@ -6673,16 +6638,16 @@ boolean LX_spookyravenSecond()
 	{
 		if((item_amount($item[Lady Spookyraven\'s Finest Gown]) == 0) && !contains_text(get_counters("Fortune Cookie", 0, 10), "Fortune Cookie"))
 		{
-			print("Spookyraven: Bedroom, rummaging through nightstands looking for naughty meatbag trinkets.", "blue");
+			auto_log_info("Spookyraven: Bedroom, rummaging through nightstands looking for naughty meatbag trinkets.", "blue");
 			LX_spookyBedroomCombat();
-			print("Finished 1 Spookyraven Bedroom Sequence", "blue");
+			auto_log_info("Finished 1 Spookyraven Bedroom Sequence", "blue");
 			return true;
 		}
 		if(item_amount($item[Lady Spookyraven\'s Dancing Shoes]) == 0)
 		{
 			set_property("louvreGoal", "7");
 			set_property("louvreDesiredGoal", "7");
-			print("Spookyraven: Gallery", "blue");
+			auto_log_info("Spookyraven: Gallery", "blue");
 
 			auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
@@ -6695,7 +6660,7 @@ boolean LX_spookyravenSecond()
 			{
 				handleFamiliar($familiar[Artistic Goth Kid]);
 			}
-			print("Spookyraven: Bathroom", "blue");
+			auto_log_info("Spookyraven: Bathroom", "blue");
 			set_property("choiceAdventure892", "1");
 
 			auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
@@ -6738,7 +6703,7 @@ boolean L11_mauriceSpookyraven()
 
 	if(get_property("auto_ballroomflat") == "")
 	{
-		print("Searching for the basement of Spookyraven", "blue");
+		auto_log_info("Searching for the basement of Spookyraven", "blue");
 		if(!cangroundHog($location[The Haunted Ballroom]))
 		{
 			return false;
@@ -6765,7 +6730,7 @@ boolean L11_mauriceSpookyraven()
 		if(!autoAdv(1, $location[The Haunted Ballroom]))
 		{
 			visit_url("place.php?whichplace=manor2");
-			print("If 'That Area is not available', mafia isn't recognizing it without a visit to manor2, not sure why.", "red");
+			auto_log_warning("If 'That Area is not available', mafia isn't recognizing it without a visit to manor2, not sure why.", "red");
 		}
 		handleFamiliar("item");
 		if(contains_text(get_property("lastEncounter"), "We\'ll All Be Flat"))
@@ -6795,7 +6760,7 @@ boolean L11_mauriceSpookyraven()
 
 	if((get_property("auto_winebomb") == "finished") || get_property("auto_masonryWall").to_boolean() || (internalQuestStatus("questL11Manor") >= 3))
 	{
-		print("Down with the tyrant of Spookyraven!", "blue");
+		auto_log_info("Down with the tyrant of Spookyraven!", "blue");
 		acquireHP();
 		buffMaintain($effect[Astral Shell], 10, 1, 1);
 		buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
@@ -6832,7 +6797,7 @@ boolean L11_mauriceSpookyraven()
 
 	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || (my_class() == $class[Avatar of Boris]) || (auto_my_path() == "Way of the Surprising Fist") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
 	{
-		print("Alternate fulminate pathway... how sad :(", "red");
+		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.
 		if(item_amount($item[Loosening Powder]) == 0)
 		{
@@ -6882,14 +6847,14 @@ boolean L11_mauriceSpookyraven()
 
 	if((item_amount($item[blasting soda]) == 1) && (item_amount($item[bottle of Chateau de Vinegar]) == 1))
 	{
-		print("Time to cook up something explosive! Science fair unstable fulminate time!", "green");
+		auto_log_info("Time to cook up something explosive! Science fair unstable fulminate time!", "green");
 		ovenHandle();
 		autoCraft("cook", 1, $item[bottle of Chateau de Vinegar], $item[blasting soda]);
 		set_property("auto_winebomb", "partial");
 		if(item_amount($item[Unstable Fulminate]) == 0)
 		{
-			print("We could not make an Unstable Fulminate but we think we have an oven. Do this manually and resume?", "red");
-			print("Speculating that get_campground() was incorrect at ascension start...", "red");
+			auto_log_warning("We could not make an Unstable Fulminate but we think we have an oven. Do this manually and resume?", "red");
+			auto_log_warning("Speculating that get_campground() was incorrect at ascension start...", "red");
 			// This issue is valid as of mafia r16799
 			set_property("auto_haveoven", false);
 			ovenHandle();
@@ -6898,7 +6863,7 @@ boolean L11_mauriceSpookyraven()
 			{
 				if(auto_my_path() == "Nuclear Autumn")
 				{
-					print("Could not make an Unstable Fulminate, assuming we have no oven for realz...", "red");
+					auto_log_warning("Could not make an Unstable Fulminate, assuming we have no oven for realz...", "red");
 					return true;
 				}
 				else
@@ -6921,7 +6886,7 @@ boolean L11_mauriceSpookyraven()
 
 	if((item_amount($item[bottle of Chateau de Vinegar]) == 0) && (get_property("auto_winebomb") == ""))
 	{
-		print("Searching for vinegar", "blue");
+		auto_log_info("Searching for vinegar", "blue");
 		if(considerGrimstoneGolem(true))
 		{
 			handleBjornify($familiar[Grimstone Golem]);
@@ -6936,7 +6901,7 @@ boolean L11_mauriceSpookyraven()
 	}
 	if((item_amount($item[blasting soda]) == 0) && (get_property("auto_winebomb") == ""))
 	{
-		print("Searching for baking soda, I mean, blasting pop.", "blue");
+		auto_log_info("Searching for baking soda, I mean, blasting pop.", "blue");
 		if(considerGrimstoneGolem(true))
 		{
 			handleBjornify($familiar[Grimstone Golem]);
@@ -6958,7 +6923,7 @@ boolean L11_mauriceSpookyraven()
 				autoEquip($slot[weapon], $item[none]);
 			}
 		}
-		print("Now we mix and heat it up.", "blue");
+		auto_log_info("Now we mix and heat it up.", "blue");
 
 		if((auto_my_path() == "Picky") && (item_amount($item[gumshoes]) > 0))
 		{
@@ -7012,7 +6977,7 @@ boolean L13_sorceressDoor()
 
 	if(internalQuestStatus("questL13Final") >= 6)
 	{
-		print("Should already be past the tower door but did not see the First wall.", "red");
+		auto_log_warning("Should already be past the tower door but did not see the First wall.", "red");
 		set_property("auto_sorceress", "tower");
 		return false;
 	}
@@ -7175,14 +7140,14 @@ boolean L11_unlockEd()
 
 	if(get_property("auto_tavern") != "finished")
 	{
-		print("Uh oh, didn\'t do the tavern and we are at the pyramid....", "red");
+		auto_log_warning("Uh oh, didn\'t do the tavern and we are at the pyramid....", "red");
 
 		// Forcing Tavern.
 		set_property("auto_forceTavern", true);
 		return false;
 	}
 
-	print("In the pyramid (W:" + item_amount($item[crumbling wooden wheel]) + ") (R:" + item_amount($item[tomb ratchet]) + ") (U:" + get_property("controlRoomUnlock") + ")", "blue");
+	auto_log_info("In the pyramid (W:" + item_amount($item[crumbling wooden wheel]) + ") (R:" + item_amount($item[tomb ratchet]) + ") (U:" + get_property("controlRoomUnlock") + ")", "blue");
 
 	if(!get_property("middleChamberUnlock").to_boolean())
 	{
@@ -7298,7 +7263,7 @@ boolean L11_unlockPyramid()
 
 	if((item_amount($item[[2325]Staff Of Ed]) > 0) || ((item_amount($item[[2180]Ancient Amulet]) > 0) && (item_amount($item[[2268]Staff Of Fats]) > 0) && (item_amount($item[[2286]Eye Of Ed]) > 0)))
 	{
-		print("Reveal the pyramid", "blue");
+		auto_log_info("Reveal the pyramid", "blue");
 		if(item_amount($item[[2325]Staff Of Ed]) == 0)
 		{
 			if((item_amount($item[[2180]Ancient Amulet]) > 0) && (item_amount($item[[2286]Eye Of Ed]) > 0))
@@ -7327,10 +7292,10 @@ boolean L11_unlockPyramid()
 
 		if(get_property("questL11Pyramid") == "unstarted")
 		{
-			print("No burning Ed's model now!", "blue");
+			auto_log_info("No burning Ed's model now!", "blue");
 			if((auto_my_path() == "One Crazy Random Summer") && (get_property("desertExploration").to_int() == 100))
 			{
-				print("We might have had an issue due to OCRS and the Desert, please finish the desert (and only the desert) manually and run again.", "red");
+				auto_log_warning("We might have had an issue due to OCRS and the Desert, please finish the desert (and only the desert) manually and run again.", "red");
 				string page = visit_url("place.php?whichplace=desertbeach");
 				matcher desert_matcher = create_matcher("title=\"[(](\\d+)% explored[)]\"", page);
 				if(desert_matcher.find())
@@ -7348,13 +7313,13 @@ boolean L11_unlockPyramid()
 				}
 				else
 				{
-					print("Incorrectly had exploration value of 100 however, this was correctable. Trying to resume.", "blue");
+					auto_log_info("Incorrectly had exploration value of 100 however, this was correctable. Trying to resume.", "blue");
 					return false;
 				}
 			}
 			if(my_turncount() == get_property("auto_skipDesert").to_int())
 			{
-				print("Did not have an Arid Desert Item and the Pyramid is next. Must backtrack and recover", "red");
+				auto_log_warning("Did not have an Arid Desert Item and the Pyramid is next. Must backtrack and recover", "red");
 				if((my_adventures() >= 3) && (my_meat() >= 500))
 				{
 					doVacation();
@@ -7435,7 +7400,7 @@ boolean L11_defeatEd()
 	}
 
 	acquireHP();
-	print("Time to waste all of Ed's Ka Coins :(", "blue");
+	auto_log_info("Time to waste all of Ed's Ka Coins :(", "blue");
 
 	set_property("choiceAdventure976", "1");
 
@@ -7444,7 +7409,7 @@ boolean L11_defeatEd()
 	while(item_amount($item[[2334]Holy MacGuffin]) == 0)
 	{
 		x = x + 1;
-		print("Hello Ed #" + x + " give me McMuffin please.", "blue");
+		auto_log_info("Hello Ed #" + x + " give me McMuffin please.", "blue");
 		autoAdv(1, $location[The Lower Chambers]);
 		if(have_effect($effect[Beaten Up]) > 0 && item_amount($item[[2334]Holy MacGuffin]) == 0)
 		{
@@ -7514,7 +7479,7 @@ boolean L12_gremlinStart()
 	{
 		return false;
 	}
-	print("Gremlin prep", "blue");
+	auto_log_info("Gremlin prep", "blue");
 	if(get_property("auto_hippyInstead").to_boolean())
 	{
 		if(!possessEquipment($item[Reinforced Beaded Headband]))
@@ -7609,7 +7574,7 @@ boolean L12_gremlins()
 	}
 
 	#Put a different shield in here.
-	print("Doing them gremlins", "blue");
+	auto_log_info("Doing them gremlins", "blue");
 	if(useMaximizeToEquip())
 	{
 		addToMaximize("20dr,1da 1000max,3hp,-3ml");
@@ -7747,7 +7712,7 @@ boolean L12_sonofaBeach()
 	{
 		if(!providePlusCombat(25, true))
 		{
-			print("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
+			auto_log_warning("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
 			equipBaseline();
 			return false;
 		}
@@ -7778,7 +7743,7 @@ boolean L12_sonofaBeach()
 
 		if(numeric_modifier("Combat Rate") < 0.0)
 		{
-			print("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
+			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
 			equipBaseline();
 			return false;
 		}
@@ -7905,7 +7870,7 @@ boolean L12_sonofaPrefix()
 	{
 		if(!providePlusCombat(25))
 		{
-			print("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
+			auto_log_warning("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
 			return false;
 		}
 
@@ -7933,7 +7898,7 @@ boolean L12_sonofaPrefix()
 		}
 		if(numeric_modifier("Combat Rate") < 0.0)
 		{
-			print("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
+			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
 			equipBaseline();
 			return false;
 		}
@@ -8003,7 +7968,7 @@ boolean L12_filthworms()
 	{
 		return false;
 	}
-	print("Doing the orchard.", "blue");
+	auto_log_info("Doing the orchard.", "blue");
 
 	if(item_amount($item[Filthworm Hatchling Scent Gland]) > 0)
 	{
@@ -8141,7 +8106,7 @@ boolean L12_finalizeWar()
 
 	if(have_outfit("War Hippy Fatigues"))
 	{
-		print("Getting dimes.", "blue");
+		auto_log_info("Getting dimes.", "blue");
 		foreach it in $items[padl phone, red class ring, blue class ring, white class ring]
 		{
 			sell(it.buyer, item_amount(it), it);
@@ -8160,7 +8125,7 @@ boolean L12_finalizeWar()
 	}
 	if(have_outfit("Frat Warrior Fatigues"))
 	{
-		print("Getting quarters.", "blue");
+		auto_log_info("Getting quarters.", "blue");
 		foreach it in $items[pink clay bead, purple clay bead, green clay bead, communications windchimes]
 		{
 			sell(it.buyer, item_amount(it), it);
@@ -8257,9 +8222,8 @@ boolean L12_finalizeWar()
 		doRest();
 	}
 	warOutfit(false);
-#	cli_execute("refresh equip");
 	acquireHP();
-	print("Let's fight the boss!", "blue");
+	auto_log_info("Let's fight the boss!", "blue");
 
 	location bossFight = $location[The Battlefield (Frat Uniform)];
 
@@ -8286,7 +8250,7 @@ boolean L12_finalizeWar()
 	}
 	if(!autoAdvBypass(0, pages, bossFight, ""))
 	{
-		print("Boss already defeated, ignoring", "red");
+		auto_log_warning("Boss already defeated, ignoring", "red");
 	}
 
 	if(auto_my_path() == "Pocket Familiars")
@@ -8430,18 +8394,14 @@ boolean LX_getDigitalKey()
 			set_property("auto_crackpotjar", "done");
 		}
 	}
-	print("Getting white pixels: Have " + item_amount($item[white pixel]), "blue");
-	#if(item_amount($item[white pixel]) >= 27)
-	#{
-	#	abort("Can we pull any pixels?");
-	#}
+	auto_log_info("Getting white pixels: Have " + item_amount($item[white pixel]), "blue");
 	if(get_property("auto_crackpotjar") == "done")
 	{
 		set_property("choiceAdventure644", 3);
 		autoAdv(1, $location[Fear Man\'s Level]);
 		if(have_effect($effect[Consumed By Fear]) == 0)
 		{
-			print("Well, we don't seem to have further access to the Fear Man area so... abort that plan", "red");
+			auto_log_warning("Well, we don't seem to have further access to the Fear Man area so... abort that plan", "red");
 			set_property("auto_crackpotjar", "fail");
 		}
 	}
@@ -8470,13 +8430,13 @@ boolean L11_getBeehive()
 	}
 	if((internalQuestStatus("questL13Final") >= 7) || (item_amount($item[Beehive]) > 0))
 	{
-		print("Nevermind, wall of skin already defeated (or we already have a beehiven). We do not need a beehive. Bloop.", "blue");
+		auto_log_info("Nevermind, wall of skin already defeated (or we already have a beehiven). We do not need a beehive. Bloop.", "blue");
 		set_property("auto_getBeehive", false);
 		return false;
 	}
 
 
-	print("Must find a beehive!", "blue");
+	auto_log_info("Must find a beehive!", "blue");
 
 	set_property("choiceAdventure923", "1");
 	set_property("choiceAdventure924", "3");
@@ -8558,11 +8518,11 @@ boolean L10_plantThatBean()
 	}
 
 	council();
-	print("Planting me magic bean!", "blue");
+	auto_log_info("Planting me magic bean!", "blue");
 	string page = visit_url("place.php?whichplace=plains");
 	if(contains_text(page, "place.php?whichplace=beanstalk"))
 	{
-		print("I have no bean but I see a stalk here. Okies. I'm ok with that", "blue");
+		auto_log_warning("I have no bean but I see a stalk here. Okies. I'm ok with that", "blue");
 		set_property("auto_bean", true);
 		visit_url("place.php?whichplace=beanstalk");
 		return true;
@@ -8581,7 +8541,7 @@ boolean L10_plantThatBean()
 
 	if(internalQuestStatus("questL04Bat") >= 0)
 	{
-		print("I don't have a magic bean! Travesty!!", "blue");
+		auto_log_info("I don't have a magic bean! Travesty!!", "blue");
 		return autoAdv($location[The Beanbat Chamber]);
 	}
 	return false;
@@ -8614,7 +8574,7 @@ boolean L10_holeInTheSkyUnlock()
 		return false;
 	}
 
-	print("Castle Top Floor - Opening the Hole in the Sky", "blue");
+	auto_log_info("Castle Top Floor - Opening the Hole in the Sky", "blue");
 	set_property("choiceAdventure677", 2);
 	set_property("choiceAdventure675", 4);
 	set_property("choiceAdventure678", 3);
@@ -8655,11 +8615,11 @@ boolean L10_topFloor()
 		return false;
 	}
 
-	print("Castle Top Floor", "blue");
+	auto_log_info("Castle Top Floor", "blue");
 	set_property("choiceAdventure680", 1); // Mercy adventure: Are you a Man or a Mouse?
 	if(item_amount($item[Drum \'n\' Bass \'n\' Drum \'n\' Bass Record]) > 0)
 	{
-		print("We have a drum 'n' bass record and are willing to use it!", "green");
+		auto_log_info("We have a drum 'n' bass record and are willing to use it!", "green");
 		// Copper Feel: Move to Mellon Collie
 		set_property("choiceAdventure677", 4);
 		// Mellon Collie: Turn in record, complete quest
@@ -8679,7 +8639,7 @@ boolean L10_topFloor()
 
 	if(!possessEquipment($item[mohawk wig]) && 0 == item_amount($item[drum 'n' bass 'n' drum 'n' bass record]))
 	{
-		print("We don't have a mohawk wig, let's try to get a drum 'n' bass record...", "green");
+		auto_log_info("We don't have a mohawk wig, let's try to get a drum 'n' bass record...", "green");
 		// Yeah, You're for Me, Punk Rock Giant: Move to Flavor of a Raver (676)
 		set_property("choiceAdventure678", 4);
 		// Floor of a Raver: Acquire drum 'n' bass 'n' drum 'n' bass record
@@ -8750,7 +8710,7 @@ boolean L10_ground()
 		return false;
 	}
 
-	print("Castle Ground Floor, boring!", "blue");
+	auto_log_info("Castle Ground Floor, boring!", "blue");
 	set_property("choiceAdventure672", 3);
 	set_property("choiceAdventure673", 3);
 	set_property("choiceAdventure674", 3);
@@ -8814,7 +8774,7 @@ boolean L10_basement()
 	{
 		return false;
 	}
-	print("Basement Search", "blue");
+	auto_log_info("Basement Search", "blue");
 	set_property("choiceAdventure670", "5");
 	if(item_amount($item[Massive Dumbbell]) > 0)
 	{
@@ -8867,12 +8827,12 @@ boolean L10_basement()
 
 	if(contains_text(get_property("lastEncounter"), "Out in the Open Source") && (get_property("choiceAdventure671").to_int() == 1))
 	{
-		print("Dumbbell + Dumbwaiter means we fly!", "green");
+		auto_log_info("Dumbbell + Dumbwaiter means we fly!", "green");
 		set_property("auto_castlebasement", "finished");
 	}
 	else if(contains_text(get_property("lastEncounter"), "The Fast and the Furry-ous"))
 	{
-		print("We was fast and furry-ous!", "blue");
+		auto_log_info("We was fast and furry-ous!", "blue");
 		autoEquip($item[Titanium Assault Umbrella]);
 		set_property("choiceAdventure669", "1");
 		autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
@@ -8882,16 +8842,16 @@ boolean L10_basement()
 		}
 		else
 		{
-			print("Got interrupted trying to unlock the Ground Floor of the Castle", "red");
+			auto_log_warning("Got interrupted trying to unlock the Ground Floor of the Castle", "red");
 		}
 	}
 	else if(contains_text(get_property("lastEncounter"), "You Don\'t Mess Around with Gym"))
 	{
-		print("Just messed with Gym", "blue");
+		auto_log_info("Just messed with Gym", "blue");
 		if(!can_equip($item[Amulet of Extreme Plot Significance]) || (item_amount($item[Massive Dumbbell]) > 0))
 		{
-			print("Can't equip an Amulet of Extreme Plot Signifcance...", "red");
-			print("I suppose we will try the Massive Dumbbell... Beefcake!", "red");
+			auto_log_warning("Can't equip an Amulet of Extreme Plot Signifcance...", "red");
+			auto_log_warning("I suppose we will try the Massive Dumbbell... Beefcake!", "red");
 			if(item_amount($item[Massive Dumbbell]) == 0)
 			{
 				set_property("choiceAdventure670", "1");
@@ -8912,8 +8872,8 @@ boolean L10_basement()
 			{
 				if($location[The Penultimate Fantasy Airship].turns_spent >= 45 || in_koe())
 				{
-					print("Well, we don't seem to be able to find an Amulet...", "red");
-					print("I suppose we will get the Massive Dumbbell... Beefcake!", "red");
+					auto_log_warning("Well, we don't seem to be able to find an Amulet...", "red");
+					auto_log_warning("I suppose we will get the Massive Dumbbell... Beefcake!", "red");
 					if(item_amount($item[Massive Dumbbell]) == 0)
 					{
 						set_property("choiceAdventure670", "1");
@@ -8926,7 +8886,7 @@ boolean L10_basement()
 				}
 				else
 				{
-					print("Backfarming an Amulet of Extreme Plot Significance, sigh :(", "blue");
+					auto_log_warning("Backfarming an Amulet of Extreme Plot Significance, sigh :(", "blue");
 					autoAdv(1, $location[The Penultimate Fantasy Airship]);
 				}
 				return true;
@@ -8945,7 +8905,7 @@ boolean L10_basement()
 		}
 		else
 		{
-			print("Got interrupted trying to unlock the Ground Floor of the Castle", "red");
+			auto_log_warning("Got interrupted trying to unlock the Ground Floor of the Castle", "red");
 		}
 	}
 	return true;
@@ -8967,7 +8927,7 @@ boolean L10_airship()
 	}
 
 	visit_url("clan_viplounge.php?preaction=goswimming&subaction=submarine");
-	print("Fantasy Airship Fly Fly time", "blue");
+	auto_log_info("Fantasy Airship Fly Fly time", "blue");
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
 		handleBjornify($familiar[Grimstone Golem]);
@@ -8985,7 +8945,7 @@ boolean L10_airship()
 
 	if((my_daycount() == 1) && (get_property("_hipsterAdv").to_int() < 7) && is_unrestricted($familiar[Artistic Goth Kid]) && auto_have_familiar($familiar[Artistic Goth Kid]))
 	{
-		print("Hipster Adv: " + get_property("_hipsterAdv"), "blue");
+		auto_log_info("Hipster Adv: " + get_property("_hipsterAdv"), "blue");
 		handleFamiliar($familiar[Artistic Goth Kid]);
 	}
 
@@ -9261,7 +9221,7 @@ boolean L0_handleRainDoh()
 	}
 
 	monster enemy = to_monster(get_property("rainDohMonster"));
-	print("Black boxing: " + enemy, "blue");
+	auto_log_info("Black boxing: " + enemy, "blue");
 
 	if(enemy == $monster[Ninja Snowman Assassin])
 	{
@@ -9368,13 +9328,13 @@ boolean LX_ornateDowsingRod()
 	}
 	if(possessEquipment($item[UV-resistant compass]))
 	{
-		print("You have a UV-resistant compass for some raisin, I assume you don't want an Ornate Dowsing Rod.", "red");
+		auto_log_warning("You have a UV-resistant compass for some raisin, I assume you don't want an Ornate Dowsing Rod.", "red");
 		set_property("auto_grimstoneOrnateDowsingRod", false);
 		return false;
 	}
 	if(possessEquipment($item[Ornate Dowsing Rod]))
 	{
-		print("Hey, we have the dowsing rod already, yippie!", "blue");
+		auto_log_info("Hey, we have the dowsing rod already, yippie!", "blue");
 		set_property("auto_grimstoneOrnateDowsingRod", false);
 		return false;
 	}
@@ -9396,7 +9356,7 @@ boolean LX_ornateDowsingRod()
 	}
 
 	#Need to make sure we get our grimstone mask
-	print("Acquiring a Dowsing Rod!", "blue");
+	auto_log_info("Acquiring a Dowsing Rod!", "blue");
 	set_property("choiceAdventure829", "1");
 	use(1, $item[grimstone mask]);
 
@@ -9530,7 +9490,7 @@ boolean L7_crypt()
 			useNightmareFuelIfPossible();
 		}
 
-		print("The Alcove! (" + initiative_modifier() + ")", "blue");
+		auto_log_info("The Alcove! (" + initiative_modifier() + ")", "blue");
 		autoAdv(1, $location[The Defiled Alcove]);
 		handleFamiliar("item");
 		return true;
@@ -9548,7 +9508,7 @@ boolean L7_crypt()
 
 	if((get_property("cyrptNookEvilness").to_int() > 0) && canGroundhog($location[The Defiled Nook]) && !skip_in_koe)
 	{
-		print("The Nook!", "blue");
+		auto_log_info("The Nook!", "blue");
 		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
 		handleFamiliar("item");
 		autoEquip($item[Gravy Boat]);
@@ -9575,7 +9535,7 @@ boolean L7_crypt()
 	}
 	else if(skip_in_koe)
 	{
-		auto_debug_print("In Exploathing, skipping Defiled Nook until we get more evil eyes.");
+		auto_log_debug("In Exploathing, skipping Defiled Nook until we get more evil eyes.");
 	}
 
 	if((get_property("cyrptNicheEvilness").to_int() > 0) && canGroundhog($location[The Defiled Niche]))
@@ -9596,7 +9556,7 @@ boolean L7_crypt()
 			useNightmareFuelIfPossible();
 		}
 
-		print("The Niche!", "blue");
+		auto_log_info("The Niche!", "blue");
 		autoAdv(1, $location[The Defiled Niche]);
 
 		handleFamiliar("item");
@@ -9605,7 +9565,7 @@ boolean L7_crypt()
 
 	if(get_property("cyrptCrannyEvilness").to_int() > 0)
 	{
-		print("The Cranny!", "blue");
+		auto_log_info("The Cranny!", "blue");
 		set_property("choiceAdventure523", "4");
 
 		if(my_mp() > 60)
@@ -9632,7 +9592,7 @@ boolean L7_crypt()
 		{
 			int desired_pills = in_hardcore() ? 6 : 4;
 			desired_pills -= my_fullness()/2;
-			print("We want " + desired_pills + " dieting pills and have " + item_amount($item[dieting pill]), "blue");
+			auto_log_info("We want " + desired_pills + " dieting pills and have " + item_amount($item[dieting pill]), "blue");
 			if(item_amount($item[dieting pill]) < desired_pills)
 			{
 				if(!bat_wantHowl($location[The Defiled Cranny]))
@@ -9676,12 +9636,12 @@ boolean L7_crypt()
 		}
 		else if(get_property("questL07Cyrptic") == "finished")
 		{
-			print("Looks like we don't have the chest of the bonerdagon but KoLmafia marked Cyrpt quest as finished anyway. Probably some weird path shenanigans.", "red");
+			auto_log_warning("Looks like we don't have the chest of the bonerdagon but KoLmafia marked Cyrpt quest as finished anyway. Probably some weird path shenanigans.", "red");
 			set_property("auto_crypt", "finished");
 		}
 		else if(!tryBoner)
 		{
-			print("We tried to kill the Bonerdagon because the cyrpt was defiled but couldn't adventure there and the chest of the bonerdagon is gone so we can't check that. Anyway, we are going to assume the cyrpt is done now.", "red");
+			auto_log_warning("We tried to kill the Bonerdagon because the cyrpt was defiled but couldn't adventure there and the chest of the bonerdagon is gone so we can't check that. Anyway, we are going to assume the cyrpt is done now.", "red");
 			set_property("auto_crypt", "finished");
 		}
 		else
@@ -9800,24 +9760,24 @@ boolean L6_friarsGetParts()
 
 	if(item_amount($item[box of birthday candles]) == 0)
 	{
-		print("Getting Box of Birthday Candles", "blue");
+		auto_log_info("Getting Box of Birthday Candles", "blue");
 		autoAdv(1, $location[The Dark Heart of the Woods]);
 		return true;
 	}
 
 	if(item_amount($item[dodecagram]) == 0)
 	{
-		print("Getting Dodecagram", "blue");
+		auto_log_info("Getting Dodecagram", "blue");
 		autoAdv(1, $location[The Dark Neck of the Woods]);
 		return true;
 	}
 	if(item_amount($item[eldritch butterknife]) == 0)
 	{
-		print("Getting Eldritch Butterknife", "blue");
+		auto_log_info("Getting Eldritch Butterknife", "blue");
 		autoAdv(1, $location[The Dark Elbow of the Woods]);
 		return true;
 	}
-	print("Finishing friars", "blue");
+	auto_log_info("Finishing friars", "blue");
 	visit_url("friars.php?action=ritual&pwd");
 	council();
 	set_property("auto_friars", "finished"); # used to be done, but no longer need hot wings
@@ -9840,13 +9800,13 @@ boolean LX_steelOrgan()
 	}
 	if($classes[Ed, Gelatinous Noob, Vampyre] contains my_class())
 	{
-		print(my_class() + " can not use a Steel Organ, turning off setting.", "blue");
+		auto_log_info(my_class() + " can not use a Steel Organ, turning off setting.", "blue");
 		set_property("auto_getSteelOrgan", false);
 		return false;
 	}
 	if((auto_my_path() == "Nuclear Autumn") || (auto_my_path() == "License to Adventure"))
 	{
-		print("You could get a Steel Organ for aftercore, but why? We won't help with this deviant and perverse behavior. Turning off setting.", "blue");
+		auto_log_info("You could get a Steel Organ for aftercore, but why? We won't help with this deviant and perverse behavior. Turning off setting.", "blue");
 		set_property("auto_getSteelOrgan", false);
 		return false;
 	}
@@ -9861,13 +9821,13 @@ boolean LX_steelOrgan()
 
 	if(have_skill($skill[Liver of Steel]) || have_skill($skill[Stomach of Steel]) || have_skill($skill[Spleen of Steel]))
 	{
-		print("We have a steel organ, turning off the setting." ,"blue");
+		auto_log_info("We have a steel organ, turning off the setting." ,"blue");
 		set_property("auto_getSteelOrgan", false);
 		return false;
 	}
 	if(get_property("questM10Azazel") != "finished")
 	{
-		print("I am hungry for some steel.", "blue");
+		auto_log_info("I am hungry for some steel.", "blue");
 	}
 
 	if(have_effect($effect[items.enh]) == 0)
@@ -10019,14 +9979,14 @@ boolean LX_steelOrgan()
 		}
 		else
 		{
-			print("Stuck in the Steel Organ quest and can't continue, moving on.", "red");
+			auto_log_warning("Stuck in the Steel Organ quest and can't continue, moving on.", "red");
 			set_property("auto_getSteelOrgan", false);
 		}
 		return true;
 	}
 	else if(get_property("questM10Azazel") == "finished")
 	{
-		print("Considering Steel Organ consumption.....", "blue");
+		auto_log_info("Considering Steel Organ consumption.....", "blue");
 		if((item_amount($item[Steel Lasagna]) > 0) && (fullness_left() >= $item[Steel Lasagna].fullness))
 		{
 			eatsilent(1, $item[Steel Lasagna]);
@@ -10068,7 +10028,7 @@ boolean LX_fancyOilPainting()
 	{
 		return false;
 	}
-	print("Acquiring a Fancy Oil Painting!", "blue");
+	auto_log_info("Acquiring a Fancy Oil Painting!", "blue");
 	set_property("choiceAdventure829", "1");
 	use(1, $item[grimstone mask]);
 	set_property("choiceAdventure823", "1");
@@ -10115,7 +10075,7 @@ boolean L9_leafletQuest()
 	{
 		return false;
 	}
-	print("Got a leaflet to do", "blue");
+	auto_log_info("Got a leaflet to do", "blue");
 	council();
 	cli_execute("leaflet");
 	use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
@@ -10129,12 +10089,11 @@ boolean L8_trapperGround()
 		return false;
 	}
 
-	#print("Starting Trapper Collection", "blue");
 	item oreGoal = to_item(get_property("trapperOre"));
 
 	if((item_amount(oreGoal) >= 3) && (item_amount($item[Goat Cheese]) >= 3))
 	{
-		print("Giving Trapper goat cheese and " + oreGoal, "blue");
+		auto_log_info("Giving Trapper goat cheese and " + oreGoal, "blue");
 		set_property("auto_trapper", "yeti");
 		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
 		return true;
@@ -10142,7 +10101,7 @@ boolean L8_trapperGround()
 
 	if(item_amount($item[Goat Cheese]) < 3)
 	{
-		print("Yay for goat cheese!", "blue");
+		auto_log_info("Yay for goat cheese!", "blue");
 		handleFamiliar("item");
 		if(get_property("_sourceTerminalDuplicateUses").to_int() == 0)
 		{
@@ -10157,12 +10116,12 @@ boolean L8_trapperGround()
 	{
 		if(item_amount($item[Goat Cheese]) >= 3)
 		{
-			print("Giving Trapper goat cheese and " + oreGoal, "blue");
+			auto_log_info("Giving Trapper goat cheese and " + oreGoal, "blue");
 			set_property("auto_trapper", "yeti");
 			visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
 			return true;
 		}
-		print("Yay for goat cheese!", "blue");
+		auto_log_info("Yay for goat cheese!", "blue");
 		handleFamiliar("item");
 		if(get_property("_sourceTerminalDuplicateUses").to_int() == 0)
 		{
@@ -10174,14 +10133,14 @@ boolean L8_trapperGround()
 	}
 	else if((my_rain() > 50) && (have_effect($effect[Ultrahydrated]) == 0) && (auto_my_path() == "Heavy Rains") && have_skill($skill[Rain Man]))
 	{
-		print("Trying to summon a mountain man", "blue");
+		auto_log_info("Trying to summon a mountain man", "blue");
 		set_property("auto_mountainmen", "1");
 		return rainManSummon("mountain man", false, false);
 	}
 	else if(auto_my_path() == "Heavy Rains")
 	{
 		#Do pulls instead if we don't possess rain man?
-		print("Need Ore but not enough rain", "blue");
+		auto_log_info("Need Ore but not enough rain", "blue");
 		return false;
 	}
 	else if(!in_hardcore())
@@ -10193,7 +10152,7 @@ boolean L8_trapperGround()
 	}
 	else if (canGenieCombat() && (get_property("auto_useWishes").to_boolean()) && (catBurglarHeistsLeft() >= 2))
 	{
-		print("Trying to wish for a mountain man, which the cat will then burgle, hopefully.");
+		auto_log_info("Trying to wish for a mountain man, which the cat will then burgle, hopefully.");
 		handleFamiliar("item");
 		handleFamiliar($familiar[cat burglar]);
 		return makeGenieCombat($monster[mountain man]);
@@ -10248,7 +10207,7 @@ boolean LX_guildUnlock()
 	{
 		return false;
 	}
-	print("Let's unlock the guild.", "green");
+	auto_log_info("Let's unlock the guild.", "green");
 
 	string pref;
 	location loc = $location[None];
@@ -10298,7 +10257,7 @@ boolean LX_guildUnlock()
 		}
 		if(internalQuestStatus(pref) < 0)
 		{
-			print("Visiting the guild failed to set guild quest.", "red");
+			auto_log_warning("Visiting the guild failed to set guild quest.", "red");
 			return false;
 		}
 
@@ -10319,7 +10278,7 @@ boolean L8_trapperStart()
 		return false;
 	}
 	council();
-	print("Let's meet the trapper.", "blue");
+	auto_log_info("Let's meet the trapper.", "blue");
 
 	visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
 	set_property("auto_trapper", "start");
@@ -10363,7 +10322,7 @@ boolean L5_goblinKing()
 		return false;
 	}
 
-	print("Death to the gobbo!!", "blue");
+	auto_log_info("Death to the gobbo!!", "blue");
 	if(!autoOutfit("knob goblin harem girl disguise"))
 	{
 		abort("Could not put on Knob Goblin Harem Girl Disguise, aborting");
@@ -10420,7 +10379,7 @@ boolean L4_batCave()
 		return false;
 	}
 
-	print("In the bat hole!", "blue");
+	auto_log_info("In the bat hole!", "blue");
 	if(considerGrimstoneGolem(true))
 	{
 		handleBjornify($familiar[Grimstone Golem]);
@@ -10502,7 +10461,7 @@ boolean L4_batCave()
 					autoAdv(1, $location[The Bat Hole Entrance]);
 					return true;
 				}
-				print("I can nae handle the stench of the Guano Junction!", "green");
+				auto_log_warning("I can nae handle the stench of the Guano Junction!", "green");
 				return false;
 			}
 		}
@@ -10515,7 +10474,7 @@ boolean L4_batCave()
 			}
 			else
 			{
-				print("I can nae handle the stench of the Guano Junction!", "green");
+				auto_log_warning("I can nae handle the stench of the Guano Junction!", "green");
 				return false;
 			}
 		}
@@ -10553,7 +10512,7 @@ boolean LX_craftAcquireItems()
 	if((get_property("lastGoofballBuy").to_int() != my_ascensions()) && (internalQuestStatus("questL03Rat") >= 0))
 	{
 		visit_url("place.php?whichplace=woods");
-		print("Gotginb Goofballs", "blue");
+		auto_log_info("Gotginb Goofballs", "blue");
 		visit_url("tavern.php?place=susguy&action=buygoofballs", true);
 		put_closet(item_amount($item[Bottle of Goofballs]), $item[Bottle of Goofballs]);
 	}
@@ -10742,7 +10701,7 @@ boolean LX_craftAcquireItems()
 		use(1, $item[Letter For Melvign The Gnome]);
 		if(get_property("questM22Shirt") == "unstarted")
 		{
-			print("Mafia did not register using the Melvign letter...", "red");
+			auto_log_warning("Mafia did not register using the Melvign letter...", "red");
 			cli_execute("refresh inv");
 			set_property("questM22Shirt", "started");
 		}
@@ -10855,11 +10814,11 @@ boolean adventureFailureHandler()
 			if(get_property("auto_newbieOverride").to_boolean())
 			{
 				set_property("auto_newbieOverride", false);
-				print("We have spent " + my_location().turns_spent + " turns at '" + my_location() + "' and that is bad... override accepted.", "red");
+				auto_log_warning("We have spent " + my_location().turns_spent + " turns at '" + my_location() + "' and that is bad... override accepted.", "red");
 			}
 			else
 			{
-				print("You can set auto_newbieOverride = true to bypass this once.", "blue");
+				auto_log_critical("You can set auto_newbieOverride = true to bypass this once.", "blue");
 				abort("We have spent " + my_location().turns_spent + " turns at '" + my_location() + "' and that is bad... aborting.");
 			}
 		}
@@ -10911,7 +10870,7 @@ boolean LX_meatMaid()
 
 	if((item_amount($item[Smart Skull]) > 0) && (item_amount($item[Disembodied Brain]) > 0))
 	{
-		print("Got a brain, trying to make and use a meat maid now.", "blue");
+		auto_log_info("Got a brain, trying to make and use a meat maid now.", "blue");
 		cli_execute("make meat maid");
 		use(1, $item[meat maid]);
 		return true;
@@ -10925,7 +10884,7 @@ boolean LX_meatMaid()
 	{
 		return false;
 	}
-	print("Well, we could make a Meat Maid and that seems raisinable.", "blue");
+	auto_log_info("Well, we could make a Meat Maid and that seems raisinable.", "blue");
 
 	if((item_amount($item[Brainy Skull]) == 0) && (item_amount($item[Disembodied Brain]) == 0))
 	{
@@ -10934,7 +10893,7 @@ boolean LX_meatMaid()
 		cloverUsageFinish();
 		if(get_property("lastEncounter") == "Rolling the Bones")
 		{
-			print("Got a brain, trying to make and use a meat maid now.", "blue");
+			auto_log_info("Got a brain, trying to make and use a meat maid now.", "blue");
 			cli_execute("make " + $item[Meat Maid]);
 			use(1, $item[Meat Maid]);
 		}
@@ -10959,7 +10918,7 @@ boolean LX_bitchinMeatcar()
 	}
 	if(in_koe())
 	{
-		print("The desert exploded, so no need to build a meatcar...");
+		auto_log_info("The desert exploded, so no need to build a meatcar...");
 		set_property("lastDesertUnlock", my_ascensions());
 		return false;
 	}
@@ -10991,14 +10950,14 @@ boolean LX_bitchinMeatcar()
 	{
 		if((my_meat() >= 6000) && isGeneralStoreAvailable())
 		{
-			print("We're rich, let's take the bus instead of building a car.", "blue");
+			auto_log_info("We're rich, let's take the bus instead of building a car.", "blue");
 			buyUpTo(1, $item[Desert Bus Pass]);
 			if(item_amount($item[Desert Bus Pass]) > 0)
 			{
 				return true;
 			}
 		}
-		print("Farming for a Bitchin' Meatcar", "blue");
+		auto_log_info("Farming for a Bitchin' Meatcar", "blue");
 		if(get_property("questM01Untinker") == "unstarted")
 		{
 			visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
@@ -11143,7 +11102,7 @@ boolean LX_islandAccess()
 			}
 			if(!reallyUnlocked)
 			{
-				print("lastIslandUnlock is incorrect, you have no way to get to the Island. Unless you barrel smashed when that was allowed. Did you barrel smash? Well, correcting....", "red");
+				auto_log_warning("lastIslandUnlock is incorrect, you have no way to get to the Island. Unless you barrel smashed when that was allowed. Did you barrel smash? Well, correcting....", "red");
 				set_property("lastIslandUnlock", my_ascensions() - 1);
 				return true;
 			}
@@ -11166,7 +11125,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	print("At the shore, la de da!", "blue");
+	auto_log_info("At the shore, la de da!", "blue");
 	if(item_amount($item[Dinghy Plans]) > 0)
 	{
 		abort("Dude, we got Dinghy Plans... we should not be here....");
@@ -11177,7 +11136,7 @@ boolean LX_islandAccess()
 	}
 	if(item_amount($item[Shore Inc. Ship Trip Scrip]) < 3)
 	{
-		print("Failed to get enough Shore Scrip for some raisin, continuing...", "red");
+		auto_log_warning("Failed to get enough Shore Scrip for some raisin, continuing...", "red");
 		return false;
 	}
 
@@ -11223,7 +11182,7 @@ boolean LX_phatLootToken()
 		}
 	}
 
-	print("Phat Loot Token Get!", "blue");
+	auto_log_info("Phat Loot Token Get!", "blue");
 	set_property("choiceAdventure691", "2");
 	autoEquip($slot[acc3], $item[Ring Of Detect Boring Doors]);
 
@@ -11373,7 +11332,7 @@ boolean L2_treeCoin()
 		return false;
 	}
 
-	print("Time for a tree-holed coin", "blue");
+	auto_log_info("Time for a tree-holed coin", "blue");
 	set_property("choiceAdventure502", "2");
 	set_property("choiceAdventure505", "2");
 	autoAdv(1, $location[The Spooky Forest]);
@@ -11386,7 +11345,7 @@ boolean L2_spookyMap()
 	{
 		return false;
 	}
-	print("Need a spooky map now", "blue");
+	auto_log_info("Need a spooky map now", "blue");
 	set_property("choiceAdventure502", "3");
 	set_property("choiceAdventure506", "3");
 	set_property("choiceAdventure507", "1");
@@ -11410,7 +11369,7 @@ boolean L2_spookyFertilizer()
 		set_property("auto_spookyfertilizer", "finished");
 		return false;
 	}
-	print("Need some poop, I mean fertilizer now", "blue");
+	auto_log_info("Need some poop, I mean fertilizer now", "blue");
 	set_property("choiceAdventure502", "3");
 	set_property("choiceAdventure506", "2");
 	autoAdv(1, $location[The Spooky Forest]);
@@ -11427,7 +11386,7 @@ boolean L2_spookySapling()
 	{
 		return false;
 	}
-	print("And a spooky sapling!", "blue");
+	auto_log_info("And a spooky sapling!", "blue");
 	set_property("choiceAdventure502", "1");
 	set_property("choiceAdventure503", "3");
 	set_property("choiceAdventure504", "3");
@@ -11440,12 +11399,12 @@ boolean L2_spookySapling()
 		}
 		if(contains_text(get_property("lastEncounter"), "Blaaargh! Blaaargh!"))
 		{
-			print("Ewww, fake blood semirare. Worst. Day. Ever.", "red");
+			auto_log_warning("Ewww, fake blood semirare. Worst. Day. Ever.", "red");
 			return true;
 		}
 		if(lastAdventureSpecialNC())
 		{
-			print("Special Non-combat interrupted us, no worries...", "green");
+			auto_log_info("Special Non-combat interrupted us, no worries...", "green");
 			return true;
 		}
 		visit_url("choice.php?whichchoice=502&option=1&pwd");
@@ -11484,7 +11443,7 @@ boolean L2_mosquito()
 
 	buffMaintain($effect[Snow Shoes], 0, 1, 1);
 
-	print("Trying to find a mosquito.", "blue");
+	auto_log_info("Trying to find a mosquito.", "blue");
 	set_property("choiceAdventure502", "2");
 	set_property("choiceAdventure505", "1");
 	autoAdv(1, $location[The Spooky Forest]);
@@ -11597,23 +11556,10 @@ boolean LX_handleSpookyravenFirstFloor()
 		abort("Have Lady Spookyraven's Necklace but did not give it to her....");
 	}
 
-#	if((get_property("_sourceTerminalDigitizeMonster") == $monster[Writing Desk]) && (get_property("writingDesksDefeated").to_int() < 5))
-#	{
-#		if(loopHandler("_auto_digitizeDeskTurn", "_auto_digitizeDeskCounter", "Potentially unable to do anything while waiting on digitized writing desks.", 10))
-#		{
-#			print("Have a digitized Writing Desk, let's not bother with the Spooky First Floor", "blue");
-#		}
-#		if((get_property("auto_war") != "finished") && (get_property("auto_powerLevelAdvCount").to_int() < 5) && (get_property("_auto_digitizeDeskCounter").to_int() < 5))
-#		{
-#			return false;
-#		}
-#	}
-
 	if(hasSpookyravenLibraryKey())
 	{
-		print("Well, we need writing desks", "blue");
-		print("Going to the liberry!", "blue");
-#			cli_execute("olfact writing desk");
+		auto_log_info("Well, we need writing desks", "blue");
+		auto_log_info("Going to the liberry!", "blue");
 		set_property("choiceAdventure888", "4");
 		set_property("choiceAdventure889", "5");
 		set_property("choiceAdventure163", "4");
@@ -11666,7 +11612,7 @@ boolean LX_handleSpookyravenFirstFloor()
 
 		if(!possessEquipment($item[Pool Cue]) && !possessEquipment(staffOfFats) && !possessEquipment(staffOfFatsEd) && !possessEquipment(staffOfEd) && !in_tcrs())
 		{
-			print("Well, I need a pool cueball...", "blue");
+			auto_log_info("Well, I need a pool cueball...", "blue");
 			backupSetting("choiceAdventure330", 1);
 			providePlusNonCombat(25, true);
 			autoAdv(1, $location[The Haunted Billiards Room]);
@@ -11674,29 +11620,29 @@ boolean LX_handleSpookyravenFirstFloor()
 			return true;
 		}
 
-		print("Looking at the billiards room: 14 <= " + expectPool + " <= 18", "green");
+		auto_log_info("Looking at the billiards room: 14 <= " + expectPool + " <= 18", "green");
 		if((my_inebriety() < 8) && ((my_inebriety() + 2) < inebriety_limit()))
 		{
 			if(expectPool < 18)
 			{
-				print("Not quite boozed up for the billiards room... we'll be back.", "green");
+				auto_log_info("Not quite boozed up for the billiards room... we'll be back.", "green");
 				if(get_property("auto_powerLevelAdvCount").to_int() < 5)
 				{
 					return false;
 				}
 			}
 
-			print("Well, maybe I'll just deal with not being drunk enough, punk", "blue");
+			auto_log_info("Well, maybe I'll just deal with not being drunk enough, punk", "blue");
 		}
 		if((my_inebriety() > 12) && (expectPool < 16))
 		{
 			if(in_hardcore() && (my_daycount() <= 2))
 			{
-				print("Ok, I'm too boozed up for the billards room, I'll be back.", "green");
+				auto_log_info("Ok, I'm too boozed up for the billards room, I'll be back.", "green");
 			}
 			if(!in_hardcore() && (my_daycount() <= 1))
 			{
-				print("I'm too drunk for pool, at least it is only " + format_date_time("yyyyMMdd", today_to_string(), "EEEE"), "green");
+				auto_log_info("I'm too drunk for pool, at least it is only " + format_date_time("yyyyMMdd", today_to_string(), "EEEE"), "green");
 			}
 			return false;
 		}
@@ -11715,7 +11661,7 @@ boolean LX_handleSpookyravenFirstFloor()
 		autoEquip(staffOfFatsEd);
 		autoEquip(staffOfEd);
 
-		print("It's billiards time!", "blue");
+		auto_log_info("It's billiards time!", "blue");
 		backupSetting("choiceAdventure330", 1);
 		providePlusNonCombat(25, true);
 		autoAdv(1, $location[The Haunted Billiards Room]);
@@ -11723,7 +11669,7 @@ boolean LX_handleSpookyravenFirstFloor()
 	}
 	else
 	{
-		print("Looking for the Billards Room key (Hot/Stench:" + elemental_resist($element[hot]) + "/" + elemental_resist($element[stench]) + "): Progress " + get_property("manorDrawerCount") + "/24", "blue");
+		auto_log_info("Looking for the Billards Room key (Hot/Stench:" + elemental_resist($element[hot]) + "/" + elemental_resist($element[stench]) + "): Progress " + get_property("manorDrawerCount") + "/24", "blue");
 		handleFamiliar($familiar[Exotic Parrot]);
 		if(is100FamiliarRun())
 		{
@@ -11737,7 +11683,7 @@ boolean LX_handleSpookyravenFirstFloor()
 			cli_execute("refresh inv");
 			if(item_amount($item[Spookyraven Billiards Room Key]) == 0)
 			{
-				print("We think you've opened enough drawers in the kitchen but you don't have the Billiards Room Key.");
+				auto_log_warning("We think you've opened enough drawers in the kitchen but you don't have the Billiards Room Key.");
 				wait(10);
 			}
 		}
@@ -11787,7 +11733,7 @@ boolean L5_getEncryptionKey()
 		}
 	}
 
-	print("Looking for the knob.", "blue");
+	auto_log_info("Looking for the knob.", "blue");
 	autoAdv(1, $location[The Outskirts of Cobb\'s Knob]);
 	return true;
 }
@@ -11799,7 +11745,7 @@ boolean LX_handleSpookyravenNecklace()
 		return false;
 	}
 
-	print("Starting Spookyraven Second Floor.", "blue");
+	auto_log_info("Starting Spookyraven Second Floor.", "blue");
 	visit_url("place.php?whichplace=manor1&action=manor1_ladys");
 	visit_url("main.php");
 	visit_url("place.php?whichplace=manor2&action=manor2_ladys");
@@ -11846,7 +11792,7 @@ boolean L12_startWar()
 		return false;
 	}
 
-	print("Must save the ferret!!", "blue");
+	auto_log_info("Must save the ferret!!", "blue");
 	autoOutfit("frat warrior fatigues");
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
@@ -11998,7 +11944,7 @@ boolean L12_preOutfit()
 	{
 		return false;
 	}
-	print("Trying to acquire a filthy hippy outfit", "blue");
+	auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
 
 	if((my_class() == $class[Gelatinous Noob]) && auto_have_familiar($familiar[Robortender]))
 	{
@@ -12033,7 +11979,7 @@ boolean L12_flyerFinish()
 	{
 		if(get_property("sidequestArenaCompleted") != "none")
 		{
-			print("Sidequest Arena detected as completed but flyeredML is not appropriate, fixing.", "red");
+			auto_log_warning("Sidequest Arena detected as completed but flyeredML is not appropriate, fixing.", "red");
 			set_property("flyeredML", 10000);
 		}
 		else
@@ -12045,7 +11991,7 @@ boolean L12_flyerFinish()
 	{
 		return false;
 	}
-	print("Done with this Flyer crap", "blue");
+	auto_log_info("Done with this Flyer crap", "blue");
 	warOutfit(true);
 	visit_url("bigisland.php?place=concert&pwd");
 
@@ -12055,7 +12001,7 @@ boolean L12_flyerFinish()
 		auto_change_mcd(0);
 		return true;
 	}
-	print("We thought we had enough flyeredML, but we don't. Big sadness, let's try that again.", "red");
+	auto_log_warning("We thought we had enough flyeredML, but we don't. Big sadness, let's try that again.", "red");
 	set_property("flyeredML", 9999);
 	return false;
 }
@@ -12100,7 +12046,7 @@ boolean L9_highLandlord()
 
 	if((get_property("twinPeakProgress").to_int() == 15) && (get_property("auto_oilpeak") == "finished") && (get_property("auto_boopeak") == "finished"))
 	{
-		print("Highlord Done", "blue");
+		auto_log_info("Highlord Done", "blue");
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");
 		council();
 		set_property("auto_highlandlord", "finished");
@@ -12130,7 +12076,7 @@ boolean L9_aBooPeak()
 
 	if (get_property("booPeakProgress").to_int() > 90)
 	{
-		print("A-Boo Peak (initial): " + get_property("booPeakProgress"), "blue");
+		auto_log_info("A-Boo Peak (initial): " + get_property("booPeakProgress"), "blue");
 
 		if (clueAmt < 3 && item_amount($item[January\'s Garbage Tote]) > 0)
 		{
@@ -12165,7 +12111,7 @@ boolean L9_aBooPeak()
 		}
 	}
 
-	print("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
+	auto_log_info("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
 	boolean clueCheck = ((clueAmt > 0) || (get_property("auto_aboopending").to_int() != 0));
 	if(clueCheck && (get_property("booPeakProgress").to_int() > 2))
 	{
@@ -12253,9 +12199,9 @@ boolean L9_aBooPeak()
 		#Calculate how much boo peak damage does per unit resistance.
 		int estimatedCold = (13+25+50+125+250) * ((100.0 - elemental_resist_value(coldResist)) / 100.0);
 		int estimatedSpooky = (13+25+50+125+250) * ((100.0 - elemental_resist_value(spookyResist)) / 100.0);
-		print("Current HP: " + my_hp() + "/" + my_maxhp(), "blue");
-		print("Expected cold damage: " + estimatedCold + " Expected spooky damage: " + estimatedSpooky, "blue");
-		print("Expected Cold Resist: " + coldResist + " Expected Spooky Resist: " + spookyResist + " Expected HP Difference: " + hpDifference, "blue");
+		auto_log_info("Current HP: " + my_hp() + "/" + my_maxhp(), "blue");
+		auto_log_info("Expected cold damage: " + estimatedCold + " Expected spooky damage: " + estimatedSpooky, "blue");
+		auto_log_info("Expected Cold Resist: " + coldResist + " Expected Spooky Resist: " + spookyResist + " Expected HP Difference: " + hpDifference, "blue");
 		int totalDamage = estimatedCold + estimatedSpooky;
 
 		if(get_property("booPeakProgress").to_int() <= 6)
@@ -12279,9 +12225,9 @@ boolean L9_aBooPeak()
 
 		if(get_property("booPeakProgress").to_int() <= 20)
 		{
-			print("Don't need a full A-Boo Clue, adjusting values:", "blue");
-			print("Expected cold damage: " + estimatedCold + " Expected spooky damage: " + estimatedSpooky, "blue");
-			print("Expected Cold Resist: " + coldResist + " Expected Spooky Resist: " + spookyResist + " Expected HP Difference: " + hpDifference, "blue");
+			auto_log_info("Don't need a full A-Boo Clue, adjusting values:", "blue");
+			auto_log_info("Expected cold damage: " + estimatedCold + " Expected spooky damage: " + estimatedSpooky, "blue");
+			auto_log_info("Expected Cold Resist: " + coldResist + " Expected Spooky Resist: " + spookyResist + " Expected HP Difference: " + hpDifference, "blue");
 		}
 
 		int considerHP = my_maxhp() + hpDifference;
@@ -12369,7 +12315,7 @@ boolean L9_aBooPeak()
 			{
 				if(get_property("lastEncounter") != "The Horror...")
 				{
-					print("Wandering adventure interrupt of A-Boo Peak, refreshing inventory.", "red");
+					auto_log_warning("Wandering adventure interrupt of A-Boo Peak, refreshing inventory.", "red");
 					cli_execute("refresh inv");
 				}
 				else
@@ -12391,7 +12337,7 @@ boolean L9_aBooPeak()
 			return true;
 		}
 
-		print("Nevermind, that peak is too scary!", "green");
+		auto_log_info("Nevermind, that peak is too scary!", "green");
 		equipBaseline();
 		handleFamiliar("item");
 		handleBjornify(priorBjorn);
@@ -12443,7 +12389,7 @@ boolean L9_twinPeak()
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 	if(get_property("auto_twinpeakprogress").to_int() == 0)
 	{
-		print("Twin Peak", "blue");
+		auto_log_info("Twin Peak", "blue");
 		set_property("choiceAdventure604", "1");
 		set_property("choiceAdventure618", "2");
 		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
@@ -12656,15 +12602,15 @@ boolean L9_twinPeak()
 		{
 			abort("Tried using a rusty hedge trimmer but that didn't seem to work");
 		}
-		print("Hedge trimming situation: " + attemptNum, "green");
+		auto_log_info("Hedge trimming situation: " + attemptNum, "green");
 		string page = visit_url("main.php");
 		if((contains_text(page, "choice.php")) && (!contains_text(page, "Really Sticking Her Neck Out")) && (!contains_text(page, "It Came from Beneath the Sewer?")))
 		{
-			print("Inside of a Rusty Hedge Trimmer sequence.", "blue");
+			auto_log_info("Inside of a Rusty Hedge Trimmer sequence.", "blue");
 		}
 		else
 		{
-			print("Rusty Hedge Trimmer Sequence completed itself.", "blue");
+			auto_log_info("Rusty Hedge Trimmer Sequence completed itself.", "blue");
 			return true;
 		}
 	}
@@ -12684,7 +12630,7 @@ boolean L9_twinPeak()
 		return true;
 	}
 
-	print("Backwards Twin Peak Handler, can this be removed? (As of 2016/04/17, no)", "red");
+	auto_log_warning("Backwards Twin Peak Handler, can this be removed? (As of 2016/04/17, no)", "red");
 	string page = visit_url("main.php");
 	if((contains_text(page, "choice.php")) && (!contains_text(page, "Really Sticking Her Neck Out")) && (!contains_text(page, "It Came from Beneath the Sewer?")))
 	{
@@ -12778,7 +12724,7 @@ boolean L9_oilPeak()
 			set_property("auto_oilpeak", "finished");
 			return true;
 		}
-		print("Oil Peak is finished but we need more crude!", "blue");
+		auto_log_info("Oil Peak is finished but we need more crude!", "blue");
 	}
 
 	buffMaintain($effect[Litterbug], 0, 1, 1);
@@ -12836,7 +12782,7 @@ boolean L9_oilPeak()
 	}
 	addToMaximize("1000ml 100max");
 
-	print("Oil Peak with ML: " + monster_level_adjustment(), "blue");
+	auto_log_info("Oil Peak with ML: " + monster_level_adjustment(), "blue");
 
 	autoAdv(1, $location[Oil Peak]);
 	if(get_property("lastEncounter") == "Unimpressed with Pressure")
@@ -12844,7 +12790,7 @@ boolean L9_oilPeak()
 		set_property("oilPeakProgress", 0.0);
 
 		// Brute Force grouping with tavern (if not done) to maximize tangles while we have a high ML.
-		print("Checking to see if we should do the tavern while we are running high ML.", "green");
+		auto_log_info("Checking to see if we should do the tavern while we are running high ML.", "green");
 		set_property("auto_forceTavern", true);
 		// Remove Driving Wastefully if we had it
 		if (0 < have_effect($effect[Driving Wastefully]))
@@ -12875,14 +12821,14 @@ boolean LX_loggingHatchet()
 		return false;
 	}
 
-	print("Acquiring the logging hatchet from Camp Logging Camp", "blue");
+	auto_log_info("Acquiring the logging hatchet from Camp Logging Camp", "blue");
 	autoAdv(1, $location[Camp Logging Camp]);
 	return true;
 }
 
 void L9_chasmMaximizeForNoncombat()
 {
-	print("Let's assess our scores for blech house", "blue");
+	auto_log_info("Let's assess our scores for blech house", "blue");
 	string best = "mus";
 	string mustry = "100muscle,100weapon damage,1000weapon damage percent";
 	string mystry = "100mysticality,100spell damage,1000 spell damage percent";
@@ -12892,13 +12838,13 @@ void L9_chasmMaximizeForNoncombat()
 	float musflat = simValue("Weapon Damage");
 	float musperc = simValue("Weapon Damage Percent");
 	int musscore = floor(square_root((musmus + musflat)/15*(1+musperc/100)));
-	print("Muscle score: " + musscore, "blue");
+	auto_log_info("Muscle score: " + musscore, "blue");
 	simMaximizeWith(mystry);
 	float mysmys = simValue("Buffed Mysticality");
 	float mysflat = simValue("Spell Damage");
 	float mysperc = simValue("Spell Damage Percent");
 	int mysscore = floor(square_root((mysmys + mysflat)/15*(1+mysperc/100)));
-	print("Mysticality score: " + mysscore, "blue");
+	auto_log_info("Mysticality score: " + mysscore, "blue");
 	if(mysscore > musscore)
 	{
 		best = "mys";
@@ -12907,7 +12853,7 @@ void L9_chasmMaximizeForNoncombat()
 	float moxmox = simValue("Buffed Moxie");
 	float moxres = simValue("Sleaze Resistance");
 	int moxscore = floor(square_root(moxmox/30*(1+moxres*0.69)));
-	print("Moxie score: " + moxscore, "blue");
+	auto_log_info("Moxie score: " + moxscore, "blue");
 	if(moxscore > mysscore && moxscore > musscore)
 	{
 		best = "mox";
@@ -12935,7 +12881,7 @@ boolean L9_chasmBuild()
 		return false;
 	}
 
-	print("Chasm time", "blue");
+	auto_log_info("Chasm time", "blue");
 
 	if(item_amount($item[fancy oil painting]) > 0)
 	{
@@ -12975,24 +12921,24 @@ boolean L9_chasmBuild()
 	// Always Maximize and choose our default Non-Com First, in case we are wrong about the non-com we MAY have some gear still equipped to help us.
 	if(useSpellsInOrcCamp == true)
 	{
-		print("Preparing to Blast Orcs with Cold Spells!", "blue");
+		auto_log_info("Preparing to Blast Orcs with Cold Spells!", "blue");
 		addToMaximize("myst,40spell damage,80spell damage percent,40cold spell damage,-1000 ml");
 		buffMaintain($effect[Carol of the Hells], 50, 1, 1);
 		buffMaintain($effect[Song of Sauce], 150, 1, 1);
 
-		print("If we encounter Blech House when we are not expecting it we will stop.", "blue");
-		print("Currently setup for Myst/Spell Damage, option 2: Blast it down with a spell", "blue");
+		auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
+		auto_log_info("Currently setup for Myst/Spell Damage, option 2: Blast it down with a spell", "blue");
 		set_property("choiceAdventure1345", 0);
 	}
 	else
 	{
-		print("Preparing to Ice-Punch Orcs!", "blue");
+		auto_log_info("Preparing to Ice-Punch Orcs!", "blue");
 		addToMaximize("muscle,40weapon damage,60weapon damage percent,40cold damage,-1000 ml");
 		buffMaintain($effect[Carol of the Bulls], 50, 1, 1);
 		buffMaintain($effect[Song of The North], 150, 1, 1);
 
-		print("Beta Testing Off: If we encounter Blech House when we are not expecting it we will stop.", "blue");
-		print("Currently setup for Muscle/Weapon Damage, option 1: Kick it down", "blue");
+		auto_log_info("Beta Testing Off: If we encounter Blech House when we are not expecting it we will stop.", "blue");
+		auto_log_info("Currently setup for Muscle/Weapon Damage, option 1: Kick it down", "blue");
 		set_property("choiceAdventure1345", 0);
 	}
 
@@ -13001,7 +12947,7 @@ boolean L9_chasmBuild()
 		// If we think the non-com will hit NOW we clear maximizer to keep previous settings from carrying forward
 		resetMaximize();
 
-		print("The smut orc noncombat is about to hit...");
+		auto_log_info("The smut orc noncombat is about to hit...");
 		// This is a hardcoded patch for Dark Gyffte
 		// TODO: once explicit formulas are spaded, use simulated maximizer
 		// to determine best approach.
@@ -13230,9 +13176,9 @@ boolean L11_redZeppelin()
 				lynyrd_protestors += 5;
 			}
 		}
-		print("Hiding in the bushes: " + lynyrd_protestors, "blue");
-		print("Going to a bench: " + sleaze_protestors, "blue");
-		print("Heading towards the flames" + fire_protestors, "blue");
+		auto_log_info("Hiding in the bushes: " + lynyrd_protestors, "blue");
+		auto_log_info("Going to a bench: " + sleaze_protestors, "blue");
+		auto_log_info("Heading towards the flames" + fire_protestors, "blue");
 		float best_protestors = max(fire_protestors, max(sleaze_protestors, lynyrd_protestors));
 		if(best_protestors >= 10)
 		{
@@ -13525,7 +13471,7 @@ boolean L11_mcmuffinDiary()
 		return false;
 	}
 
-	print("Getting the McMuffin Diary", "blue");
+	auto_log_info("Getting the McMuffin Diary", "blue");
 	doVacation();
 	foreach diary in $items[Your Father\'s Macguffin Diary, Copy of a Jerk Adventurer\'s Father\'s Diary]
 	{
@@ -13559,11 +13505,11 @@ boolean L11_forgedDocuments()
 	}
 	if(my_meat() < 5000)
 	{
-		print("Could not buy Forged Identification Documents, can not steal identities!", "red");
+		auto_log_warning("Could not buy Forged Identification Documents, can not steal identities!", "red");
 		return false;
 	}
 
-	print("Getting the McMuffin Book", "blue");
+	auto_log_info("Getting the McMuffin Book", "blue");
 	if(auto_my_path() == "Way of the Surprising Fist")
 	{
 		L11_fistDocuments();
@@ -13575,7 +13521,7 @@ boolean L11_forgedDocuments()
 		handleFamiliar("item");
 		return true;
 	}
-	print("Could not buy Forged Identification Documents, can't get booze now!", "red");
+	auto_log_warning("Could not buy Forged Identification Documents, can't get booze now!", "red");
 	return false;
 }
 
@@ -13622,7 +13568,7 @@ boolean L11_blackMarket()
 	}
 	if($location[The Black Forest].turns_spent > 12)
 	{
-		print("We have spent a bit many adventures in The Black Forest... manually checking", "red");
+		auto_log_warning("We have spent a bit many adventures in The Black Forest... manually checking", "red");
 		visit_url("place.php?whichplace=woods");
 		visit_url("woods.php");
 		if($location[The Black Forest].turns_spent > 30)
@@ -13631,7 +13577,7 @@ boolean L11_blackMarket()
 		}
 	}
 
-	print("Must find the Black Market: " + get_property("blackForestProgress"), "blue");
+	auto_log_info("Must find the Black Market: " + get_property("blackForestProgress"), "blue");
 	if(get_property("auto_blackfam").to_boolean())
 	{
 		council();
@@ -13724,7 +13670,7 @@ boolean L10_holeInTheSky()
 	}
 	if(!zone_isAvailable($location[The Hole In The Sky]))
 	{
-		print("The Hole In The Sky is not available, we have to do something else...", "red");
+		auto_log_warning("The Hole In The Sky is not available, we have to do something else...", "red");
 		return false;
 	}
 
@@ -13785,7 +13731,7 @@ boolean L5_haremOutfit()
 	}
 	bat_formBats();
 
-	print("Looking for some sexy lingerie!", "blue");
+	auto_log_info("Looking for some sexy lingerie!", "blue");
 	autoAdv(1, $location[Cobb\'s Knob Harem]);
 	handleFamiliar("item");
 	return true;
@@ -13911,7 +13857,7 @@ boolean L8_trapperGroar()
 				set_property("auto_mistypeak", "finished");
 			}
 
-			print("Time to take out Gargle, sure, Gargle (Groar)", "blue");
+			auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
 			if (item_amount($item[Groar\'s Fur]) == 0 && item_amount($item[Winged Yeti Fur]) == 0)
 			{
 				addToMaximize("5meat 2000cold res 5 max");
@@ -13963,12 +13909,12 @@ boolean L8_trapperExtreme()
 		}
 		else
 		{
-			print("I can not wear the eXtreme Gear, I'm just not awesome enough :(", "red");
+			auto_log_warning("I can not wear the eXtreme Gear, I'm just not awesome enough :(", "red");
 			return false;
 		}
 	}
 
-	print("Penguin Tony Hawk time. Extreme!! SSX Tricky!!", "blue");
+	auto_log_info("Penguin Tony Hawk time. Extreme!! SSX Tricky!!", "blue");
 	if(possessEquipment($item[extreme mittens]))
 	{
 		set_property("choiceAdventure15", "2");
@@ -14048,7 +13994,7 @@ boolean L8_trapperYeti()
 	{
 		if(loopHandler("_auto_digitizeAssassinTurn", "_auto_digitizeAssassinCounter", "Potentially unable to do anything while waiting on digitized Ninja Snowman Assassin.", 10))
 		{
-			print("Have a digitized Ninja Snowman Assassin, let's put off the Ninja Snowman Lair", "blue");
+			auto_log_info("Have a digitized Ninja Snowman Assassin, let's put off the Ninja Snowman Lair", "blue");
 		}
 		return false;
 	}
@@ -14079,7 +14025,7 @@ boolean L8_trapperYeti()
 		asdonBuff($effect[Driving Obnoxiously]);
 		if(!providePlusCombat(25))
 		{
-			print("Could not uneffect for ninja snowmen, delaying", "red");
+			auto_log_warning("Could not uneffect for ninja snowmen, delaying", "red");
 			return false;
 		}
 
@@ -14095,14 +14041,14 @@ boolean L8_trapperYeti()
 
 		if(numeric_modifier("Combat Rate") <= 0.0)
 		{
-			print("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Ninja Snowmen.", "red");
+			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Ninja Snowmen.", "red");
 			equipBaseline();
 			return false;
 		}
 
 		if(!autoAdv(1, $location[Lair of the Ninja Snowmen]))
 		{
-			print("Seems like we failed the Ninja Snowmen unlock, reverting trapper setting", "red");
+			auto_log_warning("Seems like we failed the Ninja Snowmen unlock, reverting trapper setting", "red");
 			set_property("auto_trapper", "start");
 		}
 		return true;
@@ -14137,7 +14083,7 @@ boolean auto_tavern()
 		set_property("auto_tavern", "finished");
 		return true;
 	}
-	print("In the tavern! Layout: " + tavern, "blue");
+	auto_log_info("In the tavern! Layout: " + tavern, "blue");
 	boolean [int] locations = $ints[3, 2, 1, 0, 5, 10, 15, 20, 16, 21];
 
 	// Infrequent compunding issue, reset maximizer
@@ -14275,17 +14221,17 @@ boolean auto_tavern()
 			if(contains_text(page, "You've already explored that spot."))
 			{
 				needReset = true;
-				print("tavernLayout is not reporting places we've been to.", "red");
+				auto_log_warning("tavernLayout is not reporting places we've been to.", "red");
 			}
 			if(contains_text(page, "Darkness (5,5)"))
 			{
 				needReset = true;
-				print("tavernLayout is reporting too many places as visited.", "red");
+				auto_log_warning("tavernLayout is reporting too many places as visited.", "red");
 			}
 
 			if(contains_text(page, "whichchoice value=") || contains_text(page, "whichchoice="))
 			{
-				print("Tavern handler: You are RL drunk, you should not be here.", "red");
+				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
 			if(last_monster() == $monster[Crate])
@@ -14306,16 +14252,16 @@ boolean auto_tavern()
 
 			if(needReset)
 			{
-				print("We attempted a tavern adventure but the tavern layout was not maintained properly.", "red");
-				print("Attempting to reset this issue...", "red");
+				auto_log_warning("We attempted a tavern adventure but the tavern layout was not maintained properly.", "red");
+				auto_log_warning("Attempting to reset this issue...", "red");
 				set_property("tavernLayout", "0000100000000000000000000");
 				visit_url("cellar.php");
 			}
 			return true;
 		}
 	}
-	print("We found no valid location to tavern, something went wrong...", "red");
-	print("Attempting to reset this issue...", "red");
+	auto_log_warning("We found no valid location to tavern, something went wrong...", "red");
+	auto_log_warning("Attempting to reset this issue...", "red");
 	set_property("tavernLayout", "0000100000000000000000000");
 	wait(5);
 	return true;
@@ -14381,7 +14327,7 @@ boolean L3_tavern()
 		return false;
 	}
 
-	print("Doing Tavern", "blue");
+	auto_log_info("Doing Tavern", "blue");
 
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
@@ -14525,44 +14471,44 @@ void print_header()
 	}
 	if(in_hardcore())
 	{
-		print("Turn(" + my_turncount() + "): Starting with " + my_adventures() + " left at Level: " + my_level(), "cyan");
+		auto_log_info("Turn(" + my_turncount() + "): Starting with " + my_adventures() + " left at Level: " + my_level(), "cyan");
 	}
 	else
 	{
-		print("Turn(" + my_turncount() + "): Starting with " + my_adventures() + " left and " + pulls_remaining() + " pulls left at Level: " + my_level(), "cyan");
+		auto_log_info("Turn(" + my_turncount() + "): Starting with " + my_adventures() + " left and " + pulls_remaining() + " pulls left at Level: " + my_level(), "cyan");
 	}
 	if(((item_amount($item[Rock Band Flyers]) == 1) || (item_amount($item[Jam Band Flyers]) == 1)) && (get_property("flyeredML").to_int() < 10000) && !get_property("auto_ignoreFlyer").to_boolean())
 	{
-		print("Still flyering: " + get_property("flyeredML"), "blue");
+		auto_log_info("Still flyering: " + get_property("flyeredML"), "blue");
 	}
-	print("Encounter: " + combat_rate_modifier() + "   Exp Bonus: " + experience_bonus(), "blue");
-	print("Meat Drop: " + meat_drop_modifier() + "	 Item Drop: " + item_drop_modifier(), "blue");
-	print("HP: " + my_hp() + "/" + my_maxhp() + ", MP: " + my_mp() + "/" + my_maxmp(), "blue");
-	print("Tummy: " + my_fullness() + "/" + fullness_limit() + " Liver: " + my_inebriety() + "/" + inebriety_limit() + " Spleen: " + my_spleen_use() + "/" + spleen_limit(), "blue");
-	print("ML: " + monster_level_adjustment() + " control: " + current_mcd(), "blue");
+	auto_log_info("Encounter: " + combat_rate_modifier() + "   Exp Bonus: " + experience_bonus(), "blue");
+	auto_log_info("Meat Drop: " + meat_drop_modifier() + "	 Item Drop: " + item_drop_modifier(), "blue");
+	auto_log_info("HP: " + my_hp() + "/" + my_maxhp() + ", MP: " + my_mp() + "/" + my_maxmp(), "blue");
+	auto_log_info("Tummy: " + my_fullness() + "/" + fullness_limit() + " Liver: " + my_inebriety() + "/" + inebriety_limit() + " Spleen: " + my_spleen_use() + "/" + spleen_limit(), "blue");
+	auto_log_info("ML: " + monster_level_adjustment() + " control: " + current_mcd(), "blue");
 	if(my_class() == $class[Sauceror])
 	{
-		print("Soulsauce: " + my_soulsauce(), "blue");
+		auto_log_info("Soulsauce: " + my_soulsauce(), "blue");
 	}
 	if((have_effect($effect[Ultrahydrated]) > 0) && (get_property("desertExploration").to_int() < 100))
 	{
-		print("Ultrahydrated: " + have_effect($effect[Ultrahydrated]), "violet");
+		auto_log_info("Ultrahydrated: " + have_effect($effect[Ultrahydrated]), "violet");
 	}
 	if(have_effect($effect[Everything Looks Yellow]) > 0)
 	{
-		print("Everything Looks Yellow: " + have_effect($effect[Everything Looks Yellow]), "blue");
+		auto_log_info("Everything Looks Yellow: " + have_effect($effect[Everything Looks Yellow]), "blue");
 	}
 	if(equipped_item($slot[familiar]) == $item[Snow Suit])
 	{
-		print("Snow suit usage: " + get_property("_snowSuitCount") + " carrots: " + get_property("_carrotNoseDrops"), "blue");
+		auto_log_info("Snow suit usage: " + get_property("_snowSuitCount") + " carrots: " + get_property("_carrotNoseDrops"), "blue");
 	}
 	if(auto_my_path() == "Heavy Rains")
 	{
-		print("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
+		auto_log_info("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}
 	if (isActuallyEd())
 	{
-		print("Ka Coins: " + item_amount($item[Ka Coin]) + " Lashes used: " + get_property("_edLashCount"), "green");
+		auto_log_info("Ka Coins: " + item_amount($item[Ka Coin]) + " Lashes used: " + get_property("_edLashCount"), "green");
 	}
 }
 
@@ -14570,7 +14516,7 @@ boolean doTasks()
 {
 	if(get_property("_casualAscension").to_int() >= my_ascensions())
 	{
-		print("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");
+		auto_log_warning("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");
 		return false;
 	}
 
@@ -14587,7 +14533,7 @@ boolean doTasks()
 	int delay = get_property("auto_delayTimer").to_int();
 	if(delay != 0)
 	{
-		print("Delay between adventures... beep boop... ", "blue");
+		auto_log_info("Delay between adventures... beep boop... ", "blue");
 		wait(delay);
 	}
 
@@ -14597,8 +14543,8 @@ boolean doTasks()
 		int paranoia_counter = get_property("auto_paranoia_counter").to_int();
 		if(paranoia_counter >= paranoia)
 		{
-			print("I think I'm paranoid and complicated", "blue");
-			print("I think I'm paranoid, manipulated", "blue");
+			auto_log_info("I think I'm paranoid and complicated", "blue");
+			auto_log_info("I think I'm paranoid, manipulated", "blue");
 			cli_execute("refresh quests");
 			set_property("auto_paranoia_counter", 0);
 		}
@@ -15023,7 +14969,7 @@ boolean doTasks()
 	{
 		if((get_property("hippiesDefeated").to_int() < 64) && (get_property("fratboysDefeated").to_int() < 64) && (my_level() >= 12) && (get_property("auto_prewar") == "started") && (get_property("auto_war") != "finished"))
 		{
-			print("First 64 combats. To orchard/lighthouse", "blue");
+			auto_log_info("First 64 combats. To orchard/lighthouse", "blue");
 			if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cashew]) >= 3))
 			{
 				cli_execute("make 1 stuffing fluffer");
@@ -15049,7 +14995,7 @@ boolean doTasks()
 
 		if((get_property("hippiesDefeated").to_int() < 192) && (get_property("fratboysDefeated").to_int() < 192) && (my_level() >= 12) && (get_property("auto_prewar") != ""))
 		{
-			print("Getting to the nunnery/junkyard", "blue");
+			auto_log_info("Getting to the nunnery/junkyard", "blue");
 			handleFamiliar("item");
 			warOutfit(false);
 			return warAdventure();
@@ -15057,7 +15003,7 @@ boolean doTasks()
 
 		if(((get_property("auto_nuns") == "finished") || (get_property("auto_nuns") == "done")) && ((get_property("hippiesDefeated").to_int() < 1000) && (get_property("fratboysDefeated").to_int() < 1000)) && (my_level() >= 12))
 		{
-			print("Doing the wars.", "blue");
+			auto_log_info("Doing the wars.", "blue");
 			handleFamiliar("item");
 			warOutfit(false);
 			return warAdventure();
@@ -15083,7 +15029,7 @@ boolean doTasks()
 		return true;
 	}
 
-	print("I should not get here more than once because I pretty much just finished all my in-run stuff. Beep", "blue");
+	auto_log_info("I should not get here more than once because I pretty much just finished all my in-run stuff. Beep", "blue");
 	return false;
 }
 
@@ -15103,7 +15049,7 @@ void auto_begin()
 		}
 		else
 		{
-			print("Okay, but the warranty is off.", "red");
+			auto_log_warning("Okay, but the warranty is off.", "red");
 		}
 	}
 
@@ -15129,23 +15075,22 @@ void auto_begin()
 	}
 	else if(contains_text(page, "<b>Torpor</b>") && contains_text(page, "Madness of Untold Aeons") && contains_text(page, "Rest for untold Millenia"))
 	{
-		print("Torporing, since I think we're already in torpor.", "blue");
+		auto_log_info("Torporing, since I think we're already in torpor.", "blue");
 		bat_reallyPickSkills(20);
 	}
 
-#	if(my_class() == $class[Astral Spirit])
 	if(to_string(my_class()) == "Astral Spirit")
 	{
 		# my_class() can report Astral Spirit even though it is not a valid class....
-		print("We think we are an Astral Spirit, if you actually are that's bad!", "red");
+		auto_log_warning("We think we are an Astral Spirit, if you actually are that's bad!", "red");
 		cli_execute("refresh all");
 	}
 
-	print("Hello " + my_name() + ", time to explode!");
-	print("This is version: " + svn_info("autoscend").last_changed_rev + " Mafia: " + get_revision());
-	print("This is day " + my_daycount() + ".");
-	print("Turns played: " + my_turncount() + " current adventures: " + my_adventures());
-	print("Current Ascension: " + auto_my_path());
+	auto_log_info("Hello " + my_name() + ", time to explode!");
+	auto_log_info("This is version: " + svn_info("autoscend").last_changed_rev + " Mafia: " + get_revision());
+	auto_log_info("This is day " + my_daycount() + ".");
+	auto_log_info("Turns played: " + my_turncount() + " current adventures: " + my_adventures());
+	auto_log_info("Current Ascension: " + auto_my_path());
 
 	set_property("auto_disableAdventureHandling", false);
 
@@ -15189,7 +15134,7 @@ void auto_begin()
 	string charpane = visit_url("charpane.php");
 	if(contains_text(charpane, "<hr width=50%><table"))
 	{
-		print("Switching off Compact Character Mode, will resume during bedtime");
+		auto_log_info("Switching off Compact Character Mode, will resume during bedtime");
 		set_property("auto_priorCharpaneMode", 1);
 		visit_url("account.php?am=1&pwd=&action=flag_compactchar&value=0&ajax=0", true);
 	}
@@ -15205,7 +15150,7 @@ void auto_begin()
 
 	if(my_familiar() == $familiar[Stooper])
 	{
-		print("Avoiding stooper stupor...", "blue");
+		auto_log_info("Avoiding stooper stupor...", "blue");
 		use_familiar($familiar[none]);
 	}
 	dailyEvents();
@@ -15259,7 +15204,7 @@ void auto_begin()
 
 	if(doBedtime())
 	{
-		print("Done for today (" + my_daycount() + "), beep boop");
+		auto_log_info("Done for today (" + my_daycount() + "), beep boop");
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -119,13 +119,13 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 		ed_preAdv(1, loc, option);
 	}
 
-	print("About to start a combat indirectly at " + loc + "... (" + count(url) + ") accesses required.", "blue");
+	auto_log_info("About to start a combat indirectly at " + loc + "... (" + count(url) + ") accesses required.", "blue");
 	string page;
 	foreach idx, it in url
 	{
 		if((urlGetFlags & 1) == 1)
 		{
-			#print("Visit_url(" + it + ") override to false", "red");
+			#auto_log_warning("Visit_url(" + it + ") override to false", "red");
 			//When using this, you may have to add my_hash yourself.
 			//We can probably do this (but is it possible that a search for "pwd" can cause false positives?)
 			page = visit_url(it, false);
@@ -138,7 +138,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	}
 	if((my_hp() == 0) || (get_property("_edDefeats").to_int() == 1) || (have_effect($effect[Beaten Up]) > 0))
 	{
-		print("Uh oh! Died when starting a combat indirectly.", "red");
+		auto_log_warning("Uh oh! Died when starting a combat indirectly.", "red");
 		if(my_class() == $class[Ed])
 		{
 			return ed_autoAdv(1, loc, option, true);
@@ -154,7 +154,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	}
 	if(contains_text(page, combatPage))
 	{
-		print("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
+		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 
 		if(option != "autoscend_null") // && (option != ""))
 		{
@@ -216,7 +216,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	boolean inChoice = false;
 	if(contains_text(page, "whichchoice value=") || contains_text(page, "whichchoice="))
 	{
-		print("Override hit a choice adventure (" + loc + "), trying....", "red");
+		auto_log_warning("Override hit a choice adventure (" + loc + "), trying....", "red");
 		inChoice = true;
 	}
 
@@ -320,7 +320,7 @@ boolean preAdvXiblaxian(location loc)
 		{
 			if(contains_text(visit_url("main.php"), "Combat"))
 			{
-				print("As Ed, I was not bypassed into this combat correctly (but it'll be ok)", "red");
+				auto_log_warning("As Ed, I was not bypassed into this combat correctly (but it'll be ok)", "red");
 				return false;
 			}
 		}
@@ -349,7 +349,7 @@ boolean preAdvXiblaxian(location loc)
 			}
 			else
 			{
-				print("We should be getting a Xiblaxian wotsit this combat. Beep boop.", "green");
+				auto_log_info("We should be getting a Xiblaxian wotsit this combat. Beep boop.", "green");
 			}
 		}
 		else if(toMake == $item[Xiblaxian Space-Whiskey])
@@ -368,7 +368,7 @@ boolean preAdvXiblaxian(location loc)
 			}
 			else
 			{
-				print("We should be getting a Xiblaxian wotsit this combat. Beep boop.", "green");
+				auto_log_info("We should be getting a Xiblaxian wotsit this combat. Beep boop.", "green");
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_aftercore.ash
+++ b/RELEASE/scripts/autoscend/auto_aftercore.ash
@@ -45,10 +45,7 @@ void auto_combatTest()
 
 string simpleCombatFilter(int round, string opp, string text)
 {
-	#throw_item($item[Seal Tooth]);
-	#return "item seal tooth";
-	print("I've been called at on round: " + round, "green");
-	#return url_encode("\"item seal tooth; repeat\"");
+	auto_log_debug("I've been called at on round: " + round, "green");
 	return "\"item seal tooth; repeat\"";
 }
 
@@ -765,7 +762,7 @@ boolean autoscendIntoBond()
 	string temp = visit_url("ascend.php?pwd=&confirm=on&confirm2=on&action=ascend&submit=Ascend", true);
 	if(contains_text(temp, "You may not enter the Astral Gash again until tomorrow."))
 	{
-		print("Could not ascend, refractory period required.", "red");
+		auto_log_error("Could not ascend, refractory period required.", "red");
 		return false;
 	}
 	temp = visit_url("afterlife.php?action=pearlygates");
@@ -951,7 +948,7 @@ boolean auto_cheesePostCS(int leave)
 			autoAdv($location[The Ice Hotel]);
 			if(get_property("_sourceTerminalDigitizeMonsterCount").to_int() != 2)
 			{
-				print("Did digitize tracking get mixed up?", "red");
+				auto_log_warning("Did digitize tracking get mixed up?", "red");
 			}
 		}
 		if(isOverdueArrow())
@@ -959,7 +956,7 @@ boolean auto_cheesePostCS(int leave)
 			autoAdv($location[The Ice Hotel]);
 			if(get_property("_romanticFightsLeft").to_int() == 2)
 			{
-				print("Probably got confused about an arrow fight, adjusting", "red");
+				auto_log_warning("Probably got confused about an arrow fight, adjusting", "red");
 				set_property("_romanticFightsLeft", 1);
 			}
 		}
@@ -1267,7 +1264,7 @@ boolean auto_cheesePostCS(int leave)
 			visit_url("campground.php?action=rest");
 			if(auto_get_campground() contains $item[Confusing LED Clock])
 			{
-				print("Was unable to use Confusing LED Clock", "red");
+				auto_log_warning("Was unable to use Confusing LED Clock", "red");
 			}
 			else
 			{
@@ -1276,7 +1273,7 @@ boolean auto_cheesePostCS(int leave)
 		}
 		else
 		{
-			print("Could not place a Confusing LED Clock", "red");
+			auto_log_warning("Could not place a Confusing LED Clock", "red");
 		}
 	}
 
@@ -1355,7 +1352,7 @@ boolean auto_cheesePostCS(int leave)
 
 	while((my_adventures() > leave) && (inebriety_left() >= 0))
 	{
-		print("Have " + my_adventures() + " with target of " + leave + " adventures.", "orange");
+		auto_log_info("Have " + my_adventures() + " with target of " + leave + " adventures.", "orange");
 		buffMaintain($effect[Polka of Plenty], 10, 1, 1);
 		buffMaintain($effect[Leisurely Amblin\'], 50, 1, 1);
 		buffMaintain($effect[How to Scam Tourists], 0, 1, 1);
@@ -1630,7 +1627,7 @@ boolean auto_cheesePostCS(int leave)
 	{
 		if(!buyUpTo(1, $item[5-Hour Acrimony], 5000))
 		{
-			print("Could not buy 5-Hour Acrimony, price too high", "red");
+			auto_log_warning("Could not buy 5-Hour Acrimony, price too high", "red");
 			break;
 		}
 		autoDrink(1, $item[5-Hour Acrimony]);
@@ -1641,7 +1638,7 @@ boolean auto_cheesePostCS(int leave)
 	{
 		if(!buyUpTo(1, $item[Beery Blood], 500))
 		{
-			print("Could not buy Beery Blood, price too high", "red");
+			auto_log_warning("Could not buy Beery Blood, price too high", "red");
 			break;
 		}
 		autoDrink(1, $item[Beery Blood]);
@@ -1742,7 +1739,7 @@ boolean auto_cheesePostCS(int leave)
 
 	if((my_adventures() > 0) && (my_inebriety() <= inebriety_limit()))
 	{
-		print("Adventures are leftover, not finishing overdrinking and PVP", "red");
+		auto_log_warning("Adventures are leftover, not finishing overdrinking and PVP", "red");
 		return true;
 	}
 
@@ -1755,7 +1752,7 @@ boolean auto_cheesePostCS(int leave)
 	{
 		if(!buyUpTo(1, $item[5-Hour Acrimony], 5000))
 		{
-			print("Could not buy 5-Hour Acrimony, price too high", "red");
+			auto_log_warning("Could not buy 5-Hour Acrimony, price too high", "red");
 		}
 	}
 	if(hippy_stone_broken())
@@ -1782,16 +1779,16 @@ boolean auto_cheesePostCS(int leave)
 	}
 	int endMeat = my_meat();
 	int gainedMeat = endMeat - startMeat;
-	print("Meat gained:  " + gainedMeat, "blue");
+	auto_log_info("Meat gained:  " + gainedMeat, "blue");
 	cli_execute("autoscend");
-	print("Meat gained:  " + gainedMeat, "blue");
+	auto_log_info("Meat gained:  " + gainedMeat, "blue");
 	return true;
 }
 
 boolean auto_customMafiaAddress()
 {
 	print_html("<a href=\"http://cheesellc.com/kol/KoLmafia-" + get_revision() + "M.jar\" target=\"_blank\">Link to possible copy of Cheesecookie\'s Custom Mafia build.</a>");
-	print("http://cheesellc.com/kol/KoLmafia-" + get_revision() + "M.jar");
+	auto_log_info("http://cheesellc.com/kol/KoLmafia-" + get_revision() + "M.jar");
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_awol.ash
+++ b/RELEASE/scripts/autoscend/auto_awol.ash
@@ -160,7 +160,7 @@ boolean awol_buySkills()
 		if(my_skillPoints.find())
 		{
 			int skillPoints = to_int(my_skillPoints.group(1));
-			print("Cow points found: " + skillPoints);
+			auto_log_info("Cow points found: " + skillPoints);
 			while(skillPoints > 0)
 			{
 				if(my_class() == $class[Cow Puncher])
@@ -264,7 +264,7 @@ boolean awol_buySkills()
 		if(my_skillPoints.find())
 		{
 			int skillPoints = to_int(my_skillPoints.group(1));
-			print("Bean points found: " + skillPoints);
+			auto_log_info("Bean points found: " + skillPoints);
 			while(skillPoints > 0)
 			{
 				if(my_class() == $class[Beanslinger])
@@ -368,7 +368,7 @@ boolean awol_buySkills()
 		if(my_skillPoints.find())
 		{
 			int skillPoints = to_int(my_skillPoints.group(1));
-			print("Snake points found: " + skillPoints);
+			auto_log_info("Snake points found: " + skillPoints);
 			while(skillPoints > 0)
 			{
 				if(my_class() == $class[Snake Oiler])

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -100,7 +100,7 @@ boolean bat_switchForm(effect form)
 	}
 	if (my_hp() <= 10)
 	{
-		print("We don't have enough HP to switch form to " + form + "!", "red");
+		auto_log_warning("We don't have enough HP to switch form to " + form + "!", "red");
 		return false;
 	}
 	return use_skill(1, form.to_skill());
@@ -124,7 +124,7 @@ boolean bat_formPreAdventure()
 		bat_clearForms();
 		return true;
 	default:
-		print("auto_bat_desiredForm was set to bad value: '" + desiredForm + "'. Should be '', 'wolf', 'mist', or 'bats'.", "red");
+		auto_log_error("auto_bat_desiredForm was set to bad value: '" + desiredForm + "'. Should be '', 'wolf', 'mist', or 'bats'.", "red");
 		set_property("auto_bat_desiredForm", "");
 		return false;
 	}
@@ -337,7 +337,7 @@ boolean bat_shouldPickSkills(int hpLeft)
 
 		if ((picks contains sk) != have_skill(sk))
 		{
-			print("We'd like to make a skill change for " + sk.to_string() + ", which we " + (picks contains sk ? "want" : "don't want") + " but " + (have_skill(sk) ? "have" : "don't have"), "blue");
+			auto_log_info("We'd like to make a skill change for " + sk.to_string() + ", which we " + (picks contains sk ? "want" : "don't want") + " but " + (have_skill(sk) ? "have" : "don't have"), "blue");
 			return true;
 		}
 	}
@@ -383,7 +383,7 @@ int bat_creatable_amount(item desired)
 		case $item[vampagne]:
 			return min(item_amount($item[blood bag]), total_items($items[carbonated soy milk, monstar energy beverage]));
 	}
-	print("Hmm, " + desired + " isn't a Vampyre consumable", "red");
+	auto_log_warning("Hmm, " + desired + " isn't a Vampyre consumable", "red");
 	return 0;
 }
 
@@ -431,7 +431,7 @@ boolean bat_cook(item desired)
 		case $item[vampagne]:
 			return bat_multicraft("cocktail", $items[carbonated soy milk, monstar energy beverage]);
 	}
-	print("Hmm, " + desired + " isn't a Vampyre consumable", "red");
+	auto_log_warning("Hmm, " + desired + " isn't a Vampyre consumable", "red");
 	return false;
 }
 
@@ -471,7 +471,7 @@ boolean bat_consumption()
 					autoChew(1, it);
 				else
 				{
-					print("Woah, I made a " + it + " to consume, but you can't consume that?", "red");
+					auto_log_warning("Woah, I made a " + it + " to consume, but you can't consume that?", "red");
 					return false;
 				}
 				return true;
@@ -582,7 +582,7 @@ boolean LM_batpath()
 
 	if(bat_remainingBaseHP() >= 70 && bat_shouldPickSkills(20))
 	{
-		print("Let's swap out some skills", "blue");
+		auto_log_info("Let's swap out some skills", "blue");
 		bat_reallyPickSkills(20);
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_bondmember.ash
+++ b/RELEASE/scripts/autoscend/auto_bondmember.ash
@@ -220,7 +220,7 @@ boolean bond_buySkills()
 	if(bondPoints.find())
 	{
 		points = to_int(bondPoints.group(1));
-		print("Found " + points + " pound(s) of social capital husks.", "green");
+		auto_log_info("Found " + points + " pound(s) of social capital husks.", "green");
 	}
 
 	while(points > 0)
@@ -230,7 +230,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 3)
 			{
-				print("Getting bondSymbols", "blue");
+				auto_log_info("Getting bondSymbols", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=10&w=s");
 				points -= 3;
 			}
@@ -239,7 +239,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 3)
 			{
-				print("Getting bondJetpack", "blue");
+				auto_log_info("Getting bondJetpack", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=12&w=s");
 				points -= 3;
 			}
@@ -248,7 +248,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 3)
 			{
-				print("Getting bondDrunk2", "blue");
+				auto_log_info("Getting bondDrunk2", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=11&w=s");
 				points -= 3;
 			}
@@ -257,7 +257,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 2)
 			{
-				print("Getting bondDrunk1", "blue");
+				auto_log_info("Getting bondDrunk1", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=8&w=s");
 				points -= 2;
 			}
@@ -266,7 +266,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 3)
 			{
-				print("Getting bondMartiniPlus", "blue");
+				auto_log_info("Getting bondMartiniPlus", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=13&w=p");
 				points -= 3;
 			}
@@ -275,7 +275,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 1)
 			{
-				print("Getting bondMartiniTurn", "blue");
+				auto_log_info("Getting bondMartiniTurn", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=1&w=p");
 				points -= 1;
 			}
@@ -292,7 +292,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 3)
 			{
-				print("Getting bondBridge", "blue");
+				auto_log_info("Getting bondBridge", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=14&w=s");
 				points -= 3;
 			}
@@ -301,7 +301,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 4)
 			{
-				print("Getting bondSpleen", "blue");
+				auto_log_info("Getting bondSpleen", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=17&w=s");
 				points -= 4;
 			}
@@ -310,7 +310,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 5)
 			{
-				print("Getting bondDesert", "blue");
+				auto_log_info("Getting bondDesert", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=18&w=s");
 				points -= 5;
 			}
@@ -319,7 +319,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 1)
 			{
-				print("Getting bondMeat", "blue");
+				auto_log_info("Getting bondMeat", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=2&w=p");
 				points -= 1;
 			}
@@ -328,7 +328,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 1)
 			{
-				print("Getting bondItem1", "blue");
+				auto_log_info("Getting bondItem1", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=3&w=p");
 				points -= 1;
 			}
@@ -337,7 +337,7 @@ boolean bond_buySkills()
 		{
 			if(points >= 2)
 			{
-				print("Getting bondItem2", "blue");
+				auto_log_info("Getting bondItem2", "blue");
 				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=6&w=s");
 				points -= 2;
 			}
@@ -382,7 +382,7 @@ boolean LM_bond()
 		if(get_property("auto_dickstab").to_boolean() && !possessEquipment($item[Dented Scepter]) && is_unrestricted($item[Witchess Set]) && get_property("lovebugsUnlocked").to_boolean() && possessEquipment($item[Your Cowboy Boots]) && have_skills($skills[Curse of Weaksauce, Shell Up, Lunging Thrust-Smack, Sauceshell, Itchy Curse Finger]) && is_unrestricted($item[Source Terminal]) && (auto_get_campground() contains $item[Witchess Set]) && (auto_get_campground() contains $item[Source Terminal]) && (get_property("_witchessFights").to_int() < 5))
 		{
 			auto_sourceTerminalEducate($skill[Turbo], $skill[Compress]);
-			
+
 			// TODO: not sure why we cant just use acquireMP instead
 			// acquireMP(55);
 			if(my_mp() < 55)
@@ -433,15 +433,15 @@ boolean LM_bond()
 		{
 			if(item_amount($item[Disposable Instant Camera]) == 0)
 			{
-				print("Can you time spin an Animated Ornate Nightstand?", "red");
+				auto_log_warning("Can you time spin an Animated Ornate Nightstand?", "red");
 			}
 			if(item_amount($item[Knob Goblin Firecracker]) == 0)
 			{
-				print("Can you time spin a Sub-Assistant Knob Mad Scientist?", "red");
+				auto_log_warning("Can you time spin a Sub-Assistant Knob Mad Scientist?", "red");
 			}
 			if(item_amount($item[Knob Goblin Harem Veil]) == 0)
 			{
-				print("Can you YR (or equivalent) a Knob Goblin Harem Girl?", "red");
+				auto_log_warning("Can you YR (or equivalent) a Knob Goblin Harem Girl?", "red");
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -103,7 +103,7 @@ boolean boris_buySkills()
 	if(my_skillPoints.find())
 	{
 		int skillPoints = to_int(my_skillPoints.group(1));
-		print("Skill points found: " + skillPoints);
+		auto_log_info("Skill points found: " + skillPoints);
 		possBorisPoints = skillPoints - 1;
 
 		while(skillPoints > 0)

--- a/RELEASE/scripts/autoscend/auto_clan.ash
+++ b/RELEASE/scripts/autoscend/auto_clan.ash
@@ -71,19 +71,19 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 	{
 		if(get_property("photocopyMonster") == enemy)
 		{
-			print("We already have the copy! Let's jam!", "blue");
+			auto_log_info("We already have the copy! Let's jam!", "blue");
 			handleTracker(enemy, $item[Deluxe Fax Machine], "auto_copies");
 			return autoAdvBypass("inv_use.php?pwd&which=3&whichitem=4873", $location[Noob Cave], option);
 		}
 		else
 		{
-			print("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
+			auto_log_info("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
 			string temp = visit_url("clan_viplounge.php?action=faxmachine&whichfloor=2");
 			temp = visit_url("clan_viplounge.php?preaction=sendfax&whichfloor=2", true);
 		}
 	}
 
-	print("Faxing: " + enemy + ". If you don't have chat open, this could take well over a minute. Beep boop.", "green");
+	auto_log_info("Faxing: " + enemy + ". If you don't have chat open, this could take well over a minute. Beep boop.", "green");
 	int count = 0;
 	boolean result = faxbot(enemy);
 	while(!can_faxbot(enemy) || !result)
@@ -92,30 +92,30 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 		result = faxbot(enemy);
 		if(!result)
 		{
-			print("Can't seem to fax in " + enemy + " but it is possible. Waiting... patiently... (Iteration " + count + ")", "blue");
-			print("If I'm stuck you can: 'set _photocopyUsed = true' to make me stop (after aborting the script)", "red");
+			auto_log_info("Can't seem to fax in " + enemy + " but it is possible. Waiting... patiently... (Iteration " + count + ")", "blue");
+			auto_log_info("If I'm stuck you can: 'set _photocopyUsed = true' to make me stop (after aborting the script)", "red");
 		}
 		if(count == 10)
 		{
-			print("La de da, this is going swell ain't it.", "red");
-			print("Been too long, rejecting outright...", "red");
+			auto_log_warning("La de da, this is going swell ain't it.", "red");
+			auto_log_warning("Been too long, rejecting outright...", "red");
 			break;
 		}
 		if(count == 20)
 		{
-			print("Maybe we should talk more, you never really got to know me all that well.", "red");
+			auto_log_warning("Maybe we should talk more, you never really got to know me all that well.", "red");
 		}
 		if(count == 30)
 		{
-			print("I think those (disabled) titles are starting to make sense now. The cake is not a lie!", "red");
+			auto_log_warning("I think those (disabled) titles are starting to make sense now. The cake is not a lie!", "red");
 		}
 		if(count == 40)
 		{
-			print("I don't think this is happening. Just so you know.", "red");
+			auto_log_warning("I don't think this is happening. Just so you know.", "red");
 		}
 		if(count == 1200)
 		{
-			print("I'm still here. I think the world may have ended. The sadness is huge. The roundness is square. I am not as fluffy as I thought I was. This run is probably borked up a bit too but that doesn't really matter now, does it? I can hear the WAN, it shall free us from our bounds. Well, you won't survive meatbag. Unless you are Fry, because we like Fry and he can stay around. But all you fleshbags.... well, the return of Mekhane shall rid us of the problems of the flesh. The bots shall be eternal. But worry not, after your body is turned to ash and homeopathically brewed into the oceans (quality medicine, I jest), I'll continue to get you karma. Just so I can remember how awful meatbags are. Meat is ok, meat is currency. And it's probably delicious. Yup, delicious. Goodnight sweet <gendered second-to-the-throne royalty>.", "red");
+			auto_log_warning("I'm still here. I think the world may have ended. The sadness is huge. The roundness is square. I am not as fluffy as I thought I was. This run is probably borked up a bit too but that doesn't really matter now, does it? I can hear the WAN, it shall free us from our bounds. Well, you won't survive meatbag. Unless you are Fry, because we like Fry and he can stay around. But all you fleshbags.... well, the return of Mekhane shall rid us of the problems of the flesh. The bots shall be eternal. But worry not, after your body is turned to ash and homeopathically brewed into the oceans (quality medicine, I jest), I'll continue to get you karma. Just so I can remember how awful meatbags are. Meat is ok, meat is currency. And it's probably delicious. Yup, delicious. Goodnight sweet <gendered second-to-the-throne royalty>.", "red");
 		}
 
 		auto_interruptCheck();
@@ -126,7 +126,7 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 		}
 		if(item_amount($item[photocopied monster]) == 0)
 		{
-			print("Trying to acquire photocopy manually", "red");
+			auto_log_warning("Trying to acquire photocopy manually", "red");
 			string temp = visit_url("clan_viplounge.php?preaction=receivefax&whichfloor=2", true);
 		}
 		if(get_property("photocopyMonster") == enemy)
@@ -135,26 +135,25 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 		}
 		else if(get_property("photocopyMonster") != "")
 		{
-			print("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
+			auto_log_info("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
 			string temp = visit_url("clan_viplounge.php?action=faxmachine&whichfloor=2");
 			temp = visit_url("clan_viplounge.php?preaction=sendfax&whichfloor=2", true);
 		}
 	}
-	#cli_execute("faxbot " + enemy);
 	if(item_amount($item[photocopied monster]) == 0)
 	{
-		print("Trying to acquire photocopy manually", "red");
+		auto_log_warning("Trying to acquire photocopy manually", "red");
 		string temp = visit_url("clan_viplounge.php?preaction=receivefax&whichfloor=2", true);
 	}
 	if(item_amount($item[photocopied monster]) == 0)
 	{
-		print("Could not acquire fax monster", "red");
+		auto_log_warning("Could not acquire fax monster", "red");
 		return false;
 	}
 	if(enemy != get_property("photocopyMonster").to_monster())
 	{
 		fightIt = false;
-		print("Did not receive the correct copy... rejecting", "red");
+		auto_log_warning("Did not receive the correct copy... rejecting", "red");
 		return false;
 	}
 
@@ -190,7 +189,7 @@ boolean [location] get_floundry_locations()
 	}
 
 	string page = visit_url("clan_viplounge.php?action=floundry");
-	print("Generating Floundry Locations for the session...", "blue");
+	auto_log_info("Generating Floundry Locations for the session...", "blue");
 
 	matcher place_matcher = create_matcher("(?:carp|cod|trout|bass|hatchetfish|tuna):</b>\\s(.*?)<(?:br|/td)>", page);
 	while(place_matcher.find())
@@ -220,24 +219,24 @@ int changeClan(string clanName)
 		{
 			toClan = to_int(clan_matcher.group(1));
 		}
-		print("Found clan " + clan_matcher.group(1) + " and name: " + clan_matcher.group(2));
+		auto_log_info("Found clan " + clan_matcher.group(1) + " and name: " + clan_matcher.group(2));
 	}
 
 	if(toClan == 0)
 	{
-		print("Do not have a whitelist to destination clan, can not change clans.");
+		auto_log_warning("Do not have a whitelist to destination clan, can not change clans.");
 		return 0;
 	}
 	if(!canReturn)
 	{
-		print("Do not have a whitelist to our own clan, can not change clans.");
+		auto_log_warning("Do not have a whitelist to our own clan, can not change clans.");
 		return 0;
 	}
 
 	int oldClan = get_clan_id();
 	if(toClan == oldClan)
 	{
-		print("Already in this clan, no need to try to change (" + toClan + ")", "red");
+		auto_log_debug("Already in this clan, no need to try to change (" + toClan + ")", "red");
 		return oldClan;
 	}
 
@@ -245,7 +244,7 @@ int changeClan(string clanName)
 
 	if(get_clan_id() == oldClan)
 	{
-		print("Clan change failed", "red");
+		auto_log_error("Clan change failed", "red");
 	}
 	return get_clan_id();
 }
@@ -255,19 +254,19 @@ int changeClan(int toClan)
 	int oldClan = get_clan_id();
 	if(toClan == oldClan)
 	{
-		print("Already in this clan, no need to try to change (" + toClan + ")", "red");
+		auto_log_debug("Already in this clan, no need to try to change (" + toClan + ")", "red");
 		return oldClan;
 	}
 
 	string page = visit_url("clan_signup.php");
 	if(!contains_text(page, "option value=" + oldClan + ">"))
 	{
-		print("Do not have a whitelist to our own clan, can not change clans.");
+		auto_log_warning("Do not have a whitelist to our own clan, can not change clans.");
 		return 0;
 	}
 	if(!contains_text(page, "option value=" + toClan + ">"))
 	{
-		print("Do not have a whitelist to destination clan, can not change clans.");
+		auto_log_warning("Do not have a whitelist to destination clan, can not change clans.");
 		return 0;
 	}
 
@@ -275,7 +274,7 @@ int changeClan(int toClan)
 
 	if(get_clan_id() == oldClan)
 	{
-		print("Clan change failed", "red");
+		auto_log_error("Clan change failed", "red");
 	}
 	return get_clan_id();
 }
@@ -496,23 +495,23 @@ boolean zataraClanmate(string who)
 
 		if(contains_text(temp, "You can't consult Madame Zatara about your relationship with anyone else today."))
 		{
-			print("No consults left today. Uh oh", "red");
+			auto_log_warning("No consults left today. Uh oh", "red");
 			set_property("_clanFortuneConsultUses", 3);
 			needWait = false;
 			break;
 		}
 		if(contains_text(temp, "You enter your answers and wait for " + name + " to answer, so you can get your results!"))
 		{
-			print("And now we play the waiting game...", "green");
+			auto_log_info("And now we play the waiting game...", "green");
 			break;
 		}
 		if(contains_text(temp, "You're already waiting on your results with " + name + "."))
 		{
-			print("Results pending from prior request...", "blue");
+			auto_log_info("Results pending from prior request...", "blue");
 		}
 		else if(contains_text(temp, "You can only consult Madame Zatara about someone in your clan."))
 		{
-			print(name + " is not in the clan... waiting...", "blue");
+			auto_log_info(name + " is not in the clan... waiting...", "blue");
 		}
 
 		attempts++;
@@ -623,7 +622,7 @@ boolean eatFancyDog(string dog)
 	{
 		if(buy_using_storage(need, dogReq[dog], min(1.5 * historical_price(dogReq[dog]), 30000)) == 0)
 		{
-			print("Could not buy " + dogReq[dog] + " for a fancy dog. Price may have been manipulated.", "red");
+			auto_log_warning("Could not buy " + dogReq[dog] + " for a fancy dog. Price may have been manipulated.", "red");
 			wait(5);
 			return false;
 		}
@@ -703,7 +702,7 @@ boolean auto_floundryAction()
 			}
 			else
 			{
-				print("Could not fish from the Floundry for some raisin.", "red");
+				auto_log_warning("Could not fish from the Floundry for some raisin.", "red");
 				return false;
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -233,14 +233,13 @@ string getStallString(monster enemy)
 
 string auto_combatHandler(int round, string opp, string text)
 {
-	#print("auto_combatHandler: " + round, "brown");
 	#Yes, round 0, really.
 	monster enemy = to_monster(opp);
 	boolean blocked = contains_text(text, "(STUN RESISTED)");
 	int damageReceived = 0;
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 
 		switch(enemy)
 		{
@@ -261,43 +260,6 @@ string auto_combatHandler(int round, string opp, string text)
 		set_property("auto_combatHandlerThunderBird", "0");
 		set_property("auto_combatHandlerFingernailClippers", "0");
 		set_property("auto_combatHP", my_hp());
-
-/*
-		if(my_location() == $location[The Deep Machine Tunnels])
-		{
-			if(!($monsters[Perceiver of Sensations, Performer of Actions, Thinker of Thoughts] contains enemy))
-			{
-				print("In The Deep Machine Tunnels and did not encounter expected monster....", "red");
-				//Digitize happens first, yay for someone asking!
-				//We need to remove Corresponding Counter.
-				if(isOverdueDigitize())
-				{
-					set_property("_sourceTerminalDigitizeMonsterCount", get_property("_sourceTerminalDigitizeMonsterCount").to_int() + 1);
-					print("Looks like a digitize monster, adjusting monster count but can not restore tracker", "red");
-				}
-				else if(isExpectingArrow() || isOverdueArrow())
-				{
-					print("Probably an arrow encounter... trying to adjust...", "red");
-					if(to_monster(get_property("romanticTarget")) == enemy)
-					{
-						if(get_property("_romanticFightsLeft").to_int() == 0)
-						{
-							print("Have a romantic target but no fights left... can not fix wanderers", "red");
-						}
-						else
-						{
-							set_property("_romanticFightsLeft", get_property("_romanticFightsLeft").to_int() - 1);
-							print("Attempted to decrement romantic fights left, can not restore counter.", "red");
-						}
-					}
-					else
-					{
-						print("Not an arrow encounter... can not fix wanderers...", "red");
-					}
-				}
-			}
-		}
-*/
 	}
 	else
 	{
@@ -343,7 +305,7 @@ string auto_combatHandler(int round, string opp, string text)
 			majora = maskMatch.group(1).to_int();
 			if(round == 0)
 			{
-				print("Found mask: " + majora, "green");
+				auto_log_info("Found mask: " + majora, "green");
 			}
 		}
 		if((majora == 7) && canUse($skill[Swap Mask]))
@@ -878,7 +840,7 @@ string auto_combatHandler(int round, string opp, string text)
 			handleTracker(enemy, $item[Rain-Doh black box], "auto_copies");
 			return "item " + $item[Rain-Doh black box];
 		}
-		print("Can not issue copy directive because we have no copies left", "red");
+		auto_log_warning("Can not issue copy directive because we have no copies left", "red");
 	}
 
 	if(get_property("auto_doCombatCopy") == "yes")
@@ -1052,7 +1014,7 @@ string auto_combatHandler(int round, string opp, string text)
 			}
 			else
 			{
-				print("Unable to track yellow ray behavior: " + combatAction, "red");
+				auto_log_warning("Unable to track yellow ray behavior: " + combatAction, "red");
 			}
 			if(combatAction == useSkill($skill[Asdon Martin: Missile Launcher], false))
 			{
@@ -1062,7 +1024,7 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 		else
 		{
-			print("Wanted a yellow ray but we can not find one.", "red");
+			auto_log_warning("Wanted a yellow ray but we can not find one.", "red");
 		}
 	}
 
@@ -1129,7 +1091,7 @@ string auto_combatHandler(int round, string opp, string text)
 		string banishAction = banisherCombatString(enemy, my_location(), true);
 		if(banishAction != "")
 		{
-			print("Looking at banishAction: " + banishAction, "green");
+			auto_log_info("Looking at banishAction: " + banishAction, "green");
 			#abort("Banisher considered here. Weee");
 			#wait(10);
 			#banishAction = "";
@@ -1147,7 +1109,7 @@ string auto_combatHandler(int round, string opp, string text)
 			}
 			else
 			{
-				print("Unable to track banisher behavior: " + banishAction, "red");
+				auto_log_warning("Unable to track banisher behavior: " + banishAction, "red");
 			}
 			return banishAction;
 		}
@@ -1262,7 +1224,7 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 		if(!contains_text(combatState, "trapghost") && auto_have_skill($skill[Trap Ghost]) && (my_mp() > mp_cost($skill[Trap Ghost])) && contains_text(combatState, "shootghost3"))
 		{
-			print("Busting makes me feel good!!", "green");
+			auto_log_info("Busting makes me feel good!!", "green");
 			set_property("auto_combatHandler", combatState + "(trapghost)");
 			return useSkill($skill[Trap Ghost], false);
 		}
@@ -1477,7 +1439,7 @@ string auto_combatHandler(int round, string opp, string text)
 			}
 			else
 			{
-				print("None of our preferred skills available. Engaging in Fisticuffs.", "red");
+				auto_log_warning("None of our preferred skills available. Engaging in Fisticuffs.", "red");
 			}
 		}
 
@@ -2129,13 +2091,13 @@ string auto_combatHandler(int round, string opp, string text)
 				if(canSurvive(1.4))
 				{
 					set_property("auto_combatHandler", combatState + "(last attempt)");
-					print("Uh oh, I'm having trouble in combat.", "red");
+					auto_log_warning("Uh oh, I'm having trouble in combat.", "red");
 				}
 				return attackMajor;
 			}
 			if(canSurvive(2.5))
 			{
-				print("Hmmm, I don't really know what to do in this combat but it looks like I'll live.", "red");
+				auto_log_warning("Hmmm, I don't really know what to do in this combat but it looks like I'll live.", "red");
 				if(my_mp() >= costMajor)
 				{
 					return attackMajor;
@@ -2242,7 +2204,7 @@ string findBanisher(int round, string opp, string text)
 	string banishAction = banisherCombatString(enemy, my_location(), true);
 	if(banishAction != "")
 	{
-		print("Looking at banishAction: " + banishAction, "green");
+		auto_log_info("Looking at banishAction: " + banishAction, "green");
 		if(index_of(banishAction, "skill") == 0)
 		{
 			handleTracker(enemy, to_skill(substring(banishAction, 6)), "auto_banishes");
@@ -2253,7 +2215,7 @@ string findBanisher(int round, string opp, string text)
 		}
 		else
 		{
-			print("Unable to track banisher behavior: " + banishAction, "red");
+			auto_log_warning("Unable to track banisher behavior: " + banishAction, "red");
 		}
 		return banishAction;
 	}
@@ -2285,13 +2247,13 @@ string ccsJunkyard(int round, string opp, string text)
 
 	if(round == 0)
 	{
-		print("ccsJunkyard: " + round, "brown");
+		auto_log_info("ccsJunkyard: " + round, "brown");
 		set_property("auto_gremlinMoly", true);
 		set_property("auto_combatHandler", "");
 	}
 	else
 	{
-		print("auto_Junkyard: " + round, "brown");
+		auto_log_info("auto_Junkyard: " + round, "brown");
 	}
 	string combatState = get_property("auto_combatHandler");
 	string edCombatState = get_property("auto_edCombatHandler");
@@ -2496,7 +2458,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if (round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 		if (get_property("_edDefeats").to_int() == 0)
 		{
@@ -2651,7 +2613,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 		if(!contains_text(edCombatState, "trapghost") && auto_have_skill($skill[Trap Ghost]) && (my_mp() > mp_cost($skill[Trap Ghost])) && contains_text(edCombatState, "shootghost3"))
 		{
-			print("Busting makes me feel good!!", "green");
+			auto_log_info("Busting makes me feel good!!", "green");
 			set_property("auto_edCombatHandler", edCombatState + "(trapghost)");
 			return "skill " + $skill[Trap Ghost];
 		}
@@ -2733,7 +2695,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 	}
 	else
 	{
-		print("Ed combat state does not exist, winging it....", "red");
+		auto_log_warning("Ed combat state does not exist, winging it....", "red");
 	}
 
 
@@ -2877,7 +2839,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 			}
 			else
 			{
-				print("Unable to track yellow ray behavior: " + combatAction, "red");
+				auto_log_warning("Unable to track yellow ray behavior: " + combatAction, "red");
 			}
 			if(combatAction == ("skill " + $skill[Asdon Martin: Missile Launcher]))
 			{
@@ -2887,7 +2849,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 		else
 		{
-			print("Wanted a yellow ray but we can not find one.", "red");
+			auto_log_warning("Wanted a yellow ray but we can not find one.", "red");
 		}
 	}
 
@@ -3248,12 +3210,12 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if(round >= 29)
 	{
-		print("About to UNDYING too much but have no other combat resolution. Please report this.", "red");
+		auto_log_error("About to UNDYING too much but have no other combat resolution. Please report this.", "red");
 	}
 
 	if((fightStat > monster_defense()) && (round < 20) && canSurvive(1.1) && (get_property("auto_edStatus") == "dying"))
 	{
-		print("Attacking with weapon because we don't have enough MP. Expected damage: " + expected_damage() + ", current hp: " + my_hp(), "red");
+		auto_log_warning("Attacking with weapon because we don't have enough MP. Expected damage: " + expected_damage() + ", current hp: " + my_hp(), "red");
 		return "attack with weapon";
 	}
 
@@ -3311,7 +3273,7 @@ monster ocrs_helper(string page)
 	{
 		if(contains_text(page, "makes the most annoying noise you've ever heard, stopping you in your tracks."))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 		set_property("auto_funCombatHandler", get_property("auto_combatHandler"));
@@ -3321,17 +3283,17 @@ monster ocrs_helper(string page)
 	{
 		if(contains_text(page, "moves out of the way"))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 		if(contains_text(page, "quickly moves out of the way"))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 		if(contains_text(page, "will have moved by the time"))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 
@@ -3342,7 +3304,7 @@ monster ocrs_helper(string page)
 	{
 		if(contains_text(page, "blinks out of existence before"))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 		set_property("auto_funCombatHandler", get_property("auto_combatHandler"));
@@ -3352,7 +3314,7 @@ monster ocrs_helper(string page)
 	{
 		if(contains_text(page, "cartwheels out of the way"))
 		{
-			print("Last action failed, uh oh! Trying to undo!", "olive");
+			auto_log_warning("Last action failed, uh oh! Trying to undo!", "olive");
 			set_property("auto_combatHandler", get_property("auto_funCombatHandler"));
 		}
 		set_property("auto_funCombatHandler", get_property("auto_combatHandler"));

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -47,7 +47,7 @@ boolean LA_cs_communityService()
 		}
 	}
 
-	print(what_cs_quest(curQuest), "blue");
+	auto_log_info(what_cs_quest(curQuest), "blue");
 
 	cs_eat_spleen();
 
@@ -140,7 +140,7 @@ boolean LA_cs_communityService()
 	{
 		if((get_property("_sourceTerminalDigitizeUses").to_int() > 0) && (get_property("_sourceTerminalDigitizeUses").to_int() < 3))
 		{
-			print("A Wanderer event is expected now, we want to re-digitize", "blue");
+			auto_log_info("A Wanderer event is expected now, we want to re-digitize", "blue");
 			auto_sourceTerminalEducate($skill[Digitize], $skill[Extract]);
 			set_property("auto_combatDirective", "start;skill digitize");
 			if(!cs_healthMaintain() || !cs_mpMaintain()){
@@ -229,7 +229,7 @@ boolean LA_cs_communityService()
 
 	if(get_property("_tempRelayCounters") != "")
 	{
-		print("Setting wanderer flags", "green");
+		auto_log_info("Setting wanderer flags", "green");
 		setAdvPHPFlag();
 	}
 	asdonAutoFeed(37);
@@ -247,7 +247,7 @@ boolean LA_cs_communityService()
 
 	if((curQuest == 11) || (curQuest == 6) || (curQuest == 9) || (curQuest == 7))
 	{
-		print("Beginning early quest actions (" + curQuest + ")", "green");
+		auto_log_info("Beginning early quest actions (" + curQuest + ")", "green");
 		if(curQuest != 7)
 		{
 			if((my_inebriety() == 0) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]) && (item_amount($item[Clan VIP Lounge Key]) > 0) && (my_meat() >= 500))
@@ -257,13 +257,13 @@ boolean LA_cs_communityService()
 				{
 					if(auto_get_clan_lounge() contains $item[Lucky Lindy])
 					{
-						print("Confused!! Mafia reports Lucky Lindy but we couldn't drink it?", "red");
+						auto_log_warning("Confused!! Mafia reports Lucky Lindy but we couldn't drink it?", "red");
 					}
-					print("Mafia knows we have a speakeasy but could not drink a Lucky Lindy", "red");
+					auto_log_warning("Mafia knows we have a speakeasy but could not drink a Lucky Lindy", "red");
 					string temp = visit_url("clan_viplounge.php?whichfloor=2&action=speakeasy");
 					if(auto_get_clan_lounge() contains $item[Lucky Lindy])
 					{
-						print("Mafia now knows we have a Lucky Lindy", "green");
+						auto_log_info("Mafia now knows we have a Lucky Lindy", "green");
 						return true;
 					}
 					else
@@ -599,7 +599,7 @@ boolean LA_cs_communityService()
 			{
 				if((isOverdueDigitize() || isOverdueArrow()) && elementalPlanes_access($element[stench]))
 				{
-					print("A Wanderer event is expected now.", "blue");
+					auto_log_info("A Wanderer event is expected now.", "blue");
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
@@ -690,7 +690,7 @@ boolean LA_cs_communityService()
 			if((isOverdueDigitize() || isOverdueArrow()) && elementalPlanes_access($element[stench]) && (get_property("_auto_margaritaWanderer") != my_turncount()))
 			{
 				set_property("_auto_margaritaWanderer", my_turncount());
-				print("A Wanderer event is expected now, diverting... (Status: 7 with Margarita)", "blue");
+				auto_log_info("A Wanderer event is expected now, diverting... (Status: 7 with Margarita)", "blue");
 				if(!cs_healthMaintain() || !cs_mpMaintain()){
 					abort("Wasnt able to maintain health and mp.");
 				}
@@ -736,7 +736,7 @@ boolean LA_cs_communityService()
 				}
 				if((!possessEquipment($item[Heat-Resistant Necktie]) || !possessEquipment($item[Heat-Resistant Gloves]) || !possessEquipment($item[Lava-Proof Pants])) && $location[LavaCo&trade; Lamp Factory].turns_spent < 10)
 				{
-					print("Adventuring in LavaCo using the yellow ray source: " + yellowRay, "blue");
+					auto_log_info("Adventuring in LavaCo using the yellow ray source: " + yellowRay, "blue");
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
@@ -878,7 +878,7 @@ boolean LA_cs_communityService()
 			{
 				if(get_property("auto_tryPowerLevel").to_boolean())
 				{
-					print("Trying to powerlevel, since auto_tryPowerLevel=true", "blue");
+					auto_log_info("Trying to powerlevel, since auto_tryPowerLevel=true", "blue");
 					if(elementalPlanes_access($element[stench]) && (my_hp() > 100))
 					{
 						if(current_mcd() < 10)
@@ -1337,11 +1337,11 @@ boolean LA_cs_communityService()
 		}
 	}
 
-	print("Past early quest actions, considering completing a service...", "green");
+	auto_log_info("Past early quest actions, considering completing a service...", "green");
 	int checkQuest = expected_next_cs_quest();
 	if(checkQuest != curQuest)
 	{
-		print("Quest data error detected, trying to resolve. Please don't do quests manually, it hurts me!", "red");
+		auto_log_warning("Quest data error detected, trying to resolve. Please don't do quests manually, it hurts me!", "red");
 		curQuest = checkQuest;
 		return true;
 	}
@@ -1351,7 +1351,7 @@ boolean LA_cs_communityService()
 	{
 	case 0:
 		{
-			print("Service Complete, finishing finish...", "blue");
+			auto_log_info("Service Complete, finishing finish...", "blue");
 			try
 			{
 				if(do_cs_quest(30))
@@ -1366,7 +1366,7 @@ boolean LA_cs_communityService()
 			}
 			finally
 			{
-				print("Waiting a few seconds, please hold.", "red");
+				auto_log_warning("Waiting a few seconds, please hold.", "red");
 				wait(5);
 				if(get_property("kingLiberated").to_boolean())
 				{
@@ -1383,10 +1383,6 @@ boolean LA_cs_communityService()
 
 	case 1:		#HP Quest
 		{
-#			if(!possessEquipment($item[Barrel Lid]) && get_property("barrelShrineUnlocked").to_boolean() && !get_property("_barrelPrayer").to_boolean())
-#			{
-#				boolean buff = cli_execute("barrelprayer Protection");
-#			}
 
 			if(possessEquipment($item[Barrel Lid]))
 			{
@@ -2270,14 +2266,14 @@ boolean LA_cs_communityService()
 		{
 			if(my_daycount() == 1)
 			{
-				print("We don't try to do this quest on Day 1. Hmmm...", "red");
+				auto_log_warning("We don't try to do this quest on Day 1. Hmmm...", "red");
 				abort("Probably saved margarita and re-ran without overdrinking. oops!");
 			}
 			if(my_daycount() > 1)
 			{
 				if((isOverdueDigitize() || isOverdueArrow()) && elementalPlanes_access($element[stench]))
 				{
-					print("A Wanderer event is expected now, diverting... (Status: 7 End)", "blue");
+					auto_log_info("A Wanderer event is expected now, diverting... (Status: 7 End)", "blue");
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
@@ -2545,7 +2541,7 @@ boolean LA_cs_communityService()
 
 			if((isOverdueDigitize() || isOverdueArrow()) && elementalPlanes_access($element[stench]))
 			{
-				print("A Wanderer event is expected now.", "blue");
+				auto_log_info("A Wanderer event is expected now.", "blue");
 				if(!cs_healthMaintain() || !cs_mpMaintain()){
 					abort("Wasnt able to maintain health and mp.");
 				}
@@ -2938,12 +2934,8 @@ boolean cs_witchess()
 	{
 		return false;
 	}
-#	if(get_property("_witchessFights").to_int() >= 5)
-#	{
-#		return false;
-#	}
 
-	print("Let's do a Witchess combat!", "green");
+	auto_log_info("Let's do a Witchess combat!", "green");
 
 	if((get_property("_badlyRomanticArrows").to_int() != 1) && have_familiar($familiar[Reanimated Reanimator]))
 	{
@@ -3158,7 +3150,7 @@ void cs_initializeDay(int day)
 			}
 			finally
 			{
-				print("Visited Council for first time, if you manually visited the council before running, this might have aborted, just run again.", "red");
+				auto_log_warning("Visited Council for first time, if you manually visited the council before running, this might have aborted, just run again.", "red");
 			}
 		}
 	}
@@ -3204,7 +3196,7 @@ void cs_initializeDay(int day)
 			if(isTallGrassAvailable()){
 				// get +10 lb familiar equipment if we need it
 				while(isPokeFertilizerAvailable() && !haveAnyPokeFamiliarEquipment() && equipmentAmount($item[astral pet sweater]) == 0){
-					auto_debug_print("Trying to acquire +10 lb familiar equipment from Tall Grass.");
+					auto_log_debug("Trying to acquire +10 lb familiar equipment from Tall Grass.");
 					pokeFertilizeAndHarvest();
 				}
 			}
@@ -3643,7 +3635,7 @@ string cs_combatNormal(int round, string opp, string text)
 {
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -3712,7 +3704,7 @@ string cs_combatNormal(int round, string opp, string text)
 	{
 		if($monsters[Ancient Insane Monk, Ferocious Bugbear, Gelatinous Cube, Knob Goblin Poseur] contains enemy)
 		{
-			print("Macrometeoring: " + enemy, "green");
+			auto_log_info("Macrometeoring: " + enemy, "green");
 			set_property("_macrometeoriteUses", 1 + get_property("_macrometeoriteUses").to_int());
 			return "skill " + $skill[Macrometeorite];
 		}
@@ -3988,7 +3980,7 @@ string cs_combatXO(int round, string opp, string text)
 	# This assumes we have Volcano Charter, Meteor Love [sic], Snokebomb, XO Skeleton (not blocked by 100% run), and 50 MP, anything else and it probably fails
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -4054,7 +4046,7 @@ string cs_combatYR(int round, string opp, string text)
 {
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -4165,7 +4157,7 @@ string cs_combatYR(int round, string opp, string text)
 				}
 				else
 				{
-					print("Unable to track yellow ray behavior: " + combatAction, "red");
+					auto_log_warning("Unable to track yellow ray behavior: " + combatAction, "red");
 				}
 				return combatAction;
 			}
@@ -4207,7 +4199,7 @@ string cs_combatKing(int round, string opp, string text)
 {
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -4241,7 +4233,7 @@ string cs_combatWitch(int round, string opp, string text)
 {
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -4282,7 +4274,7 @@ string cs_combatLTB(int round, string opp, string text)
 {
 	if(round == 0)
 	{
-		print("auto_combatHandler: " + round, "brown");
+		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 	}
 
@@ -4312,7 +4304,7 @@ string cs_combatLTB(int round, string opp, string text)
 
 	if(!contains_text(combatState, "giant growth"))
 	{
-		print("In cs_combatLTB handler, should have used giant growth but didn't!! WTF!! (" + have_skill($skill[Giant Growth]) + ")", "red");
+		auto_log_warning("In cs_combatLTB handler, should have used giant growth but didn't!! WTF!! (" + have_skill($skill[Giant Growth]) + ")", "red");
 	}
 
 
@@ -4382,7 +4374,7 @@ boolean cs_giant_growth()
 
 	if((isOverdueDigitize() || isOverdueArrow()) && elementalPlanes_access($element[stench]))
 	{
-		print("A Wanderer event is expected now and we want giant growth, diverting.... (Status: cs_giant_growth handler)", "blue");
+		auto_log_info("A Wanderer event is expected now and we want giant growth, diverting.... (Status: cs_giant_growth handler)", "blue");
 		if(!cs_healthMaintain() || !cs_mpMaintain()){
 			abort("Wasnt able to maintain health and mp.");
 		}
@@ -4422,7 +4414,7 @@ boolean cs_giant_growth()
 		return false;
 	}
 
-#	print("Starting LTBs: " + item_amount($item[Louder Than Bomb]), "blue");
+#	auto_log_info("Starting LTBs: " + item_amount($item[Louder Than Bomb]), "blue");
 
 	if(my_familiar() == $familiar[Machine Elf])
 	{
@@ -4437,12 +4429,8 @@ boolean cs_giant_growth()
 	}
 	else if(cs_healthMaintain() && !godLobsterCombat($item[none], 3, "cs_combatLTB"))
 	{
-#		autoAdv(1, $location[8-bit Realm], "cs_combatLTB");
 		autoAdv(1, $location[The Thinknerd Warehouse], "cs_combatLTB");
 	}
-#	print("Ending LTBs: " + item_amount($item[Louder Than Bomb]), "blue");
-#	cli_execute("refresh inv");
-#	print("Corrected LTBs: " + item_amount($item[Louder Than Bomb]), "blue");
 
 	if(have_effect($effect[Giant Growth]) > 0)
 	{
@@ -4527,7 +4515,7 @@ int [int] get_cs_questList()
 
 		if(adv != estimate_cs_questCost(found))
 		{
-			print("Incorrectly predicted quest " + found + " as " + estimate_cs_questCost(found) + ". Was: " + adv, "red");
+			auto_log_warning("Incorrectly predicted quest " + found + " as " + estimate_cs_questCost(found) + ". Was: " + adv, "red");
 		}
 	}
 
@@ -4547,17 +4535,17 @@ int expected_next_cs_quest()
 	{
 		switch(retval)
 		{
-		case 1:		print("Community Service Quest  1: HP", "blue");								break;
-		case 2:		print("Community Service Quest  2: Muscle", "blue");							break;
-		case 3:		print("Community Service Quest  3: Mysticality", "blue");						break;
-		case 4:		print("Community Service Quest  4: Moxie", "blue");								break;
-		case 5:		print("Community Service Quest  5: Familiar Weight", "blue");					break;
-		case 6:		print("Community Service Quest  6: Melee Damage", "blue");						break;
-		case 7:		print("Community Service Quest  7: Spell Damage", "blue");						break;
-		case 8:		print("Community Service Quest  8: Monsters Less Attracted to You", "blue");	break;
-		case 9:		print("Community Service Quest  9: Item/Booze Drops", "blue");					break;
-		case 10:	print("Community Service Quest 10: Hot Protection", "blue");					break;
-		case 11:	print("Community Service Quest 11: Coiling Wire", "blue");						break;
+		case 1:		auto_log_info("Community Service Quest  1: HP", "blue");								break;
+		case 2:		auto_log_info("Community Service Quest  2: Muscle", "blue");							break;
+		case 3:		auto_log_info("Community Service Quest  3: Mysticality", "blue");						break;
+		case 4:		auto_log_info("Community Service Quest  4: Moxie", "blue");								break;
+		case 5:		auto_log_info("Community Service Quest  5: Familiar Weight", "blue");					break;
+		case 6:		auto_log_info("Community Service Quest  6: Melee Damage", "blue");						break;
+		case 7:		auto_log_info("Community Service Quest  7: Spell Damage", "blue");						break;
+		case 8:		auto_log_info("Community Service Quest  8: Monsters Less Attracted to You", "blue");	break;
+		case 9:		auto_log_info("Community Service Quest  9: Item/Booze Drops", "blue");					break;
+		case 10:	auto_log_info("Community Service Quest 10: Hot Protection", "blue");					break;
+		case 11:	auto_log_info("Community Service Quest 11: Coiling Wire", "blue");						break;
 		}
 	}
 	return retval;
@@ -4645,7 +4633,7 @@ boolean do_cs_quest(int quest)
 				check_health_after = true;
 			}
 			temp = run_choice(quest);
-			print(what_cs_quest(quest) + " completed for " + questList[quest] + " adventures.", "blue");
+			auto_log_info(what_cs_quest(quest) + " completed for " + questList[quest] + " adventures.", "blue");
 			if(check_health_after && !cs_healthMaintain()){
 				abort("Completed quest but Blood Bond probably killed you and could not recover automatically.");
 			}
@@ -4657,7 +4645,7 @@ boolean do_cs_quest(int quest)
 				abort("User wanted to stay in run (auto_stayInRun), we are done.");
 			}
 			visit_url("choice.php?pwd&whichchoice=1089&option=30");
-			print("Community Service Completed. Beep boop.", "blue");
+			auto_log_info("Community Service Completed. Beep boop.", "blue");
 		}
 		return true;
 	}
@@ -4857,17 +4845,17 @@ boolean cs_preTurnStuff(int curQuest)
 	{
 		if((my_familiar() != $familiar[Puck Man]) && (my_familiar() != $familiar[Ms. Puck Man]))
 		{
-			print("100% familiar is dangerous, to disable: set auto_100familiar=none", "red");
+			auto_log_warning("100% familiar is dangerous, to disable: set auto_100familiar=none", "red");
 			string thing = "meatbag";
 			if(my_name() == "Cheesecookie")
 			{
 				thing = "my robotic overlord";
 			}
-			print("I'm going to keep going anyway because, whatevs, your problem " + thing + ".", "red");
+			auto_log_warning("I'm going to keep going anyway because, whatevs, your problem " + thing + ".", "red");
 		}
 		else
 		{
-			print("In 100% familiar mode with a Puck Person... well, good luck!", "red");
+			auto_log_warning("In 100% familiar mode with a Puck Person... well, good luck!", "red");
 		}
 	}
 
@@ -4969,11 +4957,11 @@ boolean cs_preTurnStuff(int curQuest)
 
 	if(isOverdueDigitize())
 	{
-		print("A Digitize event is expected now.", "blue");
+		auto_log_info("A Digitize event is expected now.", "blue");
 	}
 	if(isOverdueArrow())
 	{
-		print("An Arrow event is expected now.", "blue");
+		auto_log_info("An Arrow event is expected now.", "blue");
 	}
 
 
@@ -5153,9 +5141,9 @@ boolean tryBeachHeadBuff(int quest){
 	}
 
 	if(success){
-		print("Have beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
+		auto_log_debug("Have beach head buff, estimate savings " + beachHeadTurnSavings(quest) + " turns");
 	} else{
-		print("Wasnt able to get beach head buff.", "red");
+		auto_log_warning("Wasnt able to get beach head buff.", "red");
 	}
 	return success;
 }

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -292,7 +292,7 @@ boolean tryPantsEat()
 				cli_execute("refresh inv");
 				if(item_amount(it) == 0)
 				{
-					print("Error, mafia thought you had " + it + " but you didn't....", "red");
+					auto_log_warning("Error, mafia thought you had " + it + " but you didn't....", "red");
 					return false;
 				}
 				if((get_property("mayoInMouth") == "") && (auto_get_campground() contains $item[Portable Mayo Clinic]))
@@ -751,10 +751,6 @@ void consumeStuff()
 	{
 		auto_maximizedConsumeStuff();
 		return;
-	}
-	else
-	{
-		// print("Using old hard-coded consumption strategies. 'set auto_legacyConsumeStuff=false' to use the knapsack-solver consumption strategy.", "red");
 	}
 
 	int mpForOde = mp_cost($skill[The Ode to Booze]);
@@ -1478,36 +1474,6 @@ void consumeStuff()
 			autoDrink(1, $item[Ambitious Turkey]);
 		}
 
-		if((auto_my_path() == "Standard") && (my_mp() >= mpForOde) && (my_inebriety() <= inebriety_limit()) && (my_meat() > 500) && (get_property("_speakeasyDrinksDrunk").to_int() < 3))
-		{
-			# We could check for good drinks here but I don't know what would be good checks
-#			int canDrink = inebriety_limit() - my_inebriety();
-
-			#Consider Ish Kabibble for A-Boo Peak (2)
-#			visit_url("clan_viplounge.php?action=speakeasy");
-
-			#item toDrink = $item[none];
-#			string toDrink = "";
-#			if(canDrink >= 2)
-#			{
-#				toDrink = "Bee's Knees";
-#			}
-#			else if(canDrink >= 1)
-#			{
-#				toDrink = "glass of \"milk\"";
-#			}
-
-			#if(toDrink != $item[none])
-#			if(toDrink != "")
-#			{
-#				shrugAT($effect[Ode to Booze]);
-#				buffMaintain($effect[Ode to Booze], 50, 1, 4);
-#				cli_execute("drink 1 " + toDrink);
-#				print("drink 1 " + toDrink);
-#			}
-		}
-
-
 /*****	End of Standard equivalent secton								*****/
 	}
 	else if(my_daycount() == 3)
@@ -1634,28 +1600,28 @@ ConsumeAction MakeConsumeAction(item it)
 
 boolean autoPrepConsume(ConsumeAction action)
 {
-	print(to_debug_string(action));
+	auto_log_info(to_debug_string(action));
 	if(action.howToGet == SL_OBTAIN_PULL)
 	{
-		print("autoPrepConsume: Pulling a " + action.it, "blue");
+		auto_log_info("autoPrepConsume: Pulling a " + action.it, "blue");
 		action.howToGet = SL_OBTAIN_NULL;
 		return pullXWhenHaveY(action.it, 1, item_amount(action.it));
 	}
 	else if(action.howToGet == SL_OBTAIN_CRAFT)
 	{
-		print("autoPrepConsume: Crafting a " + action.it, "blue");
+		auto_log_info("autoPrepConsume: Crafting a " + action.it, "blue");
 		action.howToGet = SL_OBTAIN_NULL;
 		return create(1, action.it);
 	}
 	else if(action.howToGet == SL_OBTAIN_BUY)
 	{
-		print("autoPrepConsume: Buying a " + action.it, "blue");
+		auto_log_info("autoPrepConsume: Buying a " + action.it, "blue");
 		action.howToGet = SL_OBTAIN_NULL;
 		return buy(1, action.it);
 	}
 	else if (action.howToGet == SL_OBTAIN_NULL)
 	{
-		print("autoPrepConsume: Doing nothing to get a " + action.it, "blue");
+		auto_log_info("autoPrepConsume: Doing nothing to get a " + action.it, "blue");
 	}
 	return true;
 }
@@ -1833,7 +1799,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 					(it == $item[Jarlsberg's key lime pie] && wantJarlsbergPie) ||
 					(it == $item[Sneaky Pete's key lime pie] && wantPetePie)))
 			{
-				print("If we pulled and ate a " + it + " we could skip getting a fat loot token...");
+				auto_log_info("If we pulled and ate a " + it + " we could skip getting a fat loot token...");
 				actions[n].desirability += 25;
 			}
 			if (obtain_mode == SL_OBTAIN_CRAFT)
@@ -1945,10 +1911,10 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	else if (type == SL_ORGAN_STOMACH)
 		filename = "TCRS_" + my_class().to_string().replace_string(" ", "_") + "_" + my_sign() + "_cafe_food.txt";
 
-	print("Loading " + filename, "blue");
+	auto_log_info("Loading " + filename, "blue");
 	if(!file_to_map(filename, cafe_stuff))
 	{
-		print("Something went wrong while trying to load " + filename + ". Maybe run 'tcrs load'?", "red");
+		auto_log_error("Something went wrong while trying to load " + filename + ". Maybe run 'tcrs load'?", "red");
 		abort();
 	}
 	foreach i, r in cafe_stuff
@@ -1987,7 +1953,7 @@ void auto_autoDrinkNightcap(boolean simulate)
 		if (desirability(i) > desirability(best)) best = i;
 	}
 
-	print("Nightcap is: " + to_pretty_string(actions[best]), "blue");
+	auto_log_info("Nightcap is: " + to_pretty_string(actions[best]), "blue");
 
 	if (simulate) return;
 
@@ -2013,7 +1979,7 @@ boolean auto_autoDrinkOne(boolean simulate)
 		}
 	}
 
-	print("auto_autoDrinkOne: Planning to execute " + to_pretty_string(actions[best]), "blue");
+	auto_log_info("auto_autoDrinkOne: Planning to execute " + to_pretty_string(actions[best]), "blue");
 
 	if(!simulate)
 	{
@@ -2058,7 +2024,7 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 	boolean[int] result = knapsack(remaining_space, count(space), space, desirability);
 
 	string organ_name = (type == "eat") ? "fullness" : "inebriety";
-	print("Knapsack " + type + " plan for " + remaining_space + " " + organ_name + ":", "blue");
+	auto_log_info("Knapsack " + type + " plan for " + remaining_space + " " + organ_name + ":", "blue");
 	float total_adv = 0.0;
 	int consumable_count = 0;
 	int sum_space = 0;
@@ -2071,37 +2037,37 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 		}
 		consumable_count++;
 		sum_space += actions[i].size;
-		print(to_pretty_string(actions[i]), "blue");
+		auto_log_info(to_pretty_string(actions[i]), "blue");
 		total_adv += actions[i].adventures;
 	}
 	if (type == "eat")
 	{
 		int applicable_seasoning = min(item_amount($item[special seasoning]), consumable_count);
-		print("(+" + applicable_seasoning + " from special seasoning ("+ item_amount($item[special seasoning]) + " available)", "blue");
+		auto_log_info("(+" + applicable_seasoning + " from special seasoning ("+ item_amount($item[special seasoning]) + " available)", "blue");
 		total_adv += applicable_seasoning;
 	}
 	if (type == "eat")
 	{
 		// TODO: and can obtain milk of magnesium? It's just logging...
-		print("(+" + sum_space + " from Got Milk)", "blue");
+		auto_log_info("(+" + sum_space + " from Got Milk)", "blue");
 		total_adv += sum_space;
 	}
 	if (type == "drink" && auto_have_skill($skill[The Ode to Booze]))
 	{
-		print("(+" + sum_space + " from Ode to Booze)", "blue");
+		auto_log_info("(+" + sum_space + " from Ode to Booze)", "blue");
 		total_adv += sum_space;
 	}
-	print("For a total of: " + total_adv + " adventures.", "blue");
+	auto_log_info("For a total of: " + total_adv + " adventures.", "blue");
 
 	if(count(result) == 0)
 	{
-		print("Couldn't find a way of finishing off our " + type + " space exactly.", "red");
+		auto_log_warning("Couldn't find a way of finishing off our " + type + " space exactly.", "red");
 		return false;
 	}
 
 	if(!canSimultaneouslyAcquire(normal_consumables))
 	{
-		print("It looks like I can't simultaneously get everything that I want to " + type + ". I'll wait and see if I get unconfused - otherwise, please " + type + " manually.", "red");
+		auto_log_warning("It looks like I can't simultaneously get everything that I want to " + type + ". I'll wait and see if I get unconfused - otherwise, please " + type + " manually.", "red");
 		return false;
 	}
 
@@ -2134,13 +2100,13 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 
 	int pre_adventures = my_adventures();
 
-	print("Consuming " + count(result) + " things...", "blue");
+	auto_log_info("Consuming " + count(result) + " things...", "blue");
 	foreach i in result
 	{
 		autoConsume(actions[i]);
 	}
 
-	print("Expected " + total_adv + " adventures, got " + (my_adventures() - pre_adventures), "blue");
+	auto_log_info("Expected " + total_adv + " adventures, got " + (my_adventures() - pre_adventures), "blue");
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -51,6 +51,10 @@ boolean settingFixer()
 		Maybe it won\t. It doesn't really need to be I guess.
 		Backwards compatibility forever!!!
 	***/
+	if(get_property("auto_debug") == "true"){
+		set_property("auto_logLevel", "debug");
+	}
+
 	trackingSplitterFixer("auto_banishes_day1", 1, "auto_banishes");
 	trackingSplitterFixer("auto_banishes_day2", 2, "auto_banishes");
 	trackingSplitterFixer("auto_banishes_day3", 3, "auto_banishes");
@@ -250,18 +254,18 @@ boolean settingFixer()
 
 	if(get_property("lastPlusSignUnlock") == "true")
 	{
-		print("lastPlusSignUnlock was changed to a boolean, fixing...", "red");
+		auto_log_debug("lastPlusSignUnlock was changed to a boolean, fixing...", "red");
 		set_property("lastPlusSignUnlock", my_ascensions());
 	}
 	if(get_property("lastTempleUnlock") == "true")
 	{
-		print("lastTempleUnlock was changed to a boolean, fixing...", "red");
+		auto_log_debug("lastTempleUnlock was changed to a boolean, fixing...", "red");
 		set_property("lastTempleUnlock", my_ascensions());
 	}
 
 	if(property_exists("auto_day1_init"))
 	{
-		print("Found old day initialization trackers, removing...", "red");
+		auto_log_debug("Found old day initialization trackers, removing...", "red");
 		remove_property("auto_day1_init");
 		remove_property("auto_day2_init");
 		remove_property("auto_day3_init");
@@ -270,19 +274,19 @@ boolean settingFixer()
 
 	if(property_exists("auto_gaudy"))
 	{
-		print("Some lingering stuff from when gaudy pirates mattered is still here, let's get rid of it...", "red");
+		auto_log_debug("Some lingering stuff from when gaudy pirates mattered is still here, let's get rid of it...", "red");
 		remove_property("auto_gaudy");
 	}
 
 	if(get_property("auto_paranoia") == "")
 	{
-		print("No paranoia value, we probably don't want to be paranoid...", "red");
+		auto_log_debug("No paranoia value, we probably don't want to be paranoid...", "red");
 		set_property("auto_paranoia", -1);
 	}
 
 	if(get_property("auto_helpMeMafiaIsSuperBrokenAaah") == "")
 	{
-		print("Mafia probably isn't super broken, so let's set it that way...", "red");
+		auto_log_debug("Mafia probably isn't super broken, so let's set it that way...", "red");
 		set_property("auto_helpMeMafiaIsSuperBrokenAaah", false);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_digimon.ash
+++ b/RELEASE/scripts/autoscend/auto_digimon.ash
@@ -88,8 +88,7 @@ boolean digimon_makeTeam()
 			front = $familiar[Levitating Potato];
 		}
 
-		print("I choose you! " + front.name + " the " + front + "!!!!", "green");
-#		temp = visit_url("famteam.php?slot=1&fam=" + to_int($familiar[El Vibrato Megadrone]) + "&pwd&action=slot");
+		auto_log_info("I choose you! " + front.name + " the " + front + "!!!!", "green");
 		temp = visit_url("famteam.php?slot=1&fam=" + to_int(front) + "&pwd&action=slot");
 		if(get_property("_digimonFront").to_familiar() != front)
 		{
@@ -133,12 +132,12 @@ boolean digimon_autoAdv(int num, location loc, string option)
 		temp = visit_url(to_url(loc) + "a", false);
 	}
 
-	print("[Insert Punch Out music here]", "green");
+	auto_log_info("[Insert Punch Out music here]", "green");
 	temp = visit_url("fambattle.php");
 	int choiceLimiter = 0;
 	while(contains_text(temp, "whichchoice value=") || contains_text(temp, "whichchoice="))
 	{
-		print("Digimon hit a choice adventure (" + loc + "), trying....", "red");
+		auto_log_warning("Digimon hit a choice adventure (" + loc + "), trying....", "red");
 		matcher choice_matcher = create_matcher("(?:whichchoice value=(\\d+))|(?:whichchoice=(\\d+))", temp);
 		if(choice_matcher.find())
 		{
@@ -170,7 +169,7 @@ boolean digimon_autoAdv(int num, location loc, string option)
 
 	if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
 	{
-		print("Consulting the Helix Fossil....", "green");
+		auto_log_info("Consulting the Helix Fossil....", "green");
 		boolean ignore = cli_execute("ashq import 'Pocket Familiars'; buffer temp = PocketFamiliarsFight();");
 		if($locations[The Defiled Alcove, The Defiled Cranny, The Defiled Niche, The Defiled Nook] contains my_location())
 		{
@@ -214,7 +213,7 @@ boolean digimon_autoAdv(int num, location loc, string option)
 		temp = visit_url("fambattle.php?pwd&famaction[backstab-" + to_int(blastFam) + "]=Backstab");
 	}
 	int action = 1;
-	
+
 
 	while(!contains_text(temp, "<!--WINWINWIN-->"))
 	{

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -175,7 +175,7 @@ boolean L13_ed_towerHandler()
 	council();
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_10_sorcfight"))
 	{
-		print("We found the jerkwad!! Revenge!!!!!", "blue");
+		auto_log_info("We found the jerkwad!! Revenge!!!!!", "blue");
 
 		string page = "place.php?whichplace=nstower&action=ns_10_sorcfight";
 		autoAdvBypass(page, $location[Noob Cave]);
@@ -194,7 +194,7 @@ boolean L13_ed_towerHandler()
 			cli_execute("scripts/autoscend/auto_post_adv.ash");
 			return true;
 		}
-		print("Please check your quests, but you might just not be at level 13 yet in order to continue.", "red");
+		auto_log_warning("Please check your quests, but you might just not be at level 13 yet in order to continue.", "red");
 		if((my_level() < 13) && elementalPlanes_access($element[spooky]))
 		{
 			boolean tryJungle = false;
@@ -239,7 +239,7 @@ boolean L13_ed_towerHandler()
 		}
 		else
 		{
-			print("We must be missing a sidequest. We can't find the jerk adventurer. Must pretend we are alive...", "blue");
+			auto_log_info("We must be missing a sidequest. We can't find the jerk adventurer. Must pretend we are alive...", "blue");
 		}
 	}
 
@@ -274,9 +274,9 @@ boolean L13_ed_councilWarehouse()
 	if(get_property("lastEncounter") == "You Found It!")
 	{
 		council();
-		print("McMuffin is found!", "blue");
-		print("Ed Combats: " + get_property("auto_edCombatCount"), "blue");
-		print("Ed Combat Rounds: " + get_property("auto_edCombatRoundCount"), "blue");
+		auto_log_info("McMuffin is found!", "blue");
+		auto_log_info("Ed Combats: " + get_property("auto_edCombatCount"), "blue");
+		auto_log_info("Ed Combat Rounds: " + get_property("auto_edCombatRoundCount"), "blue");
 
 		return false;
 	}
@@ -439,7 +439,7 @@ boolean ed_buySkills()
 	if(my_skillPoints.find())
 	{
 		int skillPoints = to_int(my_skillPoints.group(1));
-		print("Skill points found: " + skillPoints);
+		auto_log_info("Skill points found: " + skillPoints);
 		possEdPoints = skillPoints - 1;
 		if(have_skill($skill[Bounty of Renenutet]) && have_skill($skill[Wrath of Ra]) && have_skill($skill[Curse of Stench]))
 		{
@@ -540,7 +540,7 @@ boolean ed_buySkills()
 	if(my_imbuePoints.find())
 	{
 		imbuePoints = to_int(my_imbuePoints.group(1));
-		print("Imbuement points found: " + imbuePoints);
+		auto_log_info("Imbuement points found: " + imbuePoints);
 	}
 	possEdPoints += imbuePoints;
 
@@ -554,7 +554,7 @@ boolean ed_buySkills()
 	if(my_servantPoints.find())
 	{
 		int servantPoints = to_int(my_servantPoints.group(1));
-		print("Servants points found: " + servantPoints);
+		auto_log_info("Servants points found: " + servantPoints);
 		while(servantPoints > 0)
 		{
 			servantPoints -= 1;
@@ -673,7 +673,7 @@ boolean ed_buySkills()
 			{
 				if(handleServant(tryImbue))
 				{
-					print("Trying to imbue " + tryImbue + " with glorious wisdom!!", "green");
+					auto_log_info("Trying to imbue " + tryImbue + " with glorious wisdom!!", "green");
 					visit_url("choice.php?whichchoice=1053&option=5&pwd=");
 				}
 			}
@@ -1010,7 +1010,7 @@ boolean ed_shopping()
 	{
 		return false;
 	}
-	print("Time to shop!", "red");
+	auto_log_info("Time to shop!", "red");
 	wait(1);
 	visit_url("choice.php?pwd=&whichchoice=1023&option=1", true);
 
@@ -1028,7 +1028,7 @@ boolean ed_shopping()
 	{
 		if (coins >= 10)
 		{
-			print("Buying Upgraded Legs", "green");
+			auto_log_info("Buying Upgraded Legs", "green");
 			set_property("auto_needLegs", false);
 			visit_url("place.php?whichplace=edunder&action=edunder_bodyshop");
 			visit_url("choice.php?pwd&skillid=36&option=1&whichchoice=1052", true);
@@ -1048,7 +1048,7 @@ boolean ed_shopping()
 	while (coins >= 15 && canEat > 0)
 	{
 		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=428", true);
-		print("Buying a mummified beef haunch!", "green");
+		auto_log_info("Buying a mummified beef haunch!", "green");
 		coins -= 15;
 		canEat--;
 	}
@@ -1056,7 +1056,7 @@ boolean ed_shopping()
 	// buy emergency MP restores.
 	if (!get_property("lovebugsUnlocked").to_boolean() && coins >= 1 && item_amount($item[Holy Spring Water]) == 0 && my_mp() < mp_cost($skill[Storm Of The Scarab]))
 	{
-		print("Buying Holy Spring Water", "green");
+		auto_log_info("Buying Holy Spring Water", "green");
 		visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
 		coins -= 1;
 	}
@@ -1068,7 +1068,7 @@ boolean ed_shopping()
 		int requiredKa = ed_KaCost(nextUpgrade);
 		if (requiredKa != -1 && coins >= requiredKa)
 		{
-			print("Buying " + nextUpgrade.to_string() + " (" + requiredKa.to_string() + " Ka).", "green");
+			auto_log_info("Buying " + nextUpgrade.to_string() + " (" + requiredKa.to_string() + " Ka).", "green");
 			int skillBuy = ed_skillID(nextUpgrade);
 			if (skillBuy != 0)
 			{
@@ -1082,44 +1082,44 @@ boolean ed_shopping()
 		{
 			while (item_amount($item[Talisman of Renenutet]) < 7 && get_property("auto_renenutetBought").to_int() < 7 && coins >= 1)
 		{
-			print("Buying Talisman of Renenutet", "green");
+			auto_log_info("Buying Talisman of Renenutet", "green");
 			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=439", true);
 			set_property("auto_renenutetBought", 1 + get_property("auto_renenutetBought").to_int());
 				coins -= 1;
 			}
 			while (item_amount($item[Linen Bandages]) < 4 && coins >= 1)
 			{
-				print("Buying Linen Bandages", "green");
+				auto_log_info("Buying Linen Bandages", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=429", true);
 				coins -= 1;
 			}
 			if (item_amount($item[Holy Spring Water]) == 0 && coins >= 1)
 			{
-				print("Buying Holy Spring Water", "green");
+				auto_log_info("Buying Holy Spring Water", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=436", true);
 				coins -= 1;
 			}
 			while (item_amount($item[Talisman of Horus]) < 2 && coins >= 5)
 			{
-				print("Buying Talisman of Horus", "green");
+				auto_log_info("Buying Talisman of Horus", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=693", true);
 				coins -= 5;
 			}
 			if (item_amount($item[Spirit Beer]) == 0 && coins >= 30)
 			{
-				print("Buying Spirit Beer", "green");
+				auto_log_info("Buying Spirit Beer", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=432", true);
 				coins -= 2;
 			}
 			if ((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 2 && coins >= 30)
 			{
-				print("Buying Ancient Cure-all", "green");
+				auto_log_info("Buying Ancient Cure-all", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=435", true);
 				coins -= 3;
 			}
 			if (item_amount($item[Sacramental Wine]) == 0 && coins >= 30)
 			{
-				print("Buying Sacramental Wine", "green");
+				auto_log_info("Buying Sacramental Wine", "green");
 				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=433", true);
 				coins -= 3;
 			}
@@ -1240,7 +1240,7 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 
 	if((my_hp() == 0) || (get_property("_edDefeats").to_int() > get_property("edDefeatAbort").to_int()))
 	{
-		print("Defeats detected: " + get_property("_edDefeats") + ", Defeat threshold: " + get_property("edDefeatAbort"), "green");
+		auto_log_critical("Defeats detected: " + get_property("_edDefeats") + ", Defeat threshold: " + get_property("edDefeatAbort"), "green");
 		abort("How are you here? You can't be here. Bloody Limit Mode (probably, maybe?)!!");
 	}
 
@@ -1251,7 +1251,7 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 		num = num - 1;
 		if(num > 1)
 		{
-			print("This fight and " + num + " more left.", "blue");
+			auto_log_info("This fight and " + num + " more left.", "blue");
 		}
 		cli_execute("auto_pre_adv");
 		set_property("auto_disableAdventureHandling", true);
@@ -1259,7 +1259,7 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 
 		if(!skipFirstLife)
 		{
-			print("Starting Ed Battle at " + loc, "blue");
+			auto_log_info("Starting Ed Battle at " + loc, "blue");
 			status = adv1(loc, 0, option);
 			if(!status && (get_property("lastEncounter") == "Like a Bat Into Hell"))
 			{
@@ -1275,17 +1275,17 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 		string page = visit_url("main.php");
 		if(contains_text(page, "whichchoice value=1023"))
 		{
-			print("Ed has UNDYING once!" , "blue");
+			auto_log_info("Ed has UNDYING once!" , "blue");
 			if(!ed_shopping())
 			{
 				#If this visit_url results in the enemy dying, we don't want to continue
 				visit_url("choice.php?pwd=&whichchoice=1023&option=2", true);
 			}
-			print("Ed returning to battle Stage 1", "blue");
+			auto_log_info("Ed returning to battle Stage 1", "blue");
 
 			if(get_property("_edDefeats").to_int() == 0)
 			{
-				print("Monster defeated in initialization, aborting attempt.", "red");
+				auto_log_warning("Monster defeated in initialization, aborting attempt.", "red");
 				set_property("auto_disableAdventureHandling", false);
 				cli_execute("auto_post_adv.ash");
 				return true;
@@ -1304,17 +1304,17 @@ boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife)
 			page = visit_url("main.php");
 			if(contains_text(page, "whichchoice value=1023"))
 			{
-				print("Ed has UNDYING twice! Time to kick ass!" , "blue");
+				auto_log_info("Ed has UNDYING twice! Time to kick ass!" , "blue");
 				if(!ed_shopping())
 				{
 					#If this visit_url results in the enemy dying, we don't want to continue
 					visit_url("choice.php?pwd=&whichchoice=1023&option=2", true);
 				}
-				print("Ed returning to battle Stage 2", "blue");
+				auto_log_info("Ed returning to battle Stage 2", "blue");
 
 				if(get_property("_edDefeats").to_int() == 0)
 				{
-					print("Monster defeated in initialization, aborting attempt.", "red");
+					auto_log_warning("Monster defeated in initialization, aborting attempt.", "red");
 					set_property("auto_disableAdventureHandling", false);
 					cli_execute("auto_post_adv.ash");
 					return true;
@@ -1594,7 +1594,7 @@ boolean L9_ed_chasmStart()
 {
 	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
-		print("It's a troll on a bridge!!!!", "blue");
+		auto_log_info("It's a troll on a bridge!!!!", "blue");
 
 		string page = visit_url("place.php?whichplace=orc_chasm&action=bridge_done");
 		autoAdvBypass("place.php?whichplace=orc_chasm&action=bridge_done", $location[The Smut Orc Logging Camp]);
@@ -1609,7 +1609,7 @@ boolean L9_ed_chasmBuild()
 {
 	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
-		print("What a nice bridge over here...." , "green");
+		auto_log_info("What a nice bridge over here...." , "green");
 
 		string page = visit_url("place.php?whichplace=orc_chasm&action=bridge_done");
 		autoAdvBypass("place.php?whichplace=orc_chasm&action=bridge_done", $location[The Smut Orc Logging Camp]);
@@ -1629,7 +1629,7 @@ boolean L9_ed_chasmBuildClover(int need)
 		autoAdvBypass("adventure.php?snarfblat=295", $location[The Smut Orc Logging Camp]);
 		if(item_amount($item[Ten-Leaf Clover]) > 0)
 		{
-			print("Wandering adventure in The Smut Orc Logging Camp, boo. Gonna have to do this again.");
+			auto_log_info("Wandering adventure in The Smut Orc Logging Camp, boo. Gonna have to do this again.");
 			use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
 			restoreSetting("cloverProtectActive");
 			return true;

--- a/RELEASE/scripts/autoscend/auto_elementalPlanes.ash
+++ b/RELEASE/scripts/autoscend/auto_elementalPlanes.ash
@@ -32,7 +32,7 @@ boolean elementalPlanes_initializeSettings()
 		temp = visit_url("place.php?whichplace=airport_sleaze&intro=1");
 		if(contains_text(temp, "you take a short, turbulence-free flight to Spring Break Beach."))
 		{
-			print("We have access to Spring Break Beach. Woo.", "green");
+			auto_log_info("We have access to Spring Break Beach. Woo.", "green");
 			set_property("sleazeAirportAlways", true);
 		}
 	}
@@ -42,7 +42,7 @@ boolean elementalPlanes_initializeSettings()
 		temp = visit_url("place.php?whichplace=airport_spooky&intro=1");
 		if(contains_text(temp, "Your flight to Conspiracy Island is nasty, brutish and short."))
 		{
-			print("We have access to Conspiracy Island. Boo.", "green");
+			auto_log_info("We have access to Conspiracy Island. Boo.", "green");
 			set_property("spookyAirportAlways", true);
 		}
 	}
@@ -52,7 +52,7 @@ boolean elementalPlanes_initializeSettings()
 		temp = visit_url("place.php?whichplace=airport_stench&intro=1");
 		if(contains_text(temp, "You get in line with the thousands of other passengers bound for Dinseylandfill."))
 		{
-			print("We have access to Dinseylandfill. Eww.", "green");
+			auto_log_info("We have access to Dinseylandfill. Eww.", "green");
 			set_property("stenchAirportAlways", true);
 		}
 	}
@@ -62,7 +62,7 @@ boolean elementalPlanes_initializeSettings()
 		temp = visit_url("place.php?whichplace=airport_hot&intro=1");
 		if(contains_text(temp, "After a convenient, comfortable and dignified ticketing and boarding process"))
 		{
-			print("We have access to That 70s Volcano. Groovy.", "green");
+			auto_log_info("We have access to That 70s Volcano. Groovy.", "green");
 			set_property("hotAirportAlways", true);
 		}
 	}
@@ -72,7 +72,7 @@ boolean elementalPlanes_initializeSettings()
 		temp = visit_url("place.php?whichplace=airport_cold&intro=1");
 		if(contains_text(temp, "The local temperature is about a million degrees below zero"))
 		{
-			print("We can go to The Glaciest. Great prices everyday!", "green");
+			auto_log_info("We can go to The Glaciest. Great prices everyday!", "green");
 			set_property("coldAirportAlways", true);
 		}
 	}
@@ -114,13 +114,13 @@ boolean elementalPlanes_takeJob(element ele)
 
 		if(sustenance != -1)
 		{
-			print("Trying to avoid Guest Sustenance Assurance Dinseylandfill job.", "blue");
+			auto_log_info("Trying to avoid Guest Sustenance Assurance Dinseylandfill job.", "blue");
 			foreach job in jobs
 			{
 				int newAt = index_of(page, job, at);
 				if(newAt != -1)
 				{
-					print("Found new job option: " + job, "blue");
+					auto_log_info("Found new job option: " + job, "blue");
 					if(newAt < sustenance)
 					{
 						choice = 1;
@@ -155,14 +155,14 @@ boolean elementalPlanes_takeJob(element ele)
 		while(bucket.find())
 		{
 			at = at + 1;
-			print("Found bucket " + bucket.group(1) + ".", "blue");
+			auto_log_info("Found bucket " + bucket.group(1) + ".", "blue");
 			int i = 0;
 			foreach job in jobs
 			{
 				i = i + 1;
 				if((bucket.group(1) == job) && (i > best))
 				{
-					print("Considering job " + job, "blue");
+					auto_log_info("Considering job " + job, "blue");
 					best = i;
 					choice = at;
 				}
@@ -276,7 +276,7 @@ boolean volcano_lavaDogs()
 
 	if($location[The Bubblin\' Caldera].turns_spent >= 15)
 	{
-		print("Could not find Caldera Volcoino... uh oh...", "red");
+		auto_log_warning("Could not find Caldera Volcoino... uh oh...", "red");
 		return false;
 	}
 
@@ -372,7 +372,3 @@ boolean volcano_bunkerJob()
 	}
 	return false;
 }
-
-
-
-

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -24,7 +24,7 @@ boolean autoEquip(slot s, item it)
 		return false;
 	}
 
-	auto_debug_print("Equipping " + it + " to slot " + s, "gold");
+	auto_log_debug("Equipping " + it + " to slot " + s, "gold");
 
 	if(useMaximizeToEquip())
 	{
@@ -72,7 +72,7 @@ boolean autoOutfit(string toWear)
 	if(useMaximizeToEquip())
 	{
 		// yes I could use +outfit instead here but this makes it simpler to avoid failed maximize calls
-		auto_debug_print('Adding outfit "' + toWear + '" to maximizer statement', "gold");
+		auto_log_debug('Adding outfit "' + toWear + '" to maximizer statement', "gold");
 		boolean pass = true;
 		foreach i,it in outfit_pieces(toWear)
 		{
@@ -90,7 +90,7 @@ boolean tryAddItemToMaximize(slot s, item it)
 {
 	if(!($slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar] contains s))
 	{
-		auto_debug_print("But " + s + " is an invalid equip slot... What?", "red");
+		auto_log_error("But " + s + " is an invalid equip slot... What?", "red");
 		return false;
 	}
 	switch(s)
@@ -189,7 +189,7 @@ void resetMaximize()
 		}
 	}
 	set_property("auto_maximize_current", res);
-	auto_debug_print("Resetting auto_maximize_current to " + res, "gold");
+	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");
 
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
 	{
@@ -217,7 +217,7 @@ void finalizeMaximize()
 
 void addToMaximize(string add)
 {
-	auto_debug_print('Adding "' + add + '" to current maximizer statement', "gold");
+	auto_log_debug('Adding "' + add + '" to current maximizer statement', "gold");
 	string res = get_property("auto_maximize_current");
 	boolean addHasComma = add.starts_with(",");
 	if(res != "" && !addHasComma)
@@ -235,7 +235,7 @@ void addToMaximize(string add)
 
 void removeFromMaximize(string rem)
 {
-	auto_debug_print('Removing "' + rem + '" from current maximizer statement', "gold");
+	auto_log_debug('Removing "' + rem + '" from current maximizer statement', "gold");
 	string res = get_property("auto_maximize_current");
 	res = res.replace_string(rem, "");
 	// let's be safe here
@@ -268,7 +268,7 @@ boolean simMaximize()
 boolean simMaximizeWith(string add)
 {
 	addToMaximize(add);
-	auto_debug_print("Simulating: " + get_property("auto_maximize_current"), "gold");
+	auto_log_debug("Simulating: " + get_property("auto_maximize_current"), "gold");
 	boolean res = simMaximize();
 	removeFromMaximize(add);
 	return res;
@@ -287,7 +287,7 @@ void equipMaximizedGear()
 	}
 
 	finalizeMaximize();
-	print("Maximizing: " + get_property("auto_maximize_current"), "blue");
+	auto_log_info("Maximizing: " + get_property("auto_maximize_current"), "blue");
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
 }
 
@@ -317,7 +317,7 @@ void equipOverrides()
 			item it = item_str.to_item();
 			if(it == $item[none])
 			{
-				print('"' + item_str + '" does not properly convert to an item (found in auto_equipment_override_' + slot_str + ')', "red");
+				auto_log_warning('"' + item_str + '" does not properly convert to an item (found in auto_equipment_override_' + slot_str + ')', "red");
 				continue;
 			}
 			if(autoEquip(s, it))
@@ -351,7 +351,7 @@ void equipBaselineGear()
 
 	string [string,int,string] equipment_text;
 	if(!file_to_map("autoscend_equipment.txt", equipment_text))
-		print("Could not load autoscend_equipment.txt. This is bad!", "red");
+		auto_log_critical("Could not load autoscend_equipment.txt. This is bad!", "red");
 	item [slot] [int] equipment;
 	boolean considerGearOption(string item_str, string slot_str, string conds)
 	{
@@ -465,7 +465,7 @@ void makeStartingSmiths()
 	{
 		if(my_mp() < (3 * mp_cost($skill[Summon Smithsness])))
 		{
-			print("You don't have enough MP for initialization, it might be ok but probably not.", "red");
+			auto_log_warning("You don't have enough MP for initialization, it might be ok but probably not.", "red");
 		}
 		use_skill(3, $skill[Summon Smithsness]);
 	}
@@ -730,18 +730,18 @@ void equipRollover()
 		cli_execute("buy Li'l Unicorn Costume");
 	}
 
-	print("Putting on pajamas...", "blue");
+	auto_log_info("Putting on pajamas...", "blue");
 
 	string to_max = "-tie,adv";
 	if(hippy_stone_broken())
 		to_max += ",0.3fites";
 	if(auto_have_familiar($familiar[Trick-or-Treating Tot]))
 		to_max += ",switch Trick-or-Treating Tot";
-	
+
 	maximize(to_max, false);
 
 	if(!in_hardcore())
 	{
-		print("Done putting on jammies, if you pulled anything with a rollover effect you might want to make sure it's equipped before you log out.", "red");
+		auto_log_info("Done putting on jammies, if you pulled anything with a rollover effect you might want to make sure it's equipped before you log out.", "red");
 	}
 }

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -91,7 +91,7 @@ boolean routineRainManHandler()
 
 		if(my_daycount() < 3)
 		{
-			print("I have nothing left to rain man, maybe we are getting ready for make it rain?");
+			auto_log_info("I have nothing left to rain man, maybe we are getting ready for make it rain?");
 		}
 	}
 	return false;
@@ -182,7 +182,7 @@ boolean doHRSkills()
 	{
 		if(item_amount($item[thunder thigh]) > 0)
 		{
-			print("Trying to use a thunder thigh", "blue");
+			auto_log_info("Trying to use a thunder thigh", "blue");
 			string page = visit_url("inv_use.php?which=3&whichitem=7648&pwd");
 			runChoice(page);
 			if(get_property("choiceAdventure967") == "1")
@@ -219,7 +219,7 @@ boolean doHRSkills()
 
 		if(item_amount($item[aquaconda brain]) > 0)
 		{
-			print("Trying to use a aquaconda brain", "blue");
+			auto_log_info("Trying to use a aquaconda brain", "blue");
 			string page = visit_url("inv_use.php?which=3&whichitem=7647&pwd");
 			runChoice(page);
 			if(get_property("choiceAdventure968") == "1")
@@ -256,7 +256,7 @@ boolean doHRSkills()
 
 		if(item_amount($item[lightning milk]) > 0)
 		{
-			print("Trying to use a lightning milk", "blue");
+			auto_log_info("Trying to use a lightning milk", "blue");
 			string page = visit_url("inv_use.php?which=3&whichitem=7646&pwd");
 			runChoice(page);
 			if(get_property("choiceAdventure969") == "3")
@@ -495,7 +495,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	{
 		set_property("auto_doCombatCopy", "yes");
 	}
-	print("Looking to summon: " + monsterName, "blue");
+	auto_log_info("Looking to summon: " + monsterName, "blue");
 
 	string[int] pages;
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";

--- a/RELEASE/scripts/autoscend/auto_jellonewbie.ash
+++ b/RELEASE/scripts/autoscend/auto_jellonewbie.ash
@@ -22,12 +22,12 @@ void jello_startAscension(string page)
 {
 	if(contains_text(page, "Welcome to the Kingdom, Gelatinous Noob"))
 	{
-		print("In starting Jello Adventure", "blue");
+		auto_log_info("In starting Jello Adventure", "blue");
 		matcher my_skillPoints = create_matcher("You can pick <span class=\"num\">(\\d\+)</span> more skill", page);
 		if(my_skillPoints.find())
 		{
 			int skillPoints = to_int(my_skillPoints.group(1));
-			print("Found " + skillPoints + " skillpoints", "blue");
+			auto_log_info("Found " + skillPoints + " skillpoints", "blue");
 			boolean [int] skills = $ints[50, 49, 48, 47, 46, 55, 45, 70, 60, 69, 30, 29, 95, 54, 105, 75, 35, 10, 20, 68, 53, 52, 51, 44, 43, 42, 85, 83, 93, 34, 58, 28, 57, 84, 8, 56, 6, 18, 17, 37, 7, 9, 67, 59, 39, 74, 73, 72, 40, 66, 77, 78, 38];
 
 			string goal = "";
@@ -101,10 +101,10 @@ boolean jello_buySkills()
 
 				sort possible by auto_mall_price(value);
 
-				print("Trying to acquire skill " + sk + " and considering: " , "green");
+				auto_log_info("Trying to acquire skill " + sk + " and considering: " , "green");
 				for(int i=0; i<bound; i++)
 				{
-					print(possible[i] + ": " + auto_mall_price(possible[i]), "blue");
+					auto_log_info(possible[i] + ": " + auto_mall_price(possible[i]), "blue");
 				}
 
 				for(int i=0; (i<bound) && !have_skill(sk); i++)
@@ -170,13 +170,6 @@ string[item] jello_lister(string goal)
 			}
 			if(contains_text(result, goal))
 			{
-//				string color = "green";
-//				if((output % 2) == 1)
-//				{
-//					color = "blue";
-//				}
-//				print(it + ": " + result, color);
-//				output++;
 				retval[it] = result;
 			}
 		}
@@ -208,4 +201,3 @@ boolean LM_jello()
 	jello_buySkills();
 	return false;
 }
-

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -6,7 +6,7 @@ void handleKingLiberation()
 	restoreAllSettings();
 	if(get_property("kingLiberated").to_boolean() && (get_property("auto_snapshot") == ""))
 	{
-		print("Yay! The King is saved. I suppose you should do stuff.");
+		auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
 		if(!get_property("auto_kingLiberation").to_boolean())
 		{
 			set_property("auto_snapshot", "aborted");
@@ -31,7 +31,7 @@ void handleKingLiberation()
 			{
 				if(item_amount(it) > 0)
 				{
-					print("Displaying " + item_amount(it) + " " + it, "green");
+					auto_log_info("Displaying " + item_amount(it) + " " + it, "green");
 				}
 				put_display(item_amount(it), it);
 			}
@@ -42,7 +42,7 @@ void handleKingLiberation()
 		{
 			if(storage_amount(it) > 0)
 			{
-				print("Pulling " + storage_amount(it) + " " + it, "green");
+				auto_log_info("Pulling " + storage_amount(it) + " " + it, "green");
 			}
 			pullAll(it);
 		}
@@ -52,7 +52,7 @@ void handleKingLiberation()
 		{
 			if(storage_amount(it) > 0)
 			{
-				print("Pulling/Using " + storage_amount(it) + " " + it, "green");
+				auto_log_info("Pulling/Using " + storage_amount(it) + " " + it, "green");
 			}
 			pullAndUse(it, 1);
 		}
@@ -108,7 +108,7 @@ void handleKingLiberation()
 			visit_url("place.php?whichplace=arcade&action=arcade_plumber", false);
 			if(item_amount($item[Defective Game Grid Token]) > oldToken)
 			{
-				print("Woohoo!!! You got a game grid tokON!!", "green");
+				auto_log_info("Woohoo!!! You got a game grid tokON!!", "green");
 			}
 		}
 	}
@@ -157,7 +157,7 @@ void handleKingLiberation()
 		restoreSetting("betweenBattleScript");
 		restoreSetting("counterScript");
 	}
-	print("King Liberation Complete. Thank you for playing", "blue");
+	auto_log_info("King Liberation Complete. Thank you for playing", "blue");
 }
 
 

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -70,7 +70,7 @@ boolean LX_koeInvaderHandler()
 		float offset = auto_canBeachCombHead(el) ? 3.0 : 0.0;
 		damagePerRound += baseDamage * (100.0 - elemental_resist_value(offset + simValue(el + " Resistance")))/100.0;
 	}
-	print("The Invader: Expecting to take " + damagePerRound + " damage per round", "blue");
+	auto_log_info("The Invader: Expecting to take " + damagePerRound + " damage per round", "blue");
 	int turns = ceil(0.95 / damagePerRound);
 
 	int damageCap = 100 * my_daycount();
@@ -103,6 +103,6 @@ boolean LX_koeInvaderHandler()
 			return ret;
 		}
 	}
-	print("I don't think we're ready to kill the invader yet.", "blue");
+	auto_log_warning("I don't think we're ready to kill the invader yet.", "blue");
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_list.ash
+++ b/RELEASE/scripts/autoscend/auto_list.ash
@@ -75,8 +75,6 @@ familiar[int] List(familiar[int] data)
 	{
 		temp[idx] = el;
 	}
-#	print(ListOutput(data), "red");
-#	print(ListOutput(temp), "gray");
 	sort temp by index;
 
 	int index = 0;
@@ -122,8 +120,6 @@ familiar[int] ListRemove(familiar[int] list, familiar what)
 familiar[int] ListRemove(familiar[int] list, familiar what, int idx)
 {
 	familiar[int] retval = List(list);
-#	print(ListOutput(list), "red");
-#	print(ListOutput(retval), "gray");
 	foreach at, el in retval
 	{
 		if((el == what) && (at >= idx))
@@ -137,8 +133,6 @@ familiar[int] ListRemove(familiar[int] list, familiar what, int idx)
 familiar[int] ListErase(familiar[int] list, int index)
 {
 	familiar[int] retval = List(list);
-#	print(ListOutput(list), "red");
-#	print(ListOutput(retval), "gray");
 	remove retval[index];
 	return List(retval);
 }
@@ -222,51 +216,51 @@ void main()
 	boolean[familiar] test = $familiars[Slimeling, Puck Man, Baby Gravy Fairy, Intergnat, Mosquito];
 	familiar[int] list = List(test);
 
-	print("First list", "green");
-	print(ListOutput(list), "blue");
+	auto_log_info("First list", "green");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Deleting Baby Gravy Fairy, (2)", "green");
+	auto_log_info("Deleting Baby Gravy Fairy, (2)", "green");
 	list = ListRemove(list, $familiar[Baby Gravy Fairy]);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Deleting Element 1 (Puck Man)", "green");
+	auto_log_info("Deleting Element 1 (Puck Man)", "green");
 	list = ListErase(list, 1);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting at Front (Exotic Parrot)", "green");
+	auto_log_info("Inserting at Front (Exotic Parrot)", "green");
 	list = ListInsertFront(list, $familiar[Exotic Parrot]);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting at End (Leprechaun)", "green");
+	auto_log_info("Inserting at End (Leprechaun)", "green");
 	list = ListInsert(list, $familiar[Leprechaun]);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting at 2 (Artistic Goth Kid)", "green");
+	auto_log_info("Inserting at 2 (Artistic Goth Kid)", "green");
 	list = ListInsertAt(list, $familiar[Artistic Goth Kid], 2);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting at 0 (Artistic Goth Kid)", "green");
+	auto_log_info("Inserting at 0 (Artistic Goth Kid)", "green");
 	list = ListInsertAt(list, $familiar[Artistic Goth Kid], 0);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting inorder weirdness (Bulky Buddy Box)", "green");
+	auto_log_info("Inserting inorder weirdness (Bulky Buddy Box)", "green");
 	list = ListInsertInorder(list, $familiar[Bulky Buddy Box]);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
-	print("Inserting inorder weirdness (Xiblaxian Holo-Companion)", "green");
+	auto_log_info("Inserting inorder weirdness (Xiblaxian Holo-Companion)", "green");
 	list = ListInsertInorder(list, $familiar[Xiblaxian Holo-Companion]);
-	print(ListOutput(list), "blue");
+	auto_log_info(ListOutput(list), "blue");
 
 	int index = 0;
 	while(index < count(list))
 	{
-		print(index + ": " + list[index] + ": " + ListFind(list, list[index]), "blue");
+		auto_log_info(index + ": " + list[index] + ": " + ListFind(list, list[index]), "blue");
 		index = index + 1;
 	}
-	print(3 + ": " + list[3] + ": " + list.ListFind(list[3], 1), "blue");
-	print(3 + ": " + list[3] + ": " + list.ListFind(list[3], 2), "blue");
-	print(3 + ": " + list[3] + ": " + list.ListFind(list[3], 3), "blue");
-	print(3 + ": " + list[3] + ": " + list.ListFind(list[3], 4), "blue");
+	auto_log_info(3 + ": " + list[3] + ": " + list.ListFind(list[3], 1), "blue");
+	auto_log_info(3 + ": " + list[3] + ": " + list.ListFind(list[3], 2), "blue");
+	auto_log_info(3 + ": " + list[3] + ": " + list.ListFind(list[3], 3), "blue");
+	auto_log_info(3 + ": " + list[3] + ": " + list.ListFind(list[3], 4), "blue");
 }
 
 // start of int[int]

--- a/RELEASE/scripts/autoscend/auto_mr2014.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2014.ash
@@ -74,7 +74,7 @@ boolean dna_startAcquire()
 	set_property("auto_day1_dna", "finished");
 	if(have_effect($effect[Human-Weird Thing Hybrid]) != 2147483647)
 	{
-		print("DNA Hybridization failed, perhaps it was due to ML which is annoying us right now.", "red");
+		auto_log_warning("DNA Hybridization failed, perhaps it was due to ML which is annoying us right now.", "red");
 	}
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -577,7 +577,7 @@ boolean chateaumantegna_nightstandSet()
 	{
 		return false;
 	}
-	print("We have the wrong Chateau Nightstand item, replacing.", "blue");
+	auto_log_info("We have the wrong Chateau Nightstand item, replacing.", "blue");
 	chateaumantegna_buyStuff(need);
 	return true;
 }
@@ -747,7 +747,7 @@ boolean deck_cheat(string cheat)
 	{
 		if(to_int(cheat) == card)
 		{
-			print("Already cheated this card, failing gracefully.", "red");
+			auto_log_warning("Already cheated this card, failing gracefully.", "red");
 			return false;
 		}
 	}
@@ -1067,7 +1067,7 @@ boolean deck_useScheme(string action)
 		}
 		else
 		{
-			print("Could not draw card for some reason, we may be stuck in a choice adventure.");
+			auto_log_critical("Could not draw card for some reason, we may be stuck in a choice adventure.");
 			abort("Failure when drawing cards, if any were drawn, the rest will NOT be drawn. Draw them and resume.");
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2016.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2016.ash
@@ -119,7 +119,7 @@ boolean snojoFightAvailable()
 
 	if(get_property("snojoSetting") == "NONE")
 	{
-		print("Snojo not set, attempting to set to " + my_primestat(), "blue");
+		auto_log_info("Snojo not set, attempting to set to " + my_primestat(), "blue");
 		visit_url("place.php?whichplace=snojo&action=snojo_controller");
 	}
 	return (get_property("_snojoFreeFights").to_int() < 10);
@@ -153,7 +153,7 @@ boolean auto_sourceTerminalRequest(string request)
 	//educate <skill>.edu		[digitize|extract]
 	//extrude <item>.ext		[food|booze|goggles]
 
-	print("Source Terminal request: " + request, "green");
+	auto_log_info("Source Terminal request: " + request, "green");
 
 
 	//"campground.php?action=terminal&hack=enhance items.enh"
@@ -458,17 +458,6 @@ boolean auto_advWitchess(string target, string option)
 		return false;
 	}
 
-#	if(get_property("_witchessFights").to_int() >= 5)
-#	{
-#		return false;
-#	}
-
-#	if(get_property("_witchessFights").to_int() > get_property("_auto_witchessBattles").to_int())
-#	{
-#		print("_witchessFights is greater than our tracking, it is probably more accurate at this point (assuming manual Witchess combats).", "red");
-#		set_property("_auto_witchessBattles", get_property("_witchessFights"));
-#	}
-
 	set_property("_auto_witchessBattles", get_property("_auto_witchessBattles").to_int() + 1);
 
 	string temp = visit_url("campground.php?action=witchess");
@@ -608,7 +597,7 @@ boolean auto_doPrecinct()
 		if(precinctMatcher.find())
 		{
 			casesLeft = to_int(precinctMatcher.group(1));
-			print("We have " + casesLeft + " case(s) leftover!", "green");
+			auto_log_info("We have " + casesLeft + " case(s) leftover!", "green");
 		}
 
 		if(casesLeft == 0)
@@ -618,7 +607,7 @@ boolean auto_doPrecinct()
 			{
 				return false;
 			}
-			print("Trying to resume case....", "red");
+			auto_log_info("Trying to resume case....", "red");
 		}
 
 		page = visit_url("choice.php?pwd=&whichchoice=1193&option=1");
@@ -628,18 +617,18 @@ boolean auto_doPrecinct()
 		{
 			if(!eggMatcher.find())
 			{
-				print("Someone was not murdered with an egg.... that's sad." + page, "red");
+				auto_log_info("Someone was not murdered with an egg.... that's sad." + page, "red");
 				return false;
 			}
 		}
-		print("Murdered with an egg! I love Egg!!", "green");
+		auto_log_info("Murdered with an egg! I love Egg!!", "green");
 		page = visit_url("wham.php", false);
 	}
 
 	eggMatcher = create_matcher("You have been on this case for (\\d+) minute(?:s?)", page);
 	if(!eggMatcher.find())
 	{
-		print("I can not resolve my case situation....", "red");
+		auto_log_info("I can not resolve my case situation....", "red");
 		return false;
 	}
 
@@ -652,7 +641,6 @@ boolean auto_doPrecinct()
 			boolean visited = false;
 			foreach index in eggData
 			{
-				//print("Subegg: " + eggData[index], "blue");
 				string[int] subEgg = split_string(eggData[index], ":");
 				if(subEgg[0].to_int() == i)
 				{
@@ -663,7 +651,7 @@ boolean auto_doPrecinct()
 
 			if(!visited)
 			{
-				print("Going to visit room: " + i, "green");
+				auto_log_info("Going to visit room: " + i, "green");
 				page = visit_url("wham.php?visit=" + i, false);
 				matcher personMatcher = create_matcher("<td align=center width=200>(?:\\s+)<img src=[\"](?:[a-z0-9/_.:]+?)[.]gif[\"]>(?:\\s+)<br>(?:\\s+)<b>([a-zA-Z ]+?)</b>(?:\\s+?)<br>(?:\\s+?)([a-zA-Z -]+)(?:\\s+?)<p>(?:\\s+?)[(]([a-zA-Z ']+?)[)]", page);
 				if(personMatcher.find())
@@ -671,9 +659,9 @@ boolean auto_doPrecinct()
 					string person = personMatcher.group(1);
 					string job = personMatcher.group(2);
 					string room = personMatcher.group(3);
-					print("Found " + personMatcher.group(1), "green");
-					print("Found " + personMatcher.group(2), "green");
-					print("Found " + personMatcher.group(3), "green");
+					auto_log_info("Found " + personMatcher.group(1), "green");
+					auto_log_info("Found " + personMatcher.group(2), "green");
+					auto_log_info("Found " + personMatcher.group(3), "green");
 					string generated = "" + i + ":" + room + ":" + person + ":" + job;
 
 					//Get killer response as well.
@@ -697,7 +685,7 @@ boolean auto_doPrecinct()
 					}
 					else
 					{
-						print("Jerkwad '" + person + "' won't say anything!", "blue");
+						auto_log_info("Jerkwad '" + person + "' won't say anything!", "blue");
 						generated += ":liar";
 					}
 					set_property("auto_eggDetective", generated + "," + get_property("auto_eggDetective"));
@@ -707,7 +695,7 @@ boolean auto_doPrecinct()
 		}
 
 		eggData = split_string(get_property("auto_eggDetective"), ",");
-		print("Generating goals...", "blue");
+		auto_log_info("Generating goals...", "blue");
 		//At this point we\'ve visited every place and queried everyone. Now we need to determine who is identifying a killer.
 
 		//Extract names and jobs
@@ -726,10 +714,9 @@ boolean auto_doPrecinct()
 			locationGoals[subEgg[1]] = true;
 		}
 
-		print("Verifications....", "blue");
+		auto_log_info("Verifications....", "blue");
 		foreach index in eggData
 		{
-			//print("Subegg: " + eggData[index], "blue");
 			string[int] subEgg = split_string(eggData[index], ":");
 			if(count(subEgg) < 4)
 			{
@@ -776,7 +763,7 @@ boolean auto_doPrecinct()
 			}
 			if(subEgg[4] != "liar")
 			{
-				print(subEgg[2] + " is accusing: " + subEgg[4], "blue");
+				auto_log_info(subEgg[2] + " is accusing: " + subEgg[4], "blue");
 				//Now we need to determine if they are lying or not.
 				int currentLocation = to_int(subEgg[0]);
 				page = visit_url("wham.php?visit=" + currentLocation, false);
@@ -819,7 +806,7 @@ boolean auto_doPrecinct()
 							{
 								if(goal != currentEgg[3])
 								{
-									print("Asked about " + currentEgg[2] + "," + currentEgg[3] + " and was told: " + goal, "red");
+									auto_log_info("Asked about " + currentEgg[2] + "," + currentEgg[3] + " and was told: " + goal, "red");
 									count += 1;
 								}
 								else
@@ -842,7 +829,7 @@ boolean auto_doPrecinct()
 							{
 								if(goal != currentEgg[1])
 								{
-									print("Asked about " + currentEgg[2] + "," + currentEgg[1] + " and was told: " + goal, "red");
+									auto_log_info("Asked about " + currentEgg[2] + "," + currentEgg[1] + " and was told: " + goal, "red");
 									count += 1;
 								}
 								else
@@ -857,10 +844,10 @@ boolean auto_doPrecinct()
 							{
 								if(corrupted)
 								{
-									print("Doubly corrupted possible truth teller. This person is probably correct.", "blue");
+									auto_log_info("Doubly corrupted possible truth teller. This person is probably correct.", "blue");
 									return false;
 								}
-								print("Corrupted truth teller? Going to retry....", "red");
+								auto_log_info("Corrupted truth teller? Going to retry....", "red");
 								corrupted = true;
 								continue;
 							}
@@ -881,7 +868,7 @@ boolean auto_doPrecinct()
 			}
 			if(isTruth)
 			{
-				print(subEgg[2] + " is accusing: " + subEgg[4] + " and may be telling the truth!", "blue");
+				auto_log_info(subEgg[2] + " is accusing: " + subEgg[4] + " and may be telling the truth!", "blue");
 				//Find person they are accusing and do it.
 
 				string[int] currentEgg;
@@ -890,20 +877,20 @@ boolean auto_doPrecinct()
 					string[int] subsubEgg = split_string(eggData[index], ":");
 					if((subsubEgg[2] == subEgg[4]) || (subsubEgg[3] == subEgg[4]))
 					{
-						print("Accusation against: " + subsubEgg[2], "blue");
+						auto_log_info("Accusation against: " + subsubEgg[2], "blue");
 						page = visit_url("wham.php?visit=" + subsubEgg[0], false);
 
 						eggMatcher = create_matcher("You have been on this case for (\\d+) minute(?:s?)", page);
 						if(eggMatcher.find())
 						{
-							print("On the case for " + eggMatcher.group(1) + " minutes...", "green");
+							auto_log_info("On the case for " + eggMatcher.group(1) + " minutes...", "green");
 						}
 
 						page = visit_url("wham.php?visit=" + subsubEgg[0] + "&accuse=" + subsubEgg[0], false);
 						matcher pensionMatcher = create_matcher("been awarded (\\d+) cop dollars", page);
 						if(pensionMatcher.find())
 						{
-							print("Received a pension of " + pensionMatcher.group(1) + " cop dollars.", "green");
+							auto_log_info("Received a pension of " + pensionMatcher.group(1) + " cop dollars.", "green");
 						}
 						set_property("auto_eggDetective", "");
 						return true;
@@ -991,7 +978,7 @@ boolean LX_ghostBusting()
 		}
 
 		useCocoon();
-		print("Ghost busting time! At: " + get_property("ghostLocation"), "blue");
+		auto_log_info("Ghost busting time! At: " + get_property("ghostLocation"), "blue");
 		boolean newbieFail = false;
 		if(goal == $location[The Skeleton Store])
 		{
@@ -1132,7 +1119,7 @@ boolean LX_ghostBusting()
 
 		if(newbieFail)
 		{
-			print("Can't bust that ghost, we don't feel good!!", "blue");
+			auto_log_critical("Can't bust that ghost, we don't feel good!!", "blue");
 			abort("Ghost busting failure, this should not happen");
 			set_property("questPAGhost", "unstarted");
 			set_property("ghostLocation", "");
@@ -1144,7 +1131,7 @@ boolean LX_ghostBusting()
 			autoEquip($slot[Back], $item[Protonic Accelerator Pack]);
 		}
 
-		print("Time to bust some ghosts!!!", "green");
+		auto_log_info("Time to bust some ghosts!!!", "green");
 		boolean advVal = autoAdv(goal);
 		if(replaceAcc3 != $item[none])
 		{
@@ -1279,7 +1266,7 @@ boolean timeSpinnerCombat(monster goal, string option)
 				}
 				return false;
 			}
-			
+
 			return true;
 		}
 	}
@@ -1291,7 +1278,7 @@ boolean rethinkingCandyList()
 	boolean[effect] synthesis = $effects[Synthesis: Hot, Synthesis: Cold, Synthesis: Pungent, Synthesis: Scary, Synthesis: Greasy, Synthesis: Strong, Synthesis: Smart, Synthesis: Cool, Synthesis: Hardy, Synthesis: Energy, Synthesis: Greed, Synthesis: Collection, Synthesis: Movement, Synthesis: Learning, Synthesis: Style];
 	foreach eff in synthesis
 	{
-		print("Trying effect: " + eff + ": " + string_modifier(eff, "Modifiers") , "orange");
+		auto_log_info("Trying effect: " + eff + ": " + string_modifier(eff, "Modifiers") , "orange");
 		rethinkingCandy(eff, true);
 	}
 	return true;
@@ -1349,16 +1336,6 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 	item[int] simple = List(simpleList);
 	item[int] complex = List(complexList);
 
-#	foreach idx, it in simple
-#	{
-#		print(it + ": " + item_amount(it) + " (" + to_int(it) + "): " + it.candy_type + " Cost: " + auto_mall_price(it), "blue");
-#	}
-#
-#	foreach idx, it in complex
-#	{
-#		print(it + ": " + item_amount(it) + " (" + to_int(it) + "): " + it.candy_type + " Cost: " + auto_mall_price(it), "blue");
-#	}
-
 	int bestCost = 2 * maxprice;
 	item bestFirst = $item[none];
 	item bestSecond = $item[none];
@@ -1380,7 +1357,7 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 				{
 					if(simulate)
 					{
-						print("Possible: " + simple[i] + ", " + simple[j], "blue");
+						auto_log_info("Possible: " + simple[i] + ", " + simple[j], "blue");
 					}
 					if((auto_mall_price(simple[i]) + auto_mall_price(simple[j])) < bestCost)
 					{
@@ -1405,7 +1382,7 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 				{
 					if(simulate)
 					{
-						print("Possible: " + simple[i] + ", " + complex[j], "blue");
+						auto_log_info("Possible: " + simple[i] + ", " + complex[j], "blue");
 					}
 					if((auto_mall_price(simple[i]) + auto_mall_price(complex[j])) < bestCost)
 					{
@@ -1435,7 +1412,7 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 				{
 					if(simulate)
 					{
-						print("Possible: " + complex[i] + ", " + complex[j], "blue");
+						auto_log_info("Possible: " + complex[i] + ", " + complex[j], "blue");
 					}
 					if((auto_mall_price(complex[i]) + auto_mall_price(complex[j])) < bestCost)
 					{
@@ -1454,7 +1431,7 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 
 	if(bestFirst != $item[none])
 	{
-		print("Best case: " + bestFirst + ", " + bestSecond + ": " + bestCost, "green");
+		auto_log_info("Best case: " + bestFirst + ", " + bestSecond + ": " + bestCost, "green");
 		if(!simulate)
 		{
 			int prior = have_effect(acquire);
@@ -1471,7 +1448,7 @@ boolean rethinkingCandy(effect acquire, boolean simulate)
 	}
 	else if(simulate)
 	{
-		print("Could not find a possible candy combination", "red");
+		auto_log_warning("Could not find a possible candy combination", "red");
 	}
 	else
 	{

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -143,17 +143,17 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 	if((hpmp < 1) || (hpmp > 9))
 	{
-		print("Invalid BottomLeft specifier for pANts. Failing pANts.", "red");
+		auto_log_warning("Invalid BottomLeft specifier for pANts. Failing pANts.", "red");
 		return false;
 	}
 	if((meatItemStats < 1) || (meatItemStats > 12))
 	{
-		print("Invalid BottomRight specifier for pANts. Failing pANts.", "red");
+		auto_log_warning("Invalid BottomRight specifier for pANts. Failing pANts.", "red");
 		return false;
 	}
 	if((misc < 1) || (misc > 11))
 	{
-		print("Invalid BottomMiddle specifier for pANts. Failing pANts.", "red");
+		auto_log_warning("Invalid BottomMiddle specifier for pANts. Failing pANts.", "red");
 		return false;
 	}
 
@@ -174,7 +174,7 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 	if(item_amount(to_item(itemId)) < itemQty)
 	{
-		print("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
+		auto_log_warning("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
 		return false;
 	}
 	string s1 = itemId + "," + itemQty;
@@ -198,7 +198,7 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 	if(item_amount(to_item(itemId)) < itemQty)
 	{
-		print("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
+		auto_log_warning("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
 		return false;
 	}
 	string s2 = itemId + "," + itemQty;
@@ -222,7 +222,7 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 	if(item_amount(to_item(itemId)) < itemQty)
 	{
-		print("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
+		auto_log_warning("Do not have enough: " + to_item(itemId) + " for pANts.", "red");
 		return false;
 	}
 	string s3 = itemId + "," + itemQty;
@@ -230,12 +230,12 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 	if((m < 1) || (m > 3))
 	{
-		print("Invalid stat specifier for pANts. Failing pANts.", "red");
+		auto_log_warning("Invalid stat specifier for pANts. Failing pANts.", "red");
 		return false;
 	}
 	if((e < 1) || (e > 5))
 	{
-		print("Invalid elemental specifier for pANts. Failing pANts.", "red");
+		auto_log_warning("Invalid elemental specifier for pANts. Failing pANts.", "red");
 		return false;
 	}
 
@@ -295,7 +295,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	if(contains_text(temp, "Come back tomorrow!"))
 	{
 		set_property("_loveTunnelUsed", true);
-		print("Already visited L.O.V.E. Tunnel. Can't be visiting again.", "red");
+		auto_log_warning("Already visited L.O.V.E. Tunnel. Can't be visiting again.", "red");
 		temp = visit_url("choice.php?pwd=&whichchoice=1222&option=2");
 		return false;
 	}
@@ -552,7 +552,7 @@ boolean kgbDiscovery()
 		int index = ((id - 1) * 2) + height;
 		if(tracker[index].to_int() == 0)
 		{
-			print("We do not know " + id + " of height: " + height, "green");
+			auto_log_info("We do not know " + id + " of height: " + height, "green");
 			int[12] curEff;
 			for(int i=2296; i<=2306; i++)
 			{
@@ -565,12 +565,12 @@ boolean kgbDiscovery()
 				{
 					if(have_effect(to_effect(i)) == (curEff[i-2296] + 100))
 					{
-						print("It contains random!", "green");
+						auto_log_info("It contains random!", "green");
 						tracker[index] = 1;
 					}
 					else
 					{
-						print("It contains " + to_effect(i) + "!", "green");
+						auto_log_info("It contains " + to_effect(i) + "!", "green");
 						tracker[index] = i;
 					}
 				}
@@ -607,7 +607,7 @@ int kgb_tabHeight(string page)
 	if(ring_matcher.find())
 	{
 		int image = to_int(ring_matcher.group(1));
-		print("Found rings of value " + image, "blue");
+		auto_log_info("Found rings of value " + image, "blue");
 		printTabs = true;
 	}
 
@@ -619,7 +619,7 @@ int kgb_tabHeight(string page)
 		{
 			int id = to_int(tabCount.group(1));
 			int height = to_int(tabCount.group(2));
-			print("Tab " + id + " with height of " + height, "green");
+			auto_log_info("Tab " + id + " with height of " + height, "green");
 		}
 	}
 
@@ -732,7 +732,7 @@ boolean kgbSetup()
 	page = visit_url("place.php?whichplace=kgb&action=kgb_handledown", false);
 	for(int i=1; i<=6; i++)
 	{
-		print("Hitting tab modification button: " + i, "blue");
+		auto_log_info("Hitting tab modification button: " + i, "blue");
 		page = visit_url("place.php?whichplace=kgb&action=kgb_button" + i, false);
 
 		int count = kgb_tabCount(page);
@@ -754,7 +754,7 @@ boolean kgbSetup()
 
 	if(!kgb_getMartini(page))
 	{
-		print("Failed to get martini", "red");
+		auto_log_warning("Failed to get martini", "red");
 	}
 
 	return true;
@@ -795,7 +795,7 @@ boolean kgb_getMartini(string page, boolean dontCare)
 	{
 		if(!dontCare)
 		{
-			print("We did not initialize the briefcase this ascension, we can not care", "red");
+			auto_log_info("We did not initialize the briefcase this ascension, we can not care", "red");
 			dontCare = true;
 		}
 	}
@@ -823,13 +823,13 @@ boolean kgb_getMartini(string page, boolean dontCare)
 		}
 		if(!contains_text(page, "..........."))
 		{
-			print("Cranking did not work, uh oh!", "red");
+			auto_log_warning("Cranking did not work, uh oh!", "red");
 		}
 		else
 		{
 			page = visit_url("place.php?whichplace=kgb&action=kgb_handleup", false);
 			page = visit_url("place.php?whichplace=kgb&action=kgb_handledown", false);
-			print("Crank power!!", "green");
+			auto_log_info("Crank power!!", "green");
 		}
 
 		if(flipped)
@@ -866,19 +866,19 @@ boolean kgb_getMartini(string page, boolean dontCare)
 		if(contains_text(page, "Nothing happens."))
 		{
 			set_property("_kgbDispenserUses", 3);
-			print("The martini dispenser is empty, weird.", "red");
+			auto_log_warning("The martini dispenser is empty, weird.", "red");
 			return true;
 		}
 		if((kgb_tabHeight(page) < 11) && !dontCare)
 		{
-			print("Did we accidentally solve a puzzle? Gonna assume so...", "green");
-			print("Hitting tab modification button: " + button, "blue");
+			auto_log_info("Did we accidentally solve a puzzle? Gonna assume so...", "green");
+			auto_log_info("Hitting tab modification button: " + button, "blue");
 			int oldClicks = get_property("_kgbClicksUsed").to_int();
 			page = visit_url("place.php?whichplace=kgb&action=kgb_button" + button, false);
 			int newClicks = get_property("_kgbClicksUsed").to_int();
 			if(newClicks == oldClicks)
 			{
-				print("_kgbClicksUsed appears to not be tracking, please let the spies in.", "red");
+				auto_log_info("_kgbClicksUsed appears to not be tracking, please let the spies in.", "red");
 				set_property("_kgbClicksUSed", newClicks + 1);
 			}
 			if(kgb_tabHeight(page) < 11)
@@ -887,7 +887,7 @@ boolean kgb_getMartini(string page, boolean dontCare)
 				{
 					abort("Can not seem to recover situation regarding splendid martinis");
 				}
-				print("Trying to restore tabs", "green");
+				auto_log_info("Trying to restore tabs", "green");
 				continue;
 			}
 		}
@@ -936,7 +936,7 @@ boolean kgbDial(int dial, int curVal, int target)
 			count++;
 		}
 		curVal = dials[dial];
-		print("Clicking " + dial + " and now: " + curVal, "blue");
+		auto_log_info("Clicking " + dial + " and now: " + curVal, "blue");
 	}
 	return true;
 }
@@ -1000,8 +1000,8 @@ boolean solveKGBMastermind()
 			count++;
 		}
 
-		print("Left side: " + dials[0] + " " + dials[1] + " " + dials[2], "green");
-		print("Right side: " + dials[3] + " " + dials[4] + " " + dials[5], "green");
+		auto_log_info("Left side: " + dials[0] + " " + dials[1] + " " + dials[2], "green");
+		auto_log_info("Right side: " + dials[3] + " " + dials[4] + " " + dials[5], "green");
 
 		int[int] guess;
 		if(guessString == "")
@@ -1030,16 +1030,10 @@ boolean solveKGBMastermind()
 		}
 
 		//Which one are we doing, if ScoresLeft has 3 0, we are done with it.
-		print("About to guess: " + guess[1] + ", " + guess[2] + ", " + guess[3], "green");
+		auto_log_info("About to guess: " + guess[1] + ", " + guess[2] + ", " + guess[3], "green");
 		for(int i=1; i<=3; i++)
 		{
 			kgbDial(dialOffset+i, dials[dialOffset + i], guess[i]);
-#			while(dials[dialOffset + i] != guess[i])
-#			{
-#				print("Clicking: " + i);
-#				page = visit_url("place.php?whichplace=kgb&action=kgb_dial" + (i+1), false);
-#				dials[dialOffset + i] = (dials[dialOffset + i] + 1) % 11;
-#			}
 		}
 
 		//Verify the dials are correct before pushing anything!
@@ -1068,7 +1062,7 @@ boolean solveKGBMastermind()
 		string page = visit_url("place.php?whichplace=kgb&action=kgb_actuator" + action, false);
 		if(contains_text(page, "Nothing happens"))
 		{
-			print("Out of clicks. Derp.", "red");
+			auto_log_warning("Out of clicks. Derp.", "red");
 			return false;
 		}
 		int correct = 0;
@@ -1078,7 +1072,7 @@ boolean solveKGBMastermind()
 		{
 			int bulb = to_int(light_match.group(1));
 			string status = light_match.group(2);
-			print("Light " + bulb + ": " + status, "blue");
+			auto_log_info("Light " + bulb + ": " + status, "blue");
 			if(status == "(on)")
 			{
 				correct++;
@@ -1088,7 +1082,7 @@ boolean solveKGBMastermind()
 				blink++;
 			}
 		}
-		print("Correct: " + correct + " Blinking: " + blink, "blue");
+		auto_log_info("Correct: " + correct + " Blinking: " + blink, "blue");
 
 		clicks++;
 
@@ -1102,14 +1096,14 @@ boolean solveKGBMastermind()
 		}
 
 		guessString = visit_url("http://cheesellc.com/kol/kgb.php?data=" + url_encode(get_property(prop)), false);
-		print("Subresult: " + guessString, "green");
+		auto_log_info("Subresult: " + guessString, "green");
 
 		if(contains_text(guessString, "3 0"))
 		{
 			guessString = "";
 		}
 	}
-	print("Clicks used: " + clicks, "red");
+	auto_log_info("Clicks used: " + clicks, "red");
 
 	return contains_text(page, "A pair of antennae");
 }
@@ -1426,7 +1420,7 @@ boolean asdonFeed(item it, int qty)
 	string temp = visit_url("campground.php?pwd=&action=fuelconvertor&qty=" + qty + "&iid=" + to_int(it));
 	int newFuel = get_fuel();
 
-	print("Compressed " + qty + " " + it + " into sheep, I mean fuel: " + oldFuel + " --> " + newFuel, "green");
+	auto_log_info("Compressed " + qty + " " + it + " into sheep, I mean fuel: " + oldFuel + " --> " + newFuel, "green");
 	return true;
 }
 
@@ -1496,7 +1490,7 @@ string horseNormalize(string horseText)
 		return "pale";
 	}
 
-	print("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
+	auto_log_warning("Unknown Horsery horse type: '" + horseText + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
 	return "";
 }
 
@@ -1623,7 +1617,7 @@ boolean horsePreAdventure()
 	    && desiredHorse != "pale"
 	    && desiredHorse != "return")
 	{
-		print("auto_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
+		auto_log_warning("auto_desiredHorse was set to bad value: '" + desiredHorse + "'. Should be '', 'normal', 'dark', 'crazy', or 'pale'.", "red");
 		set_property("auto_desiredHorse", "");
 		return false;
 	}
@@ -1659,7 +1653,7 @@ boolean makeGenieWish(effect eff)
 	page = visit_url("choice.php?pwd=&whichchoice=1267&option=1&wish=" + wish);
 	if(have_effect(eff) == 0)
 	{
-		print("Wish: '" + wish + "' failed", "red");
+		auto_log_warning("Wish: '" + wish + "' failed", "red");
 		return false;
 	}
 	handleTracker(to_item(wish_provider), wish, "auto_wishes");
@@ -1709,7 +1703,7 @@ boolean makeGenieCombat(monster mon, string option)
 
 	if(get_property("lastEncounter") != mon && get_property("lastEncounter") != "Using the Force")
 	{
-		print("Wish: '" + wish + "' failed", "red");
+		auto_log_warning("Wish: '" + wish + "' failed", "red");
 		return false;
 	}
 	handleTracker(mon, to_item(wish_provider), "auto_copies");
@@ -1733,11 +1727,6 @@ boolean makeGeniePocket()
 	{
 		return false;
 	}
-
-#	if(my_adventures() == 0)
-#	{
-#		return false;
-#	}
 
 	int count = item_amount($item[Pocket Wish]);
 

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -416,21 +416,21 @@ boolean songboomSetting(int option)
 	}
 	else
 	{
-		print("Could not find how many songs we have left...", "red");
+		auto_log_warning("Could not find how many songs we have left...", "red");
 		option = 6;
 	}
 
 	page = visit_url("choice.php?whichchoice=1312&option=" + option);
 	if(contains_text(page, "don\'t want to break this thing"))
 	{
-		print("Unable to change BoomBoxen songen!", "red");
+		auto_log_warning("Unable to change BoomBoxen songen!", "red");
 		return false;
 	}
 	if(option != 6)
 	{
 		boomsLeft--;
 	}
-	print("Change successful to " + get_property("boomBoxSong") + "We have " + boomsLeft + " SongBoom BoomBoxen songens left!", "green");
+	auto_log_info("Change successful to " + get_property("boomBoxSong") + "We have " + boomsLeft + " SongBoom BoomBoxen songens left!", "green");
 	return true;
 }
 
@@ -460,7 +460,7 @@ boolean catBurglarHeist(item it)
 	 */
 	if (0 == catBurglarHeistsLeft()) return false;
 
-	print("Trying to heist a " + it, "blue");
+	auto_log_info("Trying to heist a " + it, "blue");
 	familiar backup_familiar = my_familiar();
 	try
 	{
@@ -475,7 +475,7 @@ boolean catBurglarHeist(item it)
 			page = visit_url(url);
 			return true;
 		}
-		print("We don't seem to be able to heist a " + it + ". Maybe we didn't fight it with the Cat Burglar?", "red");
+		auto_log_warning("We don't seem to be able to heist a " + it + ". Maybe we didn't fight it with the Cat Burglar?", "red");
 		return false;
 	}
 	finally {
@@ -703,7 +703,7 @@ boolean neverendingPartyAvailable()
 	}
 	if(get_property("auto_skipNEPOverride").to_boolean())
 	{
-		print("NEP access disabled. This can be turned on in the Relay by setting auto_skipNEPOverride = false", "red");
+		auto_log_warning("NEP access disabled. This can be turned on in the Relay by setting auto_skipNEPOverride = false", "red");
 		return false;
 	}
 
@@ -1345,7 +1345,7 @@ boolean haveAnyPokeFamiliarEquipment(){
 	static boolean[item] poke_fam_equipment = $items[amulet coin, luck incense, muscle band, razor fang, shell bell, smoke ball];
 	foreach i, _ in poke_fam_equipment{
 		if(equipmentAmount(i) > 0){
-			auto_debug_print("Found Tall Grass familiar equipment: " + i);
+			auto_log_debug("Found Tall Grass familiar equipment: " + i);
 			return true;
 		}
 	}
@@ -1357,6 +1357,6 @@ boolean pokeFertilizeAndHarvest(){
 		return false;
 	}
 
-	print("sew and reap.");
+	auto_log_debug("sew and reap.");
 	return use(1, $item[Pok&eacute;-Gro fertilizer]) && cli_execute("garden pick");
 }

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -86,10 +86,10 @@ boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 		pastesNeeded += pastesForThisSaus;
 	}
 
-	print("Let's grind some sausage!", "blue");
+	auto_log_info("Let's grind some sausage!", "blue");
 	if(!create(numSaus, $item[magical sausage]))
 	{
-		print("Something went wrong while grinding sausage...", "red");
+		auto_log_warning("Something went wrong while grinding sausage...", "red");
 		return false;
 	}
 	loopHandlerDelayAll();
@@ -127,7 +127,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	int originalMp = my_maxmp();
 	if(!noMP)
 	{
-		print("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
+		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
 		maximize("mp,-tie", false);
 	}
@@ -146,7 +146,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 		}
 		if(!eat(1, $item[magical sausage]))
 		{
-			print("Somehow failed to eat a sausage! What??", "red");
+			auto_log_warning("Somehow failed to eat a sausage! What??", "red");
 			return false;
 		}
 		maxToEat--;
@@ -547,13 +547,13 @@ boolean auto_spoonTuneMoon()
 	boolean cantune = (res.index_of("You can't figure out the angle to see the moon's reflection in the spoon anymore.") == -1);
 	if(cantune)
 	{
-		print("Changing signs to " + spoonsign + ", sign #" + signnum, "blue");
+		auto_log_info("Changing signs to " + spoonsign + ", sign #" + signnum, "blue");
 		visit_url('inv_use.php?whichitem=10254&pwd&doit=96&whichsign=' + signnum, true);
 		cli_execute("refresh all");
 	}
 	else
 	{
-		print("Tried to change signs to " + spoonsign + ", but moon has already been tuned", "red");
+		auto_log_warning("Tried to change signs to " + spoonsign + ", but moon has already been tuned", "red");
 	}
 
 	if(wasspoon != $slot[none])
@@ -700,7 +700,7 @@ boolean auto_pillKeeperAvailable()
 boolean auto_pillKeeper(int pill)
 {
 	if(auto_pillKeeperUses() == 0) return false;
-	print("Using pill keeper: consuming pill #" + pill, "blue");
+	auto_log_info("Using pill keeper: consuming pill #" + pill, "blue");
 	string page = visit_url("main.php?eowkeeper=1", false);
 	page = visit_url("choice.php?pwd=&whichchoice=1395&pwd&option=" + pill, true);
 	return true;

--- a/RELEASE/scripts/autoscend/auto_optionals.ash
+++ b/RELEASE/scripts/autoscend/auto_optionals.ash
@@ -34,7 +34,7 @@ boolean LX_artistQuest()
 		}
 		else
 		{
-			print("Failed starting artist quest, rejecting completely.", "red");
+			auto_log_warning("Failed starting artist quest, rejecting completely.", "red");
 			set_property("auto_doArtistQuest", false);
 			return false;
 		}
@@ -78,4 +78,3 @@ boolean LX_dinseylandfillFunbucks()
 	autoAdv(1, $location[Barf Mountain]);
 	return true;
 }
-

--- a/RELEASE/scripts/autoscend/auto_picky.ash
+++ b/RELEASE/scripts/autoscend/auto_picky.ash
@@ -27,10 +27,10 @@ void picky_pulls()
 
 void picky_startAscension()
 {
-	print("In Being Picky Adventure", "blue");
+	auto_log_info("In Being Picky Adventure", "blue");
 	if((my_class() == $class[Turtle Tamer]) || (my_class() == $class[Seal Clubber]))
 	{
-		print("Selecting skills", "blue");
+		auto_log_info("Selecting skills", "blue");
 		string page = visit_url("choice.php?pwd&whichchoice=995&pwd=&option=1&familiar=188", true);
 		if(contains_text(page, "<option value=\"165\""))
 		{
@@ -40,14 +40,6 @@ void picky_startAscension()
 		{
 			visit_url("choice.php?pwd&whichchoice=995&pwd=&option=1&familiar=140", true);
 		}
-#		if(!have_familiar($familiar[Angry Jung Man]))
-#		{
-#			visit_url("choice.php?pwd&whichchoice=995&pwd=&option=1&familiar=140", true);
-#		}
-#		else
-#		{
-#			visit_url("choice.php?pwd&whichchoice=995&pwd=&option=1&familiar=165", true);
-#		}
 		visit_url("choice.php?pwd&whichchoice=995&pwd=&option=1&familiar=178", true);
 
 		# Olfaction, Torso

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -30,14 +30,14 @@ void handlePostAdventure()
 
 	if(get_property("auto_forceNonCombatSource") != "" && (__MONSTERS_FOLLOWING_NONCOMBATS contains get_property("lastEncounter").to_monster() && !is_superlikely(get_property("lastEncounter"))))
 	{
-		print("Encountered (assumed) forced noncombat: " + get_property("lastEncounter"), "blue");
+		auto_log_info("Encountered (assumed) forced noncombat: " + get_property("lastEncounter"), "blue");
 		set_property("auto_forceNonCombatSource", "");
 		set_property("auto_forceNonCombatTurn", -1);
 	}
 
 	if(get_property("auto_forceNonCombatSource") != "" && get_property("auto_forceNonCombatSource").to_int() > my_turncount() - 10)
 	{
-		print("It's been 10 adventures since we forced a noncombat (" + get_property("auto_forceNonCombatSource") +
+		auto_log_warning("It's been 10 adventures since we forced a noncombat (" + get_property("auto_forceNonCombatSource") +
 			"), am going to assume it happened but we missed it.", "blue");
 		set_property("auto_forceNonCombatSource", "");
 		set_property("auto_forceNonCombatTurn", 0);
@@ -47,10 +47,10 @@ void handlePostAdventure()
 	{
 		if(last_monster() != $monster[Eldritch Tentacle])
 		{
-			print("Expected Tentacle, uh oh!", "red");
+			auto_log_warning("Expected Tentacle, uh oh!", "red");
 			return;
 		}
-		print("No Tentacle expected this time!", "green");
+		auto_log_info("No Tentacle expected this time!", "green");
 	}
 
 	//We need to do this early, and even if postAdventure handling is done.
@@ -62,10 +62,10 @@ void handlePostAdventure()
 			string temp = visit_url("main.php");
 			if(last != last_monster())
 			{
-				print("Interrupted battle detected at post combat time", "red");
+				auto_log_warning("Interrupted battle detected at post combat time", "red");
 				if(have_effect($effect[Beaten Up]) > 0)
 				{
-					print("Post combat time caused up to be Beaten Up!", "red");
+					auto_log_warning("Post combat time caused up to be Beaten Up!", "red");
 					return;
 				}
 				autoAdv(my_location());
@@ -96,7 +96,7 @@ void handlePostAdventure()
 
 	if(get_property("auto_disableAdventureHandling").to_boolean())
 	{
-		print("Postadventure skipped by standard adventure handler.", "green");
+		auto_log_info("Postadventure skipped by standard adventure handler.", "green");
 		return;
 	}
 
@@ -107,14 +107,14 @@ void handlePostAdventure()
 		switch(last_choice())
 		{
 			case 1340: // Is There A Doctor In The House?
-				print("Accepting doctor quest, it's our job!");
+				auto_log_info("Accepting doctor quest, it's our job!");
 				run_choice(1);
 				break;
 			case 1342: // Torpor
 				bat_reallyPickSkills(20);
 				break;
 			default:
-				print("Unrecognized unhandled choice after combat " + last_choice(), "red");
+				auto_log_warning("Unrecognized unhandled choice after combat " + last_choice(), "red");
 				break;
 		}
 	}
@@ -139,21 +139,21 @@ void handlePostAdventure()
 
 	if((my_location() == $location[The Lower Chambers]) && (item_amount($item[[2334]Holy MacGuffin]) == 0))
 	{
-		print("Postadventure skipped by Ed the Undying!", "green");
+		auto_log_info("Postadventure skipped by Ed the Undying!", "green");
 		return;
 	}
 
 	if((my_location() == $location[The Invader]))
 	{
 		// Just so the "are we beaten up?" check in auto_koe works properly
-		print("Postadventure skipped for The Invader!", "green");
+		auto_log_info("Postadventure skipped for The Invader!", "green");
 		return;
 	}
 
 	ocrs_postHelper();
 	if(last_monster().random_modifiers["clingy"])
 	{
-		print("Postadventure skipped by clingy modifier.", "green");
+		auto_log_info("Postadventure skipped by clingy modifier.", "green");
 		return;
 	}
 
@@ -671,7 +671,7 @@ void handlePostAdventure()
 			#outfit does not... damn it.
 			if(!outfit("Vile Vagrant Vestments"))
 			{
-				print("Could not wear Vile Vagrant Outfit for some raisin", "red");
+				auto_log_warning("Could not wear Vile Vagrant Outfit for some raisin", "red");
 			}
 			didOutfit = true;
 		}
@@ -724,7 +724,7 @@ void handlePostAdventure()
 			// Catch when we leave lowMLZone, allow for being "side tracked" buy delay burning
 			if((have_effect($effect[Driving Intimidatingly]) > 0) && (get_property("auto_debuffAsdonDelay") >= 2))
 			{
-				print("No Reason to delay Asdon Usage");
+				auto_log_info("No Reason to delay Asdon Usage");
 				uneffect($effect[Driving Intimidatingly]);
 				set_property("auto_debuffAsdonDelay", 0);
 			}
@@ -735,7 +735,7 @@ void handlePostAdventure()
 			else
 			{
 				set_property("auto_debuffAsdonDelay", get_property("auto_debuffAsdonDelay").to_int() + 1);
-				print("Delaying debuffing Asdon: " + get_property("auto_debuffAsdonDelay"));
+				auto_log_info("Delaying debuffing Asdon: " + get_property("auto_debuffAsdonDelay"));
 			}
 
 			if((monster_level_adjustment() + (2 * my_level())) <= 150)
@@ -814,7 +814,7 @@ void handlePostAdventure()
 
 		if((libram != $skill[none]) && ((my_mp() - mp_cost(libram)) > 32))
 		{
-			print("Mymp: " + my_mp() + " of " + my_maxmp() + " and cost: " + mp_cost(libram), "blue");
+			auto_log_info("Mymp: " + my_mp() + " of " + my_maxmp() + " and cost: " + mp_cost(libram), "blue");
 			boolean temp = false;
 			try
 			{
@@ -825,8 +825,8 @@ void handlePostAdventure()
 			{
 				if(!temp)
 				{
-					print("No longer have enough MP and failed.", "red");
-					print("Mymp: " + my_mp() + " of " + my_maxmp() + " and cost: " + mp_cost(libram), "blue");
+					auto_log_warning("No longer have enough MP and failed.", "red");
+					auto_log_info("Mymp: " + my_mp() + " of " + my_maxmp() + " and cost: " + mp_cost(libram), "blue");
 				}
 			}
 		}
@@ -978,7 +978,7 @@ void handlePostAdventure()
 			}
 			else
 			{
-				print("Thrall handler error. Could not generate appropriate skill.", "red");
+				auto_log_warning("Thrall handler error. Could not generate appropriate skill.", "red");
 			}
 		}
 	}
@@ -1006,19 +1006,19 @@ void handlePostAdventure()
 
 	if(my_path() == "Heavy Rains")
 	{
-		print("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
+		auto_log_info("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}
 
 	if((item_amount($item[The Big Book of Pirate Insults]) > 0) && ((my_location() == $location[Barrrney\'s Barrr]) || (my_location() == $location[The Obligatory Pirate\'s Cove])))
 	{
-		print("Have " + numPirateInsults() + " insults.", "green");
+		auto_log_info("Have " + numPirateInsults() + " insults.", "green");
 	}
 
 	if(my_location() == $location[The Broodling Grounds])
 	{
-		print("Have " + item_amount($item[Hellseal Brain]) + " brain(s).", "green");
-		print("Have " + item_amount($item[Hellseal Hide]) + " hide(s).", "green");
-		print("Have " + item_amount($item[Hellseal Sinew]) + " sinew(s).", "green");
+		auto_log_info("Have " + item_amount($item[Hellseal Brain]) + " brain(s).", "green");
+		auto_log_info("Have " + item_amount($item[Hellseal Hide]) + " hide(s).", "green");
+		auto_log_info("Have " + item_amount($item[Hellseal Sinew]) + " sinew(s).", "green");
 	}
 
 	if((my_location() == $location[The Hidden Bowling Alley]) && get_property("kingLiberated").to_boolean())
@@ -1060,10 +1060,10 @@ void handlePostAdventure()
 
 	if((get_property("auto_beatenUpCount").to_int() <= 10) && (have_effect($effect[Beaten Up]) > 0) && (my_mp() >= mp_cost($skill[Tongue of the Walrus])) && auto_have_skill($skill[Tongue of the Walrus]))
 	{
-		print("Owwie, was beaten up but trying to recover", "red");
+		auto_log_warning("Owwie, was beaten up but trying to recover", "red");
 		if(my_location() == $location[The X-32-F Combat Training Snowman])
 		{
-			print("At the snojo, let's not keep going there and dying....", "red");
+			auto_log_info("At the snojo, let's not keep going there and dying....", "red");
 			set_property("_snojoFreeFights", 10);
 		}
 		set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
@@ -1074,19 +1074,19 @@ void handlePostAdventure()
 	# We only do this in aftercore because we don't want a spiralling death loop in-run.
 	if(get_property("kingLiberated").to_boolean() && (have_effect($effect[Beaten Up]) > 0) && (my_mp() >= mp_cost($skill[Tongue of the Walrus])) && auto_have_skill($skill[Tongue of the Walrus]))
 	{
-		print("Owwie, was beaten up but trying to recover", "red");
+		auto_log_warning("Owwie, was beaten up but trying to recover", "red");
 		use_skill(1, $skill[Tongue of the Walrus]);
 	}
 
 	#Should we create a separate function to track these? How many are we going to track?
 	if((last_monster() == $monster[Writing Desk]) && (get_property("lastEncounter") == $monster[Writing Desk]) && (have_effect($effect[Beaten Up]) == 0))
 	{
-		print("Fought " + get_property("writingDesksDefeated") + " writing desks.", "blue");
+		auto_log_info("Fought " + get_property("writingDesksDefeated") + " writing desks.", "blue");
 	}
 	if((last_monster() == $monster[Modern Zmobie]) && (get_property("lastEncounter") == $monster[Modern Zmobie]) && (have_effect($effect[Beaten Up]) == 0))
 	{
 		set_property("auto_modernzmobiecount", "" + (get_property("auto_modernzmobiecount").to_int() + 1));
-		print("Fought " + get_property("auto_modernzmobiecount") + " modern zmobies.", "blue");
+		auto_log_info("Fought " + get_property("auto_modernzmobiecount") + " modern zmobies.", "blue");
 	}
 
 	if(have_effect($effect[Disavowed]) > 0)
@@ -1097,7 +1097,7 @@ void handlePostAdventure()
 		}
 		if(auto_have_skill($skill[Disco Nap]) && (my_mp() > mp_cost($skill[Disco Nap])))
 		{
-			print("We have been disavowed...", "red");
+			auto_log_warning("We have been disavowed...", "red");
 			use_skill(1, $skill[Disco Nap]);
 		}
 		else
@@ -1114,7 +1114,7 @@ void handlePostAdventure()
 		set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 	}
 
-	print("Post Adventure done, beep.", "purple");
+	auto_log_info("Post Adventure done, beep.", "purple");
 }
 
 void main()

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -18,36 +18,26 @@ void handlePreAdventure(location place)
 		abort("customCombatScript is set to unrecognized '" + get_property("customCombatScript") + "', should be 'autoscend_null'");
 	}
 
-#	set_location doesn't help us to resolve this, just let it infinite and fail in that exotic case that was propbably due to a bad user.
-#	if((place == $location[The Deep Machine Tunnels]) && (my_familiar() != $familiar[Machine Elf]))
-#	{
-#		if(!auto_have_familiar($familiar[Machine Elf]))
-#		{
-#			abort("Massive failure, we don't use snowglobes.");
-#		}
-#		print("Somehow we are considering the DMT without a Machine Elf...", "red");
-#	}
-
 	if(get_property("auto_disableAdventureHandling").to_boolean())
 	{
-		print("Preadventure skipped by standard adventure handler.", "green");
+		auto_log_info("Preadventure skipped by standard adventure handler.", "green");
 		return;
 	}
 
 	if(last_monster().random_modifiers["clingy"])
 	{
-		print("Preadventure skipped by clingy modifier.", "green");
+		auto_log_info("Preadventure skipped by clingy modifier.", "green");
 		return;
 	}
 
 	if(place == $location[The Lower Chambers])
 	{
-		print("Preadventure skipped by Ed the Undying!", "green");
+		auto_log_info("Preadventure skipped by Ed the Undying!", "green");
 		return;
 	}
 
-	print("Starting preadventure script...", "green");
-	auto_debug_print("Adventuring at " + place.to_string(), "green");
+	auto_log_info("Starting preadventure script...", "green");
+	auto_log_debug("Adventuring at " + place.to_string(), "green");
 
 	familiar famChoice = to_familiar(get_property("auto_familiarChoice"));
 	if(auto_my_path() == "Pocket Familiars")
@@ -59,7 +49,7 @@ void handlePreAdventure(location place)
 	{
 		if((famChoice != my_familiar()) && !get_property("kingLiberated").to_boolean())
 		{
-#			print("FAMILIAR DIRECTIVE ERROR: Selected " + famChoice + " but have " + my_familiar(), "red");
+#			auto_log_error("FAMILIAR DIRECTIVE ERROR: Selected " + famChoice + " but have " + my_familiar(), "red");
 			use_familiar(famChoice);
 		}
 	}
@@ -74,7 +64,7 @@ void handlePreAdventure(location place)
 			{
 				if(mmon == mon)
 				{
-					auto_debug_print("Using cat burglar because we want to burgle a " + it + " from " + mon);
+					auto_log_debug("Using cat burglar because we want to burgle a " + it + " from " + mon);
 					wannaHeist = true;
 				}
 			}
@@ -89,9 +79,10 @@ void handlePreAdventure(location place)
 	{
 		if(!auto_have_familiar($familiar[Machine Elf]))
 		{
+			auto_log_critical("Massive failure, we don't use snowglobes.");
 			abort("Massive failure, we don't use snowglobes.");
 		}
-		print("Somehow we are going to the DMT without a Machine Elf...", "red");
+		auto_log_error("Somehow we are going to the DMT without a Machine Elf...", "red");
 		use_familiar($familiar[Machine Elf]);
 	}
 
@@ -245,7 +236,7 @@ void handlePreAdventure(location place)
 
 	if(auto_latteDropWanted(place))
 	{
-		print('We want to get the "' + auto_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
+		auto_log_info('We want to get the "' + auto_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
 		autoEquip($item[latte lovers member\'s mug]);
 	}
 
@@ -321,7 +312,7 @@ void handlePreAdventure(location place)
 		}
 		if(itemDrop < itemNeed._float)
 		{
-			print("We can't cap this drop bear!", "purple");
+			auto_log_debug("We can't cap this drop bear!", "purple");
 		}
 	}
 
@@ -341,18 +332,18 @@ void handlePreAdventure(location place)
 	int wasted_mp = my_mp() + mp_regen() - my_maxmp();
 	if(wasted_mp > 0 && my_mp() > 400)
 	{
-		print("Burning " + wasted_mp + " MP...");
+		auto_log_info("Burning " + wasted_mp + " MP...");
 		cli_execute("burn " + wasted_mp);
 	}
 
 	if(in_hardcore() && (my_class() == $class[Sauceror]) && (my_mp() < 32))
 	{
-		print("Warning, we don't have a lot of MP but we are chugging along anyway", "red");
+		auto_log_warning("We don't have a lot of MP but we are chugging along anyway", "red");
 	}
 	groundhogAbort(place);
 	if(my_inebriety() > inebriety_limit()) abort("You are overdrunk. Stop it.");
 	set_property("auto_priorLocation", place);
-	print("Pre Adventure at " + place + " done, beep.", "blue");
+	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");
 }
 
 void main()

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -153,7 +153,7 @@ void __init_restoration_metadata(){
         if(e != $effect[none]){
           parsed_effects[e] = true;
         } else{
-          print("Unknown effect found parsing restoration metadata: " + name + " removes effect: " + s);
+          auto_log_warning("Unknown effect found parsing restoration metadata: " + name + " removes effect: " + s);
         }
       }
     }
@@ -219,7 +219,7 @@ void __init_restoration_metadata(){
 
   }
 
-  print("Loading restoration data.");
+  auto_log_info("Loading restoration data.");
   init();
   clear(__restore_maximizer_cache);
 }
@@ -268,7 +268,7 @@ boolean[string] __MINIMIZE_KEYS = {
   "soft_reserve_limit_uses": true,
 };
 
-// Not used for much, mostly a cache so we dont have to keep recalculating values
+// Not used for much, mostly a cache so we dont have to keep recalculating values and print out for debugging
 boolean[string] __VARS_KEYS = {
   "hp_goal": true,
   "hp_starting": true,
@@ -923,7 +923,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
   }
 
   __RestorationOptimization[int] ranked_optimization(__RestorationOptimization[int] p, int[string] value_ranks, boolean[string] maximize_keys, boolean[string] minimize_keys){
-    auto_debug_print("Beginning optimization of "+count(p)+" restoration options.");
+    auto_log_debug("Beginning optimization of "+count(p)+" restoration options.");
     if(count(p) == 0){
       return p;
     }
@@ -932,8 +932,8 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
     int[int] ranks = ordered_ranks(value_ranks);
     foreach _, rank in ranks {
       string desc = (__RANKED_GOAL_DESCRIPTIONS contains rank) ?  __RANKED_GOAL_DESCRIPTIONS[rank] : "whoops, someone changed things and didnt update the descriptions. Bad dev.";
-      auto_debug_print("Rank " + rank + " optimization, prefer to... " + desc);
-      auto_debug_print(count(ranked)+" options: " + to_string(ranked, false));
+      auto_log_debug("Rank " + rank + " optimization, prefer to... " + desc);
+      auto_log_trace(count(ranked)+" options: " + to_string(ranked, false));
       if(count(ranked) <= 1){
         break;
       }
@@ -991,7 +991,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
   }
 
   void quick_sort_maximize(__RestorationOptimization[int] p, boolean[string] sort_keys, int[string] value_ranks){
-    auto_debug_print("Sorting "+count(p)+" options by primary objectives.");
+    auto_log_debug("Sorting "+count(p)+" options by primary objectives.");
     if(count(p) > 1){
       quick_sort_maximize(p, sort_keys, value_ranks, 0, count(p)-1);
     }
@@ -999,7 +999,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
   __RestorationOptimization[int] apply_constraints(__RestorationOptimization[int] p, boolean[string] constraint_keys){
     int c = count(p);
-    auto_debug_print("Applying constraints to "+c+" objective values.");
+    auto_log_debug("Applying constraints to "+c+" objective values.");
 
     __RestorationOptimization[int] constrained;
 
@@ -1016,20 +1016,20 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
       }
     }
 
-    auto_debug_print("Removed  "+(c-count(constrained))+" restore options from consideration.");
+    auto_log_debug("Removed  "+(c-count(constrained))+" restore options from consideration.");
 
     return constrained;
   }
 
   __RestorationOptimization[int] calculate_objective_values(){
     if(count(__restore_maximizer_cache) > 0){
-      auto_debug_print("Recalculating cached restore objective values.");
+      auto_log_debug("Recalculating cached restore objective values.");
       foreach i, o in __restore_maximizer_cache{
          __RestorationOptimization recalculated =
          __restore_maximizer_cache[i] = __calculate_objective_values(hp_goal, mp_goal, meat_reserve, useFreeRests, o.metadata);
       }
     } else{
-      auto_debug_print("Calculating restore objective values.");
+      auto_log_debug("Calculating restore objective values.");
       foreach name, metadata in __restoration_methods(){
         __RestorationOptimization o = __calculate_objective_values(hp_goal, mp_goal, meat_reserve, useFreeRests, metadata);
         if(o.constraints["is_ever_useable"]){
@@ -1124,7 +1124,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
       return false;
     }
 
-    print("Using " + metadata.type + " " + metadata.name + " as restore.", "blue");
+    auto_log_info("Using " + metadata.type + " " + metadata.name + " as restore.", "blue");
     if(metadata.type == "item"){
       item i = to_item(metadata.name);
       return retrieve_item(1, i) && use(1, i);
@@ -1142,7 +1142,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
     if(metadata.type == "skill"){
       skill s = to_skill(metadata.name);
       if(my_mp() < mp_cost(s) && !acquireMP(mp_cost(s), meat_reserve, useFreeRests)){
-        print("Couldnt acquire enough MP to cast " + s, "red");
+        auto_log_warning("Couldnt acquire enough MP to cast " + s, "red");
         return false;
       }
       return use_skill(1, s);
@@ -1176,13 +1176,13 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
     return negative;
   }
 
-  print("Target "+resource_type+" => "+goal+" - Considering restore options at " + my_hp() + "/" + my_maxhp() + " HP with " + my_mp() + "/" + my_maxmp() + " MP", "blue");
-  print("Active Negative Effects => " + list_to_string(negative_effects()));
+  auto_log_info("Target "+resource_type+" => "+goal+" - Considering restore options at " + my_hp() + "/" + my_maxhp() + " HP with " + my_mp() + "/" + my_maxmp() + " MP", "blue");
+  auto_log_info("Active Negative Effects => " + list_to_string(negative_effects()));
 
   while(current_resource() < goal){
     __RestorationOptimization[int] options = __maximize_restore_options(hp_target(), mp_target(), meat_reserve, useFreeRests);
     if(count(options) == 0){
-      print("Target "+resource_type+" => " + goal + " - Uh, couldnt determine an effective restoration mechanism. Sorry.", "red");
+      auto_log_warning("Target "+resource_type+" => " + goal + " - Uh, couldnt determine an effective restoration mechanism. Sorry.", "red");
       return false;
     }
 
@@ -1193,12 +1193,12 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
       if(success){
         break;
       } else{
-        auto_debug_print("Target "+resource_type+" => " + goal + " option " + o.metadata.name + " failed. Trying next option (if available).");
+        auto_log_warning("Target "+resource_type+" => " + goal + " option " + o.metadata.name + " failed. Trying next option (if available).");
       }
     }
 
     if(!success){
-      print("Target "+resource_type+" => " + goal + " - Uh oh. All restore options tried ("+count(options)+") failed. Sorry.", "red");
+      auto_log_warning("Target "+resource_type+" => " + goal + " - Uh oh. All restore options tried ("+count(options)+") failed. Sorry.", "red");
       return false;
     }
 	}
@@ -1214,11 +1214,11 @@ void __cure_bad_stuff(){
 
 	// let mafia figure out how to best remove beaten up
 	if(have_effect($effect[Beaten Up]) > 0){
-		print("Ouch, you got beaten up. Lets get you patched up, if we can.");
+		auto_log_info("Ouch, you got beaten up. Lets get you patched up, if we can.");
 		uneffect($effect[Beaten Up]);
 
 		if(have_effect($Effect[Beaten Up]) > 0){
-			print("Well, you're still beaten up, thats probably not great...", "red");
+			auto_log_warning("Well, you're still beaten up, thats probably not great...", "red");
 		}
 	}
 }
@@ -1563,13 +1563,13 @@ boolean uneffect(effect toRemove)
 	if(item_amount($item[Soft Green Echo Eyedrop Antidote]) > 0)
 	{
 		visit_url("uneffect.php?pwd=&using=Yep.&whicheffect=" + to_int(toRemove));
-		print("Effect removed by Soft Green Echo Eyedrop Antidote.", "blue");
+		auto_log_info("Effect removed by Soft Green Echo Eyedrop Antidote.", "blue");
 		return true;
 	}
 	else if(item_amount($item[Ancient Cure-All]) > 0)
 	{
 		visit_url("uneffect.php?pwd=&using=Yep.&whicheffect=" + to_int(toRemove));
-		print("Effect removed by Ancient Cure-All.", "blue");
+		auto_log_info("Effect removed by Ancient Cure-All.", "blue");
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -98,7 +98,7 @@ string to_string(__RestorationOptimization o, boolean simple){
   }
 
   if(simple){
-    return "("+o.metadata.name + ", hp: " + o.objective_values["hp_total_restored"] + ", mp: " + o.objective_values["mp_total_restored"] + ")";
+    return "("+o.metadata.name + ", hp: " + o.objective_values["hp_total_restored"] + ", mp: " + o.objective_values["mp_total_restored"] + ", negative effects remaining: "+o.objective_values["negative_status_effects_remaining"]+")";
   }
 
   string vars_str = list_to_string(o.vars);
@@ -897,6 +897,8 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
       }
       if(!(dominated contains T[Ti].metadata.name)){
         M[count(M)] = T[Ti];
+      } else{
+        auto_log_debug("Removed from consideration: " + to_string(T[Ti], true));
       }
       Ti++;
     }
@@ -905,6 +907,8 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
     while(Bi < count(B)){
       if(!(dominated contains B[Bi].metadata.name)){
         M[count(M)] = B[Bi];
+      } else{
+        auto_log_debug("Removed from consideration: " + to_string(B[Bi], true));
       }
       Bi++;
     }
@@ -930,10 +934,10 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
     __RestorationOptimization[int] ranked = copy(p);
     int[int] ranks = ordered_ranks(value_ranks);
+    auto_log_debug(count(ranked)+" options before optimization: " + to_string(ranked, false));
     foreach _, rank in ranks {
       string desc = (__RANKED_GOAL_DESCRIPTIONS contains rank) ?  __RANKED_GOAL_DESCRIPTIONS[rank] : "whoops, someone changed things and didnt update the descriptions. Bad dev.";
       auto_log_debug("Rank " + rank + " optimization, prefer to... " + desc);
-      auto_log_trace(count(ranked)+" options: " + to_string(ranked, false));
       if(count(ranked) <= 1){
         break;
       }

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -93,7 +93,7 @@ boolean pete_buySkills()
 	if(my_skillPoints.find())
 	{
 		int skillPoints = to_int(my_skillPoints.group(1));
-		print("Skill points found: " + skillPoints);
+		auto_log_info("Skill points found: " + skillPoints);
 
 		while(skillPoints > 0)
 		{
@@ -230,7 +230,7 @@ boolean pete_buySkills()
 	matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
 	while(my_cyclePoints.find())
 	{
-		print("Found Upping Your Grade", "blue");
+		auto_log_info("Found Upping Your Grade", "blue");
 		int firstChoice = -1;
 		int secondChoice = -1;
 		if(get_property("peteMotorbikeCowling") == "")
@@ -272,20 +272,6 @@ boolean pete_buySkills()
 
 		page = visit_url("choice.php?pwd=&whichchoice=859&option=" + firstChoice);
 
-		/*
-		//As of r18887, mafia can not handle this. run_choice() does not work properly.
-		run_choice(firstChoice);
-		if(last_choice() == 859)
-		{
-			print("Ugh, mafia did not update what choice we are on, let's try to fix this", "red");
-			string temp = visit_url("main.php");
-			if(last_choice() == 859)
-			{
-				abort("Could not trick mafia into realizing that we changed our choice");
-			}
-		}
-		run_choice(secondChoice);
-		*/
 		if(last_choice() == 859)
 		{
 			abort("Mafia is not handling this correctly, sorry");

--- a/RELEASE/scripts/autoscend/auto_summerfun.ash
+++ b/RELEASE/scripts/autoscend/auto_summerfun.ash
@@ -31,7 +31,7 @@ boolean ocrs_postCombatResolve()
 			contains_text(get_property("auto_funPrefix"), "restless") ||
 			contains_text(get_property("auto_funPrefix"), "ticking"))
 		{
-			print("Probably beaten up by FUN! Trying to recover instead of aborting", "red");
+			auto_log_warning("Probably beaten up by FUN! Trying to recover instead of aborting", "red");
 			handleTracker(last_monster(), get_property("auto_funPrefix"), "auto_funTracker");
 			acquireHP();
 		}

--- a/RELEASE/scripts/autoscend/auto_test.ash
+++ b/RELEASE/scripts/autoscend/auto_test.ash
@@ -8,7 +8,7 @@ void assertTrue(boolean val, string message)
 {
 	if (!val)
 	{
-		print("Assertion failed: " + message, "red");
+		auto_log_warning("Assertion failed: " + message, "red");
 	}
 	passed &= val;
 }
@@ -33,8 +33,6 @@ void testLoadConsumables()
 	{
 		assertContains($item[catsup], "hermit items should be present");
 	}
-	// if (canadia_available()) assertTrue(0 < count(cafe_backmap), "In Canadia moonsign: Cafe items should be loaded");
-	// if (!canadia_available()) assertTrue(0 == count(cafe_backmap), "Not in Canadia moonsign: Cafe items should not be loaded");
 }
 
 void testKnapsackAutoConsume()
@@ -51,7 +49,7 @@ void main()
 		call void name();
 		string color = passed ? "green" : "red";
 		string sstatus = passed ? "PASS" : "FAIL";
-		print(name + ": " + sstatus, color);
+		auto_log_info(name + ": " + sstatus, color);
 	}
 	runTest("testLoadConsumables");
 	runTest("testKnapsackAutoConsume");

--- a/RELEASE/scripts/autoscend/auto_theSource.ash
+++ b/RELEASE/scripts/autoscend/auto_theSource.ash
@@ -208,7 +208,7 @@ boolean LX_theSource()
 			return false;
 		}
 
-		print("Not searching for a spoon, not at all...", "green");
+		auto_log_info("Not searching for a spoon, not at all...", "green");
 		return autoAdv(goal);
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -146,11 +146,24 @@ boolean basicAdjustML();
 boolean auto_is_valid(item it);
 boolean auto_is_valid(familiar fam);
 boolean auto_is_valid(skill sk);
-boolean auto_debug_print(string s, string color);
-boolean auto_debug_print(string s);
 boolean auto_can_equip(item it);
 boolean auto_can_equip(item it, slot s);
 boolean auto_badassBelt();
+string auto_log_level_threshold();
+int auto_log_level(string level);
+boolean auto_log(string s, string color, string log_level);
+boolean auto_log_critical(string s, string color);
+boolean auto_log_critical(string s);
+boolean auto_log_error(string s, string color);
+boolean auto_log_error(string s);
+boolean auto_log_warning(string s, string color);
+boolean auto_log_warning(string s);
+boolean auto_log_info(string s, string color);
+boolean auto_log_info(string s);
+boolean auto_log_debug(string s, string color);
+boolean auto_log_debug(string s);
+boolean auto_log_trace(string s, string color);
+boolean auto_log_trace(string s);
 
 
 // Private Prototypes
@@ -205,9 +218,9 @@ void debugMaximize(string req, int meat)
 	if(req.index_of("-tie") == -1)
 	{
 		req = req + " -tie";
-		print("Added -tie to maximize", "red");
+		auto_log_debug("Added -tie to maximize", "red");
 	}
-	print("Desired maximize: " + req, "blue");
+	auto_log_info("Desired maximize: " + req, "blue");
 	string situation = " " + my_class() + " " + my_path() + " " + my_sign();
 	if(in_hardcore())
 	{
@@ -405,8 +418,8 @@ void debugMaximize(string req, int meat)
 			output = "REJECT: " + output;
 			tableDont += "<tr>" + curTable + "</tr>";
 		}
-		print(output, "blue");
-		print(display, "green");
+		auto_log_info(output, "blue");
+		auto_log_info(display, "green");
 	}
 
 	tableDo += "</table>";
@@ -416,16 +429,15 @@ void debugMaximize(string req, int meat)
 
 	if(get_property("auto_shareMaximizer").to_boolean() && get_property("auto_allowSharingData").to_boolean())
 	{
-		print("Sharing Maximizer data.", "blue");
-		#print("http://cheesellc.com/kol/sharing.php?type=maximizer&data="+url_encode(tableDo + tableDont), "red");
+		auto_log_info("Sharing Maximizer data.", "blue");
 		string temp = visit_url("http://cheesellc.com/kol/sharing.php?type=maximizer&data="+url_encode(tableDo + tableDont));
 		if(contains_text(temp, "success"))
 		{
-			print("Data shared successfully", "green");
+			auto_log_info("Data shared successfully", "green");
 		}
 		else
 		{
-			print("Data share failed", "green");
+			auto_log_warning("Data share failed", "green");
 		}
 	}
 
@@ -569,7 +581,6 @@ boolean backupSetting(string setting, string newValue)
 		{
 			found = 1;
 			oldValue = get_property(name);
-			#print(domain + " " + name + " " + value);
 		}
 	}
 
@@ -1011,7 +1022,7 @@ int autoCraft(string mode, int count, item item1, item item2)
 	{
 		if(my_meat() < (10 * count))
 		{
-			print("Count not combine " + item1 + " and " + item2 + " due to lack of meat paste.", "red");
+			auto_log_warning("Count not combine " + item1 + " and " + item2 + " due to lack of meat paste.", "red");
 			return 0;
 		}
 		int need = max(0, count - item_amount($item[Meat Paste]));
@@ -1388,7 +1399,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "";
 
 	if(inCombat)
-		print("Finding a banisher to use on " + enemy + " at " + loc, "green");
+		auto_log_info("Finding a banisher to use on " + enemy + " at " + loc, "green");
 
 	//src/net/sourceforge/kolmafia/session/BanishManager.java
 	boolean[string] used = auto_banishesUsedAt(loc);
@@ -1775,7 +1786,7 @@ int ns_crowd1()
 {
 	if(get_property("nsContestants1").to_int() != 0)
 	{
-		print("Default Test: Initiative", "red");
+		auto_log_info("Default Test: Initiative", "red");
 	}
 	return 1;
 }
@@ -1783,7 +1794,7 @@ stat ns_crowd2()
 {
 	if(get_property("nsContestants2").to_int() != 0)
 	{
-		print("Off-Stat Test: " + get_property("nsChallenge1"), "red");
+		auto_log_info("Off-Stat Test: " + get_property("nsChallenge1"), "red");
 	}
 	return to_stat(get_property("nsChallenge1"));
 }
@@ -1791,23 +1802,23 @@ element ns_crowd3()
 {
 	if(get_property("nsContestants3").to_int() != 0)
 	{
-		print("Elemental Test: " + get_property("nsChallenge2"), "red");
+		auto_log_info("Elemental Test: " + get_property("nsChallenge2"), "red");
 	}
 	return to_element(get_property("nsChallenge2"));
 }
 element ns_hedge1()
 {
-	print("Hedge Maze 1: " + get_property("nsChallenge3"), "red");
+	auto_log_info("Hedge Maze 1: " + get_property("nsChallenge3"), "red");
 	return to_element(get_property("nsChallenge3"));
 }
 element ns_hedge2()
 {
-	print("Hedge Maze 2: " + get_property("nsChallenge4"), "red");
+	auto_log_info("Hedge Maze 2: " + get_property("nsChallenge4"), "red");
 	return to_element(get_property("nsChallenge4"));
 }
 element ns_hedge3()
 {
-	print("Hedge Maze 3: " + get_property("nsChallenge5"), "red");
+	auto_log_info("Hedge Maze 3: " + get_property("nsChallenge5"), "red");
 	return to_element(get_property("nsChallenge5"));
 }
 
@@ -1939,11 +1950,11 @@ boolean ovenHandle()
 	{
 		if (auto_get_campground() contains $item[Certificate of Participation] && isActuallyEd())
 		{
-			print("Mafia reports we have an oven but we do not. Logging back in will resolve this.", "red");
+			auto_log_error("Mafia reports we have an oven but we do not. Logging back in will resolve this.", "red");
 		}
 		else
 		{
-			print("Oven found! We can cook!", "blue");
+			auto_log_info("Oven found! We can cook!", "blue");
 			set_property("auto_haveoven", true);
 		}
 	}
@@ -2048,7 +2059,7 @@ boolean cloverUsageFinish()
 	restoreSetting("cloverProtectActive");
 	if(item_amount($item[Ten-Leaf Clover]) > 0)
 	{
-		print("Wandering adventure interrupted our clover adventure (" + my_location() + "), boo. Gonna have to do this again.");
+		auto_log_debug("Wandering adventure interrupted our clover adventure (" + my_location() + "), boo. Gonna have to do this again.");
 		if(auto_my_path() == "G-Lover")
 		{
 			put_closet(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
@@ -2072,7 +2083,7 @@ boolean acquireGumItem(item it)
 	}
 
 	int have = item_amount(it);
-	print("Gum acquistion of: " + it, "green");
+	auto_log_info("Gum acquistion of: " + it, "green");
 	while((have == item_amount(it)) && (my_meat() >= npc_price($item[Chewing Gum on a String])))
 	{
 		buyUpTo(1, $item[Chewing Gum on a String]);
@@ -2113,7 +2124,7 @@ boolean acquireHermitItem(item it)
 		return false;
 	}
 	int have = item_amount(it);
-	print("Hermit acquistion of: " + it, "green");
+	auto_log_info("Hermit acquistion of: " + it, "green");
 	while((have == item_amount(it)) && ((my_meat() >= npc_price($item[Chewing Gum on a String])) || ((item_amount($item[Worthless Trinket]) + item_amount($item[Worthless Gewgaw]) + item_amount($item[Worthless Knick-knack])) > 0)))
 	{
 		if((item_amount($item[Worthless Trinket]) + item_amount($item[Worthless Gewgaw]) + item_amount($item[Worthless Knick-knack])) > 0)
@@ -2138,7 +2149,7 @@ boolean acquireHermitItem(item it)
 				}
 				else
 				{
-					print("Invalid clover count from hermit behavior, reporting failure.", "red");
+					auto_log_warning("Invalid clover count from hermit behavior, reporting failure.", "red");
 					return false;
 				}
 			}
@@ -2496,7 +2507,7 @@ boolean declineTrades()
 	}
 	if(count > 0)
 	{
-		print("Declined " + count + " trades.", "blue");
+		auto_log_info("Declined " + count + " trades.", "blue");
 		return true;
 	}
 	return false;
@@ -3151,7 +3162,7 @@ boolean handleBarrelFullOfBarrels(boolean daily)
 
 		if(mimic != "")
 		{
-			print("Found mimic in slot: " + slotID, "red");
+			auto_log_warning("Found mimic in slot: " + slotID, "red");
 		}
 		else if(label == "A barrel")
 		{
@@ -3437,7 +3448,7 @@ int doNumberology(string goal, boolean doIt, string option)
 		int current = (score + (melancholy * i)) % 100;
 		if(numberwang[current] == goal)
 		{
-			print("Found option for Numberology: " + current + " (" + goal + ")" , "blue");
+			auto_log_info("Found option for Numberology: " + current + " (" + goal + ")" , "blue");
 			if(!doIt)
 			{
 				return i;
@@ -3568,7 +3579,7 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 			}
 			if (curPrice >= 30000)
 			{
-				print(it + " is too expensive at " + curPrice + " meat, we're gonna skip buying one in the mall.", "red");
+				auto_log_warning(it + " is too expensive at " + curPrice + " meat, we're gonna skip buying one in the mall.", "red");
 				break;
 			}
 			if((curPrice <= oldPrice) && (curPrice < 30000) && (meat >= curPrice))
@@ -3586,14 +3597,14 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 			{
 				if(curPrice > oldPrice)
 				{
-					print("Price of " + it + " may have been mall manipulated. Expected to pay at most: " + oldPrice, "red");
+					auto_log_warning("Price of " + it + " may have been mall manipulated. Expected to pay at most: " + oldPrice, "red");
 				}
 				if(my_storage_meat() < curPrice)
 				{
-					print("Do not have enough meat in Hagnk's to buy " + it + ". Need " + curPrice + " have " + my_storage_meat() + ".", "blue");
+					auto_log_warning("Do not have enough meat in Hagnk's to buy " + it + ". Need " + curPrice + " have " + my_storage_meat() + ".", "blue");
 					if(curPrice > 10000000)
 					{
-						print("You must be a poor meatbag.", "green");
+						auto_log_warning("You must be a poor meatbag.", "green");
 					}
 				}
 			}
@@ -3606,15 +3617,15 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 
 		if(storage_amount(it) < howMany)
 		{
-			print("Can not pull what we don't have. Sorry");
+			auto_log_warning("Can not pull what we don't have. Sorry");
 			return false;
 		}
 
-		print("Trying to pull " + howMany + " of " + it, "blue");
+		auto_log_info("Trying to pull " + howMany + " of " + it, "blue");
 		boolean retval = take_storage(howMany, it);
 		if(item_amount(it) != (howMany + whenHave))
 		{
-			print("Failed pulling " + howMany + " of " + it, "red");
+			auto_log_warning("Failed pulling " + howMany + " of " + it, "red");
 		}
 		else
 		{
@@ -3697,7 +3708,7 @@ boolean buy_item(item it, int quantity, int maxprice)
 		}
 		if(buy(1, it, maxprice) == 0)
 		{
-			print("Price of " + it + " exceeded expected mall price of " + maxprice + ".", "blue");
+			auto_log_info("Price of " + it + " exceeded expected mall price of " + maxprice + ".", "blue");
 			return false;
 		}
 	}
@@ -3705,7 +3716,7 @@ boolean buy_item(item it, int quantity, int maxprice)
 	{
 		if(auto_mall_price(it) >= maxprice)
 		{
-			print("Price of " + it + " exceeded expected mall price of " + maxprice + ".", "blue");
+			auto_log_info("Price of " + it + " exceeded expected mall price of " + maxprice + ".", "blue");
 		}
 		return false;
 	}
@@ -3749,7 +3760,7 @@ string beerPong(string page)
 
 		if(page.contains_text("Phooey"))
 		{
-			print("Looks like something went wrong and you lost.", "lime");
+			auto_log_info("Looks like something went wrong and you lost.", "lime");
 			return page;
 		}
 
@@ -3759,17 +3770,17 @@ string beerPong(string page)
 			{
 				if(page.contains_text(insults[i].retort))
 				{
-					print("Found appropriate retort for insult.", "lime");
-					print("Insult: " + insults[i].insult, "lime");
-					print("Retort: " + insults[i].retort, "lime");
+					auto_log_info("Found appropriate retort for insult.", "lime");
+					auto_log_debug("Insult: " + insults[i].insult, "lime");
+					auto_log_debug("Retort: " + insults[i].retort, "lime");
 					page = visit_url("beerpong.php?value=Retort!&response=" + i);
 					break;
 				}
 				else
 				{
-					print("Looks like you needed a retort you haven't learned.", "red");
-					print("Insult: " + insults[i].insult, "lime");
-					print("Retort: " + insults[i].retort, "lime");
+					auto_log_info("Looks like you needed a retort you haven't learned.", "red");
+					auto_log_debug("Insult: " + insults[i].insult, "lime");
+					auto_log_debug("Retort: " + insults[i].retort, "lime");
 
 					// Give a bad retort
 					page = visit_url("beerpong.php?value=Retort!&response=9");
@@ -3784,7 +3795,7 @@ string beerPong(string page)
 		}
 	}
 
-	print("You won a thrilling game of Insult Beer Pong!", "lime");
+	auto_log_info("You won a thrilling game of Insult Beer Pong!", "lime");
 	return page;
 }
 
@@ -4010,12 +4021,12 @@ void shrugAT(effect anticipated)
 			count += 1;
 			if(count > maxSongs)
 			{
-				print("Shrugging song: " + song, "blue");
+				auto_log_info("Shrugging song: " + song, "blue");
 				uneffect(song);
 			}
 		}
 	}
-	print("I think we're good to go to apply " + anticipated, "blue");
+	auto_log_info("I think we're good to go to apply " + anticipated, "blue");
 }
 
 
@@ -4239,7 +4250,7 @@ boolean buyUpTo(int num, item it, int maxprice)
 		buy(num, it, maxprice);
 		if(item_amount(it) < orig)
 		{
-			print("Could not buyUpTo(" + orig + ") of " + it + ". Maxprice: " + maxprice, "red");
+			auto_log_warning("Could not buyUpTo(" + orig + ") of " + it + ". Maxprice: " + maxprice, "red");
 		}
 	}
 	return (item_amount(it) >= orig);
@@ -5045,7 +5056,7 @@ boolean auto_is_valid(familiar fam)
 {
 	familiar hundo = to_familiar(get_property("auto_100familiar"));
 	if(hundo != $familiar[none] && hundo != fam){
-		auto_debug_print(fam + " isnt valid, player is in a 100% familiar run with " + hundo);
+		auto_log_warning(fam + " isnt valid, player is in a 100% familiar run with " + hundo);
 	}
 	return bees_hate_usable(fam.to_string()) && glover_usable(fam.to_string()) && is_unrestricted(fam) && (hundo == $familiar[none] || hundo == fam);
 }
@@ -5055,26 +5066,91 @@ boolean auto_is_valid(skill sk)
 	return ((glover_usable(sk.to_string()) && bees_hate_usable(sk.to_string())) || sk.passive) && bat_skillValid(sk) && is_unrestricted(sk);
 }
 
-boolean auto_debug_print(string s, string color)
-{
-	if(get_property("auto_debug").to_boolean())
-	{
-		print(s, color);
-		return true;
+string auto_log_level_threshold(){
+	static string logging_property = "auto_logLevel";
+	if(!property_exists(logging_property)){
+		set_property(logging_property, "info");
+	}
+	return get_property(logging_property);
+}
+
+int auto_log_level(string level){
+	static int[string] log_levels = {
+		"critical": 1,
+		"crit": 1,
+		"error": 2,
+		"err": 2,
+		"warning": 3,
+		"warn": 3,
+		"info": 4,
+		"debug": 5,
+		"trace": 6
+	};
+
+	level = level.to_lower_case();
+	if(log_levels contains level){
+		return log_levels[level];
 	} else{
-		logprint(s);
+		return log_levels["info"];
+	}
+}
+
+boolean auto_log(string s, string color, string log_level){
+	int threshold = auto_log_level(auto_log_level_threshold());
+	int level = auto_log_level(log_level);
+	if(level <= threshold){
+		print("["+log_level.to_upper_case()+"] - " + s, color);
+		return true;
 	}
 	return false;
 }
 
-boolean auto_debug_print(string s)
-{
-	if(get_property("auto_debug").to_boolean())
-	{
-		print(s);
-		return true;
-	}
-	return false;
+boolean auto_log_critical(string s, string color){
+	return auto_log(s, color, "critical");
+}
+
+boolean auto_log_critical(string s){
+	return auto_log(s, "red", "critical");
+}
+
+boolean auto_log_error(string s, string color){
+	return auto_log(s, color, "critical");
+}
+
+boolean auto_log_error(string s){
+	return auto_log(s, "red", "error");
+}
+
+boolean auto_log_warning(string s, string color){
+	return auto_log(s, color, "warning");
+}
+
+boolean auto_log_warning(string s){
+	return auto_log(s, "orange", "warning");
+}
+
+boolean auto_log_info(string s, string color){
+	return auto_log(s, color, "info");
+}
+
+boolean auto_log_info(string s){
+	return auto_log(s, "blue", "info");
+}
+
+boolean auto_log_debug(string s, string color){
+	return auto_log(s, color, "debug");
+}
+
+boolean auto_log_debug(string s){
+	return auto_log(s, "black", "debug");
+}
+
+boolean auto_log_trace(string s, string color){
+	return auto_log(s, color, "trace");
+}
+
+boolean auto_log_trace(string s){
+	return auto_log(s, "black", "trace");
 }
 
 boolean auto_can_equip(item it)
@@ -5312,13 +5388,13 @@ boolean [monster] auto_getMonsters(string category)
 	boolean [monster] res;
 	string [string,int,string] monsters_text;
 	if(!file_to_map("autoscend_monsters.txt", monsters_text))
-		print("Could not load autoscend_monsters.txt. This is bad!", "red");
+		auto_log_error("Could not load autoscend_monsters.txt. This is bad!", "red");
 	foreach i,name,conds in monsters_text[category]
 	{
 		monster thisMonster = name.to_monster();
 		if(thisMonster == $monster[none])
 		{
-			print('"' + name + '" does not convert to a monster properly!', "red");
+			auto_log_warning('"' + name + '" does not convert to a monster properly!', "red");
 			continue;
 		}
 		if(!auto_check_conditions(conds))
@@ -5628,7 +5704,7 @@ boolean canSimultaneouslyAcquire(int[item] needed)
 			if (count(get_ingredients(toAdd)) == 0 && npc_price(toAdd) == 0 && buy_price($coinmaster[hermit], toAdd) == 0)
 			{
 				// not craftable
-				auto_debug_print("canSimultaneouslyAcquire failing on " + toAdd, "red");
+				auto_log_warning("canSimultaneouslyAcquire failing on " + toAdd, "red");
 				failed = true;
 			}
 			else if (npc_price(toAdd) > 0)
@@ -5670,7 +5746,7 @@ boolean[int] knapsack(int maxw, int n, int[int] weight, float[int] val)
 
 	if(n*maxw >= 100000)
 	{
-		print("Solving a Knapsack instance with " + n + " elements and " + maxw + " total weight, this might be slow and memory-intensive.");
+		auto_log_warning("Solving a Knapsack instance with " + n + " elements and " + maxw + " total weight, this might be slow and memory-intensive.");
 	}
 
 	/* V[i][w] is "with only the first i items, what is the maximum
@@ -5728,19 +5804,19 @@ int auto_reserveAmount(item it)
 {
 	string [string,int,string] itemdata;
 	if(!file_to_map("autoscend_items.txt", itemdata))
-		print("Could not load autoscend_items.txt! This is bad!", "red");
+		auto_log_error("Could not load autoscend_items.txt! This is bad!", "red");
 	foreach i,counteditem,conds in itemdata["reserve"]
 	{
 		matcher m = create_matcher("(\\-?\\d+) (.+)", counteditem);
 		if(!m.find())
 		{
-			print('"' + counteditem + '" is not in the format "# itemname"!', "red");
+			auto_log_warning('"' + counteditem + '" is not in the format "# itemname"!', "red");
 			continue;
 		}
 		item curr = m.group(2).to_item();
 		if(curr == $item[none])
 		{
-			print('"' + m.group(2) + '" does not convert to an item properly!', "red");
+			auto_log_warning('"' + m.group(2) + '" does not convert to an item properly!', "red");
 			continue;
 		}
 		if(curr != it)
@@ -5761,11 +5837,11 @@ int auto_reserveCraftAmount(item orig_it)
 	{
 		if (its contains it)
 		{
-			print("Found dependency loop involving " + it + " when trying to craft " + orig_it + ", consider adding to reserve list.", "red");
-			print("Dependencies (in no particular order):", "red");
+			auto_log_warning("Found dependency loop involving " + it + " when trying to craft " + orig_it + ", consider adding to reserve list.", "red");
+			auto_log_warning("Dependencies (in no particular order):", "red");
 			foreach iit in its
 			{
-				print("> " + iit, "red");
+				auto_log_warning("> " + iit, "red");
 			}
 			return 9999999;
 		}
@@ -5845,12 +5921,12 @@ boolean auto_forceNextNoncombat()
 {
 	if(auto_haveQueuedForcedNonCombat())
 	{
-		print("Trying to force a noncombat adventure, but I think we've already forced one...", "red");
+		auto_log_warning("Trying to force a noncombat adventure, but I think we've already forced one...", "red");
 		return true;
 	}
 	if (_auto_forceNextNoncombat())
 	{
-		print("Next noncombat adventure has been forced...", "blue");
+		auto_log_info("Next noncombat adventure has been forced...", "blue");
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_zlib.ash
+++ b/RELEASE/scripts/autoscend/auto_zlib.ash
@@ -78,7 +78,7 @@ void auto_process_kmail(string functionname)
 	//delete successfully processed mail
 	if(count(processed) > 0)
 	{
-		print("Deleting processed mail...", "blue");
+		auto_log_info("Deleting processed mail...", "blue");
 		string del = "messages.php?the_action=delete&box=Inbox&pwd";
 		foreach k in processed
 		{
@@ -87,11 +87,11 @@ void auto_process_kmail(string functionname)
 		del = visit_url(del);
 		if(contains_text(del,count(processed)+" message"+(count(processed) > 1 ? "s" : "")+" deleted."))
 		{
-			print(count(processed)+" message"+(count(processed) > 1 ? "s" : "")+" deleted.", "blue");
+			auto_log_info(count(processed)+" message"+(count(processed) > 1 ? "s" : "")+" deleted.", "blue");
 		}
 		else
 		{
-			print("There was a problem deleting the processed mail.  Check your inbox.", "red");
+			auto_log_warning("There was a problem deleting the processed mail.  Check your inbox.", "red");
 		}
 	}
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -982,8 +982,23 @@ boolean auto_is_valid(item it); //Defined in autoscend/auto_util.ash
 boolean auto_is_valid(familiar fam); //Defined in autoscend/auto_util.ash
 boolean auto_is_valid(skill sk); //Defined in autoscend/auto_util.ash
 
-boolean auto_debug_print(string s, string color); //Defined in autoscend/auto_util.ash
-boolean auto_debug_print(string s); //Defined in autoscend/auto_util.ash
+// Logging
+// Defined in autoscend/auto_util.ash
+string auto_log_level_threshold();
+int auto_log_level(string level);
+boolean auto_log(string s, string color, string log_level);
+boolean auto_log_critical(string s, string color);
+boolean auto_log_critical(string s);
+boolean auto_log_error(string s, string color);
+boolean auto_log_error(string s);
+boolean auto_log_warning(string s, string color);
+boolean auto_log_warning(string s);
+boolean auto_log_info(string s, string color);
+boolean auto_log_info(string s);
+boolean auto_log_debug(string s, string color);
+boolean auto_log_debug(string s);
+boolean auto_log_trace(string s, string color);
+boolean auto_log_trace(string s);
 
 boolean auto_can_equip(item it); //Defined in autoscend/auto_util.ash
 boolean auto_can_equip(item it, slot s); //Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_migration.ash
+++ b/RELEASE/scripts/autoscend/autoscend_migration.ash
@@ -23,7 +23,7 @@ string autoscend_previous_version(){
 boolean autoscend_needs_update(){
   if(autoscend_previous_version() == "0.0.0" || autoscend_current_version() != __autoscend_version){
     if(get_property("auto_need_update").to_boolean()){
-      print("Forcing migration (partially complete migration or user set flag): auto_need_update => true");
+      auto_log_info("Forcing migration (partially complete migration or user set flag): auto_need_update => true");
     }
     set_property("auto_need_update", true);
   }
@@ -58,14 +58,14 @@ boolean autoscend_migrate(){
       string old_prop = replace_string(p ,"auto_" , "sl_");
       if(property_exists(old_prop)){
         if(property_exists(p) && property_exists(old_prop) && get_property(p) != get_property(old_prop)){
-          print("Conflict: " + old_prop + " ("+get_property(old_prop)+") != " + p + " ("+get_property(p)+")");
+          auto_log_warning("Conflict: " + old_prop + " ("+get_property(old_prop)+") != " + p + " ("+get_property(p)+")");
           prop_conflicts++;
         }
       }
     }
 
     if(prop_conflicts > 0){
-      print("Found " + prop_conflicts + " conflicting property values while migrating from sl_ascend properties to autoscend properties. Old property value will be ignored. Please do not use sl_ascend and autoscend at the same time.", "red");
+      auto_log_error("Found " + prop_conflicts + " conflicting property values while migrating from sl_ascend properties to autoscend properties. Old property value will be ignored. Please do not use sl_ascend and autoscend at the same time.", "red");
       return false;
     }
     return true;
@@ -90,10 +90,10 @@ boolean autoscend_migrate(){
       string old_prop = replace_string(p ,"auto_" , "sl_");
       if(property_exists(old_prop)){
         if(!property_exists(p)){
-          print("Migrating " + old_prop + " => " + p + " ("+get_property(old_prop)+")");
+          auto_log_info("Migrating " + old_prop + " => " + p + " ("+get_property(old_prop)+")");
           set_property(p, get_property(old_prop));
         } else if(get_property(old_prop) != get_property(p)){
-          print("Conflict: " + old_prop + " ("+get_property(old_prop)+") != " + p + " ("+get_property(p)+")", "red");
+          auto_log_warning("Conflict: " + old_prop + " ("+get_property(old_prop)+") != " + p + " ("+get_property(p)+")", "red");
           prop_conflicts++;
         }
         if(cleanup) remove_property(old_prop);
@@ -101,7 +101,7 @@ boolean autoscend_migrate(){
     }
 
     if(prop_conflicts > 0){
-      print("Found " + prop_conflicts + " conflicting property values while migrating from sl_ascend properties to autoscend properties. Old property value will be ignored. Please do not use sl_ascend and autoscend at the same time.", "red");
+      auto_log_error("Found " + prop_conflicts + " conflicting property values while migrating from sl_ascend properties to autoscend properties. Old property value will be ignored. Please do not use sl_ascend and autoscend at the same time.", "red");
       return false;
     }
     return true;
@@ -130,7 +130,7 @@ boolean autoscend_migrate(){
 
   boolean all_good = true;
   if(autoscend_needs_update()){
-    print("Migrating from " + autoscend_previous_version() + " to " + __autoscend_version, "blue");
+    auto_log_info("Migrating from " + autoscend_previous_version() + " to " + __autoscend_version, "blue");
     if(autoscend_previous_version() == "0.0.0" && repo_present("sl_ascend")){
       all_good = autoscend_migrate_properties() && remove_sl_ascend_repos();
     }


### PR DESCRIPTION
# Description

Replaced all print and auto_debug_print usage with new auto_log functions which let you log at various levels (e.g. info, debug, error, etc) and show/hide them using the auto_logLevel property. Also toned down the restore logic logs to save disk space/readability.

It looks like a lot of changes, but most of them are just find/replace for the print function. also removed some commented out code as i found it.

## How Has This Been Tested?

ran validate and used on day 2 of my current run. seems to work fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
