### PR TITLE
Use Triple-Sized at tower test

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -6235,6 +6235,14 @@ void auto_begin()
 		visit_url("account.php?am=1&pwd=&action=flag_compactchar&value=0&ajax=0", true);
 	}
 
+	if (!get_property("_canSeekBirds").to_boolean() &&
+		(0 < item_amount($item[Bird-a-Day calendar])) &&
+		(auto_is_valid($item[Bird-a-Day calendar])))
+	{
+		auto_log_info("What a beautiful morning! What's today's bird?");
+		use(1, $item[Bird-a-Day calendar]);
+	}
+
 	ed_initializeSession();
 	bat_initializeSession();
 	questOverride();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1633,7 +1633,9 @@ boolean adjustForBanishIfPossible(monster enemy, location loc)
 {
 	if(canBanish(enemy, loc))
 	{
-		return adjustForBanish(banisherCombatString(enemy, loc));
+		string banish_string = banisherCombatString(enemy, loc);
+		auto_log_info("Adjusting to have banisher available for " + enemy + ": " + banish_string, "blue");
+		return adjustForBanish(banish_string);
 	}
 	return false;
 }
@@ -1730,7 +1732,9 @@ boolean adjustForYellowRayIfPossible(monster target)
 {
 	if(canYellowRay(target))
 	{
-		return adjustForYellowRay(yellowRayCombatString(target));
+		string yr_string = yellowRayCombatString(target);
+		auto_log_info("Adjusting to have YR available for " + target + ": " + yr_string, "blue");
+		return adjustForYellowRay(yr_string);
 	}
 	return false;
 }
@@ -1793,7 +1797,9 @@ boolean adjustForReplaceIfPossible(monster target)
 {
 	if(canReplace(target))
 	{
-		return adjustForReplace(replaceMonsterCombatString(target));
+		string rep_string = replaceMonsterCombatString(target);
+		auto_log_info("Adjusting to have replace available for " + target + ": " + rep_string, "blue");
+		return adjustForReplace(rep_string);
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3538,10 +3538,17 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 		Blessing of Your Favorite Bird,
 	]))
 		return result();
+
 	if(auto_have_skill($skill[Quiet Desperation]))
 		tryEffects($effects[Quiet Desperation]);
 	else
 		tryEffects($effects[Disco Smirk]);
+
+	if (!pass() && (0 == have_effect($effect[Triple-Sized])))
+	{
+		auto_powerfulGloveStats();
+	}
+
 	if(pass())
 		return result();
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3544,11 +3544,6 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 	else
 		tryEffects($effects[Disco Smirk]);
 
-	if (!pass() && (0 == have_effect($effect[Triple-Sized])))
-	{
-		auto_powerfulGloveStats();
-	}
-
 	if(pass())
 		return result();
 
@@ -3624,6 +3619,7 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 			Standard Issue Bravery,
 			Tomato Power,
 			Vital,
+			Triple-Sized,
 		]))
 			return result();
 
@@ -5739,6 +5735,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Toad in the Hole]:				useItem = $item[Anti-anti-antidote];			break;
 	case $effect[Tomato Power]:					useItem = $item[Tomato Juice of Powerful Power];break;
 	case $effect[Tortious]:						useItem = $item[Mocking Turtle];				break;
+	case $effect[Triple-Sized]:					useSkill = $skill[none];						break;
 	case $effect[Truly Gritty]:					useItem = $item[True Grit];						break;
 	case $effect[Twen Tea]:						useItem = $item[cuppa Twen tea];				break;
 	case $effect[Twinkly Weapon]:				useItem = $item[Twinkly Nuggets];				break;
@@ -5862,6 +5859,18 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		case $effect[Disdain of the War Snapper]:
 			useSkill = $skill[Blessing of the War Snapper];
 			break;
+		}
+	}
+
+	if (buff == $effect[Triple-Sized])
+	{
+		if (speculative)
+		{
+			return auto_powerfulGloveCharges() >= 5;
+		}
+		else
+		{
+			return auto_powerfulGloveStats();
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -696,6 +696,7 @@ boolean auto_favoriteBirdCanSeek();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_hasPowerfulGlove();			//Defined in autoscend/auto_mr2020.ash
 int auto_powerfulGloveCharges();			//Defined in autoscend/auto_mr2020.ash
 boolean auto_powerfulGloveNoncombat();		//Defined in autoscend/auto_mr2020.ash
+boolean auto_powerfulGloveStats();		//Defined in autoscend/auto_mr2020.ash
 int auto_powerfulGloveReplacesAvailable(boolean inCombat);	//Defined in autoscend/auto_mr2020.ash
 boolean auto_wantToEquipPowerfulGlove();	//Defined in autoscend/auto_mr2020.ash
 boolean auto_willEquipPowerfulGlove();		//Defined in autoscend/auto_mr2020.ash


### PR DESCRIPTION
# Description

* Use triple-sized to provide stats
* Add some logging that should clarify what banish/replace/yellow ray sources we're expecting to use.

Fixes #232 (We now have all functionality described in this issue other than using the +stats when we. Might not be a bad idea to use if the "I'm having difficulty in combat" logging triggers.)

## How Has This Been Tested?

Haven't done much testing: just `verify autoscend`. Treat with suspicion.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
