### PR TITLE
Post-rotation Exploathing fixes, new Milk of Magnesium handling

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1224,7 +1224,7 @@ void initializeDay(int day)
 	}
 
 	auto_doPrecinct();
-	if((item_amount($item[Cop Dollar]) >= 10) && (item_amount($item[Shoe Gum]) == 0))
+	if(!in_koe() && (item_amount($item[Cop Dollar]) >= 10) && (item_amount($item[Shoe Gum]) == 0))
 	{
 		boolean temp = cli_execute("make shoe gum");
 	}
@@ -2944,7 +2944,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun())
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun())
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19599; // In Kingdom of Exploathing, mark the Palindome quest as started as soon as you make the Talisman o' Namsilat.
+since r19696; // Do not worry about milk of magnesium for size 0 foods
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_aftercore.ash
+++ b/RELEASE/scripts/autoscend/auto_aftercore.ash
@@ -1169,7 +1169,7 @@ boolean auto_cheesePostCS(int leave)
 	take_storage(storage_amount($item[Cold Hi Mein]), $item[Cold Hi Mein]);
 	while((fullness_left() >= 5) && (item_amount($item[Cold Hi Mein]) > 0) && (my_level() >= 13))
 	{
-		buffMaintain($effect[Got Milk], 0, 1, 5);
+		consumeMilkOfMagnesiumIfUnused();
 		autoEat(1, $item[Cold Hi Mein]);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -4,7 +4,8 @@ script "auto_cooking.ash"
 #	Handler for in-run consumption
 #
 
-boolean dealWithMilkOfMagnesium(boolean useAdv);
+boolean acquireMilkOfMagnesiumIfUnused(boolean useAdv);
+boolean consumeMilkOfMagnesiumIfUnused(boolean useAdv);
 boolean autoEat(int howMany, item toEat);
 boolean autoEat(int howMany, item toEat, boolean silent);
 boolean autoDrink(int howMany, item toDrink);
@@ -323,15 +324,8 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 	}
 
 	int expectedFullness = toEat.fullness * howMany;
-	if(expectedFullness >= 15)
-	{
-		dealwithMilkOfMagnesium(true);
-	}
-
-	if(expectedFullness >= 10)
-	{
-		buffMaintain($effect[Got Milk], 0, 1, expectedFullness);
-	}
+	acquireMilkOfMagnesiumIfUnused(true);
+	consumeMilkOfMagnesiumIfUnused();
 
 	if(possessEquipment($item[Wrist-Boy]) && (my_meat() > 6500))
 	{
@@ -368,7 +362,9 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 	return retval;
 }
 
-boolean dealWithMilkOfMagnesium(boolean useAdv)
+
+
+boolean acquireMilkOfMagnesiumIfUnused(boolean useAdv)
 {
 	if(in_tcrs())
 	{
@@ -376,6 +372,10 @@ boolean dealWithMilkOfMagnesium(boolean useAdv)
 	}
 
 	if(item_amount($item[Milk Of Magnesium]) > 0)
+	{
+		return true;
+	}
+	if(get_property("_milkOfMagnesiumUsed").to_boolean())
 	{
 		return true;
 	}
@@ -409,6 +409,15 @@ boolean dealWithMilkOfMagnesium(boolean useAdv)
 	}
 	pullXWhenHaveY($item[Milk Of Magnesium], 1, 0);
 	return true;
+}
+
+boolean consumeMilkOfMagnesiumIfUnused()
+{
+	if(get_property("_milkOfMagnesiumUsed").to_boolean())
+	{
+		return false;
+	}
+	return use(1, $item[Milk of Magnesium]);
 }
 
 boolean canDrink(item toDrink)
