### PR TITLE
[plumber] Attempt to use cold damage at Logging Camp

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1675,12 +1675,13 @@ string auto_combatHandler(int round, string opp, string text)
 		// note: Juggle Fireballs CAN be used multiple times, but it is only
 		// useful if you have level 3 fire and therefore get healed
 
-    if(my_pp() > 2 && canUse($skill[[7332]Juggle Fireballs], true))
+		if(my_pp() > 2 && canUse($skill[[7332]Juggle Fireballs], true))
 		{
 			return useSkill($skill[[7332]Juggle Fireballs]);
 		}
 
-		if (enemy.physical_resistance >= 80)
+		if ((enemy.physical_resistance >= 80) ||
+		    (my_location() == $location[The Smut Orc Logging Camp] && (0 < equipped_amount($item[frosty button]))))
 		{
 			if (canUse($skill[[7333]Fireball Barrage], false))
 			{

--- a/RELEASE/scripts/autoscend/auto_highlands.ash
+++ b/RELEASE/scripts/autoscend/auto_highlands.ash
@@ -64,6 +64,7 @@ boolean L9_chasmBuild()
 	}
 
 	// -Combat is useless here since NC is triggered by killing Orcs...So we kill orcs better!
+	// -ML helps us deal more cold damage and trigger the NC faster.
 	asdonBuff($effect[Driving Intimidatingly]);
 
 	// Check our Load out to see if spells are the best option for Orc-Thumping
@@ -153,6 +154,11 @@ boolean L9_chasmBuild()
 		}
 		autoAdv(1, $location[The Smut Orc Logging Camp]);
 		return true;
+	}
+
+	if (in_zelda() && possessEquipment($item[frosty button]))
+	{
+		autoEquip($item[frosty button]);
 	}
 
 	if(in_hardcore())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -207,8 +207,12 @@ void handlePreAdventure(location place)
 		{
 			pool_skill += 3;
 		}
+		// Even though there are ghosts in the Billiards Room, we want to equip
+		// the pool cue to finish up the quest.
 		boolean skip_equipping_flower = place == $location[The Haunted Billiards Room] && 18 <= pool_skill;
-		// need to equip boots in ziggurat until lianas are cleared out
+
+		// Ziggurat has a ghost BUT when clearing out lianas, we want to equip
+		// machete in mainhand and use boots.
 		if(place == $location[A Massive Ziggurat])
 		{
 			int lianaFought = 0;
@@ -224,7 +228,8 @@ void handlePreAdventure(location place)
 				skip_equipping_flower = true;
 			}
 		}
-		if (is_ghost_in_zone(place) && !skip_equipping_flower)
+		if ((is_ghost_in_zone(place) && !skip_equipping_flower)
+			|| (place == $location[The Smut Orc Camp] && possessEquipment($item[frosty button])))
 		{
 			if (possessEquipment($item[bonfire flower]))
 			{

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -914,13 +914,13 @@ boolean L13_towerNSTower()
 			n_healing_items = item_amount($item[super deluxe mushroom]);
 			if(n_healing_items < 5)
 			{
-				retrieve_item(5 - n_healing_items, $item[super deluxe mushroom]);
+				retrieve_item(5, $item[super deluxe mushroom]);
 				n_healing_items = item_amount($item[super deluxe mushroom]);
 			}
 		}
 		if(n_healing_items < 5)
 		{
-			abort("We only have " + n_healing_items + "healing items, I'm not sure we can do the shadow.");
+			abort("We only have " + n_healing_items + " healing items, I'm not sure we can do the shadow.");
 		}
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);
 		return true;

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -316,15 +316,6 @@ int zelda_ppCost(skill sk)
 	}
 }
 
