### PR TITLE
some miscellaneous Ed and non-Ed changes

### DIFF
--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -14,6 +14,7 @@ Optimistic Candle	prop:optimisticCandleProgress>=25
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
 Crimbo Shrub
 # Free car fuel, or meat, or food/booze if we're really desperate
+Party Mouse
 Lil' Barrel Mimic
 # Volleyballs with a multiplier
 #Baby Mutant Rattlesnake	grimdark:0

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1558,6 +1558,23 @@ boolean LM_edTheUndying()
 		}
 	}
 
+	if (auto_campawayAvailable())
+	{
+		// keep enough firewood on hand to fill stomach and liver with campfire food
+		if (!possessEquipment($item[whittled tiara]) && item_amount($item[Stick of Firewood]) > 14)
+		{
+			buy($coinmaster[Your Campfire], 1, $item[whittled tiara])
+		}
+		if (!possessEquipment($item[whittled shorts]) && item_amount($item[Stick of Firewood]) > 14)
+		{
+			buy($coinmaster[Your Campfire], 1, $item[whittled shorts])
+		}
+		if (!possessEquipment($item[whittled owl figurine]) && item_amount($item[Stick of Firewood]) > 19)
+		{
+			buy($coinmaster[Your Campfire], 1, $item[whittled owl figurine])
+		}
+	}
+
 	if(L1_ed_island() || L1_ed_islandFallback())
 	{
 		return true;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4644,6 +4644,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Patent Sallowness]:			useItem = $item[Patent Sallowness Tonic];		break;
 	case $effect[Patience of the Tortoise]:		useSkill = $skill[Patience of the Tortoise];	break;
 	case $effect[Patient Smile]:				useSkill = $skill[Patient Smile];				break;
+	case $effect[Paul\'s Passionate Pop Song]:				useSkill = $skill[Paul\'s Passionate Pop Song];				break;
 	case $effect[Penne Fedora]:					useSkill = $skill[none];						break;
 	case $effect[Peppermint Bite]:				useItem = $item[Crimbo Peppermint Bark];		break;
 	case $effect[Peppermint Twisted]:			useItem = $item[Peppermint Twist];				break;
@@ -6030,6 +6031,11 @@ boolean enforceMLInPreAdv()
 // ADVENTURE FORCING FUNCTIONS
 boolean auto_canForceNextNoncombat()
 {
+	if (isActuallyEd())
+	{
+		return auto_pillKeeperFreeUseAvailable()
+		|| (!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0) && auto_is_valid($item[Clara\'s Bell]));
+	}
 	return auto_pillKeeperAvailable()
 	|| (!get_property("_claraBellUsed").to_boolean() && (item_amount($item[Clara\'s Bell]) > 0) && auto_is_valid($item[Clara\'s Bell]))
 	|| (item_amount($item[stench jelly]) > 0 && auto_is_valid($item[stench jelly]) && spleen_left() < $item[stench jelly].spleen);
@@ -6061,7 +6067,7 @@ boolean _auto_forceNextNoncombat()
 			set_property("auto_forceNonCombatSource", "stench jelly");
 		}
 	}
-	else if(auto_pillKeeperAvailable())
+	else if(auto_pillKeeperAvailable() && !isActuallyEd()) // don't use Spleen as Ed, it's his main source of adventures.
 	{
 		ret = auto_pillKeeper("noncombat");
 		if(ret) {


### PR DESCRIPTION
# Description

- add party mouse to stat familiars
- stop Ed from using pill keeper when it's not free
- Ed will buy whittled stuff when you have enough firewood
- add Paul's Passionate Pop Song to buffMaintain

## How Has This Been Tested?

Most of it hasn't. I'm running KoE not Ed at the moment.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
