### PR TITLE
Providers debug printing

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -788,7 +788,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
-			if (npc_price(it) > 0)
+			// don't add speakeasy drinks, because they can't actually be bought as items
+			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
 			{
 				buyables[it] = min(howmany, my_meat() / npc_price(it));
 			}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5734,7 +5734,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	{
 		return buffMaintain(useSkill, buff, mp_min, casts, turns, speculative);
 	}
-	return true;
+	return false;
 }
 
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3072,22 +3072,9 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 
 	int [element] delta;
 
-	void handleEffect(effect eff)
-	{
-		foreach ele in amt
-		{
-			delta[ele] += numeric_modifier(eff, ele + " Resistance");
-		}
-	}
-
 	int result(element ele)
 	{
 		return numeric_modifier(ele + " Resistance") + delta[ele];
-	}
-
-	boolean pass(element ele)
-	{
-		return result(ele) >= amt[ele];
 	}
 
 	int [element] result()
@@ -3098,6 +3085,37 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			res[ele] = result(ele);
 		}
 		return res;
+	}
+
+	string resultstring()
+	{
+		string s = "";
+		foreach ele in amt
+		{
+			if(s != "")
+			{
+				s += ", ";
+			}
+			s += result(ele) + " " + ele.to_string() + " resistance";
+		}
+		return s;
+	}
+
+	void handleEffect(effect eff)
+	{
+		if(speculative)
+		{
+			foreach ele in amt
+			{
+				delta[ele] += numeric_modifier(eff, ele + " Resistance");
+			}
+		}
+		auto_log_debug("We " + (speculative ? "can gain" : "just gained") + " " + eff.to_string() + ", now we have " + resultstring());
+	}
+
+	boolean pass(element ele)
+	{
+		return result(ele) >= amt[ele];
 	}
 
 	boolean pass()
@@ -3139,6 +3157,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			{
 				delta[ele] = simValue(ele + " Resistance") - numeric_modifier(ele + " Resistance");
 			}
+			auto_log_debug("With gear we can get to " + resultstring());
 		}
 	}
 
@@ -3149,7 +3168,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	{
 		foreach eff in effects
 		{
-			if(buffMaintain(eff, 0, 1, 1, speculative) && speculative)
+			if(buffMaintain(eff, 0, 1, 1, speculative))
 			{
 				handleEffect(eff);
 			}
@@ -3178,7 +3197,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	]))
 		return result();
 
-	if(bat_formMist(speculative) && speculative)
+	if(bat_formMist(speculative))
 		handleEffect($effect[Mist Form]);
 	if(pass())
 		return result();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3168,6 +3168,19 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	{
 		foreach eff in effects
 		{
+			boolean effectMatters = false;
+			foreach ele in amt
+			{
+				if(!pass(ele) && numeric_modifier(eff, ele + " Resistance") > 0)
+				{
+					effectMatters = true;
+				}
+			}
+			if(!effectMatters)
+			{
+				auto_log_debug("Skipping effect " + eff + " because it has no relevant resists");
+				continue;
+			}
 			if(buffMaintain(eff, 0, 1, 1, speculative))
 			{
 				handleEffect(eff);
@@ -3176,15 +3189,6 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 				return true;
 		}
 		return false;
-	}
-
-	boolean buffElement(element ele, boolean [effect] effects)
-	{
-		if(!pass(ele))
-		{
-			return tryEffects(effects);
-		}
-		return true;
 	}
 
 	// effects from skills
@@ -3243,32 +3247,21 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			Red Door Syndrome,
 			Well-Oiled,
 			Oiled-Up,
-			Egged On
-		]))
-			return result();
-		// element specific effects
-		buffElement($element[hot], $effects[
+			Egged On,
 			Flame-Retardant Trousers,
 			Fireproof Lips,
-		]);
-		buffElement($element[cold], $effects[
 			Insulated Trousers,
 			Fever From the Flavor,
-		]);
-		buffElement($element[stench], $effects[
 			Smelly Pants,
 			Neutered Nostrils,
-			Can't Smell Nothin',
-		]);
-		buffElement($element[spooky], $effects[
+			Can't Smell Nothin\',
 			Spookypants,
 			Balls of Ectoplasm,
 			Hyphemariffic,
-		]);
-		buffElement($element[sleaze], $effects[
 			Sleaze-Resistant Trousers,
 			Hyperoffended,
-		]);
+		]))
+			return result();
 	}
 
 	return result();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3034,7 +3034,7 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 
 	if(doEquips && amt >= 400)
 	{
-		if(buffMaintain($effect[Bow-Legged Swagger], 0, 1, 1, speculative))
+		if(!get_property("_bowleggedSwaggerUsed").to_boolean() && buffMaintain($effect[Bow-Legged Swagger], 0, 1, 1, speculative))
 		{
 			if(speculative)
 				delta += delta + numeric_modifier("Initiative");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2976,7 +2976,8 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 
 	if(canAsdonBuff($effect[Driving Quickly]))
 	{
-		if(!speculative) asdonBuff($effect[Driving Quickly]);
+		if(!speculative)
+			asdonBuff($effect[Driving Quickly]);
 		handleEffect($effect[Driving Quickly]);
 	}
 	if(pass())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4998,7 +4998,7 @@ boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns
 		return false;
 	}
 
-	if(!have_skill(source) || (have_effect(buff) >= turns))
+	if(!auto_have_skill(source) || (have_effect(buff) >= turns))
 	{
 		return false;
 	}
@@ -5040,6 +5040,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 {
 	if(in_tcrs())
 	{
+		auto_log_debug("We want to use " + source + " but are in 2CRS.", "blue");
 		return false;
 	}
 
@@ -5047,7 +5048,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if(!glover_usable(source))
+	if(!auto_is_valid(source))
 	{
 		return false;
 	}
@@ -5725,24 +5726,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}
 	}
 
-	if(!is_unrestricted(useItem))
-	{
-		return false;
-	}
-
 	if(useItem != $item[none])
 	{
-		if(in_tcrs())
-		{
-			auto_log_debug("We want to use " + useItem + " but are in 2CRS.", "blue");
-			return false;
-		}
-		else
-		{
-			return buffMaintain(useItem, buff, casts, turns, speculative);
-		}
+		return buffMaintain(useItem, buff, casts, turns, speculative);
 	}
-	if((useSkill != $skill[none]) && auto_have_skill(useSkill))
+	if(useSkill != $skill[none])
 	{
 		return buffMaintain(useSkill, buff, mp_min, casts, turns, speculative);
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3377,7 +3377,7 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			}
 			foreach st in amt
 			{
-				delta[st] = simValue(st) - my_buffedstat(st);
+				delta[st] = simValue("Buffed " + st) - my_buffedstat(st);
 			}
 			auto_log_debug("With gear we can get to " + resultstring());
 		}


### PR DESCRIPTION
# Description

Add debug printing to provider functions to help figure out any potential issues in them in the future.

Also fix an issue with speculative `buffMaintain` where it would think you could provide buffs you were incapable of providing.

## How Has This Been Tested?

Since this is primarily a logging change, I've tested by running the functions with debug logging enabled and observing the output.

As for the `buffMaintain` fix, I tested it by checking the output of `buffMaintain($effect[Hide of Sobek], 0, 1, 1, true);` before and after the change (while not Ed, of course). Before it was `true`, after it was `false`. Not extensive, but I'm not in run at the moment.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
