### PR TITLE
more changes for Ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: you may need to delete KoLMafia's svn cache if you want to switch between 
 
 ## Usage
 
-Just type auto\_ascend in the gCLI! You can configure autoscend in the relay browser via the relay
+Just type autoscend in the gCLI! You can configure autoscend in the relay browser via the relay
 script autoscend. If you ever want to interrupt the script, please use the interrupt button in
 the autoscend relay script rather than terminating via mafia with escape. Otherwise certain settings
 may not be restored properly to their pre-run values.
@@ -59,6 +59,14 @@ requirements section. Other classes should work as well, but Sauceror works best
 The recommended class/sign combination for running autoscend in TCRS is Sauceror/Blender.
 Other signs should work okay too, but they won't have any special support (like automatic diet,
 or using certain nice cheap potions).
+
+## Actually Ed the Undying
+
+The recommended choices in Valhalla for Actually Ed the Undying are 
+
+* Astral Pilsners.
+* Astral Ring if you have less than 20 skill points, Astral Belt otherwise.
+* Opossum moon sign
 
 ## Warning
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -7605,25 +7605,25 @@ boolean L12_gremlins()
 	songboomSetting("dr");
 	if(item_amount($item[molybdenum hammer]) == 0)
 	{
-		autoAdv(1, $location[Next to that barrel with something burning in it], "auto_Junkyard");
+		autoAdv(1, $location[Next to that barrel with something burning in it], "auto_JunkyardCombatHandler");
 		return true;
 	}
 
 	if(item_amount($item[molybdenum screwdriver]) == 0)
 	{
-		autoAdv(1, $location[Out by that rusted-out car], "auto_Junkyard");
+		autoAdv(1, $location[Out by that rusted-out car], "auto_JunkyardCombatHandler");
 		return true;
 	}
 
 	if(item_amount($item[molybdenum crescent wrench]) == 0)
 	{
-		autoAdv(1, $location[over where the old tires are], "auto_Junkyard");
+		autoAdv(1, $location[over where the old tires are], "auto_JunkyardCombatHandler");
 		return true;
 	}
 
 	if(item_amount($item[Molybdenum Pliers]) == 0)
 	{
-		autoAdv(1, $location[near an abandoned refrigerator], "auto_Junkyard");
+		autoAdv(1, $location[near an abandoned refrigerator], "auto_JunkyardCombatHandler");
 		return true;
 	}
 	handleFamiliar("item");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1906,7 +1906,12 @@ boolean fortuneCookieEvent()
 			goal = $location[The Haunted Pantry];
 		}
 
-		return autoAdv(goal);
+		boolean retval = autoAdv(goal);
+		if (item_amount($item[Knob Goblin lunchbox]) > 0)
+		{
+			use(item_amount($item[Knob Goblin lunchbox]), $item[Knob Goblin lunchbox]);
+		}
+		return retval;
 	}
 	return false;
 }
@@ -5441,44 +5446,40 @@ boolean LX_attemptFlyering()
 {
 	if(elementalPlanes_access($element[stench]) && auto_have_skill($skill[Summon Smithsness]))
 	{
-		autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
+		return autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
 	}
 	else if(elementalPlanes_access($element[spooky]))
 	{
-		autoAdv(1, $location[The Deep Dark Jungle]);
+		return autoAdv(1, $location[The Deep Dark Jungle]);
 	}
 	else if(elementalPlanes_access($element[cold]))
 	{
-		autoAdv(1, $location[VYKEA]);
+		return autoAdv(1, $location[VYKEA]);
 	}
 	else if(elementalPlanes_access($element[stench]))
 	{
-		autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
+		return autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
 	}
 	else if(elementalPlanes_access($element[sleaze]))
 	{
-		autoAdv(1, $location[Sloppy Seconds Diner]);
+		return autoAdv(1, $location[Sloppy Seconds Diner]);
 	}
 	else if(neverendingPartyAvailable())
 	{
-		neverendingPartyPowerlevel();
+		return neverendingPartyPowerlevel();
 	}
 	else
 	{
-		if((my_level() >= 11) && (get_property("auto_hiddenzones") == "finished"))
+		int flyer = get_property("flyeredML").to_int();
+		boolean retval = autoAdv($location[Near an Abandoned Refrigerator]);
+		if (flyer == get_property("flyeredML").to_int())
 		{
-			int flyer = get_property("flyeredML").to_int();
-			autoAdv($location[The Hidden Hospital]);
-			if(flyer == get_property("flyeredML").to_int())
-			{
-				abort("Trying to flyer but failed to flyer");
-			}
-			set_property("auto_newbieOverride", true);
-			return true;
+			abort("Trying to flyer but failed to flyer");
 		}
-		return false;
+		set_property("auto_newbieOverride", true);
+		return retval;
 	}
-	return true;
+	return false;
 }
 
 boolean powerLevelAdjustment()
@@ -5523,6 +5524,7 @@ boolean LX_attemptPowerLevel()
 		autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 		return true;
 	}
+
 	if(LX_freeCombats())
 	{
 		return true;
@@ -5615,13 +5617,13 @@ boolean LX_attemptPowerLevel()
 	{
 		autoAdv(1, $location[VYKEA]);
 	}
-	else if((elementalPlanes_access($element[sleaze])) && (my_level() < 11))
-	{
-		autoAdv(1, $location[Sloppy Seconds Diner]);
-	}
 	else if(elementalPlanes_access($element[sleaze]))
 	{
 		autoAdv(1, $location[Sloppy Seconds Diner]);
+	}
+	else if (elementalPlanes_access($element[hot]))
+	{
+		autoAdv(1, $location[The SMOOCH Army HQ]);
 	}
 	else
 	{
@@ -7603,25 +7605,25 @@ boolean L12_gremlins()
 	songboomSetting("dr");
 	if(item_amount($item[molybdenum hammer]) == 0)
 	{
-		autoAdv(1, $location[Next to that barrel with something burning in it], "ccsJunkyard");
+		autoAdv(1, $location[Next to that barrel with something burning in it], "auto_Junkyard");
 		return true;
 	}
 
 	if(item_amount($item[molybdenum screwdriver]) == 0)
 	{
-		autoAdv(1, $location[Out by that rusted-out car], "ccsJunkyard");
+		autoAdv(1, $location[Out by that rusted-out car], "auto_Junkyard");
 		return true;
 	}
 
 	if(item_amount($item[molybdenum crescent wrench]) == 0)
 	{
-		autoAdv(1, $location[over where the old tires are], "ccsJunkyard");
+		autoAdv(1, $location[over where the old tires are], "auto_Junkyard");
 		return true;
 	}
 
 	if(item_amount($item[Molybdenum Pliers]) == 0)
 	{
-		autoAdv(1, $location[near an abandoned refrigerator], "ccsJunkyard");
+		autoAdv(1, $location[near an abandoned refrigerator], "auto_Junkyard");
 		return true;
 	}
 	handleFamiliar("item");
@@ -7693,7 +7695,7 @@ boolean L12_sonofaBeach()
 		}
 	}
 
-	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0)
+	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0 && have_effect($effect[Taunt of Horus]) == 0)
 	{
 		return false;
 	}
@@ -7846,7 +7848,7 @@ boolean L12_sonofaPrefix()
 		return false;
 	}
 
-	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0)
+	if (isActuallyEd() && item_amount($item[Talisman of Horus]) == 0 && have_effect($effect[Taunt of Horus]) == 0)
 	{
 		return false;
 	}
