### PR TITLE
Another bunch of small fixes.

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -1,18 +1,4 @@
-coldAirportAlways	boolean	Do you have access to The Glaciest?
-hotAirportAlways	boolean	Do you have access to That 70s Volcano?
-sleazeAirportAlways	boolean	Do you have access to Spring Break Beach?
-spookyAirportAlways	boolean	Do you have access to Conspiracy Island?
-stenchAirportAlways	boolean	Do you have access to DinseyLandfill?
-hasDetectiveSchool	boolean	Do you have access to the Detective School?
-barrelShrineUnlocked	boolean	Do you have access to the barrel shrine?
-gingerbreadCityAvailable	boolean	Do you have access to the Gingerbread City?
-spacegateAlways	boolean	[standard] Do you have access to Spacegate?
-frAlways	boolean	[standard] Do you have access to FantasyRealm?
-prAlways	boolean	[standard] Do you have access to PirateRealm?
-neverendingPartyAlways	boolean	[standard] Do you have access to the Neverending Party?
 auto_skipNEPOverride	boolean	If true, will not use the Neverending Party even if mafia says it is available.
-voteAlways	boolean	[standard] Do you have access to the Voting Booth?
-daycareOpen	boolean	[standard] Do you have access to the Boxing Daycare?
 auto_newbieOverride	boolean	Did you fight a crate? Ugh... Report it please, but if you want the script to try again, set this to true and it'll override it. Once.
 auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? (Or in Ed, Even More Elemental Wards)?
 auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -5,67 +5,53 @@
 
 action	0	auto_interrupt	boolean	Cause script to stop before starting next turn action (instead of trying to abort midturn).
 
-any	0	coldAirportAlways	boolean	Do you have access to The Glaciest?
-any	1	hotAirportAlways	boolean	Do you have access to That 70s Volcano?
-any	2	sleazeAirportAlways	boolean	Do you have access to Spring Break Beach?
-any	3	spookyAirportAlways	boolean	Do you have access to Conspiracy Island?
-any	4	stenchAirportAlways	boolean	Do you have access to DinseyLandfill?
-any	5	hasDetectiveSchool	boolean	Do you have access to the Detective School?
-any	6	barrelShrineUnlocked	boolean	Do you have access to the barrel shrine?
-any	7	gingerbreadCityAvailable	boolean	Do you have access to the Gingerbread City?
-any	8	spacegateAlways	boolean	[standard] Do you have access to Spacegate?
-any	9	frAlways	boolean	[standard] Do you have access to FantasyRealm?
-any	10	prAlways	boolean	[standard] Do you have access to PirateRealm?
-any	11	neverendingPartyAlways	boolean	[standard] Do you have access to the Neverending Party?
-any	12	auto_skipNEPOverride	boolean	If true, will not use the Neverending Party even if mafia says it is available.
-any	13	voteAlways	boolean	[standard] Do you have access to the Voting Booth?
-any	14	daycareOpen	boolean	[standard] Do you have access to the Boxing Daycare?
-any	15	auto_newbieOverride	boolean	Did you fight a crate? Ugh... Report it please, but if you want the script to try again, set this to true and it'll override it. Once.
-any	16	auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? (Or in Ed, Even More Elemental Wards)?
-any	17	auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
-any	18	auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
-any	19	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
-any	20	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
-any	21	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
-any	22	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
-any	23	auto_diceMode	boolean	Equip all available Dice (OCRS) gear. This is probably not FUN.
-any	24	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
-any	25	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
-any	26	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	27	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	28	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	29	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	30	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
-any	31	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	32	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	33	auto_blacklistFamiliar	string	A semi-colon separate string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	34	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	35	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Ashton Kutcher (ignores Soda Bread).
-any	36	auto_limitConsume	boolean	When false, will not eat or drink anything automatically.
-any	37	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	38	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat. If you set it to "disabled" it will revert to the old equipment system, for now.
-any	39	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	40	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	41	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	42	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	43	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	44	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	45	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	46	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	47	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	48	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	49	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	50	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	51	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	52	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	53	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	54	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	55	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	56	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	57	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	58	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	59	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	60	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	0	auto_skipNEPOverride	boolean	If true, will not use the Neverending Party even if mafia says it is available.
+any	1	auto_newbieOverride	boolean	Did you fight a crate? Ugh... Report it please, but if you want the script to try again, set this to true and it'll override it. Once.
+any	2	auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? (Or in Ed, Even More Elemental Wards)?
+any	3	auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
+any	4	auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
+any	5	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
+any	6	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
+any	7	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
+any	8	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
+any	9	auto_diceMode	boolean	Equip all available Dice (OCRS) gear. This is probably not FUN.
+any	10	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
+any	11	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
+any	12	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	13	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	14	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	15	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	16	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
+any	17	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	18	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
+any	19	auto_blacklistFamiliar	string	A semi-colon separate string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Ashton Kutcher (ignores Soda Bread).
+any	22	auto_limitConsume	boolean	When false, will not eat or drink anything automatically.
+any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat. If you set it to "disabled" it will revert to the old equipment system, for now.
+any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	37	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	38	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	45	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	46	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2358,13 +2358,6 @@ boolean L13_towerNSEntrance()
 			# lx_attemptPowerLevel is before. We need to merge all of this into that....
 			set_property("auto_newbieOverride", true);
 
