### PR TITLE
Totem

### DIFF
--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -188,13 +188,6 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
-	
-	// can't equip kramko sausage grinder during certain paths, return false in those paths
-	
-	if (auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Avatar of Boris")
-	{
-		return false;
-	}
 
 	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first
 	// 7 sausage goblins using a formula of 3n+1 adventures since the previous.

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -188,6 +188,18 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
+	
+	// can't equip kramko sausage grinder during certain paths, return false in those paths just like if you didn't own kramko
+	
+	if(my_path() == "Way of the Surprising Fist")
+	{
+		return false;
+	}
+	
+	if(my_path() == "Avatar of Boris")
+	{
+		return false;
+	}
 
 	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first
 	// 7 sausage goblins using a formula of 3n+1 adventures since the previous.

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -189,14 +189,9 @@ boolean auto_sausageGoblin(location loc, string option)
 		return false;
 	}
 	
-	// can't equip kramko sausage grinder during certain paths, return false in those paths just like if you didn't own kramko
+	// can't equip kramko sausage grinder during certain paths, return false in those paths
 	
-	if(my_path() == "Way of the Surprising Fist")
-	{
-		return false;
-	}
-	
-	if(my_path() == "Avatar of Boris")
+	if (auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Avatar of Boris")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2172,41 +2172,6 @@ boolean acquireTotem()
 		return true;
 	}
 	
-	//fishing in the sewer did not work for some reason. Check some path specific scenarios
-	//first path to check is Way of the Surprising Fist. For it, try to pull the best non quest totem available.
-	
-	if(my_path() == "Way of the Surprising Fist" && !in_hardcore() )
-	{
-		if(storage_amount($item[primitive alien totem]) > 0) 
-		{
-			if(take_storage(1 , $item[primitive alien totem]))
-			{
-				return true;
-			}
-		}
-		if(storage_amount($item[Mace of the Tortoise]) > 0) 
-		{
-			if(take_storage(1 , $item[Mace of the Tortoise]))
-			{
-				return true;
-			}
-		}
-		if(storage_amount($item[Ouija Board, Ouija Board]) > 0) 
-		{
-			if(take_storage(1 , $item[Ouija Board, Ouija Board]))
-			{
-				return true;
-			}
-		}
-		if(storage_amount($item[turtle totem]) > 0) 
-		{
-			if(take_storage(1 , $item[turtle totem]))
-			{
-				return true;
-			}
-		}
-	}
-	
 	//still could not get a totem. Give up
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -27,6 +27,7 @@ boolean set_property_ifempty(string setting, string change);
 boolean restore_property(string setting, string source);
 boolean clear_property_if(string setting, string cond);
 boolean acquireGumItem(item it);
+boolean acquireTotem();
 boolean acquireHermitItem(item it);
 boolean isHermitAvailable();
 boolean isGeneralStoreAvailable();
@@ -2098,6 +2099,116 @@ boolean acquireGumItem(item it)
 	}
 
 	return (have + 1) == item_amount(it);
+}
+
+boolean acquireTotem()
+{
+	//this function checks if you have a valid totem for casting turtle tamer buffs with. Returning true if you do. If you don't, it will attempt to acquire one in a reasonable manner.
+
+	//first check if there is a valid totem in inventory or equipped, return true if there is.
+	
+	if ((0 < item_amount($item[primitive alien totem])) || (have_equipped($item[primitive alien totem])))
+	{
+		return true;
+	}
+	if ((0 < item_amount($item[Flail of the Seven Aspects])) || (have_equipped($item[Flail of the Seven Aspects])))
+	{
+		return true;
+	}
+	if ((0 < item_amount($item[Chelonian Morningstar])) || (have_equipped($item[Chelonian Morningstar])))
+	{
+		return true;
+	}
+	if ((0 < item_amount($item[Mace of the Tortoise])) || (have_equipped($item[Mace of the Tortoise])))
+	{
+		return true;
+	}
+	if ((0 < item_amount($item[Ouija Board, Ouija Board])) || (have_equipped($item[Ouija Board, Ouija Board])))
+	{
+		return true;
+	}
+	if ((0 < item_amount($item[turtle totem])) || (have_equipped($item[turtle totem])))
+	{
+		return true;
+	}
+	
+	//if no valid totems were found, check the closet for one, from best to worst. If found in closet, uncloset 1 and return true
+	
+	if (0 < closet_amount( $item[primitive alien totem] ))
+	{
+		take_closet( 1 , $item[primitive alien totem] );
+		return true;
+	}
+	if (0 < closet_amount( $item[Flail of the Seven Aspects] ))
+	{
+		take_closet( 1 , $item[turtle totem] );
+		return true;
+	}
+	if (0 < closet_amount( $item[Chelonian Morningstar] ))
+	{
+		take_closet( 1 , $item[turtle totem] );
+		return true;
+	}
+	if (0 < closet_amount( $item[Mace of the Tortoise] ))
+	{
+		take_closet( 1 , $item[turtle totem] );
+		return true;
+	}
+	if (0 < closet_amount( $item[Ouija Board, Ouija Board] ))
+	{
+		take_closet( 1 , $item[turtle totem] );
+		return true;
+	}
+	if (0 < closet_amount( $item[turtle totem] ))
+	{
+		take_closet( 1 , $item[turtle totem] );
+		return true;
+	}
+	
+	//if still not acquired, try fishing in the sewer for a turtle totem.
+	
+	if(acquireGumItem($item[turtle totem]))
+	{
+		return true;
+	}
+	
+	//fishing in the sewer did not work for some reason. Check some path specific scenarios
+	//first path to check is Way of the Surprising Fist. For it, try to pull the best non quest totem available.
+	
+	if(my_path() == "Way of the Surprising Fist" && !in_hardcore() )
+	{
+		if(storage_amount($item[primitive alien totem]) > 0) 
+		{
+			if(take_storage(1 , $item[primitive alien totem]))
+			{
+				return true;
+			}
+		}
+		if(storage_amount($item[Mace of the Tortoise]) > 0) 
+		{
+			if(take_storage(1 , $item[Mace of the Tortoise]))
+			{
+				return true;
+			}
+		}
+		if(storage_amount($item[Ouija Board, Ouija Board]) > 0) 
+		{
+			if(take_storage(1 , $item[Ouija Board, Ouija Board]))
+			{
+				return true;
+			}
+		}
+		if(storage_amount($item[turtle totem]) > 0) 
+		{
+			if(take_storage(1 , $item[turtle totem]))
+			{
+				return true;
+			}
+		}
+	}
+	
+	//still could not get a totem. Give up
+	return false;
 }
 
 boolean acquireHermitItem(item it)
