### PR TITLE
Bump Mafia version to r19810 to fix equipment checkpointing

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19771; // Re-calculate PP less aggressively
+since r19810; // Make restore() on a closed checkpoint not restore equipment
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here


### PR DESCRIPTION
# Description

Mafia checkpointing changes led to really bad bugs involving the war, Mafia fixed it, this bumps the version so nobody uses the bad version of mafia.

## How Has This Been Tested?

I used the web editor so it hasn't been

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
