### PR TITLE
Campground items are not available in Actually Ed

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -778,6 +778,9 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	int[item] large_owned;
 	int[item] craftables;
 
+	// Spaghetti breakfast is awkward since it has to be the first food consumed
+	// and we can only consume one. We don't handle this yet, so... blacklist!
+	boolean[item] blacklist = $items[spaghetti breakfast];
 	boolean[item] craftable_blacklist;
 
 	// If we have 2 sticks of firewood, the current knapsack-solver
@@ -826,6 +829,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	foreach it in $items[]
 	{
 		if (
+			!(blacklist contains it) &&
 			canConsume(it) &&
 			(organCost(it) > 0) &&
 			(it.fullness == 0 || it.inebriety == 0) &&

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4857,6 +4857,11 @@ boolean acquireTransfunctioner()
 
 int [item] auto_get_campground()
 {
+	if (isActuallyEd())
+	{
+		int [item] empty;
+		return empty;
+	}
 	int [item] campItems = get_campground();
 
 	if(campItems contains $item[Ice Harvest])


### PR DESCRIPTION
# Description

Someone in Discord reported Ed trying to use mayoflex: https://pastebin.com/0ZNCTt2Q . It appears that Mafia's `get_campground()` implementation doesn't know that Ed doesn't have campground access? This adds a guard in `auto_get_campground` to early-return if we're in Actually Ed, which should also flush out any other related bugs in Ed that nobody has reported yet.

## How Has This Been Tested?

I have checked that `verify autoscend` works locally. I have not tested the actual functionality.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
