### PR TITLE
Enforce HP when doing A-boo clue

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -12263,11 +12263,11 @@ boolean L9_aBooPeak()
 			}
 			if(useMaximizeToEquip())
 			{
-				addToMaximize("1000spooky res,1000 cold res,10hp" + parrot);
+				addToMaximize("1000spooky res,1000cold res,10000hp " + (mp_need + 10) + "max," + parrot);
 			}
 			else
 			{
-				autoMaximize("spooky res, cold res " + lihcface + " -equip snow suit" + parrot, 0, 0, false);
+				autoMaximize("spooky res,cold res " + lihcface + " -equip snow suit" + parrot, 0, 0, false);
 			}
 			adjustEdHat("ml");
 


### PR DESCRIPTION
# Description

Makes HP a VERY high value in the A-boo clue maximizer string, but caps it at the minimum we need +10. 

Fixes #
#112  

## How Has This Been Tested?

Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
