### PR TITLE
Fixed check so that if mafia or supporting scripts are behaving oddly…

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1748,7 +1748,8 @@ void initializeDay(int day)
 					{
 						buyUpTo(1, $item[Antique Accordion]);
 					}
-					else if(isArmoryAvailable())
+					// Removed "else". In some situations when mafia or supporting scripts are behaving wonky we may completely fail to get an accordion
+					if((isArmoryAvailable()) && (item_amount($item[Antique Accordion]) == 0))
 					{
 						buyUpTo(1, $item[Toy Accordion]);
 					}


### PR DESCRIPTION
… we will not fail to get an accordion to start.

# Description

Found an instance where mafia was having problems buying an antique accordion, making it so that I could not get an accordion

Fixes # (issue)

Observed issue in my run

## How Has This Been Tested?

Hasn't.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
