### PR TITLE
Equip Fire Flower for King Boo fight

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1757,6 +1757,13 @@ boolean is_ghost_in_zone(location loc)
 			return true;
 		}
 	}
+
+	// Special-case for King Boo.
+	if (in_zelda() && loc == $location[Summoning Chamber])
+	{
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
# Description

Compensating for `get_monsters()` not providing path-specific monsters. Veracity is considering changing this (https://kolmafia.us/showthread.php?24497-Spring-2020-Challenge-Path-Path-of-the-Plumber&p=155739&viewfull=1#post155739), but it's easy to handle this in autoscend, since currently it King Boo is the only place it's relevant (that I know of).

```
> ash get_monsters($location[summoning chamber])

Returned: aggregate monster [1]
0 => Lord Spookyraven
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
