### PR TITLE
Optimize getting Antique Accordion, also make prices reflect real cost rather than hardcoded

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1930,8 +1930,9 @@ void initializeDay(int day)
 			if(!($classes[Accordion Thief, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed, Vampyre] contains my_class()))
 			{
 				if ((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isArmoryAvailable() && (my_meat() > npc_price($item[Toy Accordion])))
+				{
 					buyUpTo(1, $item[Toy Accordion]);
-
+				}
 				if(!possessEquipment($item[Turtle Totem]))
 				{
 					acquireGumItem($item[Turtle Totem]);
@@ -3589,7 +3590,7 @@ boolean L11_aridDesert()
 				canBuyPaint = false;
 			}
 
-			if((item_amount($item[Can of Black Paint]) > 0) || ((my_meat() >= 1000) && canBuyPaint))
+			if((item_amount($item[Can of Black Paint]) > 0) || ((my_meat() >= npc_price($item[Can of Black Paint])) && canBuyPaint))
 			{
 				buyUpTo(1, $item[Can of Black Paint]);
 				auto_log_info("Returning the Can of Black Paint", "blue");
@@ -8970,7 +8971,7 @@ boolean Lsc_flyerSeals()
 		}
 		if((item_amount($item[bad-ass club]) == 0) && (item_amount($item[ingot of seal-iron]) > 0) && have_skill($skill[Super-Advanced Meatsmithing]))
 		{
-			if((item_amount($item[Tenderizing Hammer]) == 0) && (my_meat() > 10000))
+			if((item_amount($item[Tenderizing Hammer]) == 0) && (my_meat() >= npc_price($item[Tenderizing Hammer])))
 			{
 				buyUpTo(1, $item[Tenderizing Hammer]);
 			}
@@ -10021,13 +10022,6 @@ boolean L8_trapperGround()
 
 boolean LX_guildUnlock()
 {
-	if(!in_hardcore())
-	{
-		if(my_ascensions() >= 125)
-		{
-			return false;
-		}
-	}
 	if(!isGuildClass() || guild_store_available())
 	{
 		return false;
@@ -10410,7 +10404,7 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	if(knoll_available() && (item_amount($item[Detuned Radio]) == 0) && (my_meat() > 300) && (auto_my_path() != "G-Lover"))
+	if(knoll_available() && (item_amount($item[Detuned Radio]) == 0) && (my_meat() >= npc_price($item[Detuned Radio])) && (auto_my_path() != "G-Lover"))
 	{
 		buyUpTo(1, $item[Detuned Radio]);
 		auto_setMCDToCap();
@@ -10425,10 +10419,23 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	#Can we have some other way to check that we have AT skills?
-	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() > 12500) && (have_skill($skill[The Ode to Booze])) && (my_class() != $class[Accordion Thief]) && (auto_my_path() != "G-Lover"))
+	#Can we have some other way to check that we have AT skills? Checking all skills just to be sure.
+	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() >= npc_price($item[Antique Accordion])) && (my_class() != $class[Accordion Thief]) && (auto_my_path() != "G-Lover"))
 	{
-		buyUpTo(1, $item[Antique Accordion]);
+		boolean buyAntiqueAccordion = false;
+		boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Aloysius\' Antiphon of Aptitude, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
+		foreach SongCheck in songs
+		{
+			if(have_skill(SongCheck))
+			{
+				buyAntiqueAccordion = true;
+			}
+		}
+
+		if(buyAntiqueAccordion)
+		{
+			buyUpTo(1, $item[Antique Accordion]);
+		}
 	}
 
 	if((my_meat() > 7500) && (item_amount($item[Seal Tooth]) == 0))
@@ -10451,12 +10458,12 @@ boolean LX_craftAcquireItems()
 			// Make Spiky Turtle Shield - Requires an Adventure
 		}
 	}
-	if((get_power(equipped_item($slot[pants])) < 70) && !possessEquipment($item[Demonskin Trousers]) && (my_meat() > 350) && (item_amount($item[Demon Skin]) > 0) && (item_amount($item[Tenderizing Hammer]) > 0) && knoll_available())
+	if((get_power(equipped_item($slot[pants])) < 70) && !possessEquipment($item[Demonskin Trousers]) && (my_meat() >= npc_price($item[Pants Kit])) && (item_amount($item[Demon Skin]) > 0) && (item_amount($item[Tenderizing Hammer]) > 0) && knoll_available())
 	{
 		buyUpTo(1, $item[Pants Kit]);
 		autoCraft("smith", 1, $item[Pants Kit], $item[Demon Skin]);
 	}
