### PR TITLE
kramko can't be used in some paths

### DIFF
--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -188,6 +188,13 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
+	
+	// can't equip kramko sausage grinder during certain paths, return false in those paths
+	
+	if (auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Avatar of Boris")
+	{
+		return false;
+	}
 
 	// My (Malibu Stacey) and Ezandora's spading appears to guarantee the first
 	// 7 sausage goblins using a formula of 3n+1 adventures since the previous.


### PR DESCRIPTION
Had to resubmit as a different pull request because I bungled things up with regards to branch handling. As I was unfamiliar with git. Apparently I should use a different branch for every bug that I want to submit.

====

can't equip offhand items like kramko grinder in some paths, so don't try to fight sausage goblins in surprising fist and avatar of boris.

Fixes #200

How Has This Been Tested?

Tested in way of the surprising fist, not yet tested in avatar of boris.

In way of surprising fist I ran autoscend, and 3 times in a row it immediately failed on the first adventure as per #200
Once I made this change it proceeded to work.

@Malibu-Stacey
this includes the correction you suggested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