@@ -9459,6 +9461,31 @@ boolean L7_crypt()
 		buffMaintain($effect[Soulerskates], 0, 1, 1);
 		buffMaintain($effect[Cletus\'s Canticle of Celerity], 10, 1, 1);
 
+		if (isActuallyEd() && monster_attack($monster[modern zmobie]) >= my_maxhp())
+		{
+			// Need to be able to tank a hit from the modern zmobies as Ed
+			// as we'll never get the jump because their initiative is ridiculous.
+			// Otherwise we'll just die repeatedly.
+			if (get_property("telescopeUpgrades").to_int() > 0 && !get_property("telescopeLookedHigh").to_boolean())
+			{
+				cli_execute("telescope high");
+			}
+			if (!get_property("_lyleFavored").to_boolean())
+			{
+				cli_execute("monorail");
+			}
+			if (have_effect($effect[Butt-Rock Hair]) == 0)
+			{
+				buyUpTo(1, $item[Hair Spray]);
+				buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
+			}
+			if (have_effect($effect[Go Get \'Em, Tiger!]) == 0)
+			{
+				buyUpTo(1, $item[Ben-Gal&trade; Balm]);
+				buffMaintain($effect[Go Get \'Em, Tiger!], 0, 1, 1);
+			}
+		}
+
 		auto_beachCombHead("init");
 
 		if(have_effect($effect[init.enh]) == 0)
@@ -9624,6 +9651,10 @@ boolean L7_crypt()
 		if(auto_have_familiar($familiar[Machine Elf]))
 		{
 			handleFamiliar($familiar[Machine Elf]);
+		}
+		if (isActuallyEd())
+		{
+			auto_change_mcd(10); // get vertebra to make the necklace.
 		}
 		boolean tryBoner = autoAdv(1, $location[Haert of the Cyrpt]);
 		council();
@@ -10305,7 +10336,7 @@ boolean L5_goblinKing()
 	{
 		return false;
 	}
-	if (my_level() < 8 && get_property("auto_powerLevelAdvCount").to_int() < 9 && !isActuallyEd())
+	if (my_level() < 8 && get_property("auto_powerLevelAdvCount").to_int() < 9)
 	{
 		return false;
 	}
@@ -10390,6 +10421,7 @@ boolean L4_batCave()
 	if((item_amount($item[Sonar-In-A-Biscuit]) > 0) && (batStatus < 3))
 	{
 		use(1, $item[Sonar-In-A-Biscuit]);
+		visit_url("place.php?whichplace=bathole"); // ensure quest status is updated.
 		return true;
 	}
 
@@ -10410,6 +10442,10 @@ boolean L4_batCave()
 		bat_formWolf();
 		addToMaximize("10meat");
 		int batskinBelt = item_amount($item[Batskin Belt]);
+		if (isActuallyEd())
+		{
+			auto_change_mcd(4); // get the pants from the Boss Bat.
+		}
 		autoAdv(1, $location[The Boss Bat\'s Lair]);
 		# DIGIMON remove once mafia tracks this
 		if(item_amount($item[Batskin Belt]) != batskinBelt)
@@ -12324,10 +12360,6 @@ boolean L9_aBooPeak()
 				}
 			}
 			acquireHP();
-			if (isActuallyEd() && my_hp() == 0)
-			{
-				use(1, $item[Linen Bandages]);
-			}
 			if ((my_hp() * 4) < my_maxhp() && item_amount($item[Scroll of Drastic Healing]) > 0 && (!isActuallyEd() || my_class() != $class[Vampyre]))
 			{
 				use(1, $item[Scroll of Drastic Healing]);
@@ -12342,7 +12374,7 @@ boolean L9_aBooPeak()
 		handleFamiliar("item");
 		handleBjornify(priorBjorn);
 	}
-	else if(get_property("auto_abooclover").to_boolean() && (get_property("booPeakProgress").to_int() >= 40) && booCloversOk)
+	else if(get_property("auto_abooclover").to_boolean() && (get_property("booPeakProgress").to_int() >= 30) && booCloversOk)
 	{
 		cloverUsageInit();
 		autoAdvBypass(296, $location[A-Boo Peak]);
@@ -12937,7 +12969,7 @@ boolean L9_chasmBuild()
 		buffMaintain($effect[Carol of the Bulls], 50, 1, 1);
 		buffMaintain($effect[Song of The North], 150, 1, 1);
 
-		auto_log_info("Beta Testing Off: If we encounter Blech House when we are not expecting it we will stop.", "blue");
+		auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
 		auto_log_info("Currently setup for Muscle/Weapon Damage, option 1: Kick it down", "blue");
 		set_property("choiceAdventure1345", 0);
 	}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2,7 +2,6 @@ script "auto_combat.ash"
 
 monster ocrs_helper(string page);
 void awol_helper(string page);
-string ccsJunkyard(int round, string opp, string text);
 string auto_edCombatHandler(int round, string opp, string text);
 string auto_combatHandler(int round, string opp, string text);
 
@@ -2219,42 +2218,33 @@ string findBanisher(int round, string opp, string text)
 		}
 		return banishAction;
 	}
-
-//	if(auto_have_skill($skill[Lunging Thrust-Smack]) && (my_mp() >= mp_cost($skill[Lunging Thrust-Smack])))
-//	{
-//		return "skill lunging thrust-smack";
-//	}
-	if(auto_have_skill($skill[Storm of the Scarab]) && (my_mp() >= mp_cost($skill[Storm of the Scarab])))
+	if (canUse($skill[Storm of the Scarab]))
 	{
-		return "skill Storm of the Scarab";
+		return useSkill($skill[Storm of the Scarab], false);
 	}
 	return auto_combatHandler(round, opp, text);
-//	if(auto_have_skill($skill[Lunge Smack]) && (my_mp() >= mp_cost($skill[Lunge Smack])) && (weapon_type(equipped_item($slot[weapon])) == $stat[Muscle]))
-//	{
-//		return "skill lunge smack";
-//	}
-//	return "attack with weapon";
 }
 
-string ccsJunkyard(int round, string opp, string text)
+string auto_Junkyard(int round, string opp, string text)
 {
 	monster enemy = to_monster(opp);
 
 	if(!($monsters[A.M.C. gremlin, batwinged gremlin, erudite gremlin, spider gremlin, vegetable gremlin] contains enemy))
 	{
+		if (isActuallyEd())
+		{
+			return auto_edCombatHandler(round, opp, text);
+		}
 		return auto_combatHandler(round, opp, text);
 	}
 
+	auto_log_info("auto_Junkyard: " + round, "brown");
 	if(round == 0)
 	{
-		auto_log_info("ccsJunkyard: " + round, "brown");
 		set_property("auto_gremlinMoly", true);
 		set_property("auto_combatHandler", "");
 	}
-	else
-	{
-		auto_log_info("auto_Junkyard: " + round, "brown");
-	}
+
 	string combatState = get_property("auto_combatHandler");
 	string edCombatState = get_property("auto_edCombatHandler");
 
@@ -2323,81 +2313,69 @@ string ccsJunkyard(int round, string opp, string text)
 
 	if(round >= 28)
 	{
-		if(auto_have_skill($skill[Lunging Thrust-Smack]) && (my_mp() >= 8))
+		if (canUse($skill[Storm of the Scarab]))
 		{
-			return "skill " + $skill[Lunging Thrust-Smack];
+			return useSkill($skill[Storm of the Scarab], false);
+		}
+		else if (canUse($skill[Lunging Thrust-Smack]))
+		{
+			return useSkill($skill[Lunging Thrust-Smack], false);
 		}
 		return "attack with weapon";
 	}
 
 	if(contains_text(text, "It whips out a hammer") || contains_text(text, "He whips out a crescent") || contains_text(text, "It whips out a pair") || contains_text(text, "It whips out a screwdriver"))
 	{
-		return "item " + $item[Molybdenum Magnet];
+		return useItem($item[Molybdenum Magnet]);
 	}
 
-	if(!contains_text(combatState, "weaksauce") && auto_have_skill($skill[Curse Of Weaksauce]) && (my_mp() >= mp_cost($skill[Curse Of Weaksauce])))
+	if (canUse($skill[Curse Of Weaksauce]))
 	{
-		set_property("auto_combatHandler", combatState + "(weaksauce)");
-		return "skill " + $skill[Curse Of Weaksauce];
+		return useSkill($skill[Curse Of Weaksauce]);
 	}
 
-	if(!contains_text(combatState, "marshmallow") && auto_have_skill($skill[Curse Of The Marshmallow]) && (my_mp() > mp_cost($skill[Curse Of The Marshmallow])))
+	if (canUse($skill[Curse Of The Marshmallow]))
 	{
-		set_property("auto_combatHandler", combatState + "(marshmallow)");
-		return "skill " + $skill[Curse Of The Marshmallow];
-	}
-	if(!contains_text(combatState, "love scarab") && auto_have_skill($skill[Summon Love Scarabs]))
-	{
-		set_property("auto_combatHandler", combatState + "(love scarab)");
-		return "skill " + $skill[Summon Love Scarabs];
-	}
-	if(!contains_text(combatState, "love gnats") && auto_have_skill($skill[Summon Love Gnats]))
-	{
-		set_property("auto_combatHandler", combatState + "(love gnats)");
-		return "skill " + $skill[Summon Love Gnats];
+		return useSkill($skill[Curse Of The Marshmallow]);
 	}
 
-	if(!contains_text(combatState, "badMedicine") && auto_have_skill($skill[Bad Medicine]) && (my_mp() >= mp_cost($skill[Bad Medicine])))
+	if (canUse($skill[Summon Love Scarabs]))
 	{
-		set_property("auto_combatHandler", combatState + "(badMedicine)");
-		return "skill " + $skill[Bad Medicine];
+		return useSkill($skill[Summon Love Scarabs]);
 	}
 
-	if(!contains_text(combatState, "goodMedicine") && auto_have_skill($skill[Good Medicine]) && (my_mp() >= mp_cost($skill[Good Medicine])) && canSurvive(2.1))
+	if (canUse($skill[Summon Love Gnats]))
 	{
-		set_property("auto_combatHandler", combatState + "(goodMedicine)");
-		return "skill " + $skill[Good Medicine];
+		return useSkill($skill[Summon Love Gnats]);
 	}
 
-	if (!get_property("auto_gremlinMoly").to_boolean() && isActuallyEd())
+	if(canUse($skill[Bad Medicine]))
 	{
-		if (get_property("_edDefeats").to_int() >= 2 || get_property("auto_edStatus") == "dying")
+		return useSkill($skill[Bad Medicine]);
+	}
+
+	if(canUse($skill[Good Medicine]) && canSurvive(2.1))
+	{
+		return useSkill($skill[Good Medicine]);
+	}
+
+	if (my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
+	{
+		if (canUse($item[Rock Band Flyers]) && get_property("flyeredML").to_int() < 10000)
 		{
-			string banisher = findBanisher(round, opp, text);
-			if(banisher != "attack with weapon")
+			if (isActuallyEd())
 			{
-				return banisher;
+				set_property("auto_edStatus", "UNDYING!");
 			}
-			else if((my_mp() >= 8) && auto_have_skill($skill[Storm Of The Scarab]))
+			return useItem($item[Rock Band Flyers]);
+		}
+		if(canUse($item[Jam Band Flyers]) && get_property("flyeredML").to_int() < 10000)
+		{
+			if (isActuallyEd())
 			{
-				return "skill " + $skill[Storm Of The Scarab];
+				set_property("auto_edStatus", "UNDYING!");
 			}
-			return banisher;
-		}
-	}
-
-
-	if(!contains_text(combatState, "flyers") && (my_location() != $location[The Battlefield (Frat Uniform)]) && (my_location() != $location[The Battlefield (Hippy Uniform)]) && !get_property("auto_ignoreFlyer").to_boolean())
-	{
-		if((item_amount($item[Rock Band Flyers]) > 0) && (get_property("flyeredML").to_int() < 10000))
-		{
-			set_property("auto_combatHandler", combatState + "(flyers)");
-			return "item " + $item[Rock Band Flyers];
-		}
-		if((item_amount($item[Jam Band Flyers]) > 0) && (get_property("flyeredML").to_int() < 10000))
-		{
-			set_property("auto_combatHandler", combatState + "(flyers)");
-			return "item " + $item[Jam Band Flyers];
+			return useItem($item[Jam Band Flyers]);
 		}
 	}
 
@@ -2405,13 +2383,13 @@ string ccsJunkyard(int round, string opp, string text)
 	{
 		if (isActuallyEd())
 		{
-			if (get_property("_edDefeats").to_int() >= 2 || get_property("auto_edStatus") == "dying")
+			if (get_property("_edDefeats").to_int() >= 2)
 			{
 				return findBanisher(round, opp, text);
 			}
-			else if(item_amount($item[Seal Tooth]) > 0)
+			else if (canUse($item[Seal Tooth]) && get_property("auto_edStatus") == "UNDYING!")
 			{
-				return "item " + $item[Seal Tooth];
+				return useItem($item[Seal Tooth], false);
 			}
 		}
 		else
@@ -2420,29 +2398,17 @@ string ccsJunkyard(int round, string opp, string text)
 		}
 	}
 
-
-	if(!get_property("auto_gremlinMoly").to_boolean())
-	{
-		foreach sk in $skills[Lunging Thrust-Smack, Storm Of The Scarab, Lunge Smack]
-		{
-			if(auto_have_skill(sk) && (my_mp() >= mp_cost(sk)))
-			{
-				return "skill " + sk;
-			}
-		}
-		return "attack with weapon";
-	}
-
 	foreach it in $items[Seal Tooth, Spectre Scepter, Doc Galaktik\'s Pungent Unguent]
 	{
-		if((item_amount(it) > 0) && glover_usable(it))
+		if(canUse(it) && glover_usable(it))
 		{
-			return "item " + it;
+			return useItem(it, false);
 		}
 	}
-	if(auto_have_skill($skill[Toss]) && (my_mp() >= mp_cost($skill[Toss])))
+
+	if (canUse($skill[Toss]))
 	{
-		return "skill " + $skill[Toss];
+		return useSkill($skill[Toss], false);
 	}
 	return "attack with weapon";
 }
@@ -2489,7 +2455,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 			{
 				if (canUse(it))
 				{
-					return useItem(it);
+					return useItem(it, false);
 				}
 			}
 		}
@@ -2524,51 +2490,44 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return "attack with weapon";
 	}
 
-	if(!contains_text(combatState, "pocket crumbs") && auto_have_skill($skill[Pocket Crumbs]))
+	if (canUse($skill[Pocket Crumbs]))
 	{
-		set_property("auto_combatHandler", combatState + "(pocket crumbs)");
-		return "skill " + $skill[Pocket Crumbs];
+		return useSkill($skill[Pocket Crumbs]);
 	}
 
-	if(!contains_text(combatState, "micrometeorite") && auto_have_skill($skill[Micrometeorite]))
+	if (canUse($skill[Micrometeorite]))
 	{
-		set_property("auto_combatHandler", combatState + "(micrometeorite)");
-		return "skill " + $skill[Micrometeorite];
+		return useSkill($skill[Micrometeorite]);
 	}
 
-	if(!contains_text(combatState, "air dirty laundry") && auto_have_skill($skill[Air Dirty Laundry]))
+	if (canUse($skill[Air Dirty Laundry]))
 	{
-		set_property("auto_combatHandler", combatState + "(air dirty laundry)");
-		return "skill " + $skill[Air Dirty Laundry];
+		return useSkill($skill[Air Dirty Laundry]);
 	}
 
-	if(!contains_text(combatState, "love scarab") && auto_have_skill($skill[Summon Love Scarabs]))
+	if (canUse($skill[Summon Love Scarabs]))
 	{
-		set_property("auto_combatHandler", combatState + "(love scarab)");
-		return "skill " + $skill[Summon Love Scarabs];
+		return useSkill($skill[Summon Love Scarabs]);
 	}
 
-	if(!contains_text(combatState, "(time-spinner)") && (item_amount($item[Time-Spinner]) > 0))
+	if (canUse($item[Time-Spinner]))
 	{
-		set_property("auto_combatHandler", combatState + "(time-spinner)");
-		return "item " + $item[Time-Spinner];
+		return useItem($item[Time-Spinner]);
 	}
 
-	if(!contains_text(combatState, "(sing along)") && auto_have_skill($skill[Sing Along]) && (my_mp() > (mp_cost($skill[Sing Along]))))
+	if (canUse($skill[Sing Along]))
 	{
 		if((get_property("boomBoxSong") == "Remainin\' Alive") || ((get_property("boomBoxSong") == "Total Eclipse of Your Meat") && canSurvive(2.0)))
 		{
-			set_property("auto_combatHandler", combatState + "(sing along)");
-			return "skill " + $skill[Sing Along];
+			return useSkill($skill[Sing Along]);
 		}
 	}
 
 	if(have_equipped($item[Protonic Accelerator Pack]) && isGhost(enemy))
 	{
-		if(!contains_text(combatState, "love gnats") && auto_have_skill($skill[Summon Love Gnats]))
+		if(canUse($skill[Summon Love Gnats]))
 		{
-			set_property("auto_combatHandler", combatState + "(love gnats)");
-			return "skill " + $skill[Summon Love Gnats];
+			return useSkill($skill[Summon Love Gnats]);
 		}
 
 		if(auto_have_skill($skill[Shoot Ghost]) && (my_mp() > mp_cost($skill[Shoot Ghost])) && !contains_text(edCombatState, "shootghost3") && !contains_text(edCombatState, "trapghost"))
@@ -2660,19 +2619,14 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if(get_property("auto_edStatus") == "UNDYING!")
 	{
-		if(!contains_text(combatState, "love gnats") && auto_have_skill($skill[Summon Love Gnats]))
+		if (canUse($skill[Summon Love Gnats]))
 		{
-			set_property("auto_combatHandler", combatState + "(love gnats)");
-			return "skill " + $skill[Summon Love Gnats];
+			return useSkill($skill[Summon Love Gnats]);
 		}
 
-		if((item_amount($item[Ka Coin]) > 200) && auto_have_skill($skill[Curse of Fortune]))
+		if (item_amount($item[Ka Coin]) > 200 && canUse($skill[Curse of Fortune]))
 		{
-			if(!contains_text(combatState, "curse of fortune"))
-			{
-				set_property("auto_combatHandler", combatState + "(curse of fortune)");
-				return "skill " + $skill[Curse of Fortune];
-			}
+			return useSkill($skill[Curse of Fortune]);
 		}
 	}
 	else if(get_property("auto_edStatus") == "dying")
@@ -2686,10 +2640,9 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 		if(doStunner)
 		{
-			if(!contains_text(combatState, "love gnats") && auto_have_skill($skill[Summon Love Gnats]))
+			if (canUse($skill[Summon Love Gnats]))
 			{
-				set_property("auto_combatHandler", combatState + "(love gnats)");
-				return "skill " + $skill[Summon Love Gnats];
+				return useSkill($skill[Summon Love Gnats]);
 			}
 		}
 	}
@@ -2698,11 +2651,9 @@ string auto_edCombatHandler(int round, string opp, string text)
 		auto_log_warning("Ed combat state does not exist, winging it....", "red");
 	}
 
-
-	if(!contains_text(combatState, "sewage pistol") && auto_have_skill($skill[Fire Sewage Pistol]))
+	if (canUse($skill[Fire Sewage Pistol]))
 	{
-		set_property("auto_combatHandler", combatState + "(sewage pistol)");
-		return "skill " + $skill[Fire Sewage Pistol];
+		return useSkill($skill[Fire Sewage Pistol]);
 	}
 
 	if(enemy == $monster[Protagonist])
@@ -2710,13 +2661,11 @@ string auto_edCombatHandler(int round, string opp, string text)
 		set_property("auto_edStatus", "dying");
 	}
 
-
-	if(!contains_text(combatState, "flyers") && (my_location() != $location[The Battlefield (Frat Uniform)]) && (my_location() != $location[The Battlefield (Hippy Uniform)]) && !get_property("auto_ignoreFlyer").to_boolean())
+	if (my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
 	{
 		if (canUse($item[Rock Band Flyers]) && get_property("flyeredML").to_int() < 10000)
 		{
-			set_property("auto_combatHandler", combatState + "(flyers)");
-			if (get_property("_edDefeats").to_int() < 3 && get_property("auto_edStatus") == "dying")
+			if (get_property("_edDefeats").to_int() < 2 && get_property("auto_edStatus") == "dying")
 			{
 				set_property("auto_edStatus", "UNDYING!");
 				// abuse the ability to flyer the same monster multiple times (optimal!)
@@ -2725,8 +2674,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 		if (canUse($item[Jam Band Flyers]) && get_property("flyeredML").to_int() < 10000)
 		{
-			set_property("auto_combatHandler", combatState + "(flyers)");
-			if (get_property("_edDefeats").to_int() < 3 && get_property("auto_edStatus") == "dying")
+			if (get_property("_edDefeats").to_int() < 2 && get_property("auto_edStatus") == "dying")
 			{
 				set_property("auto_edStatus", "UNDYING!");
 				// abuse the ability to flyer the same monster multiple times (optimal!)
@@ -2737,27 +2685,27 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if((enemy == $monster[dirty thieving brigand]) && !contains_text(edCombatState, "curse of fortune"))
 	{
-		if((item_amount($item[Ka Coin]) > 0) && (auto_have_skill($skill[Curse Of Fortune])))
+		if (item_amount($item[Ka Coin]) > 0 && canUse($skill[Curse Of Fortune]))
 		{
 			set_property("auto_edCombatHandler", edCombatState + "(curse of fortune)");
 			set_property("auto_edStatus", "dying");
-			return "skill " + $skill[Curse Of Fortune];
+			return useSkill($skill[Curse Of Fortune]);
 		}
 	}
 
-	if (!contains_text(edCombatState, "curseofstench") && auto_have_skill($skill[Curse Of Stench]) && my_mp() >= mp_cost($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+	if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
 	{
 		if(auto_wantToSniff(enemy, my_location()))
 		{
 			set_property("auto_edCombatHandler", combatState + "(curseofstench)");
 			handleTracker(enemy, $skill[Curse Of Stench], "auto_sniffs");
-			return "skill " + $skill[Curse Of Stench];
+			return useSkill($skill[Curse Of Stench]);
 		}
 	}
 
 	if(my_location() == $location[The Secret Council Warehouse])
 	{
-		if (!contains_text(edCombatState, "curseofstench") && auto_have_skill($skill[Curse Of Stench]) && my_mp() >= mp_cost($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
 		{
 			boolean doStench = false;
 			#	Rememeber, we are looking to see if we have enough of the opposite item here.
@@ -2784,15 +2732,14 @@ string auto_edCombatHandler(int round, string opp, string text)
 			{
 				set_property("auto_edCombatHandler", combatState + "(curseofstench)");
 				handleTracker(enemy, $skill[Curse of Stench], "auto_sniffs");
-				return "skill " + $skill[Curse Of Stench];
+				return useSkill($skill[Curse Of Stench]);
 			}
 		}
 	}
 
-
 	if(my_location() == $location[The Smut Orc Logging Camp])
 	{
-		if (!contains_text(edCombatState, "curseofstench") && auto_have_skill($skill[Curse Of Stench]) && my_mp() >= mp_cost($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
 		{
 			boolean doStench = false;
 			string stenched = to_lower_case(get_property("stenchCursedMonster"));
@@ -2818,12 +2765,12 @@ string auto_edCombatHandler(int round, string opp, string text)
 			{
 				set_property("auto_edCombatHandler", combatState + "(curseofstench)");
 				handleTracker(enemy, $skill[Curse of Stench], "auto_sniffs");
-				return "skill " + $skill[Curse Of Stench];
+				return useSkill($skill[Curse Of Stench]);
 			}
 		}
 	}
 
-	if(!contains_text(combatState, "yellowray") && auto_wantToYellowRay(enemy, my_location()))
+	if (!contains_text(combatState, "yellowray") && canYellowRay(enemy) && auto_wantToYellowRay(enemy, my_location()))
 	{
 		string combatAction = yellowRayCombatString(enemy, true);
 		if(combatAction != "")
@@ -2853,19 +2800,17 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if (auto_have_skill($skill[Curse Of Vacation]) && my_mp() >= mp_cost($skill[Curse Of Vacation]) && get_property("auto_edStatus") == "dying")
+	if (canUse($skill[Curse Of Vacation]) && get_property("auto_edStatus") == "dying")
 	{
 		if (auto_wantToBanish(enemy, my_location()) && !(auto_banishesUsedAt(my_location()) contains "curse of vacation"))
 		{
-			set_property("auto_combatHandler", combatState + "(curse of vacation)");
 			handleTracker(enemy, $skill[Curse of Vacation], "auto_banishes");
-			return "skill " + $skill[Curse Of Vacation];
+			return useSkill($skill[Curse Of Vacation]);
 		}
 	}
 
 	if (canUse($item[Disposable Instant Camera]) && $monsters[Bob Racecar, Racecar Bob] contains enemy)
 	{
-		set_property("auto_combatHandler", combatState + "(disposable instant camera)");
 		return useItem($item[Disposable Instant Camera]);
 	}
 
@@ -2899,7 +2844,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if (!get_property("edUsedLash").to_boolean() && auto_have_skill($skill[Lash of the Cobra]) && my_mp() >= mp_cost($skill[Lash of the Cobra]))
+	if (!get_property("edUsedLash").to_boolean() && canUse($skill[Lash of the Cobra]) && get_property("_edLashCount").to_int() < 30)
 	{
 		boolean doLash = false;
 
@@ -3041,19 +2986,18 @@ string auto_edCombatHandler(int round, string opp, string text)
 			doLash = true;
 		}
 
-		if (doLash && get_property("_edLashCount").to_int() < 30)
+		if (doLash)
 		{
 			handleTracker(enemy, "auto_lashes");
-			return "skill " + $skill[Lash Of The Cobra];
+			return useSkill($skill[Lash Of The Cobra]);
 		}
 	}
 
-	if(canUse($item[Tattered Scrap of Paper]) && !contains_text(combatState, "tatters"))
+	if (canUse($item[Tattered Scrap of Paper]))
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
-			set_property("auto_combatHandler", combatState + "(tatters)");
-			return useItem($item[Tattered Scrap Of Paper]);
+			return useItem($item[Tattered Scrap Of Paper], false);
 		}
 	}
 
@@ -3100,10 +3044,10 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 		if(doRenenutet)
 		{
-			if(!contains_text(edCombatState, "curseofindecision") && auto_have_skill($skill[Curse Of Indecision]) && (my_mp() > mp_cost($skill[Curse Of Indecision])))
+			if (!contains_text(edCombatState, "curseofindecision") && canUse($skill[Curse Of Indecision]))
 			{
 				set_property("auto_edCombatHandler", edCombatState + "(curseofindecision)");
-				return "skill " + $skill[Curse Of Indecision];
+				return useSkill($skill[Curse Of Indecision]);
 			}
 			set_property("auto_edCombatHandler", edCombatState + "(talismanofrenenutet)");
 			handleTracker(enemy, "auto_renenutet");
@@ -3131,40 +3075,36 @@ string auto_edCombatHandler(int round, string opp, string text)
 			}
 		}
 
-		if((item_amount($item[Ka Coin]) > 200) && auto_have_skill($skill[Curse of Fortune]))
+		if (item_amount($item[Ka Coin]) > 200 && canUse($skill[Curse of Fortune]))
 		{
-			if(!contains_text(combatState, "curse of fortune"))
-			{
-				set_property("auto_combatHandler", combatState + "(curse of fortune)");
-				return "skill " + $skill[Curse of Fortune];
-			}
+			return useSkill($skill[Curse of Fortune]);
 		}
 
-		if(item_amount($item[Seal Tooth]) > 0)
+		if (canUse($item[Seal Tooth]))
 		{
-			return "item " + $item[Seal Tooth];
+			return useItem($item[Seal Tooth], false);
 		}
 
-		return "skill " + $skill[Mild Curse];
+		return useSkill($skill[Mild Curse], false);
 	}
 
-	if((my_mp() >= mp_cost($skill[Roar of the Lion])) && (my_location() == $location[The Secret Government Laboratory]) && auto_have_skill($skill[Roar of the Lion]))
+	if (my_location() == $location[The Secret Government Laboratory] && canUse($skill[Roar of the Lion]))
 	{
-		if(auto_have_skill($skill[Storm Of The Scarab]) && (my_buffedstat($stat[Mysticality]) >= 60))
+		if (canUse($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) >= 60)
 		{
-			return "skill " + $skill[Storm Of The Scarab];
+			return useSkill($skill[Storm Of The Scarab], false);
 		}
-		return "skill " + $skill[Roar Of The Lion];
+		return useSkill($skill[Roar Of The Lion], false);
 	}
 
-	if((my_mp() >= mp_cost($skill[Storm Of The Scarab])) && ($locations[Pirates of the Garbage Barges, The SMOOCH Army HQ, VYKEA] contains my_location()) && auto_have_skill($skill[Storm of the Scarab]))
+	if ($locations[Pirates of the Garbage Barges, The SMOOCH Army HQ, VYKEA] contains my_location() && canUse($skill[Storm of the Scarab]))
 	{
-		return "skill " + $skill[Storm Of The Scarab];
+		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
-	if (my_mp() >= mp_cost($skill[Fist Of The Mummy]) && $locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location() && auto_have_skill($skill[Fist Of The Mummy]))
+	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location() && canUse($skill[Fist Of The Mummy]))
 	{
-		return "skill " + $skill[Fist Of The Mummy];
+		return useSkill($skill[Fist Of The Mummy], false);
 	}
 
 	int fightStat = my_buffedstat(weapon_type(equipped_item($slot[weapon]))) - 20;
@@ -3173,27 +3113,26 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return "attack with weapon";
 	}
 
-	if(!contains_text(combatState, "cowboy kick") && auto_have_skill($skill[Cowboy Kick]))
+	if (canUse($skill[Cowboy Kick]))
 	{
-		set_property("auto_combatHandler", combatState + "(cowboy kick)");
-		return "skill " + $skill[Cowboy Kick];
+		return useSkill($skill[Cowboy Kick]);
 	}
 
-	if((item_amount($item[Ice-Cold Cloaca Zero]) > 0) && (my_mp() < 15) && (my_maxmp() > 200))
+	if (canUse($item[Ice-Cold Cloaca Zero]) && my_mp() < 15 && my_maxmp() > 200)
 	{
-		return "item " + $item[Ice-Cold Cloaca Zero];
+		return useItem($item[Ice-Cold Cloaca Zero]);
 	}
 
-	if(my_mp() >= mp_cost($skill[Storm Of The Scarab]) && auto_have_skill($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) > 35)
+	if (canUse($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) > 35)
 	{
-		return "skill " + $skill[Storm Of The Scarab];
+		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
 	if((enemy.physical_resistance >= 100) || (round >= 25) || canSurvive(1.25))
 	{
-		if(my_mp() >= mp_cost($skill[Fist Of The Mummy]) && auto_have_skill($skill[Fist Of The Mummy]))
+		if (canUse($skill[Fist Of The Mummy]))
 		{
-			return "skill " + $skill[Fist Of The Mummy];
+			return useSkill($skill[Fist Of The Mummy], false);
 		}
 	}
 
@@ -3201,9 +3140,9 @@ string auto_edCombatHandler(int round, string opp, string text)
 	{
 		foreach it in $items[Holy Spring Water, Spirit Beer, Sacramental Wine]
 		{
-			if(item_amount(it) > 0)
+			if(canUse(it))
 			{
-				return "item " + it;
+				return useItem(it, false);
 			}
 		}
 	}
@@ -3219,7 +3158,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return "attack with weapon";
 	}
 
-	return "skill " + $skill[Mild Curse];
+	return useSkill($skill[Mild Curse], false);
 }
 
 string auto_saberTrickMeteorShowerCombatHandler(int round, string opp, string text){

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2225,7 +2225,7 @@ string findBanisher(int round, string opp, string text)
 	return auto_combatHandler(round, opp, text);
 }
 
-string auto_Junkyard(int round, string opp, string text)
+string auto_JunkyardCombatHandler(int round, string opp, string text)
 {
 	monster enemy = to_monster(opp);
 
@@ -2238,7 +2238,7 @@ string auto_Junkyard(int round, string opp, string text)
 		return auto_combatHandler(round, opp, text);
 	}
 
-	auto_log_info("auto_Junkyard: " + round, "brown");
+	auto_log_info("auto_JunkyardCombatHandler: " + round, "brown");
 	if(round == 0)
 	{
 		set_property("auto_gremlinMoly", true);

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -1770,11 +1770,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	if(towerKeyCount() < 3)
 	{
-		if(item_amount($item[Boris's key]) == 0 && item_amount($item[fat loot token]) < 3)
+		if(item_amount($item[Boris\'s key]) == 0 && item_amount($item[fat loot token]) < 3)
 			wantBorisPie = true;
-		if(item_amount($item[Jarlsberg's key]) == 0 && item_amount($item[fat loot token]) < 2)
+		if(item_amount($item[Jarlsberg\'s key]) == 0 && item_amount($item[fat loot token]) < 2)
 			wantJarlsbergPie = true;
-		if(item_amount($item[Sneaky Pete's key]) == 0 && item_amount($item[fat loot token]) < 1)
+		if(item_amount($item[Sneaky Pete\'s key]) == 0 && item_amount($item[fat loot token]) < 1)
 			wantPetePie = true;
 	}
 
@@ -1795,9 +1795,9 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 				actions[n].desirability += min(1.0, item_amount($item[special seasoning]).to_float() * it.fullness / fullness_left());
 			}
 			if ((obtain_mode == SL_OBTAIN_PULL) && (i == 0) &&
-					((it == $item[Boris's key lime pie] && wantBorisPie) ||
-					(it == $item[Jarlsberg's key lime pie] && wantJarlsbergPie) ||
-					(it == $item[Sneaky Pete's key lime pie] && wantPetePie)))
+					((it == $item[Boris\'s key lime pie] && wantBorisPie) ||
+					(it == $item[Jarlsberg\'s key lime pie] && wantJarlsbergPie) ||
+					(it == $item[Sneaky Pete\'s key lime pie] && wantPetePie)))
 			{
 				auto_log_info("If we pulled and ate a " + it + " we could skip getting a fat loot token...");
 				actions[n].desirability += 25;

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -283,62 +283,6 @@ boolean L13_ed_councilWarehouse()
 	return true;
 }
 
-boolean adjustEdHat(string goal)
-{
-	if(!possessEquipment($item[The Crown of Ed the Undying]))
-	{
-		return false;
-	}
-	int option = -1;
-	goal = to_lower_case(goal);
-	if(((goal == "muscle") || (goal == "bear")) && (get_property("edPiece") != "bear"))
-	{
-		option = 1;
-	}
-	else if(((goal == "myst") || (goal == "mysticality") || (goal == "owl")) && (get_property("edPiece") != "owl"))
-	{
-		option = 2;
-	}
-	else if(((goal == "moxie") || (goal == "puma")) && (get_property("edPiece") != "puma"))
-	{
-		option = 3;
-	}
-	else if(((goal == "ml") || (goal == "hyena")) && (get_property("edPiece") != "hyena"))
-	{
-		option = 4;
-	}
-	else if(((goal == "meat") || (goal == "item") || (goal == "items") || (goal == "drops") || (goal == "mouse")) && (get_property("edPiece") != "mouse"))
-	{
-		option = 5;
-	}
-	else if(((goal == "regen") || (goal == "regenerate") || (goal == "miss") || (goal == "dodge") || (goal == "weasel")) && (get_property("edPiece") != "weasel"))
-	{
-		option = 6;
-	}
-	else if(((goal == "breathe") || (goal == "underwater") || (goal == "fish")) && (get_property("edPiece") != "fish"))
-	{
-		option = 7;
-	}
-
-	item oldHat = equipped_item($slot[hat]);
-
-	if(option != -1)
-	{
-		if(oldHat != $item[The Crown of Ed the Undying])
-		{
-			equip($slot[hat], $item[The Crown of Ed the Undying]);
-		}
-		visit_url("inventory.php?action=activateedhat");
-		visit_url("choice.php?pwd=&whichchoice=1063&option=" + option, true);
-		if(oldHat != $item[The Crown of Ed the Undying])
-		{
-			equip($slot[hat], oldHat);
-		}
-		return true;
-	}
-	return false;
-}
-
 boolean handleServant(servant who)
 {
 	if (!isActuallyEd())
@@ -692,76 +636,46 @@ boolean ed_eatStuff()
 	{
 		return false;
 	}
-	int canEat = (spleen_limit() - my_spleen_use()) / 5;
-	canEat = min(canEat, item_amount($item[Mummified Beef Haunch]));
-	if(canEat > 0)
+
+	// fill up on Mummified Beef Haunches as they are Ed's main source of turn-gen
+	int canEat = min((spleen_left() / 5), item_amount($item[Mummified Beef Haunch]));
+	if (canEat > 0)
 	{
 		autoChew(canEat, $item[Mummified Beef Haunch]);
 	}
-	xiblaxian_makeStuff();
 
-	if((item_amount($item[Limp Broccoli]) > 0) && (my_level() >= 5) && ((my_fullness() == 0) || (my_fullness() == 3)) && (fullness_limit() >= 2))
-	{
-		autoEat(1, $item[Limp Broccoli]);
-	}
-	if((item_amount($item[Limp Broccoli]) > 0) && (my_level() >= 5) && (my_fullness() == 2) && (fullness_limit() >= 5) && (item_amount($item[Astral Hot Dog]) == 0))
-	{
-		autoEat(1, $item[Limp Broccoli]);
-	}
-	if((item_amount($item[Xiblaxian Ultraburrito]) > 0) && (my_fullness() == 0) && (fullness_limit() >= 4) && (item_amount($item[Astral Hot Dog]) == 0))
-	{
-		autoEat(1, $item[Xiblaxian Ultraburrito]);
-	}
-	if((my_level() >= 11) && ((my_fullness() + 3) <= fullness_limit()) && (item_amount($item[Astral Hot Dog]) > 0))
-	{
-		autoEat(1, $item[Astral Hot Dog]);
-	}
-	if((my_level() >= 9) && ((my_fullness() + 3) <= fullness_limit()) && (item_amount($item[Astral Hot Dog]) > 0) && (my_adventures() < 4))
-	{
-		autoEat(1, $item[Astral Hot Dog]);
-	}
-	if(!get_property("_fancyHotDogEaten").to_boolean() && (my_daycount() == 1) && (my_level() >= 9) && ((my_fullness() + 3) <= fullness_limit()) && (item_amount($item[Astral Hot Dog]) == 0) && (my_adventures() < 10) && (item_amount($item[Clan VIP Lounge Key]) > 0))
-	{
-		eatFancyDog("video games hot dog");
-	}
-	if(get_property("auto_dickstab").to_boolean() && !get_property("_fancyHotDogEaten").to_boolean() && (my_daycount() == 1) && ((my_fullness() + 2) <= fullness_limit()) && (item_amount($item[Astral Hot Dog]) == 0) && (item_amount($item[Clan VIP Lounge Key]) > 0) && chateaumantegna_available())
-	{
-		eatFancyDog("sleeping dog");
-	}
-	if((my_daycount() >= 3) && (my_inebriety() == 0) && (inebriety_limit() == 4) && (item_amount($item[Xiblaxian Space-Whiskey]) > 0) && (my_adventures() < 10))
-	{
-		autoDrink(1, $item[Xiblaxian Space-Whiskey]);
-	}
-	if((item_amount($item[Astral Pilsner]) > 0) && ((my_inebriety() + 1) <= inebriety_limit()) && (my_level() >= 11))
-	{
-		autoDrink(1, $item[Astral Pilsner]);
-	}
-	if((item_amount($item[Astral Pilsner]) > 0) && ((my_inebriety() + 1) <= inebriety_limit()) && (my_level() >= 10) && (my_adventures() < 3))
-	{
-		autoDrink(1, $item[Astral Pilsner]);
-	}
-	if((item_amount($item[Astral Pilsner]) > 0) && ((my_inebriety() + 1) <= inebriety_limit()) && (my_level() >= 9) && (my_adventures() < 3) && (my_fullness() >= fullness_limit()))
-	{
-		autoDrink(1, $item[Astral Pilsner]);
-	}
-	if((item_amount($item[Coinspiracy]) >= 6) && ((my_inebriety() + 3) <= inebriety_limit()) && (my_adventures() < 3) && (item_amount($item[Astral Pilsner]) == 0))
-	{
-		buyUpTo(1, $item[Highest Bitter]);
-		autoDrink(1, $item[Highest Bitter]);
-	}
+	// ideally, we should only need the above in this function as the code below 
+	// should be handled by consumeStuff();
 
+	// expose semi-rare counters
 	if (!contains_text(get_counters("Fortune Cookie", 0, 200), "Fortune Cookie"))
 	{
-		if((item_amount($item[Clan VIP Lounge Key]) > 0) && (my_meat() >= 500) && (inebriety_limit() == 4) && ((my_inebriety() == 0) || (my_inebriety() == 3)) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]))
+		boolean shouldEatCookie = (my_meat() >= npc_price($item[Fortune Cookie]) && fullness_left() > 0 && my_level() < 12);
+		if (inebriety_left() > 0)
 		{
-			autoDrink(1, $item[Lucky Lindy]);
+			shouldEatCookie = (shouldEatCookie && !autoDrink(1, $item[Lucky Lindy]));
 		}
-		else if (my_meat() >= npc_price($item[Fortune Cookie]) && fullness_left() > 0 && my_level() < 12)
+		if (shouldEatCookie)
 		{
 			buyUpTo(1, $item[Fortune Cookie], npc_price($item[Fortune Cookie]));
 			autoEat(1, $item[Fortune Cookie]);
 		}
 	}
+
+	// use knapsack algorithm implementation to fill stomach and liver
+	// once we have less than 3 adventures left and a full spleen (and all spleen upgrades)
+	if (spleen_limit() == 35 && spleen_left() == 0 && my_adventures() < 3)
+	{
+		if (fullness_left() > 0)
+		{
+			return auto_knapsackAutoConsume("eat", false);
+		}
+		if (inebriety_left() > 0)
+		{
+			return auto_knapsackAutoConsume("drink", false);
+		}
+	}
+
 	return true;
 }
 
@@ -865,27 +779,27 @@ int ed_KaCost(skill upgrade)
 {
 	static int[skill] kaNeeded = {
 		$skill[Extra Spleen]: 5,
-   	$skill[Another Extra Spleen]: 10,
+		$skill[Another Extra Spleen]: 10,
 		$skill[Upgraded Legs]: 10,
 		$skill[Tougher Skin]: 10,
 		$skill[Armor Plating]: 10,
- 		$skill[Healing Scarabs]: 10,
- 		$skill[Elemental Wards]: 10,
- 		$skill[Yet Another Extra Spleen]: 15,
- 		$skill[Still Another Extra Spleen]: 20,
- 		$skill[More Legs]: 20,
+		$skill[Healing Scarabs]: 10,
+		$skill[Elemental Wards]: 10,
+		$skill[Yet Another Extra Spleen]: 15,
+		$skill[Still Another Extra Spleen]: 20,
+		$skill[More Legs]: 20,
 		$skill[Upgraded Arms]: 20,
- 		$skill[Upgraded Spine]: 20,
- 		$skill[Bone Spikes]: 20,
- 		$skill[Arm Blade]: 20,
- 		$skill[More Elemental Wards]: 20,
- 		$skill[Just One More Extra Spleen]: 25,
- 		$skill[Replacement Stomach]: 30,
- 		$skill[Replacement Liver]: 30,
+		$skill[Upgraded Spine]: 20,
+		$skill[Bone Spikes]: 20,
+		$skill[Arm Blade]: 20,
+		$skill[More Elemental Wards]: 20,
+		$skill[Just One More Extra Spleen]: 25,
+		$skill[Replacement Stomach]: 30,
+		$skill[Replacement Liver]: 30,
 		$skill[Okay Seriously, This is the Last Spleen]: 30,
- 		$skill[Even More Elemental Wards]: 30
-		};
-  if (kaNeeded contains upgrade)
+		$skill[Even More Elemental Wards]: 30
+	};
+	if (kaNeeded contains upgrade)
 	{
 		return kaNeeded[upgrade];
 	} else {
@@ -977,28 +891,28 @@ boolean ed_shopping()
 	int ed_skillID(skill upgrade)
 	{
 		static int[skill] skillIDs = {
-  		$skill[Replacement Stomach]: 28,
-  		$skill[Replacement Liver]: 29,
-  		$skill[Extra Spleen]: 30,
-  		$skill[Another Extra Spleen]: 31,
-  		$skill[Yet Another Extra Spleen]: 32,
-  		$skill[Still Another Extra Spleen]: 33,
-  		$skill[Just One More Extra Spleen]: 34,
+			$skill[Replacement Stomach]: 28,
+			$skill[Replacement Liver]: 29,
+			$skill[Extra Spleen]: 30,
+			$skill[Another Extra Spleen]: 31,
+			$skill[Yet Another Extra Spleen]: 32,
+			$skill[Still Another Extra Spleen]: 33,
+			$skill[Just One More Extra Spleen]: 34,
 			$skill[Okay Seriously, This is the Last Spleen]: 35,
-  		$skill[Upgraded Legs]: 36,
+			$skill[Upgraded Legs]: 36,
 			$skill[Upgraded Arms]: 37,
-  		$skill[Upgraded Spine]: 38,
+			$skill[Upgraded Spine]: 38,
 			$skill[Tougher Skin]:  39,
 			$skill[Armor Plating]: 40,
-  		$skill[Bone Spikes]: 41,
-  		$skill[Arm Blade]: 42,
-  		$skill[Healing Scarabs]: 43,
-  		$skill[Elemental Wards]: 44,
-  		$skill[More Elemental Wards]: 45,
-  		$skill[Even More Elemental Wards]: 46,
-  		$skill[More Legs]: 48
-			};
-  	if (skillIDs contains upgrade)
+			$skill[Bone Spikes]: 41,
+			$skill[Arm Blade]: 42,
+			$skill[Healing Scarabs]: 43,
+			$skill[Elemental Wards]: 44,
+			$skill[More Elemental Wards]: 45,
+			$skill[Even More Elemental Wards]: 46,
+			$skill[More Legs]: 48
+		};
+		if (skillIDs contains upgrade)
 		{
 			return skillIDs[upgrade];
 		} else {
@@ -1006,10 +920,6 @@ boolean ed_shopping()
 		}
 	}
 
-	if (!isActuallyEd())
-	{
-		return false;
-	}
 	auto_log_info("Time to shop!", "red");
 	wait(1);
 	visit_url("choice.php?pwd=&whichchoice=1023&option=1", true);
@@ -1133,6 +1043,11 @@ boolean ed_shopping()
 
 void ed_handleAdventureServant(location loc)
 {
+	if (loc == $location[Noob Cave])
+	{
+		return;
+	}
+	
 	// the order servants are unlocked is
 	// level 3 - Priest (extra Ka)
 	// level 6 - Cat (item drops)
@@ -1167,7 +1082,7 @@ void ed_handleAdventureServant(location loc)
 	}
 
 	// Locations where item drop is required for quest furthering purposes but we don't want to miss out on Ka if needed.
-	if ($locations[The eXtreme Slope, The Batrat and Ratbat Burrow, Cobb's Knob Harem, Twin Peak, The Black Forest, The Hidden Bowling Alley, The Copperhead Club, A Mob of Zeppelin Protesters, The Red Zeppelin] contains loc)
+	if ($locations[The Goatlet, The eXtreme Slope, The Batrat and Ratbat Burrow, Cobb's Knob Harem, Twin Peak, The Black Forest, The Hidden Bowling Alley, The Copperhead Club, A Mob of Zeppelin Protesters, The Red Zeppelin] contains loc)
 	{
 		if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]))
 		{
@@ -1346,41 +1261,6 @@ boolean ed_autoAdv(int num, location loc, string option)
 
 boolean L1_ed_island()
 {
-	return L1_ed_island(0);
-}
-
-boolean L1_ed_dinsey()
-{
-	if (!isActuallyEd())
-	{
-		return false;
-	}
-	if(!elementalPlanes_access($element[stench]))
-	{
-		return false;
-	}
-	if(my_level() < 6)
-	{
-		return false;
-	}
-	if(!get_property("auto_dickstab").to_boolean())
-	{
-		return false;
-	}
-	if(possessEquipment($item[Sewage-Clogged Pistol]) && possessEquipment($item[Perfume-Soaked Bandana]))
-	{
-		return false;
-	}
-	autoAdv(1, $location[Pirates of the Garbage Barges]);
-	return true;
-}
-
-boolean L1_ed_island(int dickstabOverride)
-{
-	if (!isActuallyEd())
-	{
-		return false;
-	}
 	if(!elementalPlanes_access($element[spooky]))
 	{
 		return false;
@@ -1391,12 +1271,7 @@ boolean L1_ed_island(int dickstabOverride)
 	{
 		if(turns_played() > 22)
 		{
-			blocker = $skill[Replacement Liver];
-			blocker = $skill[Okay Seriously, This is the Last Spleen];
-			if((dickstabOverride == 0) || (my_level() >= dickstabOverride))
-			{
-				return false;
-			}
+			return false;
 		}
 	}
 
@@ -1454,13 +1329,8 @@ boolean L1_ed_island(int dickstabOverride)
 	return true;
 }
 
-
 boolean L1_ed_islandFallback()
 {
-	if (!isActuallyEd())
-	{
-		return false;
-	}
 	if(elementalPlanes_access($element[spooky]))
 	{
 		return false;
@@ -1548,11 +1418,25 @@ boolean L1_ed_islandFallback()
 		return true;
 	}
 
+	if (my_session_adv() == 0 && my_mp() >= mp_cost($skill[Wisdom Of Thoth]) && have_skill($skill[Wisdom Of Thoth]))
+	{
+		// use our free starting 5 mp to get Wisdom of Thoth to increase our max MP 
+		// as we'll regen some when adventuring at the shore.
+		use_skill(1, $skill[Wisdom Of Thoth]);
+	}
+
 	if(LX_islandAccess())
 	{
 		return true;
 	}
 
+	if (my_servant() == $servant[Priest] && my_servant().experience < 196)
+	{
+		// make sure we have a level 15 Priest if possible
+		// so we get the extra Ka from Hippies and Goblins.
+		buffMaintain($effect[Purr of the Feline], 10, 1, 10);
+	}
+	
 	if (have_skill($skill[Upgraded Legs]) || item_amount($item[Ka coin]) >= 10)
 	{
 		if(have_outfit("Filthy Hippy Disguise") && is_wearing_outfit("Filthy Hippy Disguise"))
@@ -1561,7 +1445,6 @@ boolean L1_ed_islandFallback()
 			put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
 			equipBaseline();
 		}
-		buffMaintain($effect[Wisdom Of Thoth], 20, 1, 1);
 		if (have_skill($skill[More Legs]) && maximizeContains("-10ml"))
 		{
 			removeFromMaximize("-10ml");
@@ -1736,6 +1619,11 @@ boolean LM_edTheUndying()
 	{
 		return true;
 	}
+	// Smut Orcs are 1 Ka so build the bridge.
+	if (L9_chasmStart() || L9_chasmBuild())
+	{
+		return true;
+	}
 	// L8 quest is all 1 Ka zones for Ed (unlikely to survive Ninja Snowmen Assassins so they don't count)
 	if (L8_trapperStart() || L8_trapperGround() || L8_trapperGroar())
 	{
@@ -1758,11 +1646,6 @@ boolean LM_edTheUndying()
 	}
 	// should probably complete the tavern for drinking purposes (and rats are 1 Ka).
 	if (L3_tavern())
-	{
-		return true;
-	}
-	// Smut Orcs are 1 Ka so build the bridge.
-	if (L9_chasmStart() || L9_chasmBuild())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1089,3 +1089,59 @@ boolean deck_useScheme(string action)
 
 	return true;
 }
+
+boolean adjustEdHat(string goal)
+{
+	if(!possessEquipment($item[The Crown of Ed the Undying]))
+	{
+		return false;
+	}
+	int option = -1;
+	goal = to_lower_case(goal);
+	if(((goal == "muscle") || (goal == "bear")) && (get_property("edPiece") != "bear"))
+	{
+		option = 1;
+	}
+	else if(((goal == "myst") || (goal == "mysticality") || (goal == "owl")) && (get_property("edPiece") != "owl"))
+	{
+		option = 2;
+	}
+	else if(((goal == "moxie") || (goal == "puma")) && (get_property("edPiece") != "puma"))
+	{
+		option = 3;
+	}
+	else if(((goal == "ml") || (goal == "hyena")) && (get_property("edPiece") != "hyena"))
+	{
+		option = 4;
+	}
+	else if(((goal == "meat") || (goal == "item") || (goal == "items") || (goal == "drops") || (goal == "mouse")) && (get_property("edPiece") != "mouse"))
+	{
+		option = 5;
+	}
+	else if(((goal == "regen") || (goal == "regenerate") || (goal == "miss") || (goal == "dodge") || (goal == "weasel")) && (get_property("edPiece") != "weasel"))
+	{
+		option = 6;
+	}
+	else if(((goal == "breathe") || (goal == "underwater") || (goal == "fish")) && (get_property("edPiece") != "fish"))
+	{
+		option = 7;
+	}
+
+	item oldHat = equipped_item($slot[hat]);
+
+	if(option != -1)
+	{
+		if(oldHat != $item[The Crown of Ed the Undying])
+		{
+			equip($slot[hat], $item[The Crown of Ed the Undying]);
+		}
+		visit_url("inventory.php?action=activateedhat");
+		visit_url("choice.php?pwd=&whichchoice=1063&option=" + option, true);
+		if(oldHat != $item[The Crown of Ed the Undying])
+		{
+			equip($slot[hat], oldHat);
+		}
+		return true;
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -227,40 +227,31 @@ void handlePostAdventure()
 
 	if (isActuallyEd())
 	{
-		int maxBuff = max(5, 660 - my_turncount());
-		if(spleen_limit() < 35)
-		{
-			maxBuff = min(maxBuff, spleen_limit());
-		}
-		if(my_mp() < 40)
-		{
-			maxBuff = 5;
-		}
-
 		if ($location[The Shore\, Inc. Travel Agency] != my_location())
 		{
 			if (my_servant() != $servant[none] && my_servant().experience < 196)
 			{
-				buffMaintain($effect[Purr of the Feline], 20, 1, 10);
+				buffMaintain($effect[Purr of the Feline], 10, 1, 10);
 			}
+
+			buffMaintain($effect[Wisdom of Thoth], 10, 1, 10);
 
 			if (my_level() < 13)
 			{
-				buffMaintain($effect[Prayer of Seshat], 5, 1, 10);
+				buffMaintain($effect[Prayer of Seshat], 10, 1, 10);
 			}
 
-			buffMaintain($effect[Wisdom of Thoth], 20, 1, 10);
-			buffMaintain($effect[Power of Heka], 20, 1, 10);
-			buffMaintain($effect[Hide of Sobek], 20, 1, 10);
+			buffMaintain($effect[Power of Heka], 10, 1, 10);
+			buffMaintain($effect[Hide of Sobek], 10, 1, 10);
 
 			if(!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, Pirates of the Garbage Barges, The Secret Government Laboratory] contains my_location()))
 			{
-				buffMaintain($effect[Bounty of Renenutet], 20, 1, 10);
+				buffMaintain($effect[Bounty of Renenutet], 10, 1, 10);
 			}
 
 			if (my_level() < 13 && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && (!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()) || have_skill($skill[More Legs])))
 			{
-				buffMaintain($effect[Blessing of Serqet], 20, 1, 10);
+				buffMaintain($effect[Blessing of Serqet], 10, 1, 10);
 			}
 
 			foreach ef in $effects[Prayer Of Seshat, Wisdom Of Thoth, Power of Heka, Hide Of Sobek, Bounty Of Renenutet]
@@ -270,6 +261,10 @@ void handlePostAdventure()
 					buffMaintain(ef, 20, 1, 20);
 				}
 			}
+		}
+		else
+		{
+			buffMaintain($effect[Wisdom of Thoth], 10, 1, 10);
 		}
 
 		if((my_mp() + 100) < my_maxmp())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -158,11 +158,20 @@ void handlePreAdventure(location place)
 
 	if (isActuallyEd())
 	{
-		if((zone_combatMod(place)._int < combat_rate_modifier()) && (have_effect($effect[Shelter Of Shed]) == 0) && auto_have_skill($skill[Shelter Of Shed]))
-		{
-			acquireMP(25, my_meat());
-		}
+		// make sure we have enough MP to cast our most expensive spells
+		// Wrath of Ra (yellow ray) is 40 MP, Curse of Stench (sniff) is 35 MP & Curse of Vacation (banish) is 30 MP.
 		acquireMP(40, 1000);
+		// ensure we can cast at least Fist of the Mummy or Storm of the Scarab.
+		// so we don't waste adventures when we can't actually kill a monster.
+		acquireMP(8, 0);
+
+		if (my_hp() == 0)
+		{
+			// the game doesn't let you adventure if you have no HP even though Ed
+			// gets a full heal when he goes to the underworld
+			// only necessary if a non-combat puts you on 0 HP.
+			acquireHP();
+		}
 	}
 
 	if(my_path() == "Two Crazy Random Summer")

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -170,7 +170,7 @@ void handlePreAdventure(location place)
 			// the game doesn't let you adventure if you have no HP even though Ed
 			// gets a full heal when he goes to the underworld
 			// only necessary if a non-combat puts you on 0 HP.
-			acquireHP();
+			acquireHP(1);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1364,6 +1364,12 @@ boolean acquireHP(int goal, int meat_reserve){
   */
 boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
 
+  if (isActuallyEd() && my_hp() > 0)
+  {
+    // Ed doesn't need to heal outside of combat unless on 0 hp
+    return false;
+  }
+  
   boolean isMax = (goal == my_maxhp());
 
   __cure_bad_stuff();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1428,7 +1428,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 
 	//Peel out with Extra-Smelly Muffler, note 10 limit, increased to 30 with Racing Slicks
 
-	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member's mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent") && get_property("_auto_maximize_equip_off-hand") != "")
+	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent") && get_property("_auto_maximize_equip_off-hand") != "")
 	{
 		return "skill " + $skill[Throw Latte on Opponent];
 	}
@@ -1491,11 +1491,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Talk About Politics];
 	}
-	if((inCombat ? auto_have_skill($skill[Reflex Hammer]) : possessEquipment($item[Lil' Doctor&trade; bag])) && get_property("_reflexHammerUsed").to_int() < 3 && !(used contains "Reflex Hammer"))
+	if((inCombat ? auto_have_skill($skill[Reflex Hammer]) : possessEquipment($item[Lil\' Doctor&trade; bag])) && get_property("_reflexHammerUsed").to_int() < 3 && !(used contains "Reflex Hammer"))
 	{
 		return "skill " + $skill[Reflex Hammer];
 	}
-	if((inCombat ? auto_have_skill($skill[KGB Tranquilizer Dart]) : possessEquipment($item[Kremlin's Greatest Briefcase])) && (get_property("_kgbTranquilizerDartUses").to_int() < 3) && (my_mp() >= mp_cost($skill[KGB Tranquilizer Dart])) && (!(used contains "KGB tranquilizer dart")))
+	if((inCombat ? auto_have_skill($skill[KGB Tranquilizer Dart]) : possessEquipment($item[Kremlin\'s Greatest Briefcase])) && (get_property("_kgbTranquilizerDartUses").to_int() < 3) && (my_mp() >= mp_cost($skill[KGB Tranquilizer Dart])) && (!(used contains "KGB tranquilizer dart")))
 	{
 		boolean useIt = true;
 		if((get_property("auto_gremlins") == "finished") && (my_daycount() >= 2) && (get_property("_kgbTranquilizerDartUses").to_int() >= 2))
@@ -1575,7 +1575,7 @@ boolean adjustForBanish(string combat_string)
 {
 	if(combat_string == "skill " + $skill[Throw Latte on Opponent])
 	{
-		return autoEquip($item[latte lovers member's mug]);
+		return autoEquip($item[latte lovers member\'s mug]);
 	}
 	if(combat_string == "skill " + $skill[Give Your Opponent The Stinkeye])
 	{
@@ -1601,11 +1601,11 @@ boolean adjustForBanish(string combat_string)
 	}
 	if(combat_string == "skill " + $skill[Reflex Hammer])
 	{
-		return autoEquip($item[Lil' Doctor&trade; bag]);
+		return autoEquip($item[Lil\' Doctor&trade; bag]);
 	}
 	if(combat_string == "skill " + $skill[KGB Tranquilizer Dart])
 	{
-		return autoEquip($item[Kremlin's Greatest Briefcase]);
+		return autoEquip($item[Kremlin\'s Greatest Briefcase]);
 	}
 	if(combat_string == "skill " + $skill[Beancannon])
 	{
@@ -2983,6 +2983,11 @@ boolean fightScienceTentacle(string option)
 	if(get_property("_eldritchTentacleFought").to_boolean())
 	{
 		return false;
+	}
+
+	if (!handleServant($servant[Scribe]))
+	{
+		handleServant($servant[Cat]);
 	}
 
 	string temp = visit_url("place.php?whichplace=forestvillage&action=fv_scientist");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -58,10 +58,6 @@ boolean Lsc_flyerSeals();
 
 boolean L0_handleRainDoh();
 
-boolean L1_ed_island();							//Defined in autoscend/auto_edTheUndying.ash
-boolean L1_ed_dinsey();							//Defined in autoscend/auto_edTheUndying.ash
-boolean L1_ed_island(int dickstabOverride);		//Defined in autoscend/auto_edTheUndying.ash
-boolean L1_ed_islandFallback();					//Defined in autoscend/auto_edTheUndying.ash
 boolean L1_dnaAcquire();
 boolean L2_mosquito();
 boolean L2_treeCoin();
@@ -373,7 +369,7 @@ boolean acquireHermitItem(item it);							//Defined in autoscend/auto_util.ash
 int cloversAvailable();									//Defined in autoscend/auto_util.ash
 boolean cloverUsageInit();									//Defined in autoscend/auto_util.ash
 boolean cloverUsageFinish();								//Defined in autoscend/auto_util.ash
-boolean adjustEdHat(string goal);							//Defined in autoscend/auto_edTheUndying.ash
+boolean adjustEdHat(string goal);							//Defined in autoscend/auto_mr2015.ash
 int amountTurkeyBooze();									//Defined in autoscend/auto_util.ash
 boolean awol_buySkills();									//Defined in autoscend/auto_awol.ash
 void awol_helper(string page);								//Defined in autoscend/auto_combat.ash
@@ -463,7 +459,7 @@ int[string] auto_sourceTerminalMissing();						//Defined in autoscend/auto_mr201
 boolean auto_sourceTerminalRequest(string request);			//Defined in autoscend/auto_mr2016.ash
 int[string] auto_sourceTerminalStatus();						//Defined in autoscend/auto_mr2016.ash
 boolean auto_tavern();										//Defined in autoscend.ash
-string ccsJunkyard(int round, string opp, string text);		//Defined in autoscend/auto_combat.ash
+string auto_Junkyard(int round, string opp, string text);		//Defined in autoscend/auto_combat.ash
 int changeClan();											//Defined in autoscend/auto_clan.ash
 int changeClan(int toClan);									//Defined in autoscend/auto_clan.ash
 int changeClan(string clanName);							//Defined in autoscend/auto_clan.ash
@@ -558,7 +554,6 @@ boolean ed_autoAdv(int num, location loc, string option);		//Defined in autoscen
 boolean ed_autoAdv(int num, location loc, string option, boolean skipFirstLife);//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_doResting();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_eatStuff();										//Defined in autoscend/auto_edTheUndying.ash
-void ed_handleAdventureServant(location loc);//Defined in auto_ascend/auto_edTheUndying.ash
 void ed_initializeDay(int day);								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSession();								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSettings();								//Defined in autoscend/auto_edTheUndying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -459,7 +459,7 @@ int[string] auto_sourceTerminalMissing();						//Defined in autoscend/auto_mr201
 boolean auto_sourceTerminalRequest(string request);			//Defined in autoscend/auto_mr2016.ash
 int[string] auto_sourceTerminalStatus();						//Defined in autoscend/auto_mr2016.ash
 boolean auto_tavern();										//Defined in autoscend.ash
-string auto_Junkyard(int round, string opp, string text);		//Defined in autoscend/auto_combat.ash
+string auto_JunkyardCombatHandler(int round, string opp, string text);		//Defined in autoscend/auto_combat.ash
 int changeClan();											//Defined in autoscend/auto_clan.ash
 int changeClan(int toClan);									//Defined in autoscend/auto_clan.ash
 int changeClan(string clanName);							//Defined in autoscend/auto_clan.ash


### PR DESCRIPTION
# Description

More changes for Ed (hopefully the last for now, I really would like to work on a different path for a while e.g. KoE)
- Ed will use the new consumption code to fill stomach and liver when low on adventures (still uses Fortune Cookies/Lucky Lindy's for SR counters).
- Ed (and hopefully all other classes) do the Junkyard combats "optimally" now. Ed definitely wastes a lot fewer adventures trying to get Yossarians tools.
- Ed bugfix: When doing Sonofa beach, we no longer stop if we have no Talisman of Horus in inventory but actually have the buff it gives.
- Ed will buff using the telescope, Lyle and the cheap muscle & moxie buffs when attempting to fight modern zmobies so we don't just die repeatedly due to their massive initiative and Ed's pitiful HP.
- various other small quality of undeath changes to make Ed runs more resilient.

Fixes #9 
Fixes #87 

## How Has This Been Tested?

I've ran multiple Ed runs with this code. Most of it has been waiting for a while as I've been busy IRL for the last few weeks and then I wanted to test the new restoration stuff in Ed to make sure it didn't cause any issues as he has different mechanics for healing and relies very heavily on MP.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
