### PR TITLE
Use Powerful Glove for -combat

### DIFF
--- a/RELEASE/scripts/autoscend/auto_clan.ash
+++ b/RELEASE/scripts/autoscend/auto_clan.ash
@@ -361,7 +361,7 @@ boolean drinkSpeakeasyDrink(item drink)
 }
 
 
-boolean zataraSeaside(string who)
+boolean zataraAvailable()
 {
 	if(item_amount($item[Clan VIP Lounge Key]) == 0)
 	{
@@ -381,6 +381,12 @@ boolean zataraSeaside(string who)
 	{
 		return false;
 	}
+	return true;
+}
+
+boolean zataraSeaside(string who)
+{
+	if(!zataraAvailable()) return false;
 
 	who = to_lower_case(who);
 

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -1145,6 +1145,10 @@ boolean L12_themtharHills()
 	{
 		meat_need = meat_need - 150;
 	}
+	if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])))
+	{
+		meat_need = meat_need - 100;
+	}
 
 	use_familiar(to_familiar(get_property("auto_familiarChoice")));
 	float meatDropHave = meat_drop_modifier();
@@ -1207,6 +1211,7 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
 	buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
 	bat_formWolf();
+	zataraSeaside("meat");
 
 	{
 		warOutfit(false);

--- a/RELEASE/scripts/autoscend/auto_mr2020.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2020.ash
@@ -83,13 +83,13 @@ boolean auto_favoriteBirdCanSeek()
 boolean auto_hasPowerfulGlove()
 {
 	return possessEquipment($item[Powerful Glove]) && 
-	 !auto_is_valid($item[mint-in-box Powerful Glove]);
+		auto_is_valid($item[mint-in-box Powerful Glove]);
 }
 
 int auto_powerfulGloveCharges()
 {
 	if (!auto_hasPowerfulGlove()) return 0;
-	return 100 - get_property("_powerfulGloveBatteryPowerUse").to_int();
+	return 100 - get_property("_powerfulGloveBatteryPowerUsed").to_int();
 }
 
 boolean auto_powerfulGloveNoncombat()

--- a/RELEASE/scripts/autoscend/auto_mr2020.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2020.ash
@@ -79,3 +79,40 @@ boolean auto_favoriteBirdCanSeek()
 
 	return auto_have_skill($skill[Visit Your Favorite Bird]);
 }
+
+boolean auto_hasPowerfulGlove()
+{
+	return possessEquipment($item[Powerful Glove]) && 
+	 !auto_is_valid($item[mint-in-box Powerful Glove]);
+}
+
+int auto_powerfulGloveCharges()
+{
+	if (!auto_hasPowerfulGlove()) return 0;
+	return 100 - get_property("_powerfulGloveBatteryPowerUse").to_int();
+}
+
+boolean auto_powerfulGloveNoncombat()
+{
+	if (!auto_hasPowerfulGlove()) return false;
+
+	if (auto_powerfulGloveCharges() < 5) return false;
+
+	if (0 < have_effect($effect[Invisible Avatar])) return false;
+
+	item old;
+	if (!have_equipped($item[Powerful Glove]))
+	{
+		old = equipped_item($slot[Acc3]);
+		equip($slot[Acc3], $item[Powerful Glove]);
+	}
+
+	boolean ret = use_skill(1, $skill[CHEAT CODE: Invisible Avatar]);
+
+	if (old != $item[none])
+	{
+		equip($slot[Acc3], old);
+	}
+
+	return ret;
+}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2879,6 +2879,11 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		getHorse("noncombat");
 	}
 
+	if((numeric_modifier("Combat Rate").to_int() + equipDiff > amt))
+	{
+		auto_powerfulGloveNoncombat();
+	}
+
 	if(numeric_modifier("Combat Rate").to_int() + equipDiff > amt)
 	{
 		asdonBuff($effect[Driving Stealthily]);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -685,6 +685,9 @@ int auto_birdsSought();						//Defined in autoscend/auto_mr2020.ash
 int auto_birdsLeftToday();					//Defined in autoscend/auto_mr2020.ash
 boolean auto_birdCanSeek();					//Defined in autoscend/auto_mr2020.ash
 boolean auto_favoriteBirdCanSeek();			//Defined in autoscend/auto_mr2020.ash
+boolean auto_hasPowerfulGlove();			//Defined in autoscend/auto_mr2020.ash
+int auto_powerfulGloveCharges();			//Defined in autoscend/auto_mr2020.ash
+boolean auto_powerfulGloveNoncombat();		//Defined in autoscend/auto_mr2020.ash
 boolean getSpaceJelly();					//Defined in autoscend/auto_mr2017.ash
 int horseCost();											//Defined in autoscend/auto_mr2017.ash
 string horseNormalize(string horseText); // Defined in autoscend/auto_mr2017.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -532,6 +532,7 @@ boolean drinkSpeakeasyDrink(item drink);					//Defined in autoscend/auto_clan.as
 boolean drinkSpeakeasyDrink(string drink);					//Defined in autoscend/auto_clan.ash
 boolean eatFancyDog(string dog);							//Defined in autoscend/auto_clan.ash
 boolean zataraClanmate(string who);							//Defined in autoscend/auto_clan.ash
+boolean zataraAvailable();									//Defined in autoscend/auto_clan.ash
 boolean zataraSeaside(string who);							//Defined in autoscend/auto_clan.ash
 boolean isActuallyEd();										//Defined in auto_ascend/auto_edTheUndying.ash
 void auto_runEdCombat(string option, boolean skipFirstFight);	//Defined in autoscend/auto_edTheUndying.ash


### PR DESCRIPTION
# Description

Partially addresses #232 

## How Has This Been Tested?

I ran this code for a day and belatedly realized it wasn't using the Powerful Glove to get. After fixing two embarrassing typos, the best test I could do was:

```
> ash import <autoscend> providePlusNonCombat(25)

WARNING: Unreachable code (auto_cooking.ash, line 1120)
[INFO] - I think we're good to go to apply The Sonata of Sneakiness
[DEBUG] - Adding "-200combat 25max" to current maximizer statement
[DEBUG] - Removing "-equip fancy boots" from current maximizer statement
[DEBUG] - Adding "+equip fancy boots" to current maximizer statement
Maximizing...
240 combinations checked, best score 19,218.31
You acquire an effect: Invisible Avatar (10)
Preference _powerfulGloveBatteryPowerUsed changed from 0 to 5
CHEAT CODE: Invisible Avatar was successfully cast.
Returned: true
```

Nuns code:

```
> [INFO] - Themthar Nuns!
> [INFO] - I think we're good to go to apply Polka of Plenty
> [DEBUG] - Adding "200meat drop, [omitted]
Preference auto_familiarChoice changed from Pocket Professor to Cat Burglar
Preference auto_familiarChoice changed from Cat Burglar to Hobo Monkey

familiar Hobo Monkey (11 lbs)

Visiting Fortune Teller in clan VIP lounge
Took choice 1278/1: Consult with Zatara
choice.php?pwd&whichchoice=1278&option=1&which=-3
You acquire an effect: Meet the Meat (100)
Preference _clanFortuneBuffUsed changed from false to true
> [DEBUG] - Adding outfit "frat warrior fatigues" to maximizer statement
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