-			if(snojoFightAvailable() && (auto_my_path() == "Pocket Familiars"))
-			{
-				autoAdv(1, $location[The X-32-F Combat Training Snowman]);
-				return true;
-			}
-
-
 			if(needDigitalKey())
 			{
 				woods_questStart();
@@ -2382,10 +2375,6 @@ boolean L13_towerNSEntrance()
 						return true;
 					}
 				}
-			}
-			if(neverendingPartyPowerlevel())
-			{
-				return true;
 			}
 			if(!hasTorso())
 			{
@@ -2585,6 +2574,10 @@ boolean LX_attemptPowerLevel()
 	else if (elementalPlanes_access($element[hot]))
 	{
 		autoAdv(1, $location[The SMOOCH Army HQ]);
+	}
+	else if (neverendingPartyAvailable())
+	{
+		neverendingPartyPowerlevel();
 	}
 	else
 	{
@@ -4349,7 +4342,7 @@ boolean adventureFailureHandler()
 			}
 		}
 
-		if (get_property("auto_powerLevelAdvCount").to_int() > 20 && my_level() < 13)
+		if (get_property("auto_powerLevelAdvCount").to_int() > 20)
 		{
 			if ($location[The Haunted Gallery] == my_location())
 			{
@@ -5584,10 +5577,6 @@ boolean L3_tavern()
 	{
 		set_property("choiceAdventure1000", "1"); // Everything in Moderation: turn on the faucet (completes quest)
 		set_property("choiceAdventure1001", "2"); // Hot and Cold Dripping Rats: Leave it alone (don't fight a rat)
-		if (have_skill($skill[Shelter of Shed]) && my_mp() < mp_cost($skill[Shelter of Shed]))
-		{
-			delayTavern = true;
-		}
 	}
 	else if(!enoughElement || (my_mp() < mpNeed))
 	{
@@ -6168,6 +6157,9 @@ void auto_begin()
 	handlePulls(my_daycount());
 	initializeDay(my_daycount());
 
+	backupSetting("promptAboutCrafting", 0);
+	backupSetting("requireBoxServants", false);
+	backupSetting("breakableHandling", 4);
 	backupSetting("recoveryScript", "");
 	backupSetting("trackLightsOut", false);
 	backupSetting("autoSatisfyWithCloset", false);

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -148,7 +148,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 		}
 		urlGetFlags /= 2;
 	}
-	if((my_hp() == 0) || (get_property("_edDefeats").to_int() == 1) || (have_effect($effect[Beaten Up]) > 0))
+	if (my_hp() == 0 || have_effect($effect[Beaten Up]) > 0)
 	{
 		auto_log_warning("Uh oh! Died when starting a combat indirectly.", "red");
 		#Can we just return true here?

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1312,24 +1312,9 @@ boolean L1_ed_islandFallback()
 		}
 	}
 
-	if(get_property("neverendingPartyAlways").to_boolean() || get_property("_neverendingPartyToday").to_boolean())
+	if (neverendingPartyAvailable())
 	{
-		backupSetting("choiceAdventure1322", 2);
-		if(have_effect($effect[Tomes of Opportunity]) == 0)
-		{
-			backupSetting("choiceAdventure1324", 1);
-			backupSetting("choiceAdventure1325", 2);
-		}
-		else
-		{
-			backupSetting("choiceAdventure1324", 5);
-		}
-
-		autoAdv(1, $location[The Neverending Party]);
-		restoreSetting("choiceAdventure1322");
-		restoreSetting("choiceAdventure1324");
-		restoreSetting("choiceAdventure1325");
-		return true;
+		return neverendingPartyPowerlevel();
 	}
 	if(elementalPlanes_access($element[stench]))
 	{


### PR DESCRIPTION
# Description

The main issue here is fixing how we handle powerlevelling in the Neverend due to a report on Discord but I had a few other small fixes for annoyances/aborts I've noticed during Ed test runs or people raised on Discord pending, so I've bundled them all together.

- Remove a bunch of unnecessary IotM availability toggles from the relay page (mafia preferences support almost all of these)
- Fix powerlevelling in the Neverend to actually count as powerlevelling and not completely skip a bunch of important stuff we use to handle doing quests instead of powerlevelling when there are quests to do.
- Fix an abort that could happen if you powerlevelled in the Haunted Gallery from 12 -> 13
- Ed should no longer care about having enough MP to cast Shelter of Shed when doing the Tavern
- Add backing up settings for crafting prompts so the consumption code doesn't fall over if the user has settings we don't like/expect
- Add backing up breakable equipment setting so we don't abort unnecessarily because the mafia default for this is bad and should feel bad.
- Remove checking if Ed was one-shotted because it's a pointless abort since we get 2 more attempts at killing the thing that one-shotted us for free anyway.
- Tidy up Ed's use of the Neverend for Ka farming to use the same functions as everywhere else.

## How Has This Been Tested?

Had a 3 day HC Ed run just finish with all but the Neverend changes. Those I can't test personally as I don't have IotMs on my test account.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
