### PR TITLE
Add support for bird calendar buffs in provider functions

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -31,6 +31,7 @@ import <autoscend/auto_mr2016.ash>
 import <autoscend/auto_mr2017.ash>
 import <autoscend/auto_mr2018.ash>
 import <autoscend/auto_mr2019.ash>
+import <autoscend/auto_mr2020.ash>
 
 import <autoscend/auto_boris.ash>
 import <autoscend/auto_jellonewbie.ash>

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -788,7 +788,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
-			if (npc_price(it) > 0)
+			// don't add speakeasy drinks, because they can't actually be bought as items
+			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
 			{
 				buyables[it] = min(howmany, my_meat() / npc_price(it));
 			}

--- a/RELEASE/scripts/autoscend/auto_mr2020.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2020.ash
@@ -1,0 +1,81 @@
+script "auto_mr2020.ash"
+
+# This is meant for items that have a date of 2020
+
+boolean auto_birdIsValid()
+{
+	// can't seek a bird if you can't use the calendar
+	if(!auto_is_valid($item[Bird-a-Day calendar]))
+	{
+		return false;
+	}
+
+	// can't seek a bird if you don't own the calendar
+	if(item_amount($item[Bird-a-Day calendar]) < 1)
+	{
+		return false;
+	}
+
+	// don't want to overwrite favorite bird automatically
+	// however, if they already overwrote favorite bird manually today
+	// and we somehow have enough mp to continue casting
+	// it might as well be an option
+	// hence == 0 and not <= 0
+	if(auto_birdsLeftToday() == 0)
+	{
+		return false;
+	}
+
+	if(!get_property("_canSeekBirds").to_boolean())
+	{
+		use(1, $item[Bird-a-Day calendar]);
+	}
+
+	return true;
+}
+
+float auto_birdModifier(string mod)
+{
+	if(!auto_birdIsValid())
+	{
+		return 0;
+	}
+
+	return numeric_modifier($effect[Blessing of the Bird], mod);
+}
+
+float auto_favoriteBirdModifier(string mod)
+{
+	return numeric_modifier($effect[Blessing of Your Favorite Bird], mod);
+}
+
+int auto_birdsSought()
+{
+	return get_property("_birdsSoughtToday").to_int();
+}
+
+int auto_birdsLeftToday()
+{
+	return 6 - auto_birdsSought();
+}
+
+boolean auto_birdCanSeek()
+{
+	if(!auto_birdIsValid())
+	{
+		return false;
+	}
+
+	return auto_have_skill($skill[Seek Out a Bird]);
+}
+
+boolean auto_favoriteBirdCanSeek()
+{
+	// can't seek out your favorite if you already did today
+	if(get_property("_favoriteBirdVisited").to_boolean())
+	{
+		return false;
+	}
+
+	return auto_have_skill($skill[Visit Your Favorite Bird]);
+}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3211,6 +3211,8 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		Hide of Sobek,
 		Spectral Awareness,
 		Scarysauce,
+		Blessing of the Bird,
+		Blessing of Your Favorite Bird,
 	]))
 		return result();
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3191,7 +3191,6 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			}
 			if(!effectMatters)
 			{
-				auto_log_debug("Skipping effect " + eff + " because it has no relevant resists");
 				continue;
 			}
 			if(buffMaintain(eff, 0, 1, 1, speculative))
@@ -3415,7 +3414,6 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			}
 			if(!effectMatters)
 			{
-				auto_log_debug("Skipping effect " + eff + " because it has no relevant stats");
 				continue;
 			}
 			if(buffMaintain(eff, 0, 1, 1, speculative))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2990,6 +2990,18 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 	if(pass())
 		return result();
 