@@ -1107,8 +1116,8 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 	if (type == "eat")
 	{
 		// TODO: and can obtain milk of magnesium? It's just logging...
-		auto_log_info("(+" + sum_space + " from Got Milk)", "blue");
-		total_adv += sum_space;
+		auto_log_info("(+" + 5 + " from Milk of Magnesium)", "blue");
+		total_adv += 5;
 	}
 	if (type == "drink" && auto_have_skill($skill[The Ode to Booze]))
 	{
@@ -1143,17 +1152,8 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 
 	if(type == "eat")
 	{
-		if (in_tcrs() && get_property("auto_useWishes").to_boolean() && (0 == have_effect($effect[Got Milk])))
-		{
-			// +15 adv is worth it for daycount
-			// TODO: Some folks have requested a setting to turn this off.
-			makeGenieWish($effect[Got Milk]);
-		}
-		else
-		{
-			dealwithMilkOfMagnesium(true);
-			buffMaintain($effect[Got Milk], 0, 1, organLeft());
-		}
+		acquireMilkOfMagnesiumIfUnused(true);
+		consumeMilkOfMagnesiumIfUnused();
 	}
 
 	int pre_adventures = my_adventures();

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -832,7 +832,6 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			is_unrestricted(it) &&
 			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
 		{
-			if (it == $item[astral pilsner]) continue;
 			if((it == $item[astral pilsner] || it == $item[Cold One]) && my_level() < 11) continue;
 			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
 			if (it == $item[Cursed Punch]) continue;

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1185,7 +1185,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !is100FamiliarRun() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !is100FamiliarRun() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2016.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2016.ash
@@ -51,6 +51,10 @@ boolean snojoFightAvailable()
 	{
 		return false;
 	}
+	if(in_koe())
+	{
+		return false;
+	}
 	if(my_inebriety() > inebriety_limit())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -144,6 +144,9 @@ boolean auto_sausageEatEmUp(int maxToEat)
 			if(mpToBurn > 0)
 				cli_execute("burn " + mpToBurn);
 		}
+
+        acquireMilkOfMagnesiumIfUnused(true);
+        consumeMilkOfMagnesiumIfUnused();
 		if(!eat(1, $item[magical sausage]))
 		{
 			auto_log_warning("Somehow failed to eat a sausage! What??", "red");

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -145,8 +145,6 @@ boolean auto_sausageEatEmUp(int maxToEat)
 				cli_execute("burn " + mpToBurn);
 		}
 
-        acquireMilkOfMagnesiumIfUnused(true);
-        consumeMilkOfMagnesiumIfUnused();
 		if(!eat(1, $item[magical sausage]))
 		{
 			auto_log_warning("Somehow failed to eat a sausage! What??", "red");

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -516,7 +516,14 @@ boolean L13_sorceressDoor()
 		}
 		if(item_amount($item[Richard\'s Star Key]) == 0)
 		{
-			abort("Need Richard's Star Key for the Sorceress door :(");
+			if(!get_property("auto_getStarKey").to_boolean())
+			{
+				abort("Need Richard's Star Key for the Sorceress door. Perhaps set auto_getStarKey=true ?");
+			}
+			else
+			{
+				abort("Need Richard's Star Key for the Sorceress door, but auto_getStarKey=true so I'm not sure why we haven't gotten it already. :(");
+			}
 		}
 		visit_url("place.php?whichplace=nstower_door&action=ns_lock4");
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -498,7 +498,9 @@ boolean trySaberTrickMeteorShower();              //Defined in autoscend/auto_co
 int beachHeadTurnSavings(int quest);							//Defined in autoscend/auto_community_service.ash
 boolean tryBeachHeadBuff(int quest);							//Defined in autoscend/auto_community_service.ash
 
-boolean dealWithMilkOfMagnesium(boolean useAdv);			//Defined in autoscend/auto_cooking.ash
+boolean acquireMilkOfMagnesiumIfUnused(boolean useAdv);			//Defined in autoscend/auto_cooking.ash
+boolean consumeMilkOfMagnesiumIfUnused();					//Defined in autoscend/auto_cooking.ash
+
 void debugMaximize(string req, int meat);					//Defined in autoscend/auto_util.ash
 boolean deck_available();									//Defined in autoscend/auto_mr2015.ash
 boolean deck_cheat(string cheat);							//Defined in autoscend/auto_mr2015.ash


### PR DESCRIPTION
# Description

* Don't try to use Snojo, DMT, or shoe gum in Exploathing
* Adjust Milk of Magnesium handling, since it now gives 5 advs once/day.
* Consume Milk of Magnesium before eating magical sausages.
* When at the tower and missing the star key, alert the player that
  perhaps they should set auto_getStarKey. This mostly comes up in
  barely-supported paths where start-of-run logic doesn't set
  auto_getStarKey.

Milk of Magnesium changes partially address #214 

## How Has This Been Tested?

1 HC Exploathing run, followed by 1 HC Big! run. I own the IOTMs under test.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
