### PR TITLE
Sing

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1543,7 +1543,7 @@ string auto_combatHandler(int round, string opp, string text)
 		
 			//this is for increasing meat income. gain +25 meat per monster, at the cost of letting it act once. If healing is too costly this can be a net loss of meat. until a full cost calculator is made, limit to under 10 HP damage and no more than 20% of your remaining HP.
 			
-			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (auto_my_path() =! "Way of the Surprising Fist"))
+			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (auto_my_path() != "Way of the Surprising Fist"))
 			{
 				return useSkill($skill[Sing Along]);
 			}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1531,15 +1531,29 @@ string auto_combatHandler(int round, string opp, string text)
 		{
 			return useItem($item[Time-Spinner]);
 		}
-
-		if(canUse($skill[Sing Along]) && (get_property("boomBoxSong") == "Remainin\' Alive") && stunnable(enemy))
+		
+		if(canUse($skill[Sing Along]))
 		{
-			return useSkill($skill[Sing Along]);
-		}
-
-		if(canUse($skill[Sing Along]) && canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && stunnable(enemy))
-		{
-			return useSkill($skill[Sing Along]);
+			//15% devel, but no stun. 
+			
+			if(canSurvive(2.0) && (get_property("boomBoxSong") == "Remainin\' Alive"))
+			{
+				return useSkill($skill[Sing Along]);
+			}
+		
+			//this is for increasing meat income. gain +25 meat per monster, at the cost of letting it act once. If healing is too costly this can be a net loss of meat. until a full cost calculator is made, limit to under 10 HP damage and no more than 20% of your remaining HP.
+			
+			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (auto_my_path() =! "Way of the Surprising Fist"))
+			{
+				return useSkill($skill[Sing Along]);
+			}
+		
+			//if doing nuns quest or wall of meat, disregard profit and only check if you can survive using sing along.
+			
+			if(canSurvive(3.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && $monsters[dirty thieving brigand, wall of meat] contains enemy)
+			{
+				return useSkill($skill[Sing Along]);
+			}
 		}
 	}
 
@@ -1559,14 +1573,6 @@ string auto_combatHandler(int round, string opp, string text)
 		if(canUse($skill[Summon Love Stinkbug]) && haveUsed($skill[Summon Love Gnats]) && !contains_text(text, "STUN RESIST"))
 		{
 			return useSkill($skill[Summon Love Stinkbug]);
-		}
-
-		if(canUse($skill[Sing Along]))
-		{
-			if((get_property("boomBoxSong") == "Remainin' Alive") || (get_property("boomBoxSong") == "Total Eclipse of Your Meat"))
-			{
-				return useSkill($skill[Sing Along]);
-			}
 		}
 	}
 
@@ -2573,6 +2579,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if (canUse($skill[Sing Along]))
 	{
+		//ed can easily survive singing along thanks to undying. and healing him is essentially free.
 		if((get_property("boomBoxSong") == "Remainin\' Alive") || ((get_property("boomBoxSong") == "Total Eclipse of Your Meat") && canSurvive(2.0)))
 		{
 			return useSkill($skill[Sing Along]);


### PR DESCRIPTION
# Description

The skill sing along is often harmful instead of helpful.

The problems with its code were:
1. stunnable enemy test is pointless. as sing along does not stun

2. missing check to not use total eclipse of your meat in way of the surprising fist.

3. canSurvive needs updating for some monsters.

4. canSurvive is the wrong thing to check. the big question is "will it actually turn a profit". sing along gives the enemy a turn to act against you in exchange for giving +25 base meat (which is then multiplied by meat% bonus). that extra meat is very often not enough to pay for the healing necessary to recover from that free hit unless you are significantly higher level than the enemy. meaning you lose meat by using it against those enemies. it should instead check if you have enough moxie to be unhitable (edit: or better yet, expected damage)

5. It needs a seperate check against the "dirty thieving brigand" (for the nuns meat quest) and the "wall of meat" where it does not care about profit, only if you can survive it. Since in those two cases the extra meat income helps you save turns

6. There is some duplicate code. sing along function is called if monster level is under 150 and stunable, and again if it is under 100 and stunable. Since almost always your ML is under 100 that means both copies of this function are called for each monster. The first instance of this code had its survive threshhold increased several times in the past in an attempt to fix the issue of losing meat on singing for meat. Raising it from 2 all the way up to 5 (5 means it will sing as long as expected damage is under 20% of your HP), while the latter was not modified and is still on the original 2 (will sing so long as expected damage from it is under 50% of your HP).
This made the attempted fix on the first instance ineffective, because even if it does not get called because HP loss is too high, the second instance will be called which is will to spend up to 50% of your HP for that +25 meat, which is big loss of meat once you pay for healing.

============

changes:
1. no changes to ed, its fine.
2. removed the unnecessary duplicate call (which was why increasing cansurvive to 5.0 didn't do anything before. it just meant it used the second instance of it to call it)
3. seperated the singalong for meat into two functions, one for meat income and one for quests. the quest one just wants to survive 3 rounds (1st of which is the round in which sing along is cast). the meat one requires taking no more than 20% damage and under 10 HP damage (under many circumstances even going above 6 will turn a net loss. just not a catastrophic one as wasting 90 HP on singing along does. I will make a full calculator for it later)
4. don't try to farm meat using sing along in way of the surprising fist

There are probably a bunch of other paths where healing is overly expensive where it should just be disabled outright.

## How Has This Been Tested?

Did 3 plumber and 1 pokefam run with it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
