### PR TITLE
KoE (and general) changes...part 1

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -18,4 +18,4 @@ War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultic
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 Possessed Wine Rack
 Blue Oyster cultist
-Dirty Old Lihc	prop:cyrptNicheEvilness>25
+Dirty Old Lihc	prop:cyrptNicheEvilness>28

--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -18,3 +18,4 @@ War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultic
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 Possessed Wine Rack
 Blue Oyster cultist
+Dirty Old Lihc	prop:cyrptNicheEvilness>25

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -258,38 +258,39 @@ stat	8	Optimistic Candle	prop:optimisticCandleProgress>=25
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
 stat	9	Crimbo Shrub
 # Free car fuel, or meat, or food/booze if we're really desperate
-stat	10	Lil' Barrel Mimic
+stat	10	Party Mouse
+stat	11	Lil' Barrel Mimic
 # Volleyballs with a multiplier
 #Baby Mutant Rattlesnake	grimdark:0
 #Baby Mutant Rattlesnake	grimdark:1
 # Fairyballs
-stat	11	Elf Operative
-stat	12	Optimistic Candle
-stat	13	Rockin' Robin
+stat	12	Elf Operative
+stat	13	Optimistic Candle
+stat	14	Rockin' Robin
 # Volleychauns
-stat	14	Golden Monkey
-stat	15	Bloovian Groose
-stat	16	Unconscious Collective
-stat	17	Grim Brother
-stat	18	Dramatic Hedgehog
-stat	19	Chauvinist Pig
-stat	20	Uniclops
-stat	21	Hunchbacked Minion
-stat	22	Nervous Tick
-stat	23	Cymbal-Playing Monkey
-stat	24	Cheshire Bat
+stat	15	Golden Monkey
+stat	16	Bloovian Groose
+stat	17	Unconscious Collective
+stat	18	Grim Brother
+stat	19	Dramatic Hedgehog
+stat	20	Chauvinist Pig
+stat	21	Uniclops
+stat	22	Hunchbacked Minion
+stat	23	Nervous Tick
+stat	24	Cymbal-Playing Monkey
+stat	25	Cheshire Bat
 # Might as well build up weight for free runs, even though I'm pretty sure we don't use them...
-stat	25	Frumious Bandersnatch
+stat	26	Frumious Bandersnatch
 # Fancy
-stat	26	Miniature Sword &amp; Martini Guy
+stat	27	Miniature Sword &amp; Martini Guy
 # Slightly special volleyballs
-stat	27	Reanimated Reanimator
-stat	28	God Lobster
+stat	28	Reanimated Reanimator
+stat	29	God Lobster
 #Baby Mutant Rattlesnake	grimdark:2
 # Turtles are cute
-stat	29	Grinning Turtle
+stat	30	Grinning Turtle
 # The original
-stat	30	Blood-Faced Volleyball
+stat	31	Blood-Faced Volleyball
 
 yellowray	0	Crimbo Shrub
 # Nanorhino and He-Boulder would require a bit of extra doing to make work

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -72,6 +72,7 @@ sniff	16	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filth
 sniff	17	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 sniff	18	Possessed Wine Rack
 sniff	19	Blue Oyster cultist
+sniff	20	Dirty Old Lihc	prop:cyrptNicheEvilness>28
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1

--- a/RELEASE/data/autoscend_properties.txt
+++ b/RELEASE/data/autoscend_properties.txt
@@ -101,7 +101,6 @@
 100	auto_bat_soulmonster
 101	auto_beta_test
 102	auto_interrupt
-103	auto_invaderKilled
 104	auto_cabinetsencountered
 105	auto_wineracksencountered
 106	auto_aboopending

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,8 +1,6 @@
 script "autoscend.ash";