-	if(!possessEquipment($item[Tighty Whiteys]) && (my_meat() > 350) && (item_amount($item[White Snake Skin]) > 0) && (item_amount($item[Tenderizing Hammer]) > 0) && knoll_available())
+	if(!possessEquipment($item[Tighty Whiteys]) && (my_meat() >= npc_price($item[Pants Kit])) && (item_amount($item[White Snake Skin]) > 0) && (item_amount($item[Tenderizing Hammer]) > 0) && knoll_available())
 	{
 		buyUpTo(1, $item[Pants Kit]);
 		autoCraft("smith", 1, $item[Pants Kit], $item[White Snake Skin]);
@@ -10782,7 +10789,7 @@ boolean LX_bitchinMeatcar()
 	}
 	else
 	{
-		if((my_meat() >= 6000) && isGeneralStoreAvailable())
+		if((my_meat() >= (npc_price($item[Desert Bus Pass]) + 1000)) && isGeneralStoreAvailable())
 		{
 			auto_log_info("We're rich, let's take the bus instead of building a car.", "blue");
 			buyUpTo(1, $item[Desert Bus Pass]);
@@ -10886,7 +10893,7 @@ boolean LX_desertAlternate()
 	{
 		return false;
 	}
-	if((my_meat() >= 5000) && isGeneralStoreAvailable())
+	if((my_meat() >= npc_price($item[Desert Bus Pass])) && isGeneralStoreAvailable())
 	{
 		buyUpTo(1, $item[Desert Bus Pass]);
 		if(item_amount($item[Desert Bus Pass]) > 0)
@@ -10906,7 +10913,7 @@ boolean LX_islandAccess()
 
 	boolean canDesert = (get_property("lastDesertUnlock").to_int() == my_ascensions());
 
-	if((item_amount($item[Shore Inc. Ship Trip Scrip]) >= 3) && (item_amount($item[Dingy Dinghy]) == 0) && (my_meat() >= 400) && isGeneralStoreAvailable())
+	if((item_amount($item[Shore Inc. Ship Trip Scrip]) >= 3) && (item_amount($item[Dingy Dinghy]) == 0) && (my_meat() >= npc_price($item[dingy planks])) && isGeneralStoreAvailable())
 	{
 		cli_execute("make dinghy plans");
 		buyUpTo(1, $item[dingy planks]);
@@ -10974,7 +10981,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if((my_meat() >= 400) && (item_amount($item[Dinghy Plans]) == 0) && isGeneralStoreAvailable())
+	if((my_meat() >= npc_price($item[dingy planks])) && (item_amount($item[Dinghy Plans]) == 0) && isGeneralStoreAvailable())
 	{
 		cli_execute("make dinghy plans");
 		buyUpTo(1, $item[dingy planks]);
@@ -12000,7 +12007,7 @@ boolean L9_aBooPeak()
 
 		//	Do we need to manually adjust for the parrot?
 
-		if(black_market_available() && (item_amount($item[Can of Black Paint]) == 0) && (have_effect($effect[Red Door Syndrome]) == 0) && (my_meat() >= 1000))
+		if(black_market_available() && (item_amount($item[Can of Black Paint]) == 0) && (have_effect($effect[Red Door Syndrome]) == 0) && (my_meat() >= npc_price($item[Can of Black Paint])))
 		{
 			buyUpTo(1, $item[Can of Black Paint]);
 			coldResist += 2;
@@ -14626,11 +14633,12 @@ boolean doTasks()
 	}
 
 	if(LX_loggingHatchet())				return true;
+	if(LX_guildUnlock())				return true;
 	if(knoll_available() && get_property("auto_spoonconfirmed").to_int() == my_ascensions())
 	{
 		if(LX_bitchinMeatcar())			return true;
 	}
-	if(LX_guildUnlock())				return true;
+	if(LX_bitchinMeatcar())				return true;
 	if(L5_getEncryptionKey())			return true;
 	if(LX_handleSpookyravenNecklace())	return true;
 	if(LX_unlockPirateRealm())			return true;
@@ -14654,7 +14662,6 @@ boolean doTasks()
 	if(L5_haremOutfit())				return true;
 	if(LX_phatLootToken())				return true;
 	if(L5_goblinKing())					return true;
-	if(LX_bitchinMeatcar())				return true;
 	if(LX_islandAccess())				return true;
 
 	if(in_hardcore() && isGuildClass())

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -8971,7 +8971,7 @@ boolean Lsc_flyerSeals()
 		}
 		if((item_amount($item[bad-ass club]) == 0) && (item_amount($item[ingot of seal-iron]) > 0) && have_skill($skill[Super-Advanced Meatsmithing]))
 		{
-			if((item_amount($item[Tenderizing Hammer]) == 0) && (my_meat() >= npc_price($item[Tenderizing Hammer])))
+			if((item_amount($item[Tenderizing Hammer]) == 0) && (my_meat() >= (npc_price($item[Tenderizing Hammer]) * 2)))
 			{
 				buyUpTo(1, $item[Tenderizing Hammer]);
 			}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -301,7 +301,7 @@ boolean handleFamiliar(string type)
 			return false;
 		}
 	}
-	
+
 	string [string,int,string] familiars_text;
 	if(!file_to_map("autoscend_familiars.txt", familiars_text))
 		auto_log_critical("Could not load autoscend_familiars.txt. This is bad!", "red");
@@ -10423,6 +10423,7 @@ boolean LX_craftAcquireItems()
 	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() >= npc_price($item[Antique Accordion])) && (auto_predictAccordionTurns() < 10) && (auto_my_path() != "G-Lover"))
 	{
 		boolean buyAntiqueAccordion = false;
+		// This List contains ALL AT songs (as their skill names) in an unorganized list.
 		boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Aloysius\' Antiphon of Aptitude, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
 		foreach SongCheck in songs
 		{
@@ -12636,7 +12637,7 @@ boolean L9_oilPeak()
 			asdonBuff($effect[Driving Wastefully]);
 		}
 	}
-	
+
 	// Help protect ourselves against not getting enough crudes if tackling cartels
 	if(simMaximizeWith("1000ml 100min"))
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1929,7 +1929,7 @@ void initializeDay(int day)
 			}
 			if(!($classes[Accordion Thief, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed, Vampyre] contains my_class()))
 			{
-				if ((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isArmoryAvailable() && (my_meat() > npc_price($item[Toy Accordion])))
+				if ((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && (auto_predictAccordionTurns() < 5) && isArmoryAvailable() && (my_meat() > npc_price($item[Toy Accordion])))
 				{
 					buyUpTo(1, $item[Toy Accordion]);
 				}
@@ -1994,7 +1994,7 @@ void initializeDay(int day)
 				pulverizeThing($item[Vicar\'s Tutu]);
 			}
 			while(acquireHermitItem($item[Ten-Leaf Clover]));
-			if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && !($classes[Accordion Thief, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed, Vampyre] contains my_class()) && (auto_my_path() != "G-Lover"))
+			if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (auto_predictAccordionTurns() < 10) && !($classes[Accordion Thief, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed, Vampyre] contains my_class()) && (auto_my_path() != "G-Lover"))
 			{
 				buyUpTo(1, $item[Antique Accordion]);
 			}
@@ -10420,7 +10420,7 @@ boolean LX_craftAcquireItems()
 	}
 
 	#Can we have some other way to check that we have AT skills? Checking all skills just to be sure.
-	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() >= npc_price($item[Antique Accordion])) && (my_class() != $class[Accordion Thief]) && (auto_my_path() != "G-Lover"))
+	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() >= npc_price($item[Antique Accordion])) && (auto_predictAccordionTurns() < 10) && (auto_my_path() != "G-Lover"))
 	{
 		boolean buyAntiqueAccordion = false;
 		boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Aloysius\' Antiphon of Aptitude, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
@@ -10502,7 +10502,7 @@ boolean LX_craftAcquireItems()
 		//Demonskin Jacket, requires an adventure, knoll available doesn\'t matter here...
 	}
 
