### PR TITLE
Add provider functions for initiative, resistances, and stats

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3174,22 +3174,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Reanimated Reanimator]);
 		}
 
-		buffMaintain($effect[Sepia Tan], 0, 1, 1);
-		buffMaintain($effect[Walberg\'s Dim Bulb], 5, 1, 1);
-		buffMaintain($effect[Bone Springs], 40, 1, 1);
-		buffMaintain($effect[Springy Fusilli], 10, 1, 1);
-		buffMaintain($effect[Patent Alacrity], 0, 1, 1);
-		if((my_class() == $class[Seal Clubber]) || (my_class() == $class[Turtle Tamer]))
-		{
-			buyUpTo(1, $item[Cheap Wind-up Clock]);
-			buffMaintain($effect[Ticking Clock], 0, 1, 1);
-		}
-		buffMaintain($effect[Song of Slowness], 110, 1, 1);
-		buffMaintain($effect[Your Fifteen Minutes], 90, 1, 1);
-		buffMaintain($effect[Fishy\, Oily], 0, 1, 1);
-		buffMaintain($effect[Nearly Silent Hunting], 0, 1, 1);
-		buffMaintain($effect[Soulerskates], 0, 1, 1);
-		buffMaintain($effect[Cletus\'s Canticle of Celerity], 10, 1, 1);
+		provideInitiative(850, true);
 
 		if (isActuallyEd() && monster_attack($monster[modern zmobie]) >= my_maxhp())
 		{
@@ -3216,29 +3201,12 @@ boolean L7_crypt()
 			}
 		}
 
-		auto_beachCombHead("init");
-
-		if(have_effect($effect[init.enh]) == 0)
-		{
-			int enhances = auto_sourceTerminalEnhanceLeft();
-			if(enhances > 0)
-			{
-				auto_sourceTerminalEnhance("init");
-			}
-		}
-
-		if((have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff") == false))
-		{
-			visit_url("choice.php?pwd&whichchoice=835&option=1", true);
-		}
-
 		autoEquip($item[Gravy Boat]);
 
 		if(!useMaximizeToEquip() && (get_property("cyrptAlcoveEvilness").to_int() > 26))
 		{
 			autoEquip($item[The Nuge\'s Favorite Crossbow]);
 		}
-		bat_formBats();
 
 		addToMaximize("100initiative 850max");
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5615,8 +5615,6 @@ boolean L3_tavern()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 
-	buffMaintain($effect[Tortious], 0, 1, 1);
-	buffMaintain($effect[Litterbug], 0, 1, 1);
 	auto_setMCDToCap();
 
 	if (auto_tavern())

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -508,39 +508,30 @@ void maximize_hedge()
 	element first = ns_hedge1();
 	element second = ns_hedge2();
 	element third = ns_hedge3();
+	int [element] resGoal;
 	if((first == $element[none]) || (second == $element[none]) || (third == $element[none]))
 	{
-		uneffect($effect[Flared Nostrils]);
-		if(useMaximizeToEquip())
-		{
-			addToMaximize("200all res");
-		}
-		else
+		if(!useMaximizeToEquip())
 		{
 			autoMaximize("all res -equip snow suit", 2500, 0, false);
+		}
+		foreach ele in $elements[hot, cold, stench, sleaze, spooky]
+		{
+			resGoal[ele] = 9;
 		}
 	}
 	else
 	{
-		if ($element[stench] == first || $element[stench] == second || $element[stench] == third)
-		{
-			uneffect($effect[Flared Nostrils]);
-		}
-		if(useMaximizeToEquip())
-		{
-			addToMaximize("200" + first + " res,200" + second + " res,200" + third + " res");
-		}
-		else
+		if(!useMaximizeToEquip())
 		{
 			autoMaximize(to_string(first) + " res, " + to_string(second) + " res, " + to_string(third) + " res -equip snow suit", 2500, 0, false);
 		}
+		resGoal[first] = 9;
+		resGoal[second] = 9;
+		resGoal[third] = 9;
 	}
 
-	bat_formMist();
-	foreach eff in $effects[Egged On, Patent Prevention, Spectral Awareness]
-	{
-		buffMaintain(eff, 0, 1, 1);
-	}
+	provideResistances(resGoal, true);
 }
 
 int pullsNeeded(string data)

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -111,7 +111,8 @@ boolean bat_switchForm(effect form, boolean speculative)
 	if (0 != have_effect(form)) return true;
 	if(!have_skill(form.to_skill()))
 	{
-		bat_clearForms();
+		if(!speculative)
+			bat_clearForms();
 		return false;
 	}
 	if (my_hp() <= 10)

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -50,34 +50,50 @@ boolean bat_wantHowl(location loc)
 	return false;
 }
 
-void bat_formNone()
+boolean bat_formNone()
 {
-	if(my_class() != $class[Vampyre]) return;
+	if(my_class() != $class[Vampyre]) return false;
 	if(get_property("auto_bat_desiredForm") != "")
 	{
 		set_property("auto_bat_desiredForm", "");
 	}
+	return true;
 }
 
-void bat_formWolf()
+boolean bat_formWolf(boolean speculative)
 {
-	if(my_class() != $class[Vampyre]) return;
+	if(my_class() != $class[Vampyre]) return false;
 	set_property("auto_bat_desiredForm", "wolf");
-	bat_switchForm($effect[Wolf Form]);
+	return bat_switchForm($effect[Wolf Form], speculative);
 }
 
-void bat_formMist()
+boolean bat_formWolf()
 {
-	if(my_class() != $class[Vampyre]) return;
+	return bat_formWolf(false);
+}
+
+boolean bat_formMist(boolean speculative)
+{
+	if(my_class() != $class[Vampyre]) return false;
 	set_property("auto_bat_desiredForm", "mist");
-	bat_switchForm($effect[Mist Form]);
+	return bat_switchForm($effect[Mist Form], speculative);
 }
 
-void bat_formBats()
+boolean bat_formMist()
 {
-	if(my_class() != $class[Vampyre]) return;
+	return bat_formMist(false);
+}
+
+boolean bat_formBats(boolean speculative)
+{
+	if(my_class() != $class[Vampyre]) return false;
 	set_property("auto_bat_desiredForm", "bats");
-	bat_switchForm($effect[Bats Form]);
+	return bat_switchForm($effect[Bats Form], speculative);
+}
+
+boolean bat_formBats()
+{
+	return bat_formBats(false);
 }
 
 void bat_clearForms()
@@ -90,7 +106,7 @@ void bat_clearForms()
 	}
 }
 
-boolean bat_switchForm(effect form)
+boolean bat_switchForm(effect form, boolean speculative)
 {
 	if (0 != have_effect(form)) return true;
 	if(!have_skill(form.to_skill()))
@@ -100,10 +116,18 @@ boolean bat_switchForm(effect form)
 	}
 	if (my_hp() <= 10)
 	{
-		auto_log_warning("We don't have enough HP to switch form to " + form + "!", "red");
+		if(!speculative)
+			auto_log_warning("We don't have enough HP to switch form to " + form + "!", "red");
 		return false;
 	}
+	if(speculative)
+		return true;
 	return use_skill(1, form.to_skill());
+}
+
+boolean bat_switchForm(effect form)
+{
+	return bat_switchForm(form, false);
 }
 
 boolean bat_formPreAdventure()

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -788,7 +788,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
-			if (npc_price(it) > 0)
+			// don't add speakeasy drinks, because they can't actually be bought as items
+			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
 			{
 				buyables[it] = min(howmany, my_meat() / npc_price(it));
 			}

--- a/RELEASE/scripts/autoscend/auto_highlands.ash
+++ b/RELEASE/scripts/autoscend/auto_highlands.ash
@@ -783,32 +783,9 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	buffMaintain($effect[Drescher\'s Annoying Noise], 0, 1, 1);
-	buffMaintain($effect[Pride of the Puffin], 0, 1, 1);
-	buffMaintain($effect[Ur-kel\'s Aria of Annoyance], 0, 1, 1);
-	buffMaintain($effect[Ceaseless Snarling], 0, 1, 1);
+	auto_MaxMLToCap(auto_convertDesiredML(100), false);
 
-	int expectedML = 0;
-	auto_change_mcd(11);
-	expectedML = current_mcd();
-	if(have_skill($skill[Drescher\'s Annoying Noise]))
-	{
-		expectedML += 10;
-	}
-	if(have_skill($skill[Pride of the Puffin]))
-	{
-		expectedML += 10;
-	}
-	if(have_skill($skill[Ur-kel\'s Aria of Annoyance]))
-	{
-		expectedML += (2 * my_level());
-	}
-	if(have_skill($skill[Ceaseless Snarl]))
-	{
-		expectedML += 30;
-	}
-
-	if((monster_level_adjustment() < expectedML) && (my_level() < 12))
+	if((monster_level_adjustment() < 50) && (my_level() < 12))
 	{
 		return false;
 	}
@@ -842,12 +819,10 @@ boolean L9_oilPeak()
 		auto_log_info("Oil Peak is finished but we need more crude!", "blue");
 	}
 
-	buffMaintain($effect[Litterbug], 0, 1, 1);
-	buffMaintain($effect[Tortious], 0, 1, 1);
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 	handleFamiliar("initSuggest");
 
-	auto_MaxMLToCap(auto_convertDesiredML(100), false);
+	auto_MaxMLToCap(auto_convertDesiredML(100), true);
 
 	if (isActuallyEd() && get_property("auto_dickstab").to_boolean())
 	{
@@ -856,14 +831,6 @@ boolean L9_oilPeak()
 	if(monster_level_adjustment() < 50)
 	{
 		buffMaintain($effect[The Dinsey Look], 0, 1, 1);
-	}
-	if(monster_level_adjustment() < 100)
-	{
-		buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
-	}
-	if(monster_level_adjustment() < 60)
-	{
-		buffMaintain($effect[Punchable Face], 50, 1, 1);
 	}
 	if((monster_level_adjustment() < 60))
 	{

--- a/RELEASE/scripts/autoscend/auto_highlands.ash
+++ b/RELEASE/scripts/autoscend/auto_highlands.ash
@@ -662,91 +662,13 @@ boolean L9_twinPeak()
 
 	if(!attempt && needStench)
 	{
-		buffMaintain($effect[Astral Shell], 10, 1, 1);
-		buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
-		buffMaintain($effect[Hide of Sobek], 10, 1, 1);
-		buffMaintain($effect[Spectral Awareness], 10, 1, 1);
-		int possibleGain = 0;
-		if(item_amount($item[Polysniff Perfume]) > 0)
+		int [element] resGoal;
+		resGoal[$element[stench]] = 4;
+		// check if we can get enough stench res before we start applying anything
+		int [element] resPossible = provideResistances(resGoal, true, true);
+		if(resPossible[$element[stench]] >= 4)
 		{
-			possibleGain += 2;
-		}
-		if(item_amount($item[Pec Oil]) > 0)
-		{
-			possibleGain += 2;
-		}
-		if(item_amount($item[Oil of Parrrlay]) > 0)
-		{
-			possibleGain += 1;
-		}
-		if(item_amount($item[Can Of Black Paint]) > 0)
-		{
-			possibleGain += 2;
-		}
-
-		if(elemental_resist($element[stench]) < 4 && !useMaximizeToEquip())
-		{
-			if(possessEquipment($item[Training Legwarmers]) && glover_usable($item[Training Legwarmers]))
-			{
-				autoEquip($slot[acc3], $item[Training Legwarmers]);
-			}
-
-			familiar resist = $familiar[none];
-			if((elemental_resist($element[stench]) < 4) && !is100FamiliarRun())
-			{
-				if(auto_have_familiar($familiar[Mu]))
-				{
-					resist = $familiar[Mu];
-				}
-				else if(auto_have_familiar($familiar[Exotic Parrot]))
-				{
-					resist = $familiar[Exotic Parrot];
-				}
-				if(auto_have_familiar($familiar[Trick-Or-Treating Tot]))
-				{
-					if (possessEquipment($item[li\'l candy corn costume]) && auto_is_valid($item[li\'l candy corn costume]))
-					{
-						resist = $familiar[Trick-Or-Treating Tot];
-					}
-				}
-				if(resist != $familiar[none])
-				{
-					handleFamiliar(resist);
-					if(resist == $familiar[Trick-Or-Treating Tot])
-					{
-						autoEquip($slot[familiar], $item[li\'l candy corn costume]);
-					}
-				}
-			}
-
-			if((elemental_resist($element[stench]) < 4) && ((elemental_resist($element[stench]) + possibleGain) >= 4))
-			{
-				foreach ef in $effects[Neutered Nostrils, Oiled-Up, Well-Oiled, Red Door Syndrome]
-				{
-					if(elemental_resist($element[stench]) < 4)
-					{
-						buffMaintain(ef, 0, 1, 1);
-					}
-				}
-			}
-		}
-		else
-		{
-			addToMaximize("1000stench res 4max");
-		}
-
-		if(elemental_resist($element[stench]) < 4)
-		{
-			bat_formMist();
-		}
-
-		if(useMaximizeToEquip())
-		{
-			simMaximize();
-		}
-
-		if((useMaximizeToEquip() ? simValue("Stench Resistance") : elemental_resist($element[stench])) >= 4)
-		{
+			provideResistances(resGoal, true);
 			attemptNum = 1;
 			attempt = true;
 		}

--- a/RELEASE/scripts/autoscend/auto_macguffin.ash
+++ b/RELEASE/scripts/autoscend/auto_macguffin.ash
@@ -1314,9 +1314,12 @@ boolean L11_mauriceSpookyraven()
 	{
 		auto_log_info("Down with the tyrant of Spookyraven!", "blue");
 		acquireHP();
-		buffMaintain($effect[Astral Shell], 10, 1, 1);
-		buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
-
+		int [element] resGoal;
+		foreach ele in $elements[hot, cold, stench, sleaze, spooky]
+		{
+			resGoal[ele] = 3;
+		}
+		provideResistances(resGoal, false);
 
 		# The autoAdvBypass case is probably suitable for Ed but we'd need to verify it.
 		if (isActuallyEd())

--- a/RELEASE/scripts/autoscend/auto_mclargehuge.ash
+++ b/RELEASE/scripts/autoscend/auto_mclargehuge.ash
@@ -349,41 +349,10 @@ boolean L8_trapperGroar()
 
 	if(canGroar)
 	{
-		if(elemental_resist($element[cold]) < 5)
-		{
-			buffMaintain($effect[Astral Shell], 10, 1, 1);
-			buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
-			buffMaintain($effect[Hide of Sobek], 10, 1, 1);
-			buffMaintain($effect[Spectral Awareness], 10, 1, 1);
-			if(elemental_resist($element[cold]) < 5)
-			{
-				bat_formMist();
-			}
-		}
-		string lihcface = "";
-		if (isActuallyEd() && possessEquipment($item[The Crown of Ed the Undying]))
-		{
-			lihcface = "-equip lihc face";
-		}
-
-		if((elemental_resist($element[cold]) < 5) && (my_level() == get_property("auto_powerLevelLastLevel").to_int()))
-		{
-			autoMaximize("cold res 5 max,-tie,-equip snow suit", 0, 0, true);
-			int coldResist = simValue("Cold Resistance");
-			if(coldResist >= 5)
-			{
-				if(useMaximizeToEquip())
-				{
-					addToMaximize("2000cold res 5 max");
-				}
-				else
-				{
-					autoMaximize("cold res,-tie,-equip snow suit,-weapon", 0, 0, false);
-				}
-			}
-		}
-
-		if(elemental_resist($element[cold]) >= 5)
+		int [element] resGoal;
+		resGoal[$element[cold]] = 5;
+		// try getting resistance without equipment before bothering to change gear
+		if(provideResistances(resGoal, false) || provideResistances(resGoal, true))
 		{
 			if (internalQuestStatus("questL08Trapper") == 2)
 			{
@@ -395,7 +364,7 @@ boolean L8_trapperGroar()
 			auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
 			if (item_amount($item[Groar\'s Fur]) == 0 && item_amount($item[Winged Yeti Fur]) == 0)
 			{
-				addToMaximize("5meat 2000cold res 5 max");
+				addToMaximize("5meat");
 				//If this returns false, we might have finished already, can we check this?
 				autoAdv(1, $location[Mist-shrouded Peak]);
 			}

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -1204,7 +1204,7 @@ boolean asdonBuff(string goal)
 	return false;
 }
 
-boolean asdonBuff(effect goal)
+boolean canAsdonBuff(effect goal)
 {
 	if(!(auto_get_campground() contains $item[Asdon Martin Keyfob]))
 	{
@@ -1227,6 +1227,15 @@ boolean asdonBuff(effect goal)
 		return false;
 	}
 	if(have_effect(goal) > 0)
+	{
+		return false;
+	}
+	return true;
+}
+
+boolean asdonBuff(effect goal)
+{
+	if(!canAsdonBuff(goal))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -583,39 +583,39 @@ boolean auto_beachCombAvailable()
 
 int auto_beachCombHeadNumFrom(string name)
 {
-	int head;
 	switch (name.to_lower_case())
 	{
 		case "hot":
-			head = 1; break;
+			return 1;
 		case "cold":
-			head = 2; break;
+			return 2;
 		case "stench":
-			head = 3; break;
+			return 3;
 		case "spooky":
-			head = 4; break;
+			return 4;
 		case "sleaze":
-			head = 5; break;
+			return 5;
 		case "muscle":
 		case "musc":
-			head = 6; break;
+			return 6;
 		case "mysticality":
 		case "myst":
-			head = 7; break;
+			return 7;
 		case "moxie":
 		case "mox":
-			head = 8; break;
+			return 8;
 		case "init":
 		case "initiative":
-			head = 9; break;
+			return 9;
 		case "weight":
 		case "familiar":
-			head = 10; break;
+			return 10;
 		case "exp":
 		case "stats":
-			head = 11; break;
+			return 11;
 	}
-	return head;
+	auto_log_error("Invalid string " + name + "provided to auto_beachCombHeadNumFrom");
+	return -1;
 }
 
 effect auto_beachCombHeadEffectFromNum(int num)

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -597,11 +597,13 @@ int auto_beachCombHeadNumFrom(string name)
 		case "sleaze":
 			head = 5; break;
 		case "muscle":
+		case "musc":
 			head = 6; break;
 		case "mysticality":
 		case "myst":
 			head = 7; break;
 		case "moxie":
+		case "mox":
 			head = 8; break;
 		case "init":
 		case "initiative":
@@ -614,6 +616,31 @@ int auto_beachCombHeadNumFrom(string name)
 			head = 11; break;
 	}
 	return head;
+}
+
+effect auto_beachCombHeadEffectFromNum(int num)
+{
+	switch(num)
+	{
+		case 1: return $effect[Hot-Headed];
+		case 2: return $effect[Cold as Nice];
+		case 3: return $effect[A Brush with Grossness];
+		case 4: return $effect[Does It Have a Skull In There??];
+		case 5: return $effect[Oiled, Slick];
+		case 6: return $effect[Lack of Body-Building];
+		case 7: return $effect[We're All Made of Starfish];
+		case 8: return $effect[Pomp & Circumsands];
+		case 9: return $effect[Resting Beach Face];
+		case 10: return $effect[Do I Know You From Somewhere?];
+		case 11: return $effect[You Learned Something Maybe!];
+	}
+	auto_log_error("Invalid number " + num + " provided to auto_beachCombHeadEffectFromNum");
+	return $effect[none];
+}
+
+effect auto_beachCombHeadEffect(string name)
+{
+	return auto_beachCombHeadEffectFromNum(auto_beachCombHeadNumFrom(name));
 }
 
 boolean auto_canBeachCombHead(string name) {

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -77,7 +77,6 @@ boolean L13_towerNSContests()
 				string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 			}
 			acquireMP(150); // only uses free rests or items on hand by default
-			buffMaintain($effect[Big], 15, 1, 1);
 			if (my_class() == $class[Vampyre])
 			{
 				if(crowd_stat == $stat[muscle] && !have_skill($skill[Preternatural Strength]))
@@ -93,26 +92,14 @@ boolean L13_towerNSContests()
 				if (crowd_stat == $stat[moxie] && have_skill($skill[Sinister Charm]))
 					crowd_stat = $stat[mysticality];
 			}
+			int [stat] statGoal;
+			statGoal[crowd_stat] = 600;
+			provideStats(statGoal, true);
 			switch(crowd_stat)
 			{
 			case $stat[moxie]:
 				autoMaximize("moxie -equip snow suit", 1500, 0, false);
 
-				foreach eff in $effects[Almost Cool, Busy Bein\' Delicious, Butt-Rock Hair, Funky Coal Patina, Impeccable Coiffure, Liquidy Smoky, Locks Like the Raven, Lycanthropy\, Eh?, Memories of Puppy Love, Newt Gets In Your Eyes, Notably Lovely, Oiled Skin, Pill Power, Radiating Black Body&trade;, Seriously Mutated,  Spiky Hair, Sugar Rush, Standard Issue Bravery, Superhuman Sarcasm, Tomato Power, Vital]
-				{
-					if(crowd2Insufficient()) buffMaintain(eff, 0, 1, 1);
-				}
-
-				if(crowd2Insufficient()) buffMaintain($effect[The Moxious Madrigal], 10, 1, 1);
-				if(crowd2Insufficient()) {
-					if(auto_have_skill($skill[Quiet Desperation]))
-						buffMaintain($effect[Quiet Desperation], 10, 1, 1);
-					else
-						buffMaintain($effect[Disco Smirk], 10, 1, 1);
-				}
-				if(crowd2Insufficient()) buffMaintain($effect[Song of Bravado], 100, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Stevedave\'s Shanty of Superiority], 30, 1, 1);
-				if(crowd1Insufficient()) auto_beachCombHead("moxie");
 				if(have_effect($effect[Ten out of Ten]) == 0)
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Ten out of Ten]);
@@ -121,16 +108,6 @@ boolean L13_towerNSContests()
 			case $stat[muscle]:
 				autoMaximize("muscle -equip snow suit", 1500, 0, false);
 
-				foreach eff in $effects[Browbeaten, Extra Backbone, Extreme Muscle Relaxation, Feroci Tea, Fishy Fortification, Football Eyes, Go Get \'Em\, Tiger!, Human-Human Hybrid, Industrial Strength Starch, Juiced and Loose, Lycanthropy\, Eh?, Marinated, Phorcefullness, Pill Power, Rainy Soul Miasma, Savage Beast Inside, Seriously Mutated, Slightly Larger Than Usual, Standard Issue Bravery, Steroid Boost, Spiky Hair, Sugar Rush, Superheroic, Temporary Lycanthropy, Tomato Power, Truly Gritty, Vital, Woad Warrior]
-				{
-					if(crowd2Insufficient()) buffMaintain(eff, 0, 1, 1);
-				}
-
-				if(crowd2Insufficient()) buffMaintain($effect[Quiet Determination], 10, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Power Ballad of the Arrowsmith], 10, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Song of Bravado], 100, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Stevedave\'s Shanty of Superiority], 30, 1, 1);
-				if(crowd1Insufficient()) auto_beachCombHead("muscle");
 				if(have_effect($effect[Muddled]) == 0)
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Muddled]);
@@ -139,19 +116,6 @@ boolean L13_towerNSContests()
 			case $stat[mysticality]:
 				autoMaximize("myst -equip snow suit", 1500, 0, false);
 
-				# Gothy may have given us a strange bug during one ascension, removing it for now.
-				foreach eff in $effects[Baconstoned, Erudite, Far Out, Glittering Eyelashes, Industrial Strength Starch, Liquidy Smoky, Marinated, Mind Vision, Mutated, Mystically Oiled, OMG WTF, Pill Power, Rainy Soul Miasma, Ready to Snap, Rosewater Mark, Seeing Colors, Slightly Larger Than Usual, Standard Issue Bravery, Sweet\, Nuts, Tomato Power, Vital]
-				{
-					if(crowd2Insufficient()) buffMaintain(eff, 0, 1, 1);
-				}
-
-				if(crowd2Insufficient()) buffMaintain($effect[Quiet Judgement], 10, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[The Magical Mojomuscular Melody], 10, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Song of Bravado], 100, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Pasta Oneness], 1, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Saucemastery], 1, 1, 1);
-				if(crowd2Insufficient()) buffMaintain($effect[Stevedave\'s Shanty of Superiority], 30, 1, 1);
-				if(crowd1Insufficient()) auto_beachCombHead("mysticality");
 				if(have_effect($effect[Uncucumbered]) == 0)
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Uncucumbered]);

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -54,31 +54,7 @@ boolean L13_towerNSContests()
 			case 1:
 				acquireMP(160); // only uses free rests or items on hand by default
 
-				if(is100FamiliarRun())
-				{
-					autoMaximize("init, -equip snow suit", 1500, 0, false);
-				}
-				else
-				{
-					autoMaximize("init, switch xiblaxian holo-companion, switch oily woim, switch happy medium,switch cute meteor", 1500, 0, false);
-					handleFamiliar(my_familiar());
-				}
-
-				bat_formBats();
-
-				foreach eff in $effects[Adorable Lookout, Alacri Tea, All Fired Up, Bone Springs, Bow-Legged Swagger, Fishy\, Oily, The Glistening, Human-Machine Hybrid, Patent Alacrity, Provocative Perkiness, Sepia Tan, Sugar Rush, Ticking Clock, Well-Swabbed Ear, Your Fifteen Minutes]
-				{
-					if(crowd1Insufficient()) buffMaintain(eff, 0, 1, 1);
-				}
-
-				if(crowd1Insufficient()) buffMaintain($effect[Cletus\'s Canticle of Celerity], 10, 1, 1);
-				if(crowd1Insufficient()) buffMaintain($effect[Suspicious Gaze], 10, 1, 1);
-				if(crowd1Insufficient()) buffMaintain($effect[Springy Fusilli], 10, 1, 1);
-				if(crowd1Insufficient()) buffMaintain($effect[Walberg\'s Dim Bulb], 5, 1, 1);
-				if(crowd1Insufficient()) buffMaintain($effect[Song of Slowness], 100, 1, 1);
-				if(crowd1Insufficient()) buffMaintain($effect[Soulerskates], 0, 1, 1);
-				if(crowd1Insufficient()) asdonBuff($effect[Driving Quickly]);
-				if(crowd1Insufficient()) auto_beachCombHead("init");
+				provideInitiative(400, true);
 
 				if(crowd1Insufficient())
 				{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3498,12 +3498,14 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 	]);
 	buffStat($stat[moxie], $effects[
 		Impeccable Coiffure,
-		Quiet Desperation,
-		Disco Smirk,
 		Song of Bravado,
 		Disco State of Mind,
 		Mariachi Mood,
 	]);
+	if(auto_have_skill($skill[Quiet Desperation]))
+		buffStat($stat[moxie], $effects[Quiet Desperation]);
+	else
+		buffStat($stat[moxie], $effects[Disco Smirk]);
 	if(pass())
 		return result();
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3214,7 +3214,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		// element specific effects
 		buffElement($element[hot], $effects[
 			Flame-Retardant Trousers,
-			Fireproof Lip,
+			Fireproof Lips,
 		]);
 		buffElement($element[cold], $effects[
 			Insulated Trousers,

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2966,7 +2966,7 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 	if(pass())
 		return result();
 
-	if(doEquip && auto_have_familiar($familiar[Grim Brother]) && (have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff").to_boolean() == false))
+	if(doEquips && auto_have_familiar($familiar[Grim Brother]) && (have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff").to_boolean() == false))
 	{
 		if(speculative)
 			handleEffect($effect[Soles of Glass]);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2886,6 +2886,137 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 	return true;
 }
 
+float provideInitiative(int amt, boolean doEquips, boolean speculative)
+{
+	auto_log_info("Trying to provide " + amt + " initiative, " + (doEquips ? "with" : "without") + " equipment", "blue");
+
+	float delta = 0;
+	if(doEquips)
+	{
+		if(useMaximizeToEquip())
+		{
+			string max = "500initiative " + amt + "max";
+			if(speculative)
+			{
+				simMaximizeWith(max);
+			}
+			else
+			{
+				addToMaximize("500initiative " + amt + "max");
+				simMaximize();
+			}
+			delta = simValue("Initiative") - numeric_modifier("Initiative");
+		}
+
+		if(!speculative)
+			handleFamiliar("init");
+	}
+
+	float result()
+	{
+		return numeric_modifier("Initiative") + delta;
+	}
+
+	boolean pass()
+	{
+		return result() >= amt;
+	}
+
+	if(pass())
+		return result();
+
+	void handleEffect(effect eff)
+	{
+		delta += numeric_modifier(eff, "Initiative");
+	}
+
+	boolean tryEffects(boolean [effect] effects)
+	{
+		foreach eff in effects
+		{
+			if(buffMaintain(eff, 0, 1, 1, speculative) && speculative)
+				handleEffect(eff);
+			if(pass())
+				return true;
+		}
+		return false;
+	}
+
+	if(tryEffects($effects[Cletus's Canticle of Celerity, Springy Fusilli, Soulerskates, Walberg's Dim Bulb, Song of Slowness, Your Fifteen Minutes, Suspicious Gaze, Bone Springs, Living Fast]))
+		return result();
+
+	if(speculative)
+	{
+		if(canAsdonBuff($effect[Driving Quickly]))
+		{
+			delta += numeric_modifier($effect[Driving Quickly], "Initiative");
+		}
+	}
+	else
+	{
+		asdonBuff($effect[Driving Quickly]);
+	}
+	if(pass())
+		return result();
+
+	if(bat_formBats(speculative) && speculative)
+	{
+		handleEffect($effect[Bats Form]);
+	}
+	if(pass())
+		return result();
+
+	if(doEquip && auto_have_familiar($familiar[Grim Brother]) && (have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff").to_boolean() == false))
+	{
+		if(speculative)
+			handleEffect($effect[Soles of Glass]);
+		else
+			visit_url("choice.php?pwd&whichchoice=835&option=1", true);
+		if(pass())
+			return result();
+	}
+
+	if(tryEffects($effects[Adorable Lookout, Alacri Tea, All Fired Up, Fishy\, Oily, The Glistening, Human-Machine Hybrid, Patent Alacrity, Provocative Perkiness, Sepia Tan, Sugar Rush, Ticking Clock, Well-Swabbed Ear]))
+		return result();
+
+	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[init.enh]) == 0)
+	{
+		if(speculative)
+			handleEffect($effect[init.enh]);
+		else
+			auto_sourceTerminalEnhance("init");
+		if(pass())
+			return result();
+	}
+
+	if(doEquips && auto_canBeachCombHead("init"))
+	{
+		if(speculative)
+			handleEffect(auto_beachCombHeadEffect("init"));
+		else
+			auto_beachCombHead("init");
+	}
+	if(pass())
+		return result();
+
+	if(doEquips && amt >= 400)
+	{
+		if(buffMaintain($effect[Bow-Legged Swagger], 0, 1, 1, speculative) && speculative)
+		{
+			delta += delta + numeric_modifier("Initiative");
+		}
+		if(pass())
+			return result();
+	}
+
+	return result();
+}
+
+boolean provideInitiative(int amt, boolean doEquips)
+{
+	return provideInitiative(amt, doEquips, false) >= amt;
+}
+
 boolean auto_have_familiar(familiar fam)
 {
 	if(auto_my_path() == "License to Adventure")

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -6699,6 +6699,7 @@ boolean UrKelCheck(int UrKelToML, int UrKelUpperLimit, int UrKelLowerLimit)
 	{
 		if((get_property("auto_MLSafetyLimit") == "") || (((2 * my_level()) <= UrKelUpperLimit) && ((2 * my_level()) >= UrKelLowerLimit)))
 		{
+			shrugAT($effect[Ur-Kel\'s Aria of Annoyance]);
 			buffMaintain($effect[Ur-Kel\'s Aria of Annoyance], 0, 1, 10);
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3054,6 +3054,11 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	debugprint += (doEquips ? "with equipment" : "without equipment");
 	auto_log_info(debugprint, "blue");
 
+	if(amt[$element[stench]] > 0)
+	{
+		uneffect($effect[Flared Nostrils]);
+	}
+
 	int [element] delta;
 
 	void handleEffect(effect eff)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2942,7 +2942,18 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 		return false;
 	}
 
-	if(tryEffects($effects[Cletus's Canticle of Celerity, Springy Fusilli, Soulerskates, Walberg's Dim Bulb, Song of Slowness, Your Fifteen Minutes, Suspicious Gaze, Bone Springs, Living Fast]))
+	if(tryEffects($effects[
+		Cletus's Canticle of Celerity,
+		Springy Fusilli,
+		Soulerskates,
+		Walberg's Dim Bulb,
+		Song of Slowness,
+		Your Fifteen Minutes,
+		Suspicious Gaze,
+		Bone Springs,
+		Living Fast,
+		Nearly Silent Hunting,
+	]))
 		return result();
 
 	if(speculative)
@@ -2976,7 +2987,20 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 			return result();
 	}
 
-	if(tryEffects($effects[Adorable Lookout, Alacri Tea, All Fired Up, Fishy\, Oily, The Glistening, Human-Machine Hybrid, Patent Alacrity, Provocative Perkiness, Sepia Tan, Sugar Rush, Ticking Clock, Well-Swabbed Ear]))
+	if(tryEffects($effects[
+		Adorable Lookout,
+		Alacri Tea,
+		All Fired Up,
+		Fishy\, Oily,
+		The Glistening,
+		Human-Machine Hybrid,
+		Patent Alacrity,
+		Provocative Perkiness,
+		Sepia Tan,
+		Sugar Rush,
+		Ticking Clock,
+		Well-Swabbed Ear,
+	]))
 		return result();
 
 	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[init.enh]) == 0)
@@ -3129,7 +3153,13 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	}
 
 	// effects from skills
-	if(tryEffects($effects[Elemental Saucesphere, Astral Shell, Hide of Sobek, Spectral Awareness, Scarysauce]))
+	if(tryEffects($effects[
+		Elemental Saucesphere,
+		Astral Shell,
+		Hide of Sobek,
+		Spectral Awareness,
+		Scarysauce,
+	]))
 		return result();
 
 	if(bat_formMist(speculative) && speculative)
@@ -3174,14 +3204,36 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	if(doEquips)
 	{
 		// effects from items that we'd have to buy or have found
-		if(tryEffects($effects[Red Door Syndrome, Well-Oiled, Oiled-Up, Egged On]))
+		if(tryEffects($effects[
+			Red Door Syndrome,
+			Well-Oiled,
+			Oiled-Up,
+			Egged On
+		]))
 			return result();
 		// element specific effects
-		buffElement($element[hot], $effects[Flame-Retardant Trousers, Fireproof Lips]);
-		buffElement($element[cold], $effects[Insulated Trousers, Fever From the Flavor]);
-		buffElement($element[stench], $effects[Smelly Pants, Neutered Nostrils, Can't Smell Nothin']);
-		buffElement($element[spooky], $effects[Spookypants, Balls of Ectoplasm, Hyphemariffic]);
-		buffElement($element[sleaze], $effects[Sleaze-Resistant Trousers, Hyperoffended]);
+		buffElement($element[hot], $effects[
+			Flame-Retardant Trousers,
+			Fireproof Lip,
+		]);
+		buffElement($element[cold], $effects[
+			Insulated Trousers,
+			Fever From the Flavor,
+		]);
+		buffElement($element[stench], $effects[
+			Smelly Pants,
+			Neutered Nostrils,
+			Can't Smell Nothin',
+		]);
+		buffElement($element[spooky], $effects[
+			Spookypants,
+			Balls of Ectoplasm,
+			Hyphemariffic,
+		]);
+		buffElement($element[sleaze], $effects[
+			Sleaze-Resistant Trousers,
+			Hyperoffended,
+		]);
 	}
 
 	return result();
@@ -3277,12 +3329,23 @@ float provideML(int amt, boolean doEquips, boolean speculative)
 		return false;
 	}
 
-	if(tryEffects($effects[Ur-Kel's Aria of Annoyance, Drescher's Annoying Noise, Pride of the Puffin, Ceaseless Snarling, Punchable Face]))
+	if(tryEffects($effects[
+		Ur-Kel's Aria of Annoyance,
+		Drescher's Annoying Noise,
+		Pride of the Puffin,
+		Ceaseless Snarling,
+		Punchable Face,
+	]))
 		return finish();
 
 	if(doEquips)
 	{
-		if(tryEffects($effects[Litterbug, Tortious, Sweetbreads Flamb&eacute;, The Dinsey Look]))
+		if(tryEffects($effects[
+			Litterbug,
+			Tortious,
+			Sweetbreads Flamb&eacute;,
+			The Dinsey Look,
+		]))
 			return finish();
 	}
 
@@ -3414,22 +3477,105 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 		return pass(st);
 	}
 
-	buffStat($stat[muscle], $effects[Juiced and Loose, Quiet Determination, Power Ballad of the Arrowsmith, Seal Clubbing Frenzy, Patience of the Tortoise]);
-	buffStat($stat[mysticality], $effects[Mind Vision, Quiet Judgement, The Magical Mojomuscular Melody, Pasta Oneness, Saucemastery]);
-	buffStat($stat[moxie], $effects[Impeccable Coiffure, Quiet Desperation, Disco Smirk, Song of Bravado, Disco State of Mind, Mariachi Mood]);
+	buffStat($stat[muscle], $effects[
+		Juiced and Loose,
+		Quiet Determination,
+		Power Ballad of the Arrowsmith,
+		Seal Clubbing Frenzy,
+		Patience of the Tortoise,
+	]);
+	buffStat($stat[mysticality], $effects[
+		Mind Vision,
+		Quiet Judgement,
+		The Magical Mojomuscular Melody,
+		Pasta Oneness,
+		Saucemastery,
+	]);
+	buffStat($stat[moxie], $effects[
+		Impeccable Coiffure,
+		Quiet Desperation,
+		Disco Smirk,
+		Song of Bravado,
+		Disco State of Mind,
+		Mariachi Mood,
+	]);
 	if(pass())
 		return result();
 
-	if(tryEffects($effects[Song of Bravado, Stevedave's Shanty of Superiority]))
+	if(tryEffects($effects[
+		Song of Bravado,
+		Stevedave's Shanty of Superiority,
+	]))
 		return result();
 
 	// buffs from items
 	if(doEquips)
 	{
-		buffStat($stat[muscle], $effects[Browbeaten, Extra Backbone, Extreme Muscle Relaxation, Feroci Tea, Fishy Fortification, Football Eyes, Go Get \'Em\, Tiger!, Lycanthropy\, Eh?, Marinated, Phorcefullness, Rainy Soul Miasma, Savage Beast Inside, Steroid Boost, Spiky Hair, Sugar Rush, Superheroic, Temporary Lycanthropy, Truly Gritty, Vital, Woad Warrior]);
-		buffStat($stat[mysticality], $effects[Baconstoned, Erudite, Far Out, Glittering Eyelashes, Liquidy Smoky, Marinated, Mystically Oiled, OMG WTF, Rainy Soul Miasma, Ready to Snap, Rosewater Mark, Seeing Colors, Sweet\, Nuts]);
-		buffStat($stat[moxie], $effects[Almost Cool, Busy Bein' Delicious, Butt-Rock Hair, Funky Coal Patina, Liquidy Smoky, Locks Like the Raven, Lycanthropy\, Eh?, Memories of Puppy Love, Newt Gets In Your Eyes, Notably Lovely, Oiled Skin, Radiating Black Body&trade;, Spiky Hair, Sugar Rush, Superhuman Sarcasm]);
-		tryEffects($effects[Human-Human Hybrid, Industrial Strength Starch, Mutated, Seriously Mutated, Pill Power, Slightly Larger Than Usual, Standard Issue Bravery, Tomato Power, Vital]);
+		buffStat($stat[muscle], $effects[
+			Browbeaten,
+			Extra Backbone,
+			Extreme Muscle Relaxation,
+			Feroci Tea,
+			Fishy Fortification,
+			Football Eyes,
+			Go Get \'Em\, Tiger!,
+			Lycanthropy\, Eh?,
+			Marinated,
+			Phorcefullness,
+			Rainy Soul Miasma,
+			Savage Beast Inside,
+			Steroid Boost,
+			Spiky Hair,
+			Sugar Rush,
+			Superheroic,
+			Temporary Lycanthropy,
+			Truly Gritty,
+			Vital,
+			Woad Warrior
+		]);
+		buffStat($stat[mysticality], $effects[
+			Baconstoned,
+			Erudite,
+			Far Out,
+			Glittering Eyelashes,
+			Liquidy Smoky,
+			Marinated,
+			Mystically Oiled,
+			OMG WTF,
+			Rainy Soul Miasma,
+			Ready to Snap,
+			Rosewater Mark,
+			Seeing Colors,
+			Sweet\, Nuts,
+		]);
+		buffStat($stat[moxie], $effects[
+			Almost Cool,
+			Busy Bein' Delicious,
+			Butt-Rock Hair,
+			Funky Coal Patina,
+			Liquidy Smoky,
+			Locks Like the Raven,
+			Lycanthropy\, Eh?,
+			Memories of Puppy Love,
+			Newt Gets In Your Eyes,
+			Notably Lovely,
+			Oiled Skin,
+			Radiating Black Body&trade;,
+			Spiky Hair,
+			Sugar Rush,
+			Superhuman Sarcasm,
+		]);
+		tryEffects($effects[
+			Human-Human Hybrid,
+			Industrial Strength Starch,
+			Mutated,
+			Seriously Mutated,
+			Pill Power,
+			Slightly Larger Than Usual,
+			Standard Issue Bravery,
+			Tomato Power,
+			Vital,
+		]);
 
 		foreach st in amt
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -96,6 +96,7 @@ void shrugAT();
 void shrugAT(effect anticipated);
 boolean buyUpTo(int num, item it);
 boolean buyUpTo(int num, item it, int maxprice);
+boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns);
 effect effectNeededFirstGate(string data);
 boolean buyableMaintain(item toMaintain, int howMany);
@@ -4293,7 +4294,7 @@ boolean buyUpTo(int num, item it, int maxprice)
 	return (item_amount(it) >= orig);
 }
 
-boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns)
+boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns, boolean speculative)
 {
 	if(!glover_usable(buff))
 	{
@@ -4333,11 +4334,12 @@ boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns
 	{
 		return false;
 	}
-	use_skill(casts, source);
+	if(!speculative)
+		use_skill(casts, source);
 	return true;
 }
 
-boolean buffMaintain(item source, effect buff, int uses, int turns)
+boolean buffMaintain(item source, effect buff, int uses, int turns, boolean speculative)
 {
 	if(in_tcrs())
 	{
@@ -4372,11 +4374,12 @@ boolean buffMaintain(item source, effect buff, int uses, int turns)
 	{
 		return false;
 	}
-	use(uses, source);
+	if(!speculative)
+		use(uses, source);
 	return true;
 }
 
-boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
+boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative)
 {
 	skill useSkill = $skill[none];
 	item useItem = $item[none];
@@ -5027,15 +5030,19 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 		}
 		else
 		{
-			return buffMaintain(useItem, buff, casts, turns);
+			return buffMaintain(useItem, buff, casts, turns, speculative);
 		}
 	}
-
 	if((useSkill != $skill[none]) && auto_have_skill(useSkill))
 	{
-		return buffMaintain(useSkill, buff, mp_min, casts, turns);
+		return buffMaintain(useSkill, buff, mp_min, casts, turns, speculative);
 	}
 	return true;
+}
+
+boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
+{
+	return buffMaintain(buff, mp_min, casts, turns, false);
 }
 
 // Checks to see if we are already wearing a facial expression before using buffMaintain

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4671,7 +4671,33 @@ boolean beehiveConsider()
 boolean[skill] ATSongList()
 {
 	// This List contains ALL AT songs in order from Most to Least Important as to determine what effect to shrug off.
-	boolean[skill] songs = $skills[Inigo\'s Incantation of Inspiration, The Ballad of Richie Thingfinder, Chorale of Companionship, The Ode to Booze, Ur-Kel\'s Aria of Annoyance, Carlweather\'s Cantata of Confrontation, The Sonata of Sneakiness, Paul\'s Passionate Pop Song, Fat Leon\'s Phat Loot Lyric, The Polka of Plenty, Aloysius\' Antiphon of Aptitude, Donho\'s Bubbly Ballad, Prelude of Precision, Elron\'s Explosive Etude, Benetton\'s Medley of Diversity, Dirge of Dreadfulness, Stevedave\'s Shanty of Superiority, The Psalm of Pointiness, Brawnee\'s Anthem of Absorption, Jackasses\' Symphony of Destruction, The Power Ballad of the Arrowsmith, Cletus\'s Canticle of Celerity, Cringle\'s Curative Carol, The Magical Mojomuscular Melody, The Moxious Madrigal];
+	boolean[skill] songs = $skills[
+		Inigo\'s Incantation of Inspiration,
+		The Ballad of Richie Thingfinder,
+		Chorale of Companionship,
+		The Ode to Booze,
+		Ur-Kel\'s Aria of Annoyance,
+		Carlweather\'s Cantata of Confrontation,
+		The Sonata of Sneakiness,
+		Fat Leon\'s Phat Loot Lyric,
+		The Polka of Plenty,
+		Aloysius\' Antiphon of Aptitude,
+		Paul\'s Passionate Pop Song,
+		Donho\'s Bubbly Ballad,
+		Prelude of Precision,
+		Elron\'s Explosive Etude,
+		Benetton\'s Medley of Diversity,
+		Dirge of Dreadfulness,
+		Stevedave\'s Shanty of Superiority,
+		The Psalm of Pointiness,
+		Brawnee\'s Anthem of Absorption,
+		Jackasses\' Symphony of Destruction,
+		The Power Ballad of the Arrowsmith,
+		Cletus\'s Canticle of Celerity,
+		Cringle\'s Curative Carol,
+		The Magical Mojomuscular Melody,
+		The Moxious Madrigal,
+	];
 
 	return songs;
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -856,6 +856,8 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative); //Defin
 boolean provideInitiative(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 int [element] provideResistances(int [element] amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideResistances(int [element] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+float provideML(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideML(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 void pullAll(item it);										//Defined in autoscend/auto_util.ash
 void pullAndUse(item it, int uses);							//Defined in autoscend/auto_util.ash
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);	//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -378,9 +378,10 @@ boolean in_koe();											//Defined in autoscend/auto_koe.ash
 boolean boris_buySkills();									//Defined in autoscend/auto_boris.ash
 void boris_initializeDay(int day);							//Defined in autoscend/auto_boris.ash
 void boris_initializeSettings();							//Defined in autoscend/auto_boris.ash
+boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);//Defined in autoscend/auto_util.ash
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns);//Defined in autoscend/auto_util.ash
-boolean buffMaintain(item source, effect buff, int uses, int turns);//Defined in autoscend/auto_util.ash
-boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns);//Defined in autoscend/auto_util.ash
+boolean buffMaintain(item source, effect buff, int uses, int turns, boolean speculative);//Defined in autoscend/auto_util.ash
+boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns, boolean speculative);//Defined in autoscend/auto_util.ash
 boolean buyUpTo(int num, item it);							//Defined in autoscend/auto_util.ash
 boolean buyUpTo(int num, item it, int maxprice);			//Defined in autoscend/auto_util.ash
 boolean buy_item(item it, int quantity, int maxprice);		//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1074,11 +1074,15 @@ boolean bat_consumption(); // Defined in autoscend/auto_batpath.ash
 boolean bat_skillValid(skill sk); // Defined in autoscend/auto_batpath.ash
 boolean bat_tryBloodBank(); // Defined in autoscend/auto_batpath.ash
 boolean bat_wantHowl(location loc); // Defined in autoscend/auto_batpath.ash
-void bat_formNone(); // Defined in autoscend/auto_batpath.ash
-void bat_formWolf(); // Defined in autoscend/auto_batpath.ash
-void bat_formMist(); // Defined in autoscend/auto_batpath.ash
-void bat_formBats(); // Defined in autoscend/auto_batpath.ash
+boolean bat_formNone(); // Defined in autoscend/auto_batpath.ash
+boolean bat_formWolf(boolean speculative); // Defined in autoscend/auto_batpath.ash
+boolean bat_formWolf(); // Defined in autoscend/auto_batpath.ash
+boolean bat_formMist(boolean speculative); // Defined in autoscend/auto_batpath.ash
+boolean bat_formMist(); // Defined in autoscend/auto_batpath.ash
+boolean bat_formBats(boolean speculative); // Defined in autoscend/auto_batpath.ash
+boolean bat_formBats(); // Defined in autoscend/auto_batpath.ash
 void bat_clearForms(); // Defined in autoscend/auto_batpath.ash
+boolean bat_switchForm(effect form, boolean speculative); // Defined in autoscend/auto_batpath.ash
 boolean bat_switchForm(effect form); // Defined in autoscend/auto_batpath.ash
 boolean bat_formPreAdventure(); // Defined in autoscend/auto_batpath.ash
 boolean LM_batpath(); // Defined in autoscend/auto_batpath.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -668,6 +668,7 @@ boolean auto_canBeachCombHead(string name);	// Defined in autoscend/auto_mr2019.
 boolean auto_beachCombHead(string name);	// Defined in autoscend/auto_mr2019.ash
 int auto_beachCombFreeUsesLeft();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_beachUseFreeCombs();	// Defined in autoscend/auto_mr2019.ash
+effect auto_beachCombHeadEffect(string name); // Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayAvailable();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayGrabBuffs();	// Defined in autoscend/auto_mr2019.ash
 int auto_pillKeeperUses();						//Defined in autoscend/auto_mr2019.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -859,6 +859,14 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 boolean provideResistances(int [element] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 float provideML(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideML(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideStats(int [stat] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+float provideMuscle(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideMuscle(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+float provideMysticality(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideMysticality(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+float provideMoxie(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideMoxie(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 void pullAll(item it);										//Defined in autoscend/auto_util.ash
 void pullAndUse(item it, int uses);							//Defined in autoscend/auto_util.ash
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);	//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -854,6 +854,8 @@ boolean acquireCombatMods(int amt);							//Defined in autoscend/auto_util.ash
 boolean acquireCombatMods(int amt, boolean doEquips);		//Defined in autoscend/auto_util.ash
 float provideInitiative(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideInitiative(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+int [element] provideResistances(int [element] amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideResistances(int [element] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 void pullAll(item it);										//Defined in autoscend/auto_util.ash
 void pullAndUse(item it, int uses);							//Defined in autoscend/auto_util.ash
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);	//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -702,6 +702,7 @@ boolean kgb_getMartini(string page);						//Defined in autoscend/auto_mr2017.ash
 boolean kgb_getMartini(string page, boolean dontCare);		//Defined in autoscend/auto_mr2017.ash
 boolean kgbModifiers(string mod);							//Defined in autoscend/auto_mr2017.ash
 boolean haveAsdonBuff();											//Defined in autoscend/auto_mr2017.ash
+boolean canAsdonBuff(effect goal);						//Defined in autoscend/auto_mr2017.ash
 boolean asdonBuff(effect goal);								//Defined in autoscend/auto_mr2017.ash
 boolean asdonBuff(string goal);								//Defined in autoscend/auto_mr2017.ash
 boolean asdonFeed(item it, int qty);						//Defined in autoscend/auto_mr2017.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -857,8 +857,6 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative); //Defin
 boolean provideInitiative(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 int [element] provideResistances(int [element] amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideResistances(int [element] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
-float provideML(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
-boolean provideML(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideStats(int [stat] amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 float provideMuscle(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -852,6 +852,8 @@ boolean providePlusNonCombat(int amt);						//Defined in autoscend/auto_util.ash
 boolean providePlusNonCombat(int amt, boolean doEquips);	//Defined in autoscend/auto_util.ash
 boolean acquireCombatMods(int amt);							//Defined in autoscend/auto_util.ash
 boolean acquireCombatMods(int amt, boolean doEquips);		//Defined in autoscend/auto_util.ash
+float provideInitiative(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
+boolean provideInitiative(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 void pullAll(item it);										//Defined in autoscend/auto_util.ash
 void pullAndUse(item it, int uses);							//Defined in autoscend/auto_util.ash
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);	//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

Moves a bunch of repeated manual calls for various buffs in to general functions to provide a given stat, so we only have to add future effects that provide that stat in one place, instead of everywhere we use that stat.

Also I'm not sure why that "Don't attempt to buy speakeasy drinks" commit is there, considering it's already been merged in to autoscend in a separate pull request... any help with getting that excluded from this pull request so we don't have a weird dupe commit would be appreciated.

## How Has This Been Tested?

I've done five hardcore standard runs with these changes and they seem to work as expected.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
