### PR TITLE
Support CHEAT CODE: Replace Enemy, 

### DIFF
--- a/BUILD/monsters/replace.dat
+++ b/BUILD/monsters/replace.dat
@@ -1,0 +1,39 @@
+Banshee Librarian	item:Killing Jar>0
+Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4
+Knob Goblin Madam	item:Knob Goblin Perfume>0
+Bookbat
+Craven Carven Raven
+Drunk Goat
+Knight In White Satin
+Knob Goblin Harem Guard
+Mad Wino
+Plaid Ghost
+Possessed Laundry Press
+Sabre-Toothed Goat
+Senile Lihc
+Skeletal Sommelier
+Slick Lihc
+White Chocolate Golem
+Stone Temple Pirate	item:Eyepatch>0
+# lobsterfrogman (todo: add more wanderers)
+Government Agent	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Terrible Mutant	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Government Bureaucrat	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Slime Blob	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Angry Ghost	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Annoyed Snake	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+Sausage Goblin	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+# community service
+Lava Golem	path:Community Service;loc:LavaCo&trade; Lamp Factory
+Healing Crystal Golem	path:Community Service;loc:The Velvet / Gold Mine
+Mine Worker (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
+Mine Worker (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
+Mine Overseer (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask=0
+Mine Overseer (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask=0
+Factory-Irregular Skeleton	path:Community Service;loc:The Skeleton Store
+Remaindered Skeleton	path:Community Service;loc:The Skeleton Store
+Swarm of Skulls	path:Community Service;loc:The Skeleton Store
+Ancient Insane Monk	path:Community Service;loc:The Haiku Dungeon
+Ferocious Bugbear	path:Community Service;loc:The Haiku Dungeon
+Gelatinous Cube	path:Community Service;loc:The Haiku Dungeon
+Knob Goblin Poseur	path:Community Service;loc:The Haiku Dungeon

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -52,6 +52,45 @@ banish	46	Wardr&ouml;b Nightstand
 banish	47	Warehouse Janitor
 banish	48	Upgraded Ram
 
+replace	0	Banshee Librarian	item:Killing Jar>0
+replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4
+replace	2	Knob Goblin Madam	item:Knob Goblin Perfume>0
+replace	3	Bookbat
+replace	4	Craven Carven Raven
+replace	5	Drunk Goat
+replace	6	Knight In White Satin
+replace	7	Knob Goblin Harem Guard
+replace	8	Mad Wino
+replace	9	Plaid Ghost
+replace	10	Possessed Laundry Press
+replace	11	Sabre-Toothed Goat
+replace	12	Senile Lihc
+replace	13	Skeletal Sommelier
+replace	14	Slick Lihc
+replace	15	White Chocolate Golem
+replace	16	Stone Temple Pirate	item:Eyepatch>0
+# lobsterfrogman (todo: add more wanderers)
+replace	17	Government Agent	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	18	Terrible Mutant	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	19	Government Bureaucrat	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	20	Slime Blob	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	21	Angry Ghost	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	22	Annoyed Snake	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+replace	23	Sausage Goblin	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
+# community service
+replace	24	Lava Golem	path:Community Service;loc:LavaCo&trade; Lamp Factory
+replace	25	Healing Crystal Golem	path:Community Service;loc:The Velvet / Gold Mine
+replace	26	Mine Worker (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
+replace	27	Mine Worker (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
+replace	28	Mine Overseer (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask=0
+replace	29	Mine Overseer (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask=0
+replace	30	Factory-Irregular Skeleton	path:Community Service;loc:The Skeleton Store
+replace	31	Remaindered Skeleton	path:Community Service;loc:The Skeleton Store
+replace	32	Swarm of Skulls	path:Community Service;loc:The Skeleton Store
+replace	33	Ancient Insane Monk	path:Community Service;loc:The Haiku Dungeon
+replace	34	Ferocious Bugbear	path:Community Service;loc:The Haiku Dungeon
+replace	35	Gelatinous Cube	path:Community Service;loc:The Haiku Dungeon
+
 sniff	0	pygmy shaman	loc:The Hidden Apartment Building;sgeea:3;!effect:Thrice-Cursed
 sniff	1	Gurgle the Turgle
 sniff	2	Writing Desk	!prop:writingDesksDefeated=5

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -93,6 +93,8 @@ void generateTrackingData(string tracked, boolean hasSkill)
 		tracking[x] = replace_all(paren, "");
 		matcher asdon = create_matcher("Asdon Martin:", tracking[x]);
 		tracking[x] = replace_all(asdon, "Asdon Martin -");
+		matcher cheat = create_matcher("CHEAT CODE:", tracking[x]);
+		tracking[x] = replace_all(cheat, "CHEAT CODE -");
 		string[int] current = split_string(tracking[x], ":");
 		int curDay = to_int(current[0]);
 		string enemy = current[1];
@@ -262,6 +264,9 @@ void main()
 
 	writeln("<h2>Copies</h2>");
 	generateTrackingData("auto_copies", true);
+
+	writeln("<h2>Replaces</h2>");
+	generateTrackingData("auto_replaces", true);
 
 	writeln("<h2>Instakills</h2>");
 	generateTrackingData("auto_instakill", true);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19810; // Make restore() on a closed checkpoint not restore equipment
+since r19861; // skill.name
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -172,6 +172,7 @@ void initializeSettings()
 	set_property("auto_wishes", "");
 	set_property("auto_writingDeskSummon", false);
 	set_property("auto_yellowRays", "");
+	set_property("auto_replaces", "");
 	set_property("auto_consumeKeyLimePies", true);
 	set_property("auto_skipNuns", "false");
 	set_property("choiceAdventure1003", 0);
@@ -442,9 +443,9 @@ boolean LX_burnDelay()
 	// then a scaling monster is probably going to be a bad time
 	if(in_zelda() && !zelda_canDealScalingDamage())
 	{
-		// unless we can still kill it in like two hits or so, then it should probably be fine?
+		// unless we can still kill it in one hit, then it should probably be fine?
 		int predictedScalerHP = to_int(0.75 * (my_buffedstat($stat[Muscle]) + monster_level_adjustment()));
-		if(predictedScalerHP > 30)
+		if(predictedScalerHP > 15)
 		{
 			auto_log_info("Want to burn delay with scaling wanderers, but we can't deal scaling damage yet and it would be too strong :(");
 			wannaVote = false;

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -687,10 +687,6 @@ boolean L12_sonofaPrefix()
 	{
 		return false;
 	}
-	if((get_property("fratboysDefeated").to_int() < 64) && get_property("auto_hippyInstead").to_boolean())
-	{
-		return false;
-	}
 	if(item_amount($item[barrel of gunpowder]) >= 4 && !auto_voteMonster())
 	{
 		return false;
@@ -712,19 +708,29 @@ boolean L12_sonofaPrefix()
 
 	if(!(auto_get_campground() contains $item[Source Terminal]))
 	{
-		if(possessEquipment($item[&quot;I voted!&quot; sticker]))
+		if((auto_voteMonster() || auto_sausageGoblin()) && adjustForReplaceIfPossible())
 		{
-			if(auto_voteMonster() && auto_have_skill($skill[Meteor Lore]) && (get_property("_macrometeoriteUses").to_int() < 10))
+			try
 			{
 				if(item_amount($item[barrel of gunpowder]) < 4)
 				{
 					set_property("auto_doCombatCopy", "yes");
 				}
-				set_property("auto_combatDirective", "start;skill macrometeorite");
-				auto_voteMonster(false, $location[Sonofa Beach], "");
+				if (auto_voteMonster())
+				{
+					auto_voteMonster(false, $location[Sonofa Beach], "");
+					return true;
+				}
+				else if (auto_sausageGoblin())
+				{
+					auto_sausageGoblin($location[Sonofa Beach], "");
+					return true;
+				}
+			}
+			finally
+			{
 				set_property("auto_combatDirective", "");
 				set_property("auto_doCombatCopy", "no");
-				return true;
 			}
 		}
 		return false;
@@ -844,6 +850,10 @@ boolean L12_sonofaFinish()
 		return false;
 	}
 	if(!haveWarOutfit())
+	{
+		return false;
+	}
+	if((get_property("fratboysDefeated").to_int() < 64) && get_property("auto_hippyInstead").to_boolean())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -1821,12 +1821,19 @@ boolean spacegateVaccine(effect ef)
 	return true;
 }
 
+boolean auto_hasMeteorLore()
+{
+	return have_skill($skill[Meteor Lore]) &&
+		auto_is_valid($item[Pocket Meteor Guide]) &&
+		auto_is_valid($skill[Meteor Lore]);
+}
+
 int auto_meteorShowersUsed(){
 	return get_property("_meteorShowerUses").to_int();
 }
 
 int auto_meteorShowersAvailable(){
-	if(!is_unrestricted($skill[Meteor Lore]) || !have_skill($skill[Meteor Lore])){
+	if(!auto_hasMeteorLore()){
 		return 0;
 	}
 
@@ -1838,7 +1845,7 @@ int auto_macroMeteoritesUsed(){
 }
 
 int auto_macrometeoritesAvailable(){
-	if(!is_unrestricted($skill[Meteor Lore]) || !have_skill($skill[Meteor Lore])){
+	if(!auto_hasMeteorLore()){
 		return 0;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_mr2020.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2020.ash
@@ -117,6 +117,20 @@ boolean auto_powerfulGloveNoncombat()
 	return ret;
 }
 
+int auto_powerfulGloveReplacesPossible()
+{
+	if (!auto_hasPowerfulGlove()) return 0;
+
+	return (auto_powerfulGloveCharges() / 10).to_int();
+}
+
+int auto_powerfulGloveReplacesAvailable()
+{
+	if (!have_equipped($item[Powerful Glove])) return 0;
+
+	return auto_powerfulGloveReplacesPossible();
+}
+
 boolean auto_wantToEquipPowerfulGlove()
 {
 	if (!auto_hasPowerfulGlove()) return false;

--- a/RELEASE/scripts/autoscend/auto_mr2020.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2020.ash
@@ -117,18 +117,20 @@ boolean auto_powerfulGloveNoncombat()
 	return ret;
 }
 
-int auto_powerfulGloveReplacesPossible()
+// Returns if replaces are available, optionally only if the Powerful Glove is equipped
+int auto_powerfulGloveReplacesAvailable(boolean inCombat)
 {
 	if (!auto_hasPowerfulGlove()) return 0;
+
+	if (inCombat && !have_equipped($item[Powerful Glove])) return 0;
 
 	return (auto_powerfulGloveCharges() / 10).to_int();
 }
 
+// Returns if replaces are available if the Powerful Glove was equipped
 int auto_powerfulGloveReplacesAvailable()
 {
-	if (!have_equipped($item[Powerful Glove])) return 0;
-
-	return auto_powerfulGloveReplacesPossible();
+	return auto_powerfulGloveReplacesAvailable(false);
 }
 
 boolean auto_wantToEquipPowerfulGlove()

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -239,6 +239,11 @@ void handlePreAdventure(location place)
 		{
 			adjustForBanishIfPossible(mon, place);
 		}
+
+		if(auto_wantToReplace(mon, place))
+		{
+			adjustForReplaceIfPossible(mon);
+		}
 	}
 
 	if (in_koe() && possessEquipment($item[low-pressure oxygen tank]))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -6252,7 +6252,7 @@ boolean auto_check_conditions(string conds)
 				if(req_loc == $location[none])
 					abort('"' + condition_data + '" does not properly convert to a location!');
 				return my_location() == req_loc;
-			// data: <propname><comparison operator><integer value>
+			// data: <location><comparison operator><integer value>
 			// As a precaution, autoscend aborts if to_location returns $location[none]
 			case "turnsspent":
 				matcher m6 = create_matcher("([^=<>]+)([=<>]+)(.+)", condition_data);
@@ -6264,7 +6264,7 @@ boolean auto_check_conditions(string conds)
 				if(!($strings[=,==] contains m6.group(2)))
 					return compare_numbers(loc.turns_spent, m6.group(3).to_int(), m6.group(2));
 				return loc.turns_spent == m6.group(3).to_int();
-			// data: <location><comparison operator><value>
+			// data: <propname><comparison operator><value>
 			// >/</>=/<= only supported for integer properties!
 			case "prop":
 				matcher m2 = create_matcher("([^=<>]+)([=<>]+)(.+)", condition_data);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1746,7 +1746,7 @@ string replaceMonsterCombatString(monster target, boolean inCombat)
 	{
 		return "skill " + $skill[Macrometeorite];
 	}
-	if (inCombat ? auto_powerfulGloveReplacesAvailable() > 0 : auto_powerfulGloveReplacesPossible() > 0)
+	if (auto_powerfulGloveReplacesAvailable(inCombat) > 0)
 	{
 		return "skill " + $skill[CHEAT CODE: Replace Enemy];
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1740,6 +1740,69 @@ boolean adjustForYellowRayIfPossible()
 	return adjustForYellowRayIfPossible($monster[none]);
 }
 
+string replaceMonsterCombatString(monster target, boolean inCombat)
+{
+	if (auto_macrometeoritesAvailable() > 0)
+	{
+		return "skill " + $skill[Macrometeorite];
+	}
+	if (inCombat ? auto_powerfulGloveReplacesAvailable() > 0 : auto_powerfulGloveReplacesPossible() > 0)
+	{
+		return "skill " + $skill[CHEAT CODE: Replace Enemy];
+	}
+	return "";
+}
+
+string replaceMonsterCombatString(monster target)
+{
+	return replaceMonsterCombatString(target, false);
+}
+
+string replaceMonsterCombatString()
+{
+	return replaceMonsterCombatString($monster[none]);
+}
+
+# Use this to determine if it is safe to enter a replace monster combat.
+boolean canReplace(monster target)
+{
+	return replaceMonsterCombatString(target) != "";
+}
+
+boolean canReplace()
+{
+	return canReplace($monster[none]);
+}
+
+/* Adjust equipment/familiars to have access to the desired replace monster
+ */
+boolean adjustForReplace(string combat_string)
+{
+	if(combat_string == ("skill " + $skill[Macrometeorite]))
+	{
+		return true;
+	}
+	if(combat_string == ("skill " + $skill[CHEAT CODE: Replace Enemy]))
+	{
+		return auto_forceEquipPowerfulGlove();
+	}
+	return false;
+}
+
+boolean adjustForReplaceIfPossible(monster target)
+{
+	if(canReplace(target))
+	{
+		return adjustForReplace(replaceMonsterCombatString(target));
+	}
+	return false;
+}
+
+boolean adjustForReplaceIfPossible()
+{
+	return adjustForReplaceIfPossible($monster[none]);
+}
+
 string statCard()
 {
 	switch(my_primestat())
@@ -6189,7 +6252,19 @@ boolean auto_check_conditions(string conds)
 				if(req_loc == $location[none])
 					abort('"' + condition_data + '" does not properly convert to a location!');
 				return my_location() == req_loc;
-			// data: <propname><comparison operator><value>
+			// data: <propname><comparison operator><integer value>
+			// As a precaution, autoscend aborts if to_location returns $location[none]
+			case "turnsspent":
+				matcher m6 = create_matcher("([^=<>]+)([=<>]+)(.+)", condition_data);
+				if(!m6.find())
+					abort('"' + condition_data + '" is not a proper turnsspent condition format!');
+				location loc = to_location(m6.group(1));
+				if(loc == $location[none])
+					abort('"' + condition_data + '" does not properly convert to a location!');
+				if(!($strings[=,==] contains m6.group(2)))
+					return compare_numbers(loc.turns_spent, m6.group(3).to_int(), m6.group(2));
+				return loc.turns_spent == m6.group(3).to_int();
+			// data: <location><comparison operator><value>
 			// >/</>=/<= only supported for integer properties!
 			case "prop":
 				matcher m2 = create_matcher("([^=<>]+)([=<>]+)(.+)", condition_data);
@@ -6316,6 +6391,15 @@ boolean auto_wantToYellowRay(monster enemy, location loc)
 	boolean [monster] toSniff = auto_getMonsters("yellowray");
 	set_location(locCache);
 	return toSniff[enemy];
+}
+
+boolean auto_wantToReplace(monster enemy, location loc)
+{
+	location locCache = my_location();
+	set_location(loc);
+	boolean [monster] toReplace = auto_getMonsters("replace");
+	set_location(locCache);
+	return toReplace[enemy];
 }
 
 int total_items(boolean [item] items)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -391,6 +391,8 @@ boolean buyableMaintain(item toMaintain, int howMany, int meatMin);//Defined in 
 boolean buyableMaintain(item toMaintain, int howMany, int meatMin, boolean condition);//Defined in autoscend/auto_util.ash
 boolean canYellowRay(monster target); //Defined in autoscend/auto_util.ash
 boolean canYellowRay();										//Defined in autoscend/auto_util.ash
+boolean canReplace(monster target);	//Defined in autoscend/auto_util.ash
+boolean canReplace();				//Defined in autoscend/auto_util.ash
 boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string option);//Defined in autoscend/auto_adventure.ash
 boolean autoChew(int howMany, item toChew);					//Defined in autoscend/auto_cooking.ash
 float expectedAdventuresFrom(item it);						//Defined in autoscend/auto_cooking.ash
@@ -691,6 +693,8 @@ boolean auto_favoriteBirdCanSeek();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_hasPowerfulGlove();			//Defined in autoscend/auto_mr2020.ash
 int auto_powerfulGloveCharges();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_powerfulGloveNoncombat();		//Defined in autoscend/auto_mr2020.ash
+int auto_powerfulGloveReplacesPossible();	//Defined in autoscend/auto_mr2020.ash
+int auto_powerfulGloveReplacesAvailable();	//Defined in autoscend/auto_mr2020.ash
 boolean auto_wantToEquipPowerfulGlove();	//Defined in autoscend/auto_mr2020.ash
 boolean auto_willEquipPowerfulGlove();		//Defined in autoscend/auto_mr2020.ash
 boolean auto_forceEquipPowerfulGlove();		//Defined in autoscend/auto_mr2020.ash
@@ -740,11 +744,12 @@ boolean makeGeniePocket();									//Defined in autoscend/auto_mr2017.ash
 boolean spacegateVaccineAvailable();						//Defined in autoscend/auto_mr2017.ash
 boolean spacegateVaccineAvailable(effect ef);				//Defined in autoscend/auto_mr2017.ash
 boolean spacegateVaccine(effect ef);						//Defined in autoscend/auto_mr2017.ash
-int auto_meteorShowersUsed();                     //Defined in autoscend/auto_mr2017.ash
-int auto_meteorShowersAvailable();                //Defined in autoscend/auto_mr2017.ash
-int auto_macroMeteoritesUsed();                   //Defined in autoscend/auto_mr2017.ash
-int auto_macrometeoritesAvailable();              //Defined in autoscend/auto_mr2017.ash
-int auto_meteoriteAdesUsed();                   //Defined in autoscend/auto_mr2017.ash
+boolean auto_hasMeteorLore();								//Defined in autoscend/auto_mr2017.ash
+int auto_meteorShowersUsed();								//Defined in autoscend/auto_mr2017.ash
+int auto_meteorShowersAvailable();							//Defined in autoscend/auto_mr2017.ash
+int auto_macroMeteoritesUsed();								//Defined in autoscend/auto_mr2017.ash
+int auto_macrometeoritesAvailable();						//Defined in autoscend/auto_mr2017.ash
+int auto_meteoriteAdesUsed();								//Defined in autoscend/auto_mr2017.ash
 boolean handleBarrelFullOfBarrels(boolean daily);			//Defined in autoscend/auto_util.ash
 boolean handleCopiedMonster(item itm);						//Defined in autoscend/auto_util.ash
 boolean handleCopiedMonster(item itm, string option);		//Defined in autoscend/auto_util.ash
@@ -953,16 +958,23 @@ void woods_questStart();									//Defined in autoscend/auto_util.ash
 boolean xiblaxian_makeStuff();								//Defined in autoscend/auto_mr2014.ash
 string yellowRayCombatString(monster target, boolean inCombat); //Defined in autoscend/auto_util.ash
 string yellowRayCombatString(monster target);					//Defined in autoscend/auto_util.ash
-string yellowRayCombatString();								//Defined in autoscend/auto_util.ash
-boolean adjustForYellowRay(string combat_string); //Defined in autoscend/auto_util.ash
-boolean adjustForYellowRayIfPossible(monster target); //Defined in autoscend/auto_util.ash
-boolean adjustForYellowRayIfPossible(); //Defined in autoscend/auto_util.ash
+string yellowRayCombatString();									//Defined in autoscend/auto_util.ash
+boolean adjustForYellowRay(string combat_string); 				//Defined in autoscend/auto_util.ash
+boolean adjustForYellowRayIfPossible(monster target);			//Defined in autoscend/auto_util.ash
+boolean adjustForYellowRayIfPossible();							//Defined in autoscend/auto_util.ash
+string replaceMonsterCombatString(monster target, boolean inCombat);	//Defined in autoscend/auto_util.ash
+string replaceMonsterCombatString(monster target);						//Defined in autoscend/auto_util.ash
+string replaceMonsterCombatString();									//Defined in autoscend/auto_util.ash
+boolean adjustForReplace(string combat_string);					//Defined in autoscend/auto_util.ash
+boolean adjustForReplaceIfPossible(monster target);				//Defined in autoscend/auto_util.ash
+boolean adjustForReplaceIfPossible();							//Defined in autoscend/auto_util.ash
 string banisherCombatString(monster enemy, location loc, boolean inCombat); //Defined in autoscend/auto_util.ash
 string banisherCombatString(monster enemy, location loc);	//Defined in autoscend/auto_util.ash
 boolean[string] auto_banishesUsedAt(location loc); // Defined in autoscend/auto_util.ash
 boolean auto_wantToBanish(monster enemy, location loc); // Defined in autoscend/auto_util.ash
 boolean auto_wantToSniff(monster enemy, location loc); // Defined in autoscend/auto_util.ash
 boolean auto_wantToYellowRay(monster enemy, location loc); // Defined in autoscend/auto_util.ash
+boolean auto_wantToReplace(monster enemy, location loc); // Defined in autoscend/auto_util.ash
 int total_items(boolean [item] items); // Defined in autoscend/auto_util.ash
 boolean zoneCombat(location loc);							//Defined in autoscend/auto_util.ash
 boolean zoneItem(location loc);								//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -693,8 +693,7 @@ boolean auto_favoriteBirdCanSeek();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_hasPowerfulGlove();			//Defined in autoscend/auto_mr2020.ash
 int auto_powerfulGloveCharges();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_powerfulGloveNoncombat();		//Defined in autoscend/auto_mr2020.ash
-int auto_powerfulGloveReplacesPossible();	//Defined in autoscend/auto_mr2020.ash
-int auto_powerfulGloveReplacesAvailable();	//Defined in autoscend/auto_mr2020.ash
+int auto_powerfulGloveReplacesAvailable(boolean inCombat);	//Defined in autoscend/auto_mr2020.ash
 boolean auto_wantToEquipPowerfulGlove();	//Defined in autoscend/auto_mr2020.ash
 boolean auto_willEquipPowerfulGlove();		//Defined in autoscend/auto_mr2020.ash
 boolean auto_forceEquipPowerfulGlove();		//Defined in autoscend/auto_mr2020.ash


### PR DESCRIPTION
# Description

Move monster replacement logic to use a data file
Move macrometeorite logic to common functions, add support for CHEAT CODE: Replace Enemy
Track monster replacement in auto_replaces instead of auto_otherstuff
Plumber: Don't fight scaling monsters without scaling damage unless a one hit ko is possible as I was losing a lot of fights
Allow replacing into lobserfrogmen when auto_hippyInstead before 64 frat defeated (auto_hippyInstead has some additional issues I may look at in another PR)
Fix ambiguous skills not being used in combat correctly
TODO for a different PR: The community service monster replacements are in the data file, but currently unused

## How Has This Been Tested?

Plumber Day 1:
* Successfully used CHEAT CODE: Replace Enemy on Banshee Librarian after acquiring a killing jar
* Successfully used CHEAT CODE: Replace Enemy on Bookbat

Plumber Day 2:
* Successfully used CHEAT CODE: Replace Enemy on Sabre-toothed Goat x2
* Successfully used CHEAT CODE: Replace Enemy on Skeletal Sommelier x3
* Successfully used CHEAT CODE: Replace Enemy on Mad Wino

Plumber Day 3:
* Successfully used CHEAT CODE: Replace Enemy on Sausage Goblin -> Lobsterfrogman x4
* Successfully used CHEAT CODE: Replace Enemy on Angry Ghost -> Lobsterfrogman
```
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
