### PR TITLE
Add a list of locations where to ignore latte drops if they conflict …

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -243,7 +243,9 @@ void handlePreAdventure(location place)
 		}
 	}
 
-	if(auto_latteDropWanted(place))
+	// Latte may conflict with certain quests. Ignore latte drops for the greater good.
+	boolean[location] IgnoreLatteDrop = $locations[The Haunted Boiler Room];
+	if((auto_latteDropWanted(place)) && (!(IgnoreLatteDrop contains place)))
 	{
 		auto_log_info('We want to get the "' + auto_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
 		autoEquip($item[latte lovers member\'s mug]);


### PR DESCRIPTION
…with quests.

# Description
Latte in boiler room is a constant thorn in our side. The latte drop has no bearing on ascension. Added a list to add other locations where we can ignore the latte if more needs arise.

Fixes # (issue)

Issues still being reported on Discord.

## How Has This Been Tested?

Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
