### PR TITLE
Minor fix for an issue with shield of the pastalord

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -788,7 +788,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
-			if (npc_price(it) > 0)
+			// don't add speakeasy drinks, because they can't actually be bought as items
+			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
 			{
 				buyables[it] = min(howmany, my_meat() / npc_price(it));
 			}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4542,7 +4542,13 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Flaming Weapon]:				useItem = $item[Hot Nuggets];					break;
 	case $effect[Flamibili Tea]:				useItem = $item[cuppa Flamibili Tea];			break;
 	case $effect[Flexibili Tea]:				useItem = $item[cuppa Flexibili Tea];			break;
-	case $effect[Flimsy Shield of the Pastalord]:useSkill = $skill[Shield of the Pastalord];	break;
+	case $effect[Flimsy Shield of the Pastalord]:
+		useSkill = $skill[Shield of the Pastalord];
+		if(my_class() == $class[Pastamancer])
+		{
+			buff = $effect[Shield of the Pastalord];
+		}
+		break;
 	case $effect[Florid Cheeks]:				useItem = $item[Henna Face Paint];				break;
 	case $effect[Football Eyes]:				useItem = $item[Black Facepaint];				break;
 	case $effect[Fortunate Resolve]:			useItem = $item[Resolution: Be Luckier];		break;
@@ -4773,7 +4779,13 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	case $effect[Sepia Tan]:					useItem = $item[Old Bronzer];					break;
 	case $effect[Serendipi Tea]:				useItem = $item[cuppa Serendipi tea];			break;
 	case $effect[Seriously Mutated]:			useItem = $item[Extra-Potent Gremlin Mutagen];	break;
-	case $effect[Shield of the Pastalord]:		useSkill = $skill[Shield of the Pastalord];		break;
+	case $effect[Shield of the Pastalord]:
+		useSkill = $skill[Shield of the Pastalord];
+		if(my_class() != $class[Pastamancer])
+		{
+			buff = $effect[Flimsy Shield of the Pastalord];
+		}
+		break;
 	case $effect[Shelter of Shed]:				useSkill = $skill[Shelter of Shed];				break;
 	case $effect[Shrieking Weasel]:				useItem = $item[Shrieking Weasel Holo-Record];	break;
 	case $effect[Simmering]:					useSkill = $skill[Simmer];						break;


### PR DESCRIPTION
# Description

Fixes a minor issue I encountered during a Pastamancer run where I had wasted a ton of mp getting up to over 2000 turns of Shield of the Pastalord while my other buffs only had around 20 turns. The source of the issue was that `buffMaintain` was checking for the effect Flimsy Shield of the Pastalord to see if we had enough turns that we didn't need to cast it again. I also did the reverse for calling `buffMaintain` with regular Shield of the Pastalord just to be thorough, even though `buffMaintain` is never called on the non-flimsy version as the code stands (nor should it be for the sake of consistency).

Once again, this pull request seems to be including my already merged commit to prevent buying speakeasy drinks... Not sure how to solve that issue.

## How Has This Been Tested?

I have tested this as Pastamancer by calling `ash import<autoscend.ash> buffMaintain($effect[Flimsy Shield of the Pastalord], 0, 1, 1)` in the gCLI and observing that it no longer cast the spell when I had turns of the effect, then using an sgeea to remove the effect and repeating the line of code and seeing that it does still cast the spell when I don't have turns of the effect. I have not yet tested the case of being a class other than a Pastamancer, but considering that the new code is wrapped in an `if(my_class() == $class[Pastamancer])` check, it seems highly unlikely this would cause any issues for that case. Will test when possible nevertheless.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