@@ -4357,7 +4468,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Arched Eyebrow of the Archmage]:useSkill = $skill[Arched Eyebrow of the Archmage];break;
 	case $effect[Armor-Plated]:					useItem = $item[Bent Scrap Metal];				break;
 	case $effect[Ashen Burps]:					useItem = $item[ash soda];						break;
-	case $effect[Astral Shell]:					useSkill = $skill[Astral Shell];				break;
+	case $effect[Astral Shell]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Astral Shell];
+		}																						break;
 	case $effect[Baconstoned]:
 		if(item_amount($item[Vial of Baconstone Juice]) > 0)
 		{
@@ -4428,7 +4543,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Cold Hard Skin]:				useItem = $item[Frost-Rimed Seal Hide];			break;
 	case $effect[Contemptible Emanations]:		useItem = $item[Cologne of Contempt];			break;
 	case $effect[The Cupcake of Wrath]:			useItem = $item[Green-Frosted Astral Cupcake];	break;
-	case $effect[Curiosity of Br\'er Tarrypin]:	useSkill = $skill[Curiosity of Br\'er Tarrypin];break;
+	case $effect[Curiosity of Br\'er Tarrypin]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Curiosity of Br\'er Tarrypin];
+		}																						break;
 	case $effect[Dance of the Sugar Fairy]:		useItem = $item[Sugar Fairy];					break;
 	case $effect[Destructive Resolve]:			useItem = $item[Resolution: Be Feistier];		break;
 	case $effect[Dexteri Tea]:					useItem = $item[cuppa Dexteri tea];				break;
@@ -4453,7 +4572,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Eldritch Alignment]:			useItem = $item[Eldritch Alignment Spray];		break;
 	case $effect[Elemental Saucesphere]:		useSkill = $skill[Elemental Saucesphere];		break;
 	case $effect[Empathy]:
-		if(have_familiar($familiar[Mosquito]))
+		if(have_familiar($familiar[Mosquito]) && acquireTotem())
 		{
 			useSkill = $skill[Empathy of the Newt];
 		}																						break;
@@ -4501,7 +4620,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Frown]:						useSkill = $skill[Frown Muscles];				break;
 	case $effect[Funky Coal Patina]:			useItem = $item[Coal Dust];						break;
 	case $effect[Gelded]:						useItem = $item[Chocolate Filthy Lucre];		break;
-	case $effect[Ghostly Shell]:				useSkill = $skill[Ghostly Shell];				break;
+	case $effect[Ghostly Shell]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Ghostly Shell];
+		}																						break;
 	case $effect[The Glistening]:				useItem = $item[Vial of the Glistening];		break;
 	case $effect[Glittering Eyelashes]:			useItem = $item[Glittery Mascara];				break;
 	case $effect[Go Get \'Em\, Tiger!]:			useItem = $item[Ben-gal&trade; Balm];			break;
@@ -4549,7 +4672,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Irresistible Resolve]:			useItem = $item[Resolution: Be Sexier];			break;
 	case $effect[Jackasses\' Symphony of Destruction]:useSkill = $skill[Jackasses\' Symphony of Destruction];	break;
 	case $effect[Jalape&ntilde;o Saucesphere]:	useSkill = $skill[Jalape&ntilde;o Saucesphere];	break;
-	case $effect[Jingle Jangle Jingle]:			useSkill = $skill[Jingle Bells];				break;
+	case $effect[Jingle Jangle Jingle]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Jingle Bells];
+		}																						break;
 	case $effect[Joyful Resolve]:				useItem = $item[Resolution: Be Happier];		break;
 	case $effect[Juiced and Jacked]:			useItem = $item[Pumpkin Juice];					break;
 	case $effect[Juiced and Loose]:				useSkill = $skill[Steroid Bladder];				break;
