### PR TITLE
Smart pool

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -11581,14 +11581,6 @@ boolean LX_handleSpookyravenFirstFloor()
 		item staffOfFats = $item[2268];
 		item staffOfFatsEd = $item[7964];
 		item staffOfEd = $item[7961];
-		if(possessEquipment(staffOfFats) || possessEquipment(staffOfFatsEd) || possessEquipment(staffOfEd))
-		{
-			expectPool += 5;
-		}
-		else if(possessEquipment($item[Pool Cue]))
-		{
-			expectPool += 3;
-		}
 		if((have_effect($effect[Chalky Hand]) > 0) || (item_amount($item[Handful of Hand Chalk]) > 0))
 		{
 			expectPool += 3;
@@ -11608,6 +11600,26 @@ boolean LX_handleSpookyravenFirstFloor()
 		if(have_effect($effect[Swimming with Sharks]) > 0)
 		{
 			expectPool += 3;
+		}
+
+		// Prevent the needless equipping of Cues if we don't need it.
+		boolean usePoolEquips = true;
+
+		if(expectPool < 18)
+		{
+			if(possessEquipment(staffOfFats) || possessEquipment(staffOfFatsEd) || possessEquipment(staffOfEd))
+			{
+				expectPool += 5;
+			}
+			else if(possessEquipment($item[Pool Cue]))
+			{
+				expectPool += 3;
+			}
+		}
+		else
+		{
+				auto_log_info("I don't need to equip a cue to beat this ghostie.", "blue");
+				boolean usePoolEquips = false;
 		}
 
 		if(!possessEquipment($item[Pool Cue]) && !possessEquipment(staffOfFats) && !possessEquipment(staffOfFatsEd) && !possessEquipment(staffOfEd) && !in_tcrs())
@@ -11652,14 +11664,18 @@ boolean LX_handleSpookyravenFirstFloor()
 		{
 			set_property("choiceAdventure875", "2");
 		}
-		if(possessEquipment($item[Pool Cue]))
+
+		if(usePoolEquips)
 		{
-			buffMaintain($effect[Chalky Hand], 0, 1, 1);
+			if(possessEquipment($item[Pool Cue]))
+			{
+				buffMaintain($effect[Chalky Hand], 0, 1, 1);
+			}
+			autoEquip($slot[weapon], $item[Pool Cue]);
+			autoEquip(staffOfFats);
+			autoEquip(staffOfFatsEd);
+			autoEquip(staffOfEd);
 		}
-		autoEquip($slot[weapon], $item[Pool Cue]);
-		autoEquip(staffOfFats);
-		autoEquip(staffOfFatsEd);
-		autoEquip(staffOfEd);
 
 		auto_log_info("It's billiards time!", "blue");
 		backupSetting("choiceAdventure330", 1);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -12263,11 +12263,11 @@ boolean L9_aBooPeak()
 			}
 			if(useMaximizeToEquip())
 			{
-				addToMaximize("1000spooky res,1000 cold res,10hp" + parrot);
+				addToMaximize("1000spooky res,1000cold res,10000hp " + (mp_need + 10) + "max," + parrot);
 			}
 			else
 			{
-				autoMaximize("spooky res, cold res " + lihcface + " -equip snow suit" + parrot, 0, 0, false);
+				autoMaximize("spooky res,cold res " + lihcface + " -equip snow suit" + parrot, 0, 0, false);
 			}
 			adjustEdHat("ml");
 

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -53,7 +53,6 @@ boolean LX_koeInvaderHandler()
 	buffMaintain($effect[Scarysauce], 10, 1, 1);
 
 	resetMaximize();
-	addToMaximize("200 all res");
 
 	if(!possessEquipment($item[meteorb]))
 		retrieve_item(1, $item[meteorb]);
@@ -61,7 +60,7 @@ boolean LX_koeInvaderHandler()
 	pullXWhenHaveY($item[meteorb], 1, 0);
 	autoEquip($slot[off-hand], $item[meteorb]);
 
-	simMaximize();
+	simMaximizeWith("200 all res");
 
 	float damagePerRound = 0.0;
 	float baseDamage = 1.0 - 0.1 * my_daycount();
@@ -92,6 +91,9 @@ boolean LX_koeInvaderHandler()
 			buffMaintain($effect[Song of Sauce], 150, 1, 1);
 			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
 			acquireMP(100, 0);
+
+			// Use maximizer now that we are for sure fighting the Invader
+			addToMaximize("200 all res");
 
 			set_property("choiceAdventure1393", 1); // Take care of it...
 			boolean ret = autoAdv(1, $location[The Invader]);


### PR DESCRIPTION
# Description
Stops equipping pool cues if we don't need it.

Fixes # 
None reported. I was annoyed.

## How Has This Been Tested?
Will test in a few days

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
