### PR TITLE
Remove parse-breaking ';' in monsters.dat

### DIFF
--- a/BUILD/monsters/replace.dat
+++ b/BUILD/monsters/replace.dat
@@ -24,7 +24,7 @@ Angry Ghost	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouse
 Annoyed Snake	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
 Sausage Goblin	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
 # community service
-Lava Golem	path:Community Service;loc:LavaCo&trade; Lamp Factory
+Lava Golem	path:Community Service;loc:LavaCo Lamp Factory
 Healing Crystal Golem	path:Community Service;loc:The Velvet / Gold Mine
 Mine Worker (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
 Mine Worker (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -78,7 +78,7 @@ replace	21	Angry Ghost	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sideques
 replace	22	Annoyed Snake	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
 replace	23	Sausage Goblin	loc:Sonofa Beach;item:barrel of gunpowder<5;prop:sidequestLighthouseCompleted=none
 # community service
-replace	24	Lava Golem	path:Community Service;loc:LavaCo&trade; Lamp Factory
+replace	24	Lava Golem	path:Community Service;loc:LavaCo Lamp Factory
 replace	25	Healing Crystal Golem	path:Community Service;loc:The Velvet / Gold Mine
 replace	26	Mine Worker (female)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0
 replace	27	Mine Worker (male)	path:Community Service;loc:The Velvet / Gold Mine;item:High-Temperature Mining Mask>0


### PR DESCRIPTION
# Description

We use ';' as a delimiter in data files, so "LavaCo&trade; Lamp Factory"
was splitting into "LavaCo&trade" and " Lamp Factory", crashing the
condition-parsing engine:

    "LavaCo™" does not properly convert to a location!

To fix this, I replaced "LavaCo&trade; Lamp Factory" with "LavaCo Lamp
Factory", removing the stray ';'. Mafia will correctly coerce the
no-trademark string to the correct location via

    `to_location("LavaCo Lamp Factory")`

so behavior is unchanged.

## How Has This Been Tested?

I modified local data files to

```
replace    24    Lava Golem    loc:LavaCo&trade; Lamp Factory
```

so I could test outside of Community Service (outside of CS it would short-circuit the check, which is why we didn't find this before). I ran

```
ash import <autoscend> auto_wantToReplace($monster[lava golem], $location[LavaCo&trade; Lamp Factory])
```

observed the crash, made the above amendment, observed that it behaved correctly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
