### PR TITLE
Fixing maximizer issue with the Invader

### DIFF
--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -53,7 +53,6 @@ boolean LX_koeInvaderHandler()
 	buffMaintain($effect[Scarysauce], 10, 1, 1);
 
 	resetMaximize();
-	addToMaximize("200 all res");
 
 	if(!possessEquipment($item[meteorb]))
 		retrieve_item(1, $item[meteorb]);
@@ -61,7 +60,7 @@ boolean LX_koeInvaderHandler()
 	pullXWhenHaveY($item[meteorb], 1, 0);
 	autoEquip($slot[off-hand], $item[meteorb]);
 
-	simMaximize();
+	simMaximizeWith("200 all res");
 
 	float damagePerRound = 0.0;
 	float baseDamage = 1.0 - 0.1 * my_daycount();
@@ -92,6 +91,9 @@ boolean LX_koeInvaderHandler()
 			buffMaintain($effect[Song of Sauce], 150, 1, 1);
 			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
 			acquireMP(100, 0);
+
+			// Use maximizer now that we are for sure fighting the Invader
+			addToMaximize("200 all res");
 
 			set_property("choiceAdventure1393", 1); // Take care of it...
 			boolean ret = autoAdv(1, $location[The Invader]);


### PR DESCRIPTION
# Description

Uses `simMaximizerWith()` rather than `simMaximizer()` before the Invader. Also moved the addition of the maximizer string until we were sure we are ready to fight.

Fixes #144

## How Has This Been Tested?

Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
