### PR TITLE
Pokefam1

### DIFF
--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -152,6 +152,10 @@ boolean godLobsterCombat(item it, int goal, string option)
 	{
 		return false;
 	}
+	if(pathForbidsFamiliars())
+	{
+		return false;
+	}
 	if((goal < 1) || (goal > 3))
 	{
 		return false;
@@ -307,7 +311,8 @@ boolean fantasyRealmToken()
 		return false;
 	}
 	set_property("auto_familiarChoice", "none");
-	use_familiar($familiar[none]);
+	if(!pathForbidsFamiliars())			//check that path allows familiars at all, don't set familiar to none if path forbids familiars.
+		use_familiar($familiar[none]);
 
 	if(possessEquipment($item[FantasyRealm G. E. M.]))
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -70,6 +70,7 @@ int amountTurkeyBooze();
 int numPirateInsults();
 int fastenerCount();
 int lumberCount();
+boolean pathForbidsFamiliars();
 skill preferredLibram();
 boolean playwith(item toy, string prop);
 boolean playwith(skill sk, string prop);
@@ -1828,6 +1829,17 @@ element ns_hedge3()
 {
 	auto_log_info("Hedge Maze 3: " + get_property("nsChallenge5"), "red");
 	return to_element(get_property("nsChallenge5"));
+}
+
+boolean pathForbidsFamiliars()
+{
+//this function checks if current path forbids familiars outright. To quickly disable certain functionality in such paths. Worth nothing that mafia's built in is_unrestricted(familiar) seems to be rather iffy. For example it does not report god lobster as being restricted in pokefam, even though no familiars are allowed in pokefam at all. Instead familiars can be equipped as pokefams, not as familiars.
+
+	if($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, License to Adventure, Pocket Familiars] contains auto_my_path())
+    {
+		return true;
+    }
+    return false;
 }
 
 skill preferredLibram()

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -856,6 +856,7 @@ boolean ocrs_postHelper();									//Defined in autoscend/auto_summerfun.ash
 void oldPeoplePlantStuff();									//Defined in autoscend/auto_floristfriar.ash
 boolean organsFull();										//Defined in autoscend/auto_util.ash
 boolean ovenHandle();										//Defined in autoscend/auto_util.ash
+boolean pathForbidsFamiliars();								//Defined in autoscend/auto_util.ash
 boolean pete_buySkills();									//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeDay(int day);							//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeSettings();								//Defined in autoscend/auto_sneakypete.ash


### PR DESCRIPTION
# Description

Adds a function to auto_util.ash called boolean pathForbidsFamiliars() which returns true on paths where familiars are entirely forbidden. Applies that function at two spots in mr2018 file.

## How Has This Been Tested?

Tested an earlier version of it with pokefam where it fixed errors with god lobster and fantasy realm. Since then I changed it from pathAllowsFamiliar() to pathForbidsFamiliars() as well as moved the function from mr2018 file to auto_util file (it will need to be applied to many more places, not just mr2018)

Most up to date version of this was tested in standard so far, where it successfully fought god lobster, indicating that this at least did not break god lobster fight

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
