### PR TITLE
Add Camp Logging Camp to auto_zone to prevent looping

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1297,6 +1297,15 @@ generic_t zone_available(location loc)
 			retval._boolean = gnomads_available();
 		}
 		break;
+
+	// We go here to get the Logging Hatchet
+	case $location[Camp Logging Camp]:
+		if((!in_koe()) && (canadia_available()))
+		{
+			retval._boolean = true;
+		}
+		break;
+
 	case $location[The Thinknerd Warehouse]:
 		if(internalQuestStatus("questM22Shirt") >= 0)
 		{


### PR DESCRIPTION
# Description
Script looping when we try to get logging hatchet. Added Camp Logging Camp to the possibilities in auto_zone

Fixes # (issue)
reported on discord

## How Has This Been Tested?
Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
