### PR TITLE
BugFix: remove color specification from abort message

### DIFF
--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1181,7 +1181,7 @@ boolean autoEdAdv(int num, location loc, string option)
 	}
 	if (loc == $location[Noob Cave])
 	{
-		abort("We don't do this any more. Bug report this with the call stack please.", "red");
+		abort("We don't do this any more. Bug report this with the call stack please.");
 	}
 	if((option == "") || (option == "auto_combatHandler"))
 	{


### PR DESCRIPTION
# Description
Color specification in abort message causing script to fail.

Fixes # (issue)

reported on discord

## How Has This Been Tested?
---

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