-	if(in_koe() && creatable_amount($item[Antique Accordion]) > 0 && !possessEquipment($item[Antique Accordion]))
+	if((in_koe() && creatable_amount($item[Antique Accordion]) > 0 && !possessEquipment($item[Antique Accordion])) && (auto_predictAccordionTurns() < 10))
 	{
 		retrieve_item(1, $item[Antique Accordion]);
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -10423,9 +10423,8 @@ boolean LX_craftAcquireItems()
 	if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && (my_meat() >= npc_price($item[Antique Accordion])) && (auto_predictAccordionTurns() < 10) && (auto_my_path() != "G-Lover"))
 	{
 		boolean buyAntiqueAccordion = false;
-		// This List contains ALL AT songs (as their skill names) in an unorganized list.
-		boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Aloysius\' Antiphon of Aptitude, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
-		foreach SongCheck in songs
+
+	foreach SongCheck in ATSongList()
 		{
 			if(have_skill(SongCheck))
 			{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4020,9 +4020,8 @@ void shrugAT(effect anticipated)
 	}
 
 	int count = 1;
-	#Put these in priority of keeping.
-	#This needs to be a comprehensive list
-	boolean[effect] songs = $effects[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Aloysius\' Antiphon of Aptitude, Fat Leon\'s Phat Loot Lyric, Polka of Plenty, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
+	// This List contains ALL AT songs (as their effects) in order from Most to Least Important as to determine what effect to shrug off.
+	boolean[effect] songs = $effects[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Fat Leon\'s Phat Loot Lyric, Polka of Plenty, Aloysius\' Antiphon of Aptitude, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
 
 	effect last = $effect[none];
 	foreach song in songs
@@ -5927,7 +5926,7 @@ int auto_convertDesiredML(int DML)
 	{
 		DesiredML = DML;
 	}
-		
+
 	return DesiredML;
 }
 
@@ -5975,7 +5974,7 @@ boolean auto_setMCDToCap()
 // We use this function to determine the suitability of using Ur-Kel's
 boolean UrKelCheck(int UrKelToML, int UrKelUpperLimit, int UrKelLowerLimit)
 {
-	if((have_effect($effect[Ur-Kel\'s Aria of Annoyance]) == 0) && ((monster_level_adjustment() + (2 * my_level())) <= auto_convertDesiredML(UrKelToML)))                           
+	if((have_effect($effect[Ur-Kel\'s Aria of Annoyance]) == 0) && ((monster_level_adjustment() + (2 * my_level())) <= auto_convertDesiredML(UrKelToML)))
 	{
 		if((get_property("auto_MLSafetyLimit") == "") || (((2 * my_level()) <= UrKelUpperLimit) && ((2 * my_level()) >= UrKelLowerLimit)))
 		{
@@ -6004,7 +6003,7 @@ boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 
 
 // 30
-	// Start with the biggest and drill down for max ML  
+	// Start with the biggest and drill down for max ML
 	if((monster_level_adjustment() + 30) <= auto_convertDesiredML(ToML))
 	{
 		buffMaintain($effect[Ceaseless Snarling], 0, 1, 10);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -91,6 +91,7 @@ boolean pulverizeThing(item it);
 boolean buy_item(item it, int quantity, int maxprice);
 string tryBeerPong();
 boolean hasShieldEquipped();
+boolean[skill] ATSongList();
 void shrugAT();
 void shrugAT(effect anticipated);
 boolean buyUpTo(int num, item it);
@@ -3985,6 +3986,13 @@ boolean beehiveConsider()
 	return true;
 }
 
+boolean[skill] ATSongList()
+{
+	// This List contains ALL AT songs in order from Most to Least Important as to determine what effect to shrug off.
+	boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Aloysius\' Antiphon of Aptitude, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
+
+	return songs;
+}
 
 void shrugAT()
 {
@@ -4020,19 +4028,17 @@ void shrugAT(effect anticipated)
 	}
 
 	int count = 1;
-	// This List contains ALL AT songs (as their effects) in order from Most to Least Important as to determine what effect to shrug off.
-	boolean[effect] songs = $effects[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Fat Leon\'s Phat Loot Lyric, Polka of Plenty, Aloysius\' Antiphon of Aptitude, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
 
 	effect last = $effect[none];
-	foreach song in songs
+	foreach ATsong in ATSongList()
 	{
-		if(have_effect(song) > 0)
+		if(have_effect(to_effect(ATsong)) > 0)
 		{
 			count += 1;
 			if(count > maxSongs)
 			{
-				auto_log_info("Shrugging song: " + song, "blue");
-				uneffect(song);
+				auto_log_info("Shrugging song: " + ATsong, "blue");
+				uneffect(to_effect(ATsong));
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1965,7 +1965,7 @@ boolean ovenHandle()
 		}
 	}
 
-	if(!get_property("auto_haveoven").to_boolean() && (my_meat() > 4000) && isGeneralStoreAvailable())
+	if(!get_property("auto_haveoven").to_boolean() && (my_meat() >= (npc_price($item[Dramatic&trade; range]) + 1000)) && isGeneralStoreAvailable())
 	{
 		buyUpTo(1, $item[Dramatic&trade; range]);
 		use(1, $item[Dramatic&trade; range]);


### PR DESCRIPTION
# Description
Changed OoP for unlocking Guild and Beach (meatcar), so that we can get the Antique Accordion faster.

Converted a lot of prices to reference npc_price() instead of a hardcoded price. Allowing for more accurate acquisition.

Fixes # (issue)
MP drain from casting expensive songs for 5 songs each, problems getting items from NPCs caused by incorrect or inaccurate item costs.

## How Has This Been Tested?
2/3 Softcore run

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
