### PR TITLE
Fix Boss Bat's Lair zone_available check

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -944,7 +944,7 @@ generic_t zone_available(location loc)
 		}
 		break;
 	case $location[The Boss Bat\'s Lair]:
-		if(internalQuestStatus("questL04Bat") >= 3)
+		if(internalQuestStatus("questL04Bat") == 3 )
 		{
 			retval._boolean = true;
 		}


### PR DESCRIPTION
# Description

Autoscend was attempting to burn delay in the The Boss Bat's Lair after the quest is completed because zone_available was incorrectly returning true.

The Boss Bat's Lair is only available if questL04Bat is step3

Fixes issue reported in discord.

## How Has This Been Tested?

I started a new run and verified delay burning never occurred in The Boss Bat's Lair after that quest was completed.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
