### PR TITLE
Grindsausage

### DIFF
--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -47,6 +47,12 @@ boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 
 	if(casingsOwned == 0)
 		return false;
+		
+	//it is actually possible to have a casing but not have the kramko grinder
+	if(!possessEquipment($item[Kramco Sausage-o-Matic&trade;]))
+	{
+		return false;
+	}
 
 	if(numSaus <= 0)
 		return false;


### PR DESCRIPTION
# Description

it is actually possible to have a casing but not have the kramko grinder. for example if your grinder is in the display case.

## How Has This Been Tested?

was getting an error about being unable to grind sausage after every turn in a plumber run. After I made this change it stopped giving said error.
also I copy pasted that if function to test for if you have kramko from another part of the mr_2019 file

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