-since r19583; // Automatically recognize when KoL changes an effect name. Gr8tness -> Gr8ness.
+since r19599; // In Kingdom of Exploathing, mark the Palindome quest as started as soon as you make the Talisman o' Namsilat.
 /***
-	Killing is wrong, and bad. There should be a new, stronger word for killing like badwrong or badong. YES, killing is badong. From this moment, I will stand for the opposite of killing, gnodab.
-
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
 
@@ -916,9 +914,9 @@ boolean warAdventure()
 	return true;
 }
 
-boolean doThemtharHills()
+boolean L12_ThemtharHills()
 {
-	if(auto_my_path() == "Two Crazy Random Summer" || in_koe())
+	if(in_tcrs() || in_koe())
 	{
 		set_property("auto_nuns", "finished"); // if only :(
 		return false;
@@ -1326,18 +1324,12 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[Numberwang], 1, 0);
 		}
-#		pullXWhenHaveY($item[milk of magnesium], 1, 0);
 		if(auto_my_path() == "Pocket Familiars")
 		{
 			pullXWhenHaveY($item[Ring Of Detect Boring Doors], 1, 0);
 			pullXWhenHaveY($item[Pick-O-Matic Lockpicks], 1, 0);
 			pullXWhenHaveY($item[Eleven-Foot Pole], 1, 0);
 		}
-
-#		pullXWhenHaveY($item[thor\'s pliers], 1, 0);
-		#pullXWhenHaveY($item[the big book of pirate insults], 1, 0);
-#		pullXWhenHaveY($item[mojo filter], 1, 0);
-		#pullXWhenHaveY($item[camp scout backpack], 1, 0);
 
 		if((my_class() == $class[Sauceror]) || (my_class() == $class[Pastamancer]))
 		{
@@ -1489,12 +1481,12 @@ boolean fortuneCookieEvent()
 			goal = $location[The Castle in the Clouds in the Sky (Top Floor)];
 		}
 
-		if (goal == $location[The Castle in the Clouds in the Sky (Top Floor)] && (get_property("semirareLocation") == goal || item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || get_property("auto_nuns") == "done" || get_property("auto_nuns") == "finished" || internalQuestStatus("questL10Garbage") < 9 || get_property("lastCastleTopUnlock").to_int() < my_ascensions() || get_property("auto_castleground") != "finished" || get_property("sidequestNunsCompleted") != "none"))
+		if (goal == $location[The Castle in the Clouds in the Sky (Top Floor)] && (get_property("semirareLocation") == goal || item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || get_property("auto_nuns") == "done" || get_property("auto_nuns") == "finished" || internalQuestStatus("questL10Garbage") < 9 || get_property("lastCastleTopUnlock").to_int() < my_ascensions() || get_property("auto_castleground") != "finished" || get_property("sidequestNunsCompleted") != "none" || in_koe()))
 		{
 			goal = $location[The Limerick Dungeon];
 		}
 
-		if (goal == $location[The Limerick Dungeon] && (get_property("semirareLocation") == goal || item_amount($item[Cyclops Eyedrops]) > 0 || get_property("auto_orchard") == "start" || get_property("auto_orchard") == "done" || get_property("auto_orchard") == "finished" || get_property("lastFilthClearance").to_int() >= my_ascensions() || get_property("sidequestOrchardCompleted") != "none" || get_property("currentHippyStore") != "none" || isActuallyEd()))
+		if (goal == $location[The Limerick Dungeon] && (get_property("semirareLocation") == goal || item_amount($item[Cyclops Eyedrops]) > 0 || get_property("auto_orchard") == "start" || get_property("auto_orchard") == "done" || get_property("auto_orchard") == "finished" || get_property("lastFilthClearance").to_int() >= my_ascensions() || get_property("sidequestOrchardCompleted") != "none" || get_property("currentHippyStore") != "none" || isActuallyEd() || in_koe()))
 		{
 			goal = $location[The Copperhead Club];
 		}
@@ -1708,6 +1700,10 @@ void initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 1)
 		{
+			if (item_amount($item[Newbiesport&trade; tent]) > 0)
+			{
+				use(1, $item[Newbiesport&trade; tent]);
+			}
 			kgbSetup();
 			if(item_amount($item[transmission from planet Xi]) > 0)
 			{
@@ -1840,37 +1836,6 @@ void initializeDay(int day)
 			{
 				pullXWhenHaveY($item[frost flower], 1, 0);
 			}
-			pullXWhenHaveY($item[hand in glove], 1, 0);
-			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
-			pullXWhenHaveY($item[wet stew], 1, 0);
-
-			if(!get_property("auto_useCubeling").to_boolean() && (towerKeyCount() == 0) && (fullness_left() >= 4))
-			{
-				if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
-				{
-					pullXWhenHaveY($item[Boris\'s Key Lime Pie], 1, 0);
-				}
-				if((item_amount($item[Sneaky Pete\'s Key]) == 0) && canEat($item[Sneaky Pete\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Sneaky Pete\'s Key]))
-				{
-					pullXWhenHaveY($item[Sneaky Pete\'s Key Lime Pie], 1, 0);
-				}
-				if((item_amount($item[Jarlsberg\'s Key]) == 0) && canEat($item[Jarlsberg\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Jarlsberg\'s Key]))
-				{
-					pullXWhenHaveY($item[Jarlsberg\'s Key Lime Pie], 1, 0);
-				}
-			}
-			else if(fullness_left() >= 5)
-			{
-				if(canEat(whatHiMein()))
-				{
-					pullXWhenHaveY(whatHiMein(), 2, 0);
-				}
-			}
-
-#			if((item_amount($item[glass of goat\'s milk]) == 0) || (auto_my_path() == "Picky"))
-#			{
-#				pullXWhenHaveY($item[milk of magnesium], 1, 0);
-#			}
 		}
 		if (chateaumantegna_havePainting() && !isActuallyEd() && auto_my_path() != "Community Service")
 		{
@@ -2106,14 +2071,14 @@ boolean doBedtime()
 		if(!LX_freeCombats()) break;
 	}
 
-	if((my_class() == $class[Seal Clubber]) && guild_store_available() && isHermitAvailable() && (auto_my_path() != "G-Lover"))
+	if((my_class() == $class[Seal Clubber]) && guild_store_available() && (auto_my_path() != "G-Lover"))
 	{
 		handleFamiliar("stat");
 		int oldSeals = get_property("_sealsSummoned").to_int();
 		while((get_property("_sealsSummoned").to_int() < 5) && (!get_property("kingLiberated").to_boolean()) && (my_meat() > 4500))
 		{
 			boolean summoned = false;
-			if((my_daycount() == 1) && (my_level() >= 6))
+			if((my_daycount() == 1) && (my_level() >= 6) && isHermitAvailable())
 			{
 				cli_execute("make figurine of an ancient seal");
 				buyUpTo(3, $item[seal-blubber candle]);
@@ -2433,24 +2398,6 @@ boolean doBedtime()
 		if((item_amount($item[set of jacks]) > 0) && !get_property("_setOfJacksUsed").to_boolean())
 		{
 			use(1, $item[set of jacks]);
-		}
-	}
-
-	if(my_daycount() == 1)
-	{
-		if((pulls_remaining() > 1) && !possessEquipment($item[antique machete]) && (my_class() != $class[Avatar of Boris]) && (auto_my_path() != "Way of the Surprising Fist") && (auto_my_path() != "Pocket Familiars"))
-		{
-			if(item_amount($item[Antique Machete]) == 0)
-			{
-				pullXWhenHaveY($item[Antique Machete], 1, 0);
-			}
-		}
-		if((pulls_remaining() > 1) && (get_property("auto_palindome") != "finished") )
-		{
-			if(item_amount($item[wet stew]) == 0)
-			{
-				pullXWhenHaveY($item[wet stew], 1, 0);
-			}
 		}
 	}
 
@@ -3602,14 +3549,6 @@ boolean L11_palindome()
 		return true;
 	}
 
-	// TODO: Mafia doesn't believe you can adventure in the Palindome in KoE
-	// until questL11Palindome is not 'unstarted'. This is a filthy hack to
-	// bypass this that SHOULD BE REMOVED WHEN MAFIA SORTS THIS OUT.
-	if(in_koe() && get_property("questL11Palindome") == "unstarted")
-	{
-		set_property("questL11Palindome", "started");
-	}
-
 	if(!possessEquipment($item[Talisman O\' Namsilat]))
 	{
 		return false;
@@ -3645,8 +3584,8 @@ boolean L11_palindome()
 
 	if((item_amount($item[Wet Stunt Nut Stew]) > 0) && !possessEquipment($item[Mega Gem]))
 	{
-		if(equipped_amount($item[Talisman o' Namsilat]) == 0)
-			equip($slot[acc3], $item[Talisman o' Namsilat]);
+		if(equipped_amount($item[Talisman o\' Namsilat]) == 0)
+			equip($slot[acc3], $item[Talisman o\' Namsilat]);
 		visit_url("place.php?whichplace=palindome&action=pal_mrlabel");
 	}
 
@@ -3716,7 +3655,7 @@ boolean L11_palindome()
 
 
 		# is step 4 when we got the wet stunt nut stew?
-		if(get_property("questL11Palindome") != "step5")
+		if (internalQuestStatus("questL11Palindome") < 5)
 		{
 			if(item_amount($item[&quot;2 Love Me\, Vol. 2&quot;]) > 0)
 			{
@@ -3777,7 +3716,7 @@ boolean L11_palindome()
 		string[int] pages;
 		pages[0] = "place.php?whichplace=palindome&action=pal_drlabel";
 		pages[1] = "choice.php?pwd&whichchoice=131&option=" + palinChoice;
-		if(autoAdvBypass(0, pages, $location[Noob Cave], "")) {}
+		autoAdvBypass(0, pages, $location[Noob Cave], "");
 
 		if(item_amount($item[[2268]Staff Of Fats]) == 1)
 		{
@@ -3791,7 +3730,7 @@ boolean L11_palindome()
 		{
 			handleBjornify($familiar[Grimstone Golem]);
 		}
-		if(internalQuestStatus("questL11Palindome") >= 2)
+		if (internalQuestStatus("questL11Palindome") > 1)
 		{
 			if(!get_property("auto_bruteForcePalindome").to_boolean())
 			{
@@ -5021,25 +4960,16 @@ boolean L12_lastDitchFlyer()
 	}
 
 	auto_log_info("Not enough flyer ML but we are ready for the war... uh oh", "blue");
-	boolean doHoleInTheSky = needStarKey();
 
-	if(doHoleInTheSky)
+	if (needStarKey())
 	{
-		if(item_amount($item[Steam-Powered Model Rocketship]) == 0)
+		if (!zone_isAvailable($location[The Hole in the Sky]))
 		{
-			set_property("choiceAdventure677", "2");
-			set_property("choiceAdventure678", "3");
-			handleFamiliar("initSuggest");
-			providePlusNonCombat(25);
-			autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
-			handleFamiliar("item");
+			return (L10_topFloor() || L10_holeInTheSkyUnlock());
 		}
 		else
 		{
-			if((item_amount($item[star]) < 8) || (item_amount($item[line]) < 7))
-			{
-				handleFamiliar("item");
-			}
+			handleFamiliar("item");
 			if(LX_getStarKey())
 			{
 				return true;
@@ -5246,7 +5176,7 @@ boolean LX_attemptPowerLevel()
 	{
 		// burn all spare clovers after level 12 if we need to powerlevel.
 		int cloverLimit = get_property("auto_wandOfNagamar").to_boolean() ? 1 : 0;
-		if (my_level() >= 12 && get_property("questL12War") == "finished" && cloversAvailable() > cloverLimit)
+		if (my_level() >= 12 && internalQuestStatus("questL12War") > 1 && cloversAvailable() > cloverLimit)
 		{
 			//Determine where to go for clover stats, do not worry about clover failures
 			location whereTo = $location[none];
@@ -5960,7 +5890,7 @@ boolean L11_unlockHiddenCity()
 
 	boolean useStoneWool = true;
 
-	if(auto_my_path() == "G-Lover" || auto_my_path() == "Two Crazy Random Summer")
+	if (auto_my_path() == "G-Lover" || in_tcrs())
 	{
 		if(my_adventures() <= 3)
 		{
@@ -5988,7 +5918,7 @@ boolean L11_unlockHiddenCity()
 
 	boolean bypassResult = autoAdvBypass(280);
 
-	if(auto_my_path() == "G-Lover" || auto_my_path() == "Two Crazy Random Summer")
+	if (auto_my_path() == "G-Lover" || in_tcrs())
 	{
 		if(get_property("lastEncounter") != "The Hidden Heart of the Hidden Temple")
 		{
@@ -6024,10 +5954,6 @@ boolean L11_unlockHiddenCity()
 	visit_url("choice.php?whichchoice=125&option=3&pwd");
 	auto_log_info("Hidden Temple Unlocked");
 	set_property("auto_hiddenunlock", "finished");
-	if(!possessEquipment($item[Antique Machete]) && !in_hardcore())
-	{
-		pullXWhenHaveY($item[Antique Machete], 1, 0);
-	}
 
 	restoreSetting("choiceAdventure579");
 	restoreSetting("choiceAdventure581");
@@ -6061,7 +5987,7 @@ boolean L11_nostrilOfTheSerpent()
 	auto_log_info("Must get a snake nose.", "blue");
 	boolean useStoneWool = true;
 
-	if(auto_my_path() == "G-Lover" || auto_my_path() == "Two Crazy Random Summer")
+	if (auto_my_path() == "G-Lover" || in_tcrs())
 	{
 		if(my_adventures() <= 3)
 		{
@@ -6087,7 +6013,7 @@ boolean L11_nostrilOfTheSerpent()
 
 	set_property("choiceAdventure582", "1");
 	set_property("choiceAdventure579", "2");
-	if(auto_my_path() == "G-Lover" || auto_my_path() == "Two Crazy Random Summer")
+	if (auto_my_path() == "G-Lover" || in_tcrs())
 	{
 		if(!autoAdvBypass(280))
 		{
@@ -6898,14 +6824,14 @@ boolean L11_unlockPyramid()
 		if (in_koe())
 		{
 			visit_url("place.php?whichplace=exploathing_beach&action=expl_pyramidpre");
-			set_property("questL11Pyramid", "started");
+			cli_execute("refresh quests");
 		}
 		else
 		{
 			visit_url("place.php?whichplace=desertbeach&action=db_pyramid1");
 		}
 
-		if(get_property("questL11Pyramid") == "unstarted")
+		if (internalQuestStatus("questL11Pyramid") < 0)
 		{
 			auto_log_info("No burning Ed's model now!", "blue");
 			if((auto_my_path() == "One Crazy Random Summer") && (get_property("desertExploration").to_int() == 100))
@@ -7571,7 +7497,7 @@ boolean L12_filthworms()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Two Crazy Random Summer")
+	if (in_tcrs() || in_koe())
 	{
 		return false;
 	}
@@ -7875,7 +7801,10 @@ boolean L12_finalizeWar()
 
 boolean LX_getDigitalKey()
 {
-	if(in_koe()) { return false; }
+	if (in_koe())
+	{
+		return false;
+	}
 	if(contains_text(get_property("nsTowerDoorKeysUsed"), "digital key"))
 	{
 		return false;
@@ -8155,12 +8084,12 @@ boolean L10_topFloor()
 		// Copper feel: Turn in airship (will fight otherwise)
 		set_property("choiceAdventure677", 1);
 	}
-	if((item_amount($item[mohawk wig]) == 0) && !in_hardcore())
+	if (!possessEquipment($item[mohawk wig]) && auto_can_equip($item[mohawk wig]) && !in_hardcore())
 	{
 		pullXWhenHaveY($item[Mohawk Wig], 1, 0);
 	}
 
-	if(!possessEquipment($item[mohawk wig]) && 0 == item_amount($item[drum 'n' bass 'n' drum 'n' bass record]))
+	if(!possessEquipment($item[mohawk wig]) && 0 == item_amount($item[Drum \'n\' Bass \'n\' Drum \'n\' Bass Record]))
 	{
 		auto_log_info("We don't have a mohawk wig, let's try to get a drum 'n' bass record...", "green");
 		// Yeah, You're for Me, Punk Rock Giant: Move to Flavor of a Raver (676)
@@ -8234,23 +8163,16 @@ boolean L10_ground()
 	}
 
 	auto_log_info("Castle Ground Floor, boring!", "blue");
-	set_property("choiceAdventure672", 3);
-	set_property("choiceAdventure673", 3);
-	set_property("choiceAdventure674", 3);
-	if (isActuallyEd())
+	set_property("choiceAdventure672", 3); // There's No Ability Like Possibility: Skip
+	set_property("choiceAdventure673", 1); // Putting Off Is Off-Putting: Very Overdue Library Book then Skip
+	set_property("choiceAdventure674", 3); // Huzzah!: Skip
+	if (isActuallyEd() || (auto_my_path() == "Pocket Familiars"))
 	{
-		set_property("choiceAdventure1026", 3);
+		set_property("choiceAdventure1026", 3); // Home on the Free Range: Skip
 	}
 	else
 	{
-		if((item_amount($item[Electric Boning Knife]) > 0) || (auto_my_path() == "Pocket Familiars"))
-		{
-			set_property("choiceAdventure1026", 3);
-		}
-		else
-		{
-			set_property("choiceAdventure1026", 2);
-		}
+		set_property("choiceAdventure1026", 2); // Home on the Free Range: Get Electric Boning Knife then Skip
 	}
 
 	if(auto_have_familiar($familiar[Ms. Puck Man]))
@@ -8298,14 +8220,14 @@ boolean L10_basement()
 		return false;
 	}
 	auto_log_info("Basement Search", "blue");
-	set_property("choiceAdventure670", "5");
+	set_property("choiceAdventure670", "5"); // You Don't Mess Around with Gym: Open Ground floor (with amulet)
 	if(item_amount($item[Massive Dumbbell]) > 0)
 	{
-		set_property("choiceAdventure671", "1");
+		set_property("choiceAdventure671", "1"); // Out in the Open Source: Open Ground floor
 	}
 	else
 	{
-		set_property("choiceAdventure671", "4");
+		set_property("choiceAdventure671", "4"); // Out in the Open Source: Go to Fitness Choice
 	}
 
 	if(my_primestat() == $stat[Muscle])
@@ -8318,11 +8240,11 @@ boolean L10_basement()
 
 	if(possessEquipment($item[Titanium Assault Umbrella]) && can_equip($item[Titanium Assault Umbrella]))
 	{
-		set_property("choiceAdventure669", "4");
+		set_property("choiceAdventure669", "4"); // The Fast and the Furry-ous: Skip (and ensure reoccurance)
 	}
 	else
 	{
-		set_property("choiceAdventure669", "1");
+		set_property("choiceAdventure669", "1"); // The Fast and the Furry-ous: Open Ground floor (with Umbrella) or Neckbeard Choice
 	}
 
 	if(auto_have_familiar($familiar[Ms. Puck Man]))
@@ -8357,7 +8279,7 @@ boolean L10_basement()
 	{
 		auto_log_info("We was fast and furry-ous!", "blue");
 		autoEquip($item[Titanium Assault Umbrella]);
-		set_property("choiceAdventure669", "1");
+		set_property("choiceAdventure669", "1"); // The Fast and the Furry-ous: Open Ground floor (with Umbrella)
 		autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 		if(contains_text(get_property("lastEncounter"), "The Fast and the Furry-ous"))
 		{
@@ -8375,19 +8297,12 @@ boolean L10_basement()
 		{
 			auto_log_warning("Can't equip an Amulet of Extreme Plot Signifcance...", "red");
 			auto_log_warning("I suppose we will try the Massive Dumbbell... Beefcake!", "red");
-			if(item_amount($item[Massive Dumbbell]) == 0)
-			{
-				set_property("choiceAdventure670", "1");
-			}
-			else
-			{
-				set_property("choiceAdventure670", "2");
-			}
+			set_property("choiceAdventure670", "1"); // You Don't Mess Around with Gym: Get Massive Dumbbell then Skip
 			autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 			return true;
 		}
 
-		set_property("choiceAdventure670", "5");
+		set_property("choiceAdventure670", "5"); // You Don't Mess Around with Gym: Open Ground floor (with amulet)
 		if(!possessEquipment($item[Amulet Of Extreme Plot Significance]))
 		{
 			pullXWhenHaveY($item[Amulet of Extreme Plot Significance], 1, 0);
@@ -8397,14 +8312,7 @@ boolean L10_basement()
 				{
 					auto_log_warning("Well, we don't seem to be able to find an Amulet...", "red");
 					auto_log_warning("I suppose we will get the Massive Dumbbell... Beefcake!", "red");
-					if(item_amount($item[Massive Dumbbell]) == 0)
-					{
-						set_property("choiceAdventure670", "1");
-					}
-					else
-					{
-						set_property("choiceAdventure670", "2");
-					}
+					set_property("choiceAdventure670", "1"); // You Don't Mess Around with Gym: Get Massive Dumbbell then Skip
 					autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 				}
 				else
@@ -8415,7 +8323,7 @@ boolean L10_basement()
 				return true;
 			}
 		}
-		set_property("choiceAdventure670", "4");
+		set_property("choiceAdventure670", "4"); // You Don't Mess Around with Gym: Open Ground floor (with amulet)
 
 		if(!autoEquip($slot[acc3], $item[Amulet Of Extreme Plot Significance]))
 		{
@@ -8455,15 +8363,15 @@ boolean L10_airship()
 	{
 		handleBjornify($familiar[Grimstone Golem]);
 	}
-	set_property("choiceAdventure178", "2");
+	set_property("choiceAdventure178", "2"); // Hammering the Armory: Skip
 
 	if(item_amount($item[Model Airship]) == 0)
 	{
-		set_property("choiceAdventure182", "4");
+		set_property("choiceAdventure182", "4"); // Random Lack of an Encounter: Get Model Airship
 	}
 	else
 	{
-		set_property("choiceAdventure182", "1");
+		set_property("choiceAdventure182", "1"); // Random Lack of an Encounter: Fight!
 	}
 
 	if((my_daycount() == 1) && (get_property("_hipsterAdv").to_int() < 7) && is_unrestricted($familiar[Artistic Goth Kid]) && auto_have_familiar($familiar[Artistic Goth Kid]))
@@ -8831,7 +8739,7 @@ boolean L7_crypt()
 		use(1, $item[Evil Eye]);
 	}
 
-	boolean skip_in_koe = in_koe() && (get_property("cyrptNookEvilness").to_int() > 25) && get_property("questL12War") != "finished";
+	boolean skip_in_koe = in_koe() && (get_property("cyrptNookEvilness").to_int() > 25) && get_property("questL12HippyFrat") != "finished";
 
 	if((get_property("cyrptNookEvilness").to_int() > 0) && canGroundhog($location[The Defiled Nook]) && !skip_in_koe)
 	{
@@ -9059,10 +8967,6 @@ boolean L6_friarsGetParts()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 
-#	if((my_daycount() == 1) && (get_property("_hipsterAdv").to_int() < 7) && (item_amount($item[hot wing]) >= 3) && is_unrestricted($familiar[Artistic Goth Kid]))
-#	{
-#		handleFamiliar($familiar[Artistic Goth Kid]);
-#	}
 	buffMaintain($effect[Snow Shoes], 0, 1, 1);
 	buffMaintain($effect[Gummed Shoes], 0, 1, 1);
 
@@ -9431,6 +9335,7 @@ boolean L8_trapperGround()
 		if(pulls_remaining() >= (3 - item_amount(oreGoal)))
 		{
 			pullXWhenHaveY(oreGoal, 3 - item_amount(oreGoal), item_amount(oreGoal));
+			return true;
 		}
 	}
 	else if (canGenieCombat() && (get_property("auto_useWishes").to_boolean()) && (catBurglarHeistsLeft() >= 2))
@@ -9634,7 +9539,6 @@ boolean L5_goblinKing()
 	}
 
 	autoAdv(1, $location[Throne Room]);
-	cli_execute("refresh quests");
 
 	if((item_amount($item[Crown of the Goblin King]) > 0) || (item_amount($item[Glass Balls of the Goblin King]) > 0) || (item_amount($item[Codpiece of the Goblin King]) > 0) || (get_property("questL05Goblin") == "finished"))
 	{
@@ -9679,6 +9583,10 @@ boolean L4_batCave()
 		}
 		set_property("auto_bat", "finished");
 		council();
+		if (in_koe())
+		{
+			cli_execute("refresh quests");
+		}
 		return true;
 	}
 	if(batStatus >= 3)
@@ -9761,7 +9669,7 @@ boolean L4_batCave()
 		}
 	}
 
-	if (isActuallyEd() && cloversAvailable() > 0 && batStatus <= 1)
+	if (cloversAvailable() > 0 && batStatus <= 1)
 	{
 		cloverUsageInit();
 		autoAdvBypass(31, $location[Guano Junction]);
@@ -10048,7 +9956,7 @@ boolean LX_craftAcquireItems()
 
 boolean councilMaintenance()
 {
-	if(auto_my_path() == "Community Service")
+	if (auto_my_path() == "Community Service" || in_koe())
 	{
 		return false;
 	}
@@ -10728,7 +10636,10 @@ boolean L2_mosquito()
 	{
 		council();
 		set_property("auto_mosquito", "finished");
-		string temp = visit_url("tavern.php?place=barkeep");
+		if (in_koe())
+		{
+			cli_execute("refresh quests");
+		}
 	}
 	if(get_property("auto_mosquito") == "finished")
 	{
@@ -10736,10 +10647,11 @@ boolean L2_mosquito()
 	}
 
 	buffMaintain($effect[Snow Shoes], 0, 1, 1);
+	providePlusNonCombat(25);
 
 	auto_log_info("Trying to find a mosquito.", "blue");
-	set_property("choiceAdventure502", "2");
-	set_property("choiceAdventure505", "1");
+	set_property("choiceAdventure502", "2"); // Arboreal Respite: go to Consciousness of a Stream
+	set_property("choiceAdventure505", "1"); // Consciousness of a Stream: Acquire Mosquito Larva
 	autoAdv(1, $location[The Spooky Forest]);
 	return true;
 }
@@ -11104,7 +11016,7 @@ boolean L12_startWar()
 		return false;
 	}
 
-	if((my_basestat($stat[Muscle]) < 70) || (my_basestat($stat[Mysticality]) < 70) || (my_basestat($stat[Moxie]) < 70))
+	if (my_basestat($stat[Mysticality]) < 70 || my_basestat($stat[Moxie]) < 70)
 	{
 		return false;
 	}
@@ -11473,7 +11385,7 @@ boolean L9_aBooPeak()
 			coldResist += 2;
 			spookyResist += 2;
 		}
-		else if((get_property("auto_blackmap") == "finished") && (item_amount($item[Can of Black Paint]) > 0) && (have_effect($effect[Red Door Syndrome]) == 0))
+		else if (item_amount($item[Can of Black Paint]) > 0 && have_effect($effect[Red Door Syndrome]) == 0)
 		{
 			coldResist += 2;
 			spookyResist += 2;
@@ -11990,8 +11902,8 @@ boolean L9_twinPeak()
 	}
 	else
 	{
-		handleFamiliar("item"); // should probably call this before adventuring no?
 		autoAdv(1, $location[Twin Peak]);
+		handleFamiliar("item");
 	}
 	return true;
 }
@@ -12003,7 +11915,14 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	int expectedML = 10;
+	buffMaintain($effect[Drescher\'s Annoying Noise], 0, 1, 1);
+	buffMaintain($effect[Pride of the Puffin], 0, 1, 1);
+	buffMaintain($effect[Ur-kel\'s Aria of Annoyance], 0, 1, 1);
+	buffMaintain($effect[Ceaseless Snarling], 0, 1, 1);
+
+	int expectedML = 0;
+	auto_change_mcd(11);
+	expectedML = current_mcd();
 	if(have_skill($skill[Drescher\'s Annoying Noise]))
 	{
 		expectedML += 10;
@@ -12365,15 +12284,7 @@ boolean L9_chasmBuild()
 		}
 	}
 
-	need = 30 - get_property("chasmBridgeProgress").to_int();
-	if((need <= 3) && (need >= 1) && (cloversAvailable() > 0))
-	{
-		cloverUsageInit();
-		autoAdvBypass("adventure.php?snarfblat=295", $location[The Smut Orc Logging Camp]);
-		cloverUsageFinish();
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-	}
-	else
+	if (get_property("chasmBridgeProgress").to_int() < 30)
 	{
 		foreach it in $items[Loadstone, Logging Hatchet]
 		{
@@ -12391,11 +12302,6 @@ boolean L9_chasmBuild()
 		}
 		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 		return true;
-	}
-	if(get_property("chasmBridgeProgress").to_int() < 30)
-	{
-		abort("Umm.... we failed the smut orcs. Sorry bro.");
-		abort("Our chasm bridge situation is borken. Beep boop.");
 	}
 	visit_url("place.php?whichplace=highlands&action=highlands_dude");
 	return true;
@@ -12472,7 +12378,7 @@ boolean L11_redZeppelin()
 			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
 			makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
 		}
-		if(my_path() == "Two Crazy Random Summer")
+		if(in_tcrs())
 		{
 			if(my_class() == $class[Sauceror] && my_sign() == "Blender")
 			{
@@ -12734,11 +12640,6 @@ boolean L11_shenCopperhead()
 
 boolean L11_talismanOfNam()
 {
-	if(my_level() < 11)
-	{
-		return false;
-	}
-
 	if(L11_shenCopperhead() || L11_redZeppelin() || L11_ronCopperhead())
 	{
 		return true;
@@ -12776,16 +12677,9 @@ boolean L11_mcmuffinDiary()
 		set_property("auto_mcmuffin", "start");
 		return true;
 	}
-	if(my_adventures() < 4)
+	if (my_adventures() < 4 || my_meat() < 500 || item_amount($item[Forged Identification Documents]) == 0)
 	{
-		return false;
-	}
-	if(my_meat() < 500)
-	{
-		return false;
-	}
-	if(item_amount($item[Forged Identification Documents]) == 0)
-	{
+		auto_log_warning("Could not vacation at the shore to find your fathers diary!", "red");
 		return false;
 	}
 
@@ -12861,28 +12755,7 @@ boolean L11_blackMarket()
 	{
 		return false;
 	}
-#	Mafia probably handles this correctly now.
-#	if(auto_my_path() == "Pocket Familiars")
-#	{
-#		string temp = visit_url("woods.php", false);
-#	}
-	if(black_market_available())
-	{
-		set_property("auto_blackmap", "document");
-		if(auto_my_path() == "Way of the Surprising Fist")
-		{
-			L11_fistDocuments();
-		}
-		if(my_meat() >= 5000)
-		{
-			buyUpTo(1, $item[forged identification documents]);
-		}
-		if(item_amount($item[Forged Identification Documents]) > 0)
-		{
-			set_property("auto_blackmap", "finished");
-		}
-		return true;
-	}
+
 	if($location[The Black Forest].turns_spent > 12)
 	{
 		auto_log_warning("We have spent a bit many adventures in The Black Forest... manually checking", "red");
@@ -12890,7 +12763,7 @@ boolean L11_blackMarket()
 		visit_url("woods.php");
 		if($location[The Black Forest].turns_spent > 30)
 		{
-			abort("We have spent too many turns in The Black Forest and haven't found The Black Market. Something is wrong. (Find Black Forest, set auto_blackmap=document, do not buy Forged Identification Documents");
+			abort("We have spent too many turns in The Black Forest and haven't found The Black Market. Something is wrong. (try \"refresh quests\" on the cli)");
 		}
 	}
 
@@ -12898,12 +12771,12 @@ boolean L11_blackMarket()
 	if(get_property("auto_blackfam").to_boolean())
 	{
 		council();
-		if(!possessEquipment($item[Blackberry Galoshes]))
+		if (!possessEquipment($item[Blackberry Galoshes]) && auto_can_equip($item[Blackberry Galoshes]))
 		{
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
 		}
 		set_property("auto_blackfam", false);
-		set_property("choiceAdventure923", "1");
+		set_property("choiceAdventure923", "1"); // All Over the Map: Head toward the blackberry patch
 	}
 
 	if(item_amount($item[beehive]) > 0)
@@ -12913,20 +12786,20 @@ boolean L11_blackMarket()
 
 	if(get_property("auto_getBeehive").to_boolean())
 	{
-		set_property("choiceAdventure924", "3");
-		set_property("choiceAdventure1018", "1");
-		set_property("choiceAdventure1019", "1");
+		set_property("choiceAdventure924", "3"); // You Found Your Thrill: Head toward the buzzing sound (get beehive step 1)
+		set_property("choiceAdventure1018", "1"); // Bee Persistent: Keep going (get beehive step 2)
+		set_property("choiceAdventure1019", "1"); // Bee Rewarded: Almost... there... (get beehive step 3)
 	}
 	else
 	{
-		if(!possessEquipment($item[Blackberry Galoshes]) && (item_amount($item[Blackberry]) >= 3) && !(my_class() == $class[Vampyre]))
+		if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && my_class() != $class[Vampyre])
 		{
-			set_property("choiceAdventure924", "2");
-			set_property("choiceAdventure928", "4");
+			set_property("choiceAdventure924", "2"); // You Found Your Thrill: Visit the cobbler's house
+			set_property("choiceAdventure928", "4"); // The Blackberry Cobbler: Make some galoshes
 		}
 		else
 		{
-			set_property("choiceAdventure924", "1");
+			set_property("choiceAdventure924", "1"); // You Found Your Thrill: Attack the bushes (fight blackberry bush)
 		}
 	}
 
@@ -13370,32 +13243,18 @@ boolean L8_trapperNinjaLair()
 
 boolean auto_tavern()
 {
-	if(get_property("auto_tavern") == "finished")
-	{
-		return false;
-	}
-	if(my_level() < 3)
+	if (internalQuestStatus("questL03Rat") < 1 || internalQuestStatus("questL03Rat") > 1)
 	{
 		return false;
 	}
 
-	if(internalQuestStatus("questL03Rat") < 1)
-	{
-		string temp = visit_url("tavern.php?place=barkeep");
-	}
 	string temp = visit_url("cellar.php");
 	if(contains_text(temp, "You should probably talk to the bartender before you go poking around in the cellar."))
 	{
 		abort("Quest not yet started, talk to Bart Ender and re-run.");
 	}
-	# Mafia usually fixes tavernLayout when we visit the cellar. However, it sometimes leaves it in a broken state so we can't guarantee this will actually help. However, it will result in no net change in tavernLayout so at least we can abort.
-	string tavern = get_property("tavernLayout");
-	if(index_of(tavern, "3") != -1)
-	{
-		set_property("auto_tavern", "finished");
-		return true;
-	}
-	auto_log_info("In the tavern! Layout: " + tavern, "blue");
+
+	auto_log_info("In the tavern! Layout: " + get_property("tavernLayout"), "blue");
 	boolean [int] locations = $ints[3, 2, 1, 0, 5, 10, 15, 20, 16, 21];
 
 	// Infrequent compunding issue, reset maximizer
@@ -13504,8 +13363,12 @@ boolean auto_tavern()
 		{
 			providePlusNonCombat(25);
 		}
+		else
+		{
+			providePlusCombat(25);
+		}
 
-		tavern = get_property("tavernLayout");
+		string tavern = get_property("tavernLayout");
 		if(tavern == "0000000000000000000000000")
 		{
 			string temp = visit_url("cellar.php");
@@ -13576,17 +13439,14 @@ boolean auto_tavern()
 
 boolean L3_tavern()
 {
-	if(get_property("auto_tavern") == "finished")
+	if (internalQuestStatus("questL03Rat") < 0 || internalQuestStatus("questL03Rat") > 2)
 	{
 		return false;
 	}
-	if(my_adventures() < 10)
+
+	if (internalQuestStatus("questL03Rat") < 1)
 	{
-		return false;
-	}
-	if(get_counters("Fortune Cookie", 0, 10) == "Fortune Cookie")
-	{
-		return false;
+		visit_url("tavern.php?place=barkeep");
 	}
 
 	int mpNeed = 0;
@@ -13605,9 +13465,9 @@ boolean L3_tavern()
 
 	if (isActuallyEd())
 	{
-		set_property("choiceAdventure1000", "1");
-		set_property("choiceAdventure1001", "2");
-		if((my_mp() < 15) && have_skill($skill[Shelter of Shed]))
+		set_property("choiceAdventure1000", "1"); // Everything in Moderation: turn on the faucet (completes quest)
+		set_property("choiceAdventure1001", "2"); // Hot and Cold Dripping Rats: Leave it alone (don't fight a rat)
+		if (have_skill($skill[Shelter of Shed]) && my_mp() < mp_cost($skill[Shelter of Shed]))
 		{
 			delayTavern = true;
 		}
@@ -13619,6 +13479,7 @@ boolean L3_tavern()
 			delayTavern = true;
 		}
 	}
+
 	if(my_level() == get_property("auto_powerLevelLastLevel").to_int())
 	{
 		delayTavern = false;
@@ -13641,31 +13502,24 @@ boolean L3_tavern()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 
-	buffMaintain($effect[The Sonata of Sneakiness], 20, 1, 1);
-	buffMaintain($effect[Smooth Movements], 10, 1, 1);
 	buffMaintain($effect[Tortious], 0, 1, 1);
 	buffMaintain($effect[Litterbug], 0, 1, 1);
 	auto_setMCDToCap();
 
-	if(get_property("questL03Rat") == "unstarted")
+	if (auto_tavern())
 	{
-		string temp = visit_url("tavern.php?place=barkeep");
+		return true;
 	}
 
-	while(auto_tavern())
+	if (internalQuestStatus("questL03Rat") > 1)
 	{
-		if(my_adventures() <= 0)
-		{
-			abort("Ran out of adventures while doing the tavern.");
-		}
-		wait(4);
+		visit_url("tavern.php?place=barkeep");
+		set_property("auto_tavern", "finished");
+		council();
+		return true;
 	}
-	visit_url("tavern.php?place=barkeep");
-	set_property("auto_tavern", "finished");
-	council();
-	return true;
+	return false;
 }
-
 
 boolean LX_setBallroomSong()
 {
@@ -13732,7 +13586,7 @@ boolean L12_clearBattlefield()
 				warOutfit(false);
 			}
 
-			item warKillDoubler = get_property("auto_hippyInstead").to_boolean() ? $item[Jacob\'s rung] : $item[Haunted paddle-ball];
+			item warKillDoubler = my_primestat() == $stat[mysticality] ? $item[Jacob\'s rung] : $item[Haunted paddle-ball];
 			pullXWhenHaveY(warKillDoubler, 1, 0);
 			if(possessEquipment(warKillDoubler))
 			{
@@ -13740,7 +13594,7 @@ boolean L12_clearBattlefield()
 			}
 
 			item food_item = $item[none];
-			foreach it in $items[space chowder, ghuol guolash]
+			foreach it in $items[pie man was not meant to eat, spaghetti with Skullheads, gnocchetti di Nietzsche, Spaghetti con calaveras, space chowder, Spaghetti with ghost balls, Crudles, Agnolotti arboli, Shells a la shellfish, Linguini immondizia bianco, Fettucini Inconnu, ghuol guolash, suggestive strozzapreti, Fusilli marrownarrow]
 			{
 				if(item_amount(it) > 0)
 				{
@@ -13977,7 +13831,16 @@ boolean doTasks()
 
 	basicAdjustML();
 	powerLevelAdjustment();
-	handleFamiliar("item");
+	if (is100FamiliarRun())
+	{
+		// re-equip a familiar if it's a 100% run just in case something unequipped it
+		// looking at you auto_maximizedConsumeStuff()...
+		handleFamiliar(to_familiar(get_property("auto_100familiar")));
+	}
+	else
+	{
+		handleFamiliar("item");
+	}
 	basicFamiliarOverrides();
 
 	councilMaintenance();
@@ -14262,7 +14125,7 @@ boolean doTasks()
 
 	if((my_level() >= 12) && ((get_property("hippiesDefeated").to_int() >= 192) || get_property("auto_hippyInstead").to_boolean()) && (get_property("auto_nuns") == ""))
 	{
-		if(doThemtharHills())
+		if(L12_ThemtharHills())
 		{
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -295,9 +295,9 @@ string auto_combatHandler(int round, string opp, string text)
 
 	boolean doBanisher = !get_property("kingLiberated").to_boolean();
 
-	int majora = -1;
 	if(my_path() == "Disguises Delimit")
 	{
+		int majora = -1;
 		matcher maskMatch = create_matcher("mask(\\d+).png", text);
 		if(maskMatch.find())
 		{
@@ -313,10 +313,6 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 		if(majora == 3)
 		{
-//			if((round > 10) && (my_mp() > mp_cost($skill[Swap Mask])))
-//			{
-//				return "skill " + $skill[Swap Mask];
-//			}
 			if(canSurvive(1.5))
 			{
 				return "attack with weapon";
@@ -481,11 +477,6 @@ string auto_combatHandler(int round, string opp, string text)
 		{
 			return "item " + $item[Beehive];
 		}
-#		if((!contains_text(combatState, "love stinkbug")) && auto_have_skill($skill[Summon Love Stinkbug]))
-#		{
-#			set_property("auto_combatHandler", combatState + "(love stinkbug)");
-#			return "skill summon love stinkbug";
-#		}
 
 		if(canUse($skill[Shell Up]) && (round >= 3))
 		{
@@ -544,15 +535,16 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 	}
 
-	if(enemy.to_string() == "the invader" && auto_have_skill($skill[Weapon of the Pastalord]))
+	if (enemy == $monster[The Invader] && canUse($skill[Weapon of the Pastalord], false))
 	{
 		return useSkill($skill[Weapon of the Pastalord], false);
 	}
 
-	if(enemy.to_string() == "skeleton astronaut")
+	if (enemy == $monster[Skeleton astronaut])
 	{
-		if(my_daycount() == 1 && item_amount($item[Exploding cigar]) > 0){
-			return "item " + $item[Exploding cigar];
+		if(my_daycount() == 1 && canUse($item[Exploding cigar], false))
+		{
+			return useItem($item[Exploding cigar]);
 		}
 		int dmg = 0;
 		foreach el in $elements[hot, cold, sleaze, spooky, stench]
@@ -2193,7 +2185,6 @@ string auto_combatHandler(int round, string opp, string text)
 	}
 
 	return attackMinor;
-#	return get_ccs_action(round);
 }
 
 string findBanisher(int round, string opp, string text)
@@ -2218,7 +2209,7 @@ string findBanisher(int round, string opp, string text)
 		}
 		return banishAction;
 	}
-	if (canUse($skill[Storm of the Scarab]))
+	if (canUse($skill[Storm of the Scarab], false))
 	{
 		return useSkill($skill[Storm of the Scarab], false);
 	}
@@ -2313,11 +2304,11 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 
 	if(round >= 28)
 	{
-		if (canUse($skill[Storm of the Scarab]))
+		if (canUse($skill[Storm of the Scarab], false))
 		{
 			return useSkill($skill[Storm of the Scarab], false);
 		}
-		else if (canUse($skill[Lunging Thrust-Smack]))
+		else if (canUse($skill[Lunging Thrust-Smack], false))
 		{
 			return useSkill($skill[Lunging Thrust-Smack], false);
 		}
@@ -2387,7 +2378,7 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 			{
 				return findBanisher(round, opp, text);
 			}
-			else if (canUse($item[Seal Tooth]) && get_property("auto_edStatus") == "UNDYING!")
+			else if (canUse($item[Seal Tooth], false) && get_property("auto_edStatus") == "UNDYING!")
 			{
 				return useItem($item[Seal Tooth], false);
 			}
@@ -2400,13 +2391,13 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 
 	foreach it in $items[Seal Tooth, Spectre Scepter, Doc Galaktik\'s Pungent Unguent]
 	{
-		if(canUse(it) && glover_usable(it))
+		if(canUse(it, false) && glover_usable(it))
 		{
 			return useItem(it, false);
 		}
 	}
 
-	if (canUse($skill[Toss]))
+	if (canUse($skill[Toss], false))
 	{
 		return useSkill($skill[Toss], false);
 	}
@@ -2993,7 +2984,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if (canUse($item[Tattered Scrap of Paper]))
+	if (canUse($item[Tattered Scrap of Paper], false))
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
@@ -3056,7 +3047,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus]))
+	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false))
 	{
 		return useItem($item[Short Writ of Habeas Corpus]);
 	}
@@ -3080,7 +3071,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 			return useSkill($skill[Curse of Fortune]);
 		}
 
-		if (canUse($item[Seal Tooth]))
+		if (canUse($item[Seal Tooth], false))
 		{
 			return useItem($item[Seal Tooth], false);
 		}
@@ -3088,21 +3079,21 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return useSkill($skill[Mild Curse], false);
 	}
 
-	if (my_location() == $location[The Secret Government Laboratory] && canUse($skill[Roar of the Lion]))
+	if (my_location() == $location[The Secret Government Laboratory] && canUse($skill[Roar of the Lion], false))
 	{
-		if (canUse($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) >= 60)
+		if (canUse($skill[Storm Of The Scarab], false) && my_buffedstat($stat[Mysticality]) >= 60)
 		{
 			return useSkill($skill[Storm Of The Scarab], false);
 		}
 		return useSkill($skill[Roar Of The Lion], false);
 	}
 
-	if ($locations[Pirates of the Garbage Barges, The SMOOCH Army HQ, VYKEA] contains my_location() && canUse($skill[Storm of the Scarab]))
+	if ($locations[Pirates of the Garbage Barges, The SMOOCH Army HQ, VYKEA] contains my_location() && canUse($skill[Storm of the Scarab], false))
 	{
 		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
-	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location() && canUse($skill[Fist Of The Mummy]))
+	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location() && canUse($skill[Fist Of The Mummy], false))
 	{
 		return useSkill($skill[Fist Of The Mummy], false);
 	}
@@ -3123,14 +3114,14 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return useItem($item[Ice-Cold Cloaca Zero]);
 	}
 
-	if (canUse($skill[Storm Of The Scarab]) && my_buffedstat($stat[Mysticality]) > 35)
+	if (canUse($skill[Storm Of The Scarab], false) && my_buffedstat($stat[Mysticality]) > 35)
 	{
 		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
 	if((enemy.physical_resistance >= 100) || (round >= 25) || canSurvive(1.25))
 	{
-		if (canUse($skill[Fist Of The Mummy]))
+		if (canUse($skill[Fist Of The Mummy], false))
 		{
 			return useSkill($skill[Fist Of The Mummy], false);
 		}

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -2122,7 +2122,10 @@ boolean auto_maximizedConsumeStuff()
 		}
 		if(inebriety_left() > 0)
 		{
-			use_familiar($familiar[none]);
+			if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper])
+			{
+				use_familiar($familiar[none]);
+			}
 			return auto_knapsackAutoConsume("drink", false);
 		}
 		if(fullness_left() > 0)

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -290,5 +290,17 @@ boolean settingFixer()
 		set_property("auto_helpMeMafiaIsSuperBrokenAaah", false);
 	}
 
+	if(property_exists("auto_beta_test"))
+	{
+		auto_log_debug("Beta testing features should be guarded behind their own individual properties...", "red");
+		remove_property("auto_beta_test");
+	}
+
+	if(property_exists("auto_invaderKilled"))
+	{
+		auto_log_debug("No longer need to track the invaders status ourselves as mafia does it now...", "red");
+		remove_property("auto_invaderKilled");
+	}
+
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1475,6 +1475,11 @@ boolean L1_ed_islandFallback()
 
 boolean L9_ed_chasmStart()
 {
+	if (internalQuestStatus("questL09Topping") < 0)
+	{
+		return false;
+	}
+
 	if (isActuallyEd() && !get_property("auto_chasmBusted").to_boolean())
 	{
 		auto_log_info("It's a troll on a bridge!!!!", "blue");

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -16,7 +16,6 @@ boolean koe_initializeSettings()
 		set_property("auto_airship", "finished");
 		set_property("auto_holeinthesky", false);
 		set_property("auto_grimstoneOrnateDowsingRod", "false");
-		set_property("auto_invaderKilled", false);
 		set_property("auto_paranoia", 3);
 
 		// The Hidden Temple is originally unlocked
@@ -24,6 +23,7 @@ boolean koe_initializeSettings()
 		set_property("auto_spookymap", "finished");
 		set_property("auto_treecoin", "finished");
 		set_property("auto_spookysapling", "finished");
+		return true;
 	}
 	return false;
 }
@@ -34,8 +34,11 @@ boolean LX_koeInvaderHandler()
 	{
 		return false;
 	}
-	if(get_property("auto_invaderKilled").to_boolean())
+	if (internalQuestStatus("questL13Final") < 3 || get_property("spaceInvaderDefeated").to_boolean())
 	{
+		// invader drops 10 white pixels so fight it before we do the hedge maze
+		// as we need elemental resists for both and we may be able to get enough
+		// pixels for the digital key if we still require them.
 		return false;
 	}
 
@@ -101,7 +104,6 @@ boolean LX_koeInvaderHandler()
 			{
 				abort("We died to the invader. Do it manually please?");
 			}
-			set_property("auto_invaderKilled", true);
 			return ret;
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -174,7 +174,7 @@ void handlePreAdventure(location place)
 		}
 	}
 
-	if(my_path() == "Two Crazy Random Summer")
+	if(in_tcrs())
 	{
 		if(my_class() == $class[Sauceror] && my_sign() == "Blender")
 		{
@@ -269,7 +269,7 @@ void handlePreAdventure(location place)
 		autoEquip($slot[acc3], $item[Talisman O\' Namsilat]);
 	}
 
-	if((place == $location[The Haunted Wine Cellar]) && (my_turncount() != 0) && (get_property("auto_winebomb") == "partial"))
+	if((place == $location[The Haunted Boiler Room]) && (my_turncount() != 0) && (get_property("auto_winebomb") == "partial"))
 	{
 		if(!possessEquipment($item[Unstable Fulminate]))
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -528,7 +528,7 @@ int doNumberology(string goal, boolean doIt, string option);//Defined in autosce
 int doNumberology(string goal, string option);				//Defined in autoscend/auto_util.ash
 boolean doTasks();											//Defined in autoscend.ash
 boolean keepOnTruckin();									//Defined in autoscend/auto_cooking.ash
-boolean doThemtharHills();									//Defined in autoscend.ash
+boolean L12_ThemtharHills();									//Defined in autoscend.ash
 boolean isSpeakeasyDrink(item drink); //Defined in autoscend/auto_clan.ash
 boolean canDrinkSpeakeasyDrink(item drink); //Defined in autoscend/auto_clan.ash
 boolean drinkSpeakeasyDrink(item drink);					//Defined in autoscend/auto_clan.ash


### PR DESCRIPTION
# Description
- add dirty old lihc to sniff targets with appropriate property check
- actually add Party Mouse to familiars (forgot to run the build script last time)
- remove auto_beta_test if it exists (another thing missed out in a previous PR)
- change all checks for 2CRS to use in_tcrs()
- in KoE don't bother fighting the Invader until we're at the hedge maze. Also use the mafia property to track if it's been killed.
- Fix an issue with 100% familiar runs where using the new consumption logic would remove familiars and not re-equip them so you'd adventure with no familiar.
- update minimum KoLMafia version since they fixed the issue with the Palindome quest in KoE
- rename doThemtharHills() to L12_ThemtharHills()
- KoE should not attempt to get Inhalers (since no nuns) nor Cyclops Eyedrops (since no Limerick Dungeon and no filthworms)
- set up your Newbiesport tent in your campground so you're not sleeping in the dirt like an animal
- L2_Mosquito will only concern itself with the mosquito quest and will use non-combat sources to make it potentially faster.
- Don't use clovers when building the bridge. With the new NC and having to do Copperhead now it's generally a waste of a clover (doesn't apply to Ed, he has his own logic for using clovers for bridge parts which is unchanged).
- Add some checks that we can actually equip stuff we're attempting to pull to speed up quests before we pull it so we don't pull things we can't use. Also remove other places which pull these for the same reason.
- Tavern quest now works like all other quests in that it uses adventures one at a time rather than a while loop. It also handles speaking to Bart Ender to open the cellar itself and doesn't expect L2_mosquito to do its work for it.
- Tavern quest will also use +combat sources if we don't have at least 3 of the 4 elemental damage sources required to skip non-combats so we maximise potential rat king encounters.
- In KoE we will pull the Jacobs Rung for myst classes when doing the battlefield (both doublers work for both sides). Also add a bunch more stuff to the list of items we'll use for the NC because the old list was rather short.

## How Has This Been Tested?

Ran a few KoE runs with different classes.
Note: This is a chunk of the changes I'm using as again, I'm trying to break them up into smaller PR chunks so they're easier to review. Reviewing it all would be a huge pain & even this is larger than I would like ideally.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
