### PR TITLE
Don't attempt to buy speakeasy drinks

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -788,7 +788,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
-			if (npc_price(it) > 0)
+			// don't add speakeasy drinks, because they can't actually be bought as items
+			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
 			{
 				buyables[it] = min(howmany, my_meat() / npc_price(it));
 			}


### PR DESCRIPTION
# Description

Fixes issue Kendaer reported on discord where the knapsack diet consumption code will try to "buy" speakeasy drinks and fail, because they aren't actually items to buy. It does so by disabling speakeasy drinks in that code completely, because they should probably not be automatically consumed just for their adventure content, they should be consumed for their effects if at all.

## How Has This Been Tested?
Only testing done was to make sure the script doesn't have any syntax errors or such via importing it and getting no errors. It's a simple change but difficult for me to test atm because I would need to do a non-standard run where I somehow didn't have better sources of booze for pure adventures than speakeasy drinks (which is far from the case since I have the source terminal, among other things). Kendaer should be able to test it fairly easily though.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.