### PR TITLE
stores

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2182,7 +2182,7 @@ boolean isHermitAvailable()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Kingdom of Exploathing")
+	if(in_koe())
 	{
 		return false;
 	}
@@ -2199,7 +2199,7 @@ boolean isGalaktikAvailable()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Kingdom of Exploathing")
+	if(in_koe())
 	{
 		return false;
 	}
@@ -2221,11 +2221,11 @@ boolean isGeneralStoreAvailable()
 
 boolean isMusGuildStoreAvailable()
 {
-	if(($classes[seal clubber, turtle tamer] contains my_class()) && guild_store_available())
+	if ($classes[seal clubber, turtle tamer] contains my_class() && guild_store_available())
 	{
 		return true;
 	}
-	if ((my_class() == $class[accordion thief]) && (my_level() >= 9) && guild_store_available())
+	if (my_class() == $class[accordion thief] && my_level() >= 9 && guild_store_available())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -30,6 +30,7 @@ boolean acquireGumItem(item it);
 boolean acquireHermitItem(item it);
 boolean isHermitAvailable();
 boolean isGeneralStoreAvailable();
+boolean isMusGuildStoreAvailable();
 boolean isArmoryAvailable();
 boolean isGalaktikAvailable();
 boolean isUnclePAvailable();
@@ -2198,6 +2199,10 @@ boolean isGalaktikAvailable()
 	{
 		return false;
 	}
+	if(auto_my_path() == "Kingdom of Exploathing")
+	{
+		return false;
+	}
 	return true;
 }
 
@@ -2212,6 +2217,19 @@ boolean isGeneralStoreAvailable()
 		return false;
 	}
 	return true;
+}
+
+boolean isMusGuildStoreAvailable()
+{
+	if(($classes[seal clubber, turtle tamer] contains my_class()) && guild_store_available())
+	{
+		return true;
+	}
+	if ((my_class() == $class[accordion thief]) && (my_level() >= 9) && guild_store_available())
+	{
+		return true;
+	}
+	return false;
 }
 
 boolean isArmoryAvailable()
@@ -4228,7 +4246,7 @@ boolean buyUpTo(int num, item it, int maxprice)
 	{
 		return false;
 	}
-	if(($items[Blood of the Wereseal, Cheap Wind-Up Clock, Turtle Pheromones] contains it) && !guild_store_available())
+	if(($items[Blood of the Wereseal, Cheap Wind-Up Clock, Turtle Pheromones] contains it) && !isMusGuildStoreAvailable())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -30,7 +30,6 @@ boolean acquireGumItem(item it);
 boolean acquireHermitItem(item it);
 boolean isHermitAvailable();
 boolean isGeneralStoreAvailable();
-boolean isMusGuildStoreAvailable();
 boolean isArmoryAvailable();
 boolean isGalaktikAvailable();
 boolean isUnclePAvailable();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -793,6 +793,7 @@ boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash
 boolean isGalaktikAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGeneralStoreAvailable();							//Defined in autoscend/auto_util.ash
+boolean isMusGuildStoreAvailable();							//Defined in autoscend/auto_util.ash
 boolean isArmoryAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGhost(monster mon);								//Defined in autoscend/auto_util.ash
 boolean isGuildClass();										//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
1. galaktik is not available in exploathing

2. when trying to buy blood of the wereseal, cheap wind-up clock, or turtle pheromones autoscend only checked if the _current class_ guild store was available, instead of specifically if the smacketeria is available. 

Playing as a sauceror this lead to trying and failing to buy blood of the wereseal (I am guessing more commonly the windup clock in the tower init test)
Not a huge issue because it just prints a warning when this happens instead of aborting the script.

Still, made a function specifically for testing the smacketeria
And changed the existing check to use this new function instead of just checking if current class guild store is available.

## How Has This Been Tested?

So far only ran it for a bit in standard. Will keep using it over the next week to see if any issues crop up

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
