### PR TITLE
Bloodandstuff

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -81,7 +81,7 @@ boolean canUse(skill sk, boolean onlyOnce)
 		my_thunder() < thunder_cost(sk) ||
 		my_rain() < rain_cost(sk) ||
 		my_soulsauce() < soulsauce_cost(sk) ||
-		zelda_ppCurr() < zelda_ppCost(sk)
+		my_pp() < zelda_ppCost(sk)
 	)
 		return false;
 
@@ -1668,7 +1668,7 @@ string auto_combatHandler(int round, string opp, string text)
 	{
 		// note: Juggle Fireballs CAN be used multiple times, but it is only
 		// useful if you have level 3 fire and therefore get healed
-		if(zelda_ppCurr() > 2 && canUse($skill[Juggle Fireballs], true))
+		if(my_pp() > 2 && canUse($skill[Juggle Fireballs], true))
 		{
 			return useSkill($skill[Juggle Fireballs]);
 		}

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -236,7 +236,7 @@ boolean L12_preOutfit()
 
 boolean L12_startWar()
 {
-	if (internalQuestStatus("questL12War") < 0 || internalQuestStatus("questL12War") > 0)
+	if (internalQuestStatus("questL12War") != 0)
 	{
 		return false;
 	}
@@ -247,6 +247,11 @@ boolean L12_startWar()
 	}
 
 	if (!haveWarOutfit() || my_basestat($stat[Mysticality]) < 70 || my_basestat($stat[Moxie]) < 70)
+	{
+		return false;
+	}
+
+	if(get_property("lastIslandUnlock").to_int() < my_ascensions())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1110,13 +1110,12 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
   }
 
   boolean use_opportunity_blood_skills(int hp_restored_per_use){
-    boolean success = true;
     int restored = my_hp() + hp_restored_per_use;
     int waste = min(my_hp()-1, restored-my_maxhp());
-    if(waste <= 0) return success;
+    if(waste <= 0) return true;
     // both blood skills we care about cost 30
     int casts_total = waste / 30;
-    if(casts_total <= 0) return success;
+    if(casts_total <= 0) return true;
     // ratio should be 1 / the number of turns of that effect per cast
     float [skill] skill_ratios;
     float total_ratio = 0.0;
@@ -1140,6 +1139,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
     if(casts_so_far < casts_total){
       to_cast[pick_blood_skill()] += casts_total - casts_so_far;
     }
+    boolean success = true;
     foreach sk, times in to_cast{
       success &= use_skill(times, sk);
     }

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1111,20 +1111,37 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 
   boolean use_opportunity_blood_skills(int hp_restored_per_use){
     boolean success = true;
-    while(true){
-      skill blood_skill = pick_blood_skill();
-      if(blood_skill != $skill[none]){
-        int restored = my_hp() + hp_restored_per_use;
-        int waste = min(my_hp()-1, restored-my_maxhp());
-        int casts = floor(waste / hp_cost(blood_skill));
-        if(casts > 0){
-          success &= use_skill(1, blood_skill);
-        } else{
-          break;
-        }
-      } else{
-        break;
-      }
+    int restored = my_hp() + hp_restored_per_use;
+    int waste = min(my_hp()-1, restored-my_maxhp());
+    if(waste <= 0) return success;
+    // both blood skills we care about cost 30
+    int casts_total = waste / 30;
+    if(casts_total <= 0) return success;
+    // ratio should be 1 / the number of turns of that effect per cast
+    float [skill] skill_ratios;
+    float total_ratio = 0.0;
+    if(auto_have_skill($skill[Blood Bubble])){
+      float bubble_ratio = 1.0 / 3.0;
+      skill_ratios[$skill[Blood Bubble]] = bubble_ratio;
+      total_ratio += bubble_ratio;
+    }
+    if(auto_have_skill($skill[Blood Bond])){
+      float bond_ratio = 1.0 / 10.0;
+      skill_ratios[$skill[Blood Bond]] = bond_ratio;
+      total_ratio += bond_ratio;
+    }
+    int casts_so_far;
+    int [skill] to_cast;
+    foreach sk, ratio in skill_ratios{
+      int times_to_cast = floor(casts_total * ratio / total_ratio);
+      to_cast[sk] = times_to_cast;
+      casts_so_far += times_to_cast;
+    }
+    if(casts_so_far < casts_total){
+      to_cast[pick_blood_skill()] += casts_total - casts_so_far;
+    }
+    foreach sk, times in to_cast{
+      success &= use_skill(times, sk);
     }
     return success;
   }

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -321,22 +321,6 @@ boolean [skill] zelda_combatSkills = $skills[
 	Multi-Bounce,
 ];
 
-// TODO: Remove this function when my_pp() works
-int zelda_ppCurr()
-{
-	if(!in_zelda())
-	{
-		return 0;
-	}
-
-	int pp = my_maxpp();
-	foreach sk in zelda_combatSkills
-	{
-		pp -= zelda_ppCost(sk) * usedCount(sk);
-	}
-	return pp;
-}
-
 boolean zelda_canDealScalingDamage()
 {
 	// TODO: When mafia tracks costumes, account for level 3 basic attacks

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1144,7 +1144,6 @@ boolean zelda_buyEquipment(item it); // Defined in autoscend/auto_zelda.ash
 boolean zelda_nothingToBuy(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_buyStuff(); // Defined in autoscend/auto_zelda.ash
 int zelda_ppCost(skill sk); // Defined in autoscend/auto_zelda.ash
-int zelda_ppCurr(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_canDealScalingDamage(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_skillValid(skill sk); // Defined in autoscend/auto_zelda.ash
 


### PR DESCRIPTION
# Description

The main part of this pull request is switching to calculating how many times to cast blood bond and blood bubble each ahead of time when using them, instead of casting them one by one, since that could result in an absurd number of server hits for no good reason.

I also fixed an issue where the script would attempt to start the war before unlocking the island if you were high enough level already (such as when eating a pie man was not meant to eat pizza in path of the plumber).

Finally, I got rid of `zelda_ppCurr` because it is no longer necessary.

## How Has This Been Tested?

I've done several plumber runs with these changes, but only one non-plumber run, which is what is needed to test the blood skill stuff. Absolutely no issues popped up as a result of the blood skill change though, so I'm fairly confident in it.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