@@ -4684,7 +4811,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Record Hunger]:				useItem = $item[The Pigs Holo-Record];			break;
 	case $effect[Red Lettered]:					useItem = $item[Red Letter];					break;
 	case $effect[Red Door Syndrome]:			useItem = $item[Can of Black Paint];			break;
-	case $effect[Reptilian Fortitude]:			useSkill = $skill[Reptilian Fortitude];			break;
+	case $effect[Reptilian Fortitude]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Reptilian Fortitude];
+		}																						break;
 	case $effect[A Rose by Any Other Material]:	useItem = $item[Squeaky Toy Rose];				break;
 	case $effect[Rosewater Mark]:				useItem = $item[Old Rosewater Cream];			break;
 	case $effect[Rotten Memories]:				useSkill = $skill[Rotten Memories];				break;
@@ -4739,7 +4870,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Spectral Awareness]: useSkill = $skill[Spectral Awareness]; break;
 	case $effect[Spice Haze]:					useSkill = $skill[Bind Spice Ghost];			break;
 	case $effect[Spiky Hair]:					useItem = $item[Super-Spiky Hair Gel];			break;
-	case $effect[Spiky Shell]:					useSkill = $skill[Spiky Shell];					break;
+	case $effect[Spiky Shell]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Spiky Shell];
+		}																						break;
 	case $effect[Spiritually Awake]:			useItem = $item[Holy Spring Water];				break;
 	case $effect[Spiritually Aware]:			useItem = $item[Spirit Beer];					break;
 	case $effect[Spiritually Awash]:			useItem = $item[Sacramental Wine];				break;
@@ -4777,7 +4912,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Takin\' It Greasy]:			useSkill = $skill[Grease Up];					break;
 	case $effect[Taunt of Horus]:				useItem = $item[Talisman of Horus];				break;
 	case $effect[Temporary Lycanthropy]:		useItem = $item[Blood of the Wereseal];			break;
-	case $effect[Tenacity of the Snapper]:		useSkill = $skill[Tenacity of the Snapper];		break;
+	case $effect[Tenacity of the Snapper]:
+		if(acquireTotem())
+		{
+			useSkill = $skill[Tenacity of the Snapper];
+		}																						break;
 	case $effect[There is a Spoon]:				useItem = $item[Dented Spoon];					break;
 	case $effect[This is Where You\'re a Viking]:useItem = $item[VYKEA woadpaint];				break;
 	case $effect[Throwing Some Shade]:			useItem = $item[Shady Shades];					break;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -352,6 +352,7 @@ boolean councilMaintenance();								//Defined in autoscend.ash
 boolean [location] get_floundry_locations();				//Defined in autoscend/auto_clan.ash
 int[item] auto_get_clan_lounge();								//Defined in autoscend/auto_clan.ash
 boolean acquireGumItem(item it);							//Defined in autoscend/auto_util.ash
+boolean acquireTotem();										//Defined in autoscend/auto_util.ash
 boolean acquireHermitItem(item it);							//Defined in autoscend/auto_util.ash
 int cloversAvailable();									//Defined in autoscend/auto_util.ash
 boolean cloverUsageInit();									//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

autoscend has methods for trying to acquire an accordion and a turtle totem.

buffMaintain (auto_util.ash:4961) does not integrate with those methods.
it just calls on turtle tamer and accordion thief buffs without regards to whether you have one or not, using mafia's
use_skill(casts, source)

When that happens, mafia's own automatic acquisition methods kick in.
Those can cause issues, for example if the reason you didn't have a turtle totem is because you are completely out of meat and can't sewer. Then mafia will just abort, stopping autoscend from running at all. (a difficult problem in way of the surprising fist where you don't have easy way to make meat to afford sewering).

I have fixed the turtle tamer side of the problem by adding
acquireTotem()
It checks if you have a totem, if you don't it tries to get one using existing autoscend function
acquireGumItem($item[turtle totem])

acquireTotem() is designed to be a wrapper in buffMaintain for all totem requiring buffs. If a totem is available or was successfully acquired it will return true and the buff will proceed. If a totem cannot be reasonably acquired it will return false and buffMaintain will simply skip using that specific buff.
I went ahead and integrated it into all buffs that require a totem.

This is an incomplete fix, an accordion equivalent is still needed.
Related issues:
#202 

## How Has This Been Tested?

Tested in way of the surprising fist run, where it repeatedly errored out at being unable to acquire a totem until I made the above changes.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
