### PR TITLE
Misc. Plumber fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_giant_trash.ash
+++ b/RELEASE/scripts/autoscend/auto_giant_trash.ash
@@ -151,6 +151,8 @@ boolean L10_basement()
 	}
 
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
+	resetMaximize();
+	
 	handleFamiliar("item");
 
 	if(contains_text(get_property("lastEncounter"), "The Fast and the Furry-ous"))

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -1338,7 +1338,13 @@ boolean fightClubNap()
 boolean fightClubSpa()
 {
 	int option = 4;
-	switch(my_primestat())
+	stat st = my_primestat();
+	if (in_zelda())
+	{
+		// We deal 250% of our Moxie, so if our Muscle is too high we... die.
+		st = $stat[moxie];
+	}
+	switch(st)
 	{
 	case $stat[Muscle]:			option = 1;		break;
 	case $stat[Mysticality]:	option = 3;		break;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -254,14 +254,6 @@ void handlePreAdventure(location place)
 		autoEquip($item[latte lovers member\'s mug]);
 	}
 
-	// Use some instakills.
-	item DOCTOR_BAG = $item[Lil\' Doctor&trade; Bag];
-	if(auto_is_valid(DOCTOR_BAG) && possessEquipment(DOCTOR_BAG) && (get_property("_chestXRayUsed").to_int() < 3) && my_adventures() <= 19)
-	{
-		auto_log_info("We still haven't used Chest X-Ray, so let's equip the doctor bag.");
-		autoEquip($slot[acc3], DOCTOR_BAG);
-	}
-
 	if(in_zelda())
 	{
 		int pool_skill = speculative_pool_skill();
@@ -329,6 +321,14 @@ void handlePreAdventure(location place)
 			auto_log_debug("I expect to be flyering, equipping Pill Keeper to skip the first hit.");
 			autoEquip($slot[acc3], $item[Eight Days a Week Pill Keeper]);
 		}
+	}
+
+	// Use some instakills.
+	item DOCTOR_BAG = $item[Lil\' Doctor&trade; Bag];
+	if(auto_is_valid(DOCTOR_BAG) && possessEquipment(DOCTOR_BAG) && (get_property("_chestXRayUsed").to_int() < 3) && my_adventures() <= 19)
+	{
+		auto_log_info("We still haven't used Chest X-Ray, so let's equip the doctor bag.");
+		autoEquip($slot[acc3], DOCTOR_BAG);
 	}
 
 	equipOverrides();

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -318,7 +318,19 @@ void handlePreAdventure(location place)
 				autoEquip($slot[acc3], $item[work boots]);
 			}
 		}
+
+		// It is dangerous out there! Take this!
+		int flyeredML = get_property("flyeredML").to_int();
+		boolean have_pill_keeper = (0 <equipmentAmount($item[Eight Days a Week Pill Keeper])) && 
+			(is_unrestricted($item[Unopened Eight Days a Week Pill Keeper]));
+
+		if(0 < flyeredML && flyeredML < 10000 && in_zelda() && have_pill_keeper)
+		{
+			auto_log_debug("I expect to be flyering, equipping Pill Keeper to skip the first hit.");
+			autoEquip($slot[acc3], $item[Eight Days a Week Pill Keeper]);
+		}
 	}
+
 	equipOverrides();
 
 	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -313,7 +313,7 @@ void handlePreAdventure(location place)
 
 		// It is dangerous out there! Take this!
 		int flyeredML = get_property("flyeredML").to_int();
-		boolean have_pill_keeper = (0 <equipmentAmount($item[Eight Days a Week Pill Keeper])) && 
+		boolean have_pill_keeper = (possessEquipment($item[Eight Days a Week Pill Keeper])) &&
 			(is_unrestricted($item[Unopened Eight Days a Week Pill Keeper]));
 
 		if(0 < flyeredML && flyeredML < 10000 && in_zelda() && have_pill_keeper)


### PR DESCRIPTION
# Description

* Reset maximizer when doubling-up adventures in Castle.
  Fixes bug that could happen when preadventure equips three
  accessories, finds the noncombat that requires the amulet, and then
  complains that there's no space to equip the amulet.

* Don't get Muddled in Plumber, since we mostly kill with moxie and it
  might make our muscle too high. Hopefully this will make scaling
  fights on Day 2+ a little less lethal? :)

* Equip Pill Keeper in Plumber when flyering. Although we still don't
  always win initiative, so the effect might be limited.

* Fix bug where in some cases, we would not have an un-allocated
  accessory slot for the Fancy Boots in Path of the Plumber.

## How Has This Been Tested?

Ran fine during Day 2 of a softcore plumber run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
