### PR TITLE
Fix crash in postadventure with zero MP regen

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -886,7 +886,7 @@ void handlePostAdventure()
 		buffMaintain($effect[Carol of the Thrills], 30, 1, 1);
 
 		// Aptitude is not worth it to maintain if we have Ur-Kel's
-		if(((40 / regen) < auto_predictAccordionTurns()) && (have_effect($effect[Ur-Kel\'s Aria of Annoyance]) == 0))
+		if((40 < regen * auto_predictAccordionTurns()) && (have_effect($effect[Ur-Kel\'s Aria of Annoyance]) == 0))
 		{
 			buffMaintain($effect[Aloysius\' Antiphon of Aptitude], 40, 1, 1);
 		}


### PR DESCRIPTION
# Description

[Crash reported in Discord](https://cdn.discordapp.com/attachments/538086828234899458/672654502574161951/unknown.png)

## How Has This Been Tested?

`verify auto_post_adv` and nothing else.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