+	if(auto_birdModifier("Initiative") > 0)
+	{
+		if(tryEffects($effects[Blessing of the Bird]))
+			return result();
+	}
+
+	if(auto_favoriteBirdModifier("Initiative") > 0)
+	{
+		if(tryEffects($effects[Blessing of Your Favorite Bird]))
+			return result();
+	}
+
 	if(doEquips && auto_have_familiar($familiar[Grim Brother]) && (have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff").to_boolean() == false))
 	{
 		if(!speculative)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5216,14 +5216,14 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Boon of the War Snapper]:		useSkill = $skill[Spirit Boon];					break;
 	case $effect[Bounty of Renenutet]:			useSkill = $skill[Bounty of Renenutet];			break;
 	case $effect[Bow-Legged Swagger]:			useSkill = $skill[Bow-Legged Swagger];			break;
-	case $effect[Bram's Bloody Bagatelle]:		useSkill = $skill[Bram's Bloody Bagatelle];		break;
+	case $effect[Bram\'s Bloody Bagatelle]:		useSkill = $skill[Bram\'s Bloody Bagatelle];		break;
 	case $effect[Brawnee\'s Anthem of Absorption]:useSkill = $skill[Brawnee\'s Anthem of Absorption];break;
 	case $effect[Brilliant Resolve]:			useItem = $item[Resolution: Be Smarter];		break;
 	case $effect[Brooding]:						useSkill = $skill[Brood];						break;
 	case $effect[Browbeaten]:					useItem = $item[Old Eyebrow Pencil];			break;
 	case $effect[Busy Bein\' Delicious]:		useItem = $item[Crimbo fudge];					break;
 	case $effect[Butt-Rock Hair]:				useItem = $item[Hair Spray];					break;
-	case $effect[Can't Smell Nothin']:	useItem = $item[Dogsgotnonoz pills];	break;
+	case $effect[Can\'t Smell Nothin\']:	useItem = $item[Dogsgotnonoz pills];	break;
 	case $effect[Carlweather\'s Cantata of Confrontation]:useSkill = $skill[Carlweather\'s Cantata of Confrontation];break;
 	case $effect[Carol Of The Bulls]: useSkill = $skill[Carol Of The Bulls]; break;
 	case $effect[Carol Of The Hells]: useSkill = $skill[Carol Of The Hells]; break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5192,6 +5192,16 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Black Eyes]:					useItem = $item[Black Eye Shadow];				break;
 	case $effect[Blackberry Politeness]:		useItem = $item[Blackberry Polite];				break;
 	case $effect[Blessing of Serqet]:			useSkill = $skill[Blessing of Serqet];			break;
+	case $effect[Blessing of the Bird]:
+		if(auto_birdCanSeek())
+		{
+			useSkill = $skill[Seek Out a Bird];
+		}																						break;
+	case $effect[Blessing of Your Favorite Bird]:
+		if(auto_favoriteBirdCanSeek())
+		{
+			useSkill = $skill[Visit Your Favorite Bird];
+		}																						break;
 	case $effect[Blinking Belly]:				useSkill = $skill[Firefly Abdomen];				break;
 	case $effect[Blood-Gorged]:					useItem = $item[Vial Of Blood Simple Syrup];	break;
 	case $effect[Blood Bond]:					useSkill = $skill[Blood Bond];					break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3405,6 +3405,19 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 	{
 		foreach eff in effects
 		{
+			boolean effectMatters = false;
+			foreach st in amt
+			{
+				if(!pass(st) && (numeric_modifier(eff, st) > 0 || numeric_modifier(eff, st + " Percent") > 0))
+				{
+					effectMatters = true;
+				}
+			}
+			if(!effectMatters)
+			{
+				auto_log_debug("Skipping effect " + eff + " because it has no relevant stats");
+				continue;
+			}
 			if(buffMaintain(eff, 0, 1, 1, speculative))
 			{
 				handleEffect(eff);
@@ -3415,60 +3428,48 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 		return false;
 	}
 
-	boolean buffStat(stat st, boolean [effect] effects)
-	{
-		if(!pass(st))
-		{
-			foreach eff in effects
-			{
-				if(buffMaintain(eff, 0, 1, 1, speculative))
-				{
-					handleEffect(eff);
-				}
-				if(pass(st))
-					return true;
-			}
-		}
-		return pass(st);
-	}
-
-	buffStat($stat[muscle], $effects[
+	if(tryEffects($effects[
+		// muscle effects
 		Juiced and Loose,
 		Quiet Determination,
 		Power Ballad of the Arrowsmith,
 		Seal Clubbing Frenzy,
 		Patience of the Tortoise,
-	]);
-	buffStat($stat[mysticality], $effects[
+		
+		// myst effects
 		Mind Vision,
 		Quiet Judgement,
 		The Magical Mojomuscular Melody,
 		Pasta Oneness,
 		Saucemastery,
-	]);
-	buffStat($stat[moxie], $effects[
+
+		// moxie effects
 		Impeccable Coiffure,
 		Song of Bravado,
 		Disco State of Mind,
 		Mariachi Mood,
-	]);
-	if(auto_have_skill($skill[Quiet Desperation]))
-		buffStat($stat[moxie], $effects[Quiet Desperation]);
-	else
-		buffStat($stat[moxie], $effects[Disco Smirk]);
-	if(pass())
-		return result();
 
-	if(tryEffects($effects[
+		// all-stat effects
 		Song of Bravado,
 		Stevedave's Shanty of Superiority,
+
+		// varying effects
+		Blessing of the Bird,
+		Blessing of Your Favorite Bird,
 	]))
+		return result();
+	if(auto_have_skill($skill[Quiet Desperation]))
+		tryEffects($effects[Quiet Desperation]);
+	else
+		tryEffects($effects[Disco Smirk]);
+	if(pass())
 		return result();
 
 	// buffs from items
 	if(doEquips)
 	{
-		buffStat($stat[muscle], $effects[
+		if(tryEffects($effects[
+			// muscle effects
 			Browbeaten,
 			Extra Backbone,
 			Extreme Muscle Relaxation,
@@ -3488,9 +3489,9 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			Temporary Lycanthropy,
 			Truly Gritty,
 			Vital,
-			Woad Warrior
-		]);
-		buffStat($stat[mysticality], $effects[
+			Woad Warrior,
+
+			// myst effects
 			Baconstoned,
 			Erudite,
 			Far Out,
@@ -3504,8 +3505,8 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			Rosewater Mark,
 			Seeing Colors,
 			Sweet\, Nuts,
-		]);
-		buffStat($stat[moxie], $effects[
+
+			// moxie effects
 			Almost Cool,
 			Busy Bein' Delicious,
 			Butt-Rock Hair,
@@ -3521,8 +3522,8 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			Spiky Hair,
 			Sugar Rush,
 			Superhuman Sarcasm,
-		]);
-		tryEffects($effects[
+
+			// all-stat effects
 			Human-Human Hybrid,
 			Industrial Strength Starch,
 			Mutated,
@@ -3532,7 +3533,8 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			Standard Issue Bravery,
 			Tomato Power,
 			Vital,
-		]);
+		]))
+			return result();
 
 		foreach st in amt
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -678,6 +678,13 @@ boolean auto_pillKeeperFreeUseAvailable();	//Defined in autoscend/auto_mr2019.as
 boolean auto_pillKeeperAvailable();			//Defined in autoscend/auto_mr2019.ash
 boolean auto_pillKeeper(int pill);			//Defined in autoscend/auto_mr2019.ash
 boolean auto_pillKeeper(string pill);		//Defined in autoscend/auto_mr2019.ash
+boolean auto_birdIsValid();					//Defined in autoscend/auto_mr2020.ash
+float auto_birdModifier(string mod);		//Defined in autoscend/auto_mr2020.ash
+float auto_favoriteBirdModifier(string mod);//Defined in autoscend/auto_mr2020.ash
+int auto_birdsSought();						//Defined in autoscend/auto_mr2020.ash
+int auto_birdsLeftToday();					//Defined in autoscend/auto_mr2020.ash
+boolean auto_birdCanSeek();					//Defined in autoscend/auto_mr2020.ash
+boolean auto_favoriteBirdCanSeek();			//Defined in autoscend/auto_mr2020.ash
 boolean getSpaceJelly();					//Defined in autoscend/auto_mr2017.ash
 int horseCost();											//Defined in autoscend/auto_mr2017.ash
 string horseNormalize(string horseText); // Defined in autoscend/auto_mr2017.ash


### PR DESCRIPTION
# Description

Will seek out a bird or visit your favorite bird when possible to provide initiative, resistances, or stats.

Also adds auto_mr2020.ash, with some bird calendar functions, since those are needed to be able to use the bird calendar in the first place.

## How Has This Been Tested?

I played around with the provider functions and observed them behaving as I would expect with my current bird buffs, so it's not super duper thoroughly tested but I think it's probably tested enough.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
