### PR TITLE
Added Drunken Rat King to the no-instakill list

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2271,7 +2271,10 @@ boolean instakillable(monster mon)
 		slime blob, terrible mutant, government bureaucrat, angry ghost, annoyed snake,
 
 		// Tentacles
-		Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl, Eldritch Tentacle
+		Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl, Eldritch Tentacle,
+
+		// Other Monsters that Mafia returns as instakillable (or not a boss), that really aren't
+		Drunken Rat King
 	];
 
 	if(not_instakillable contains mon)


### PR DESCRIPTION
# Description

Mafia returns DRK as not a boss, but it is. Added it to the list and started a new entry for other randos like this.

Fixes # (issue)
#75 

## How Has This Been Tested?
Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
