### PR TITLE
Aptitude is not worth maintaining if we already have Ur-Kel's active,…

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -863,7 +863,8 @@ void handlePostAdventure()
 		// Generic +Stat Buffs
 		buffMaintain($effect[Carol of the Thrills], 30, 1, 1);
 
-		if((40 / regen) < auto_predictAccordionTurns())
+		// Aptitude is not worth it to maintain if we have Ur-Kel's
+		if(((40 / regen) < auto_predictAccordionTurns()) && (have_effect($effect[Ur-Kel\'s Aria of Annoyance]) == 0))
 		{
 			buffMaintain($effect[Aloysius\' Antiphon of Aptitude], 40, 1, 1);
 		}


### PR DESCRIPTION
… so make room for other songs

# Description

Aptitude will drain way too much MP and take up a song slot for little effect. If we have Ur-Kel's active it is not worth it.

Fixes # (issue)

MP drain

## How Has This Been Tested?

Running SC AT.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
