### PR TITLE
Adding the use of Mu as an alternative to Exotic Parrot

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -303,7 +303,7 @@ boolean handleFamiliar(string type)
 			return false;
 		}
 	}
-	
+
 	string [string,int,string] familiars_text;
 	if(!file_to_map("autoscend_familiars.txt", familiars_text))
 		auto_log_critical("Could not load autoscend_familiars.txt. This is bad!", "red");
@@ -10967,7 +10967,14 @@ boolean LX_handleSpookyravenFirstFloor()
 	else
 	{
 		auto_log_info("Looking for the Billards Room key (Hot/Stench:" + elemental_resist($element[hot]) + "/" + elemental_resist($element[stench]) + "): Progress " + get_property("manorDrawerCount") + "/24", "blue");
-		handleFamiliar($familiar[Exotic Parrot]);
+		if(auto_have_familiar($familiar[Mu])
+		{
+			handleFamiliar($familiar[Mu]);
+		}
+		else if(auto_have_familiar($familiar[Exotic Parrot])
+		{
+			handleFamiliar($familiar[Exotic Parrot]);
+		}
 		if(is100FamiliarRun())
 		{
 			if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Candy Corn Costume]) > 0))
@@ -11428,7 +11435,7 @@ boolean L9_aBooPeak()
 		{
 			lihcface = "-equip lihc face";
 		}
-		string parrot = ", switch exotic parrot, switch trick-or-treating tot";
+		string parrot = ", switch exotic parrot, switch mu, switch trick-or-treating tot";
 		if(is100FamiliarRun())
 		{
 			parrot = "";
@@ -11598,7 +11605,15 @@ boolean L9_aBooPeak()
 				}
 				set_property("auto_aboopending", my_turncount());
 			}
-			handleFamiliar($familiar[Exotic Parrot]);
+			if(auto_have_familiar($familiar[Mu])
+			{
+				handleFamiliar($familiar[Mu]);
+			}
+			else if(auto_have_familiar($familiar[Exotic Parrot])
+			{
+				handleFamiliar($familiar[Exotic Parrot]);
+			}
+
 			# When booPeakProgress <= 0, we want to leave this adventure. Can we?
 			# I can not figure out how to do this via ASH since the adventure completes itself?
 			# However, in mafia, (src/net/sourceforge/kolmafia/session/ChoiceManager.java)
@@ -11803,9 +11818,13 @@ boolean L9_twinPeak()
 			familiar resist = $familiar[none];
 			if((elemental_resist($element[stench]) < 4) && !is100FamiliarRun())
 			{
-				if(auto_have_familiar($familiar[Exotic Parrot]))
+				if(auto_have_familiar($familiar[Mu])
 				{
-					resist = $familiar[Exotic Parrot];
+					handleFamiliar($familiar[Mu]);
+				}
+				else if(auto_have_familiar($familiar[Exotic Parrot])
+				{
+					handleFamiliar($familiar[Exotic Parrot]);
 				}
 				if(auto_have_familiar($familiar[Trick-Or-Treating Tot]))
 				{
@@ -12071,7 +12090,7 @@ boolean L9_oilPeak()
 			asdonBuff($effect[Driving Wastefully]);
 		}
 	}
-	
+
 	// Help protect ourselves against not getting enough crudes if tackling cartels
 	if(simMaximizeWith("1000ml 100min"))
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -11820,11 +11820,11 @@ boolean L9_twinPeak()
 			{
 				if(auto_have_familiar($familiar[Mu])
 				{
-					handleFamiliar($familiar[Mu]);
+					resist = $familiar[Mu];
 				}
 				else if(auto_have_familiar($familiar[Exotic Parrot])
 				{
-					handleFamiliar($familiar[Exotic Parrot]);
+					resist = $familiar[Exotic Parrot];
 				}
 				if(auto_have_familiar($familiar[Trick-Or-Treating Tot]))
 				{

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -2697,6 +2697,11 @@ boolean LA_cs_communityService()
 				}
 				forceEquip($slot[familiar], $item[Li\'l Candy Corn Costume]);
 			}
+			else if(have_familiar($familiar[Mu]))
+			{
+				use_familiar($familiar[Mu]);
+				forceEquip($slot[familiar], $item[Astral Pet Sweater]);
+			}
 			else if(have_familiar($familiar[Exotic Parrot]))
 			{
 				use_familiar($familiar[Exotic Parrot]);
@@ -2779,7 +2784,7 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Protection from Bad Stuff], 0, 1, 1);
 			buffMaintain($effect[Human-Elemental Hybrid], 0, 1, 1);
 			buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
-			if(my_familiar() == $familiar[Exotic Parrot])
+			if((my_familiar() == $familiar[Exotic Parrot]) || (my_familiar() == $familiar[Mu]))
 			{
 				buffMaintain($effect[Leash of Linguini], 12, 1, 1);
 				buffMaintain($effect[Empathy], 15, 1, 1);


### PR DESCRIPTION
# Description
Adds Mu as an alternative to Exotic Parrot

Fixes # (issue)
Issue reported on HC chat on KoL

## How Has This Been Tested?

Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