-boolean [skill] zelda_combatSkills = $skills[
-	[25001]Hammer Throw,
-	[25002]Ultra Smash,
-	[25003]Juggle Fireballs,
-	[25004]Fireball Barrage,
-	[25005]Spin Jump,
-	[25006]Multi-Bounce,
-];
-
 boolean zelda_canDealScalingDamage()
 {
 	// TODO: When mafia tracks costumes, account for level 3 basic attacks

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -199,7 +199,11 @@ boolean zelda_buyableIsNothing(zelda_buyable zb)
 
 zelda_buyable zelda_nextBuyable()
 {
-	if (!have_skill($skill[Lucky Buckle]))
+	if (!possessEquipment($item[[10462]fire flower]))
+	{
+		return zelda_buyableItem($item[[10462]fire flower]);
+	}
+	else if (!have_skill($skill[Lucky Buckle]))
 	{
 		return zelda_buyableSkill($skill[Lucky Buckle]);
 	}


### PR DESCRIPTION
# Description

Preliminary Logging Camp optimization for Plumber runs.

Also has two minor changes thrown in, one of which fixes #256

## How Has This Been Tested?

Correctly equipped frosty button and fire flower at the Logging Camp in a high-starting-coin high-IOTM Plumber run. Correctly used fire abilities.

```
[INFO] - If we encounter Blech House when we are not expecting it we will stop.
[INFO] - Currently setup for Muscle/Weapon Damage, option 1: Kick it down
[INFO] - Equipping frosty button to slot acc1
Preference _auto_maximize_equip_acc1 changed from to frosty button
Preference auto_combatHandler changed from (banishercheck)(sk7333) to

[INFO] - Starting preadventure script...
[DEBUG] - Adventuring at The Smut Orc Logging Camp
[INFO] - Equipping [10462]fire flower to slot weapon
Preference _auto_maximize_equip_weapon changed from to [10462]fire flower
[DEBUG] - Adding "50item 900max" to current maximizer statement
[INFO] - Equipping Powerful Glove to slot acc3
Preference _auto_maximize_equip_acc3 changed from to Powerful Glove
[DEBUG] - Removing "-equip [10462]fire flower" from current maximizer statement
[DEBUG] - Adding "+equip [10462]fire flower" to current maximizer statement
[DEBUG] - Removing "-equip frosty button" from current maximizer statement
[DEBUG] - Adding "+equip frosty button" to current maximizer statement
[DEBUG] - Removing "-equip Powerful Glove" from current maximizer statement
[DEBUG] - Adding "+equip Powerful Glove" to current maximizer statement
Maximizing...
16 combinations checked, best score 27,440.69
[DEBUG] - We can't cap this drop bear!
[DEBUG] - Removing "-equip [10462]fire flower" from current maximizer statement
[DEBUG] - Adding "+equip [10462]fire flower" to current maximizer statement
[DEBUG] - Removing "-equip frosty button" from current maximizer statement
[DEBUG] - Adding "+equip frosty button" to current maximizer statement
[DEBUG] - Removing "-equip Powerful Glove" from current maximizer statement
[DEBUG] - Adding "+equip Powerful Glove" to current maximizer statement
Maximizing...
16 combinations checked, best score 27,440.69
Checkpoints cleared.
[DEBUG] - Going into a LOW ML ZONE with ML: 0
[INFO] - Pre Adventure at The Smut Orc Logging Camp done, beep.

Visit to Mountain: The Smut Orc Logging Camp in progress...

[253] The Smut Orc Logging Camp
Preference lastEncounter changed from smut orc screwer to smut orc pipelayer
Encounter: smut orc pipelayer
Preference _lastCombatStarted changed from 20200324024538 to 20200324024544
Round 0: Jeparo wins initiative!
[INFO] - auto_combatHandler: 0
Preference auto_combatHP changed from 486 to 491
Preference auto_combatHandler changed from to (banishercheck)
[WARNING] - None of our preferred skills available. Engaging in Fisticuffs.
Preference auto_combatHandler changed from (banishercheck) to (banishercheck)(sk7333)
Round 1: Jeparo casts FIREBALL BARRAGE!
Round 2: smut orc pipelayer takes 582 damage.
Round 2: Jeparo wins the fight!
...
Preference smutOrcNoncombatProgress changed from 10 to 15
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
