### PR TITLE
Move the Unlock Warnings to Debug due to confusion in the community.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -68,12 +68,12 @@ boolean zone_unlock(location loc){
 	if(loc == $location[The Thinknerd Warehouse]){
 		unlocked = unlock_thinknerd();
 	} else{
-		auto_log_warning("Dont know how to unlock " + loc);
+		auto_log_debug("Dont know how to unlock " + loc);
 		return false;
 	}
 
 	if(!unlocked){
-		auto_log_warning("Wasnt able to unlock " + loc);
+		auto_log_debug("Wasnt able to unlock " + loc);
 	}
 
 	return unlocked;


### PR DESCRIPTION
# Description
Changes the Warnings printed when the script checks for zones to Debug. The script can get a bit spammy when searching for where to burn delay, and it is scaring people.

Fixes # (issue)

## How Has This Been Tested?
Nope.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
