### PR TITLE
Adding doWeaksauce check to two areas where it was missing.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1382,7 +1382,7 @@ string auto_combatHandler(int round, string opp, string text)
 			}
 		}
 
-		if(canUse($skill[Curse Of Weaksauce]) && (my_class() == $class[Sauceror]) && (my_mp() >= 20))
+		if(canUse($skill[Curse Of Weaksauce]) && (my_class() == $class[Sauceror]) && (my_mp() >= 20) && doWeaksauce)
 		{
 			return useSkill($skill[Curse Of Weaksauce]);
 		}
@@ -1626,7 +1626,7 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 	}
 
-	if(canUse($skill[Curse Of Weaksauce]) && (my_class() == $class[Sauceror]) && (my_mp() >= 32 || haveUsed($skill[Stuffed Mortar Shell])))
+	if(canUse($skill[Curse Of Weaksauce]) && (my_class() == $class[Sauceror]) && (my_mp() >= 32 || haveUsed($skill[Stuffed Mortar Shell])) && doWeaksauce)
 	{
 		return useSkill($skill[Curse Of Weaksauce]);
 	}


### PR DESCRIPTION
# Description
Found doWeaksauce checks to be missing in some instances, causing us to waste a turn on invader bullets.

Fixes # (issue)
Reported on Discord.

## How Has This Been Tested?
Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to. **BUG FIX FOR master BRANCH**
