### PR TITLE
Plumber1

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -229,7 +229,7 @@ void handlePreAdventure(location place)
 			}
 		}
 		if ((is_ghost_in_zone(place) && !skip_equipping_flower)
-			|| (place == $location[The Smut Orc Camp] && possessEquipment($item[frosty button])))
+			|| (place == $location[The Smut Orc Logging Camp] && possessEquipment($item[frosty button])))
 		{
 			if (possessEquipment($item[bonfire flower]))
 			{

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -199,13 +199,13 @@ boolean zelda_buyableIsNothing(zelda_buyable zb)
 
 zelda_buyable zelda_nextBuyable()
 {
-	if (!possessEquipment($item[[10462]fire flower]))
-	{
-		return zelda_buyableItem($item[[10462]fire flower]);
-	}
-	else if (!have_skill($skill[Lucky Buckle]))
+	if (!have_skill($skill[Lucky Buckle]))
 	{
 		return zelda_buyableSkill($skill[Lucky Buckle]);
+	}
+	else if (!possessEquipment($item[[10462]fire flower]))
+	{
+		return zelda_buyableItem($item[[10462]fire flower]);
 	}
 	else if (!have_skill($skill[Secret Eye]))
 	{


### PR DESCRIPTION
# Description
related to commit #257

switch order on purchases in plumber so that lucky buckle is bought first, before fireflower.
This will pay for the fire flower in 7 combats.
and you are unlikely to face a ghost in the first few combats of a run. this only really matters for people on their very first plumber run ever, for which it slightly improves their economy by a few turns. if they already finished at least 1 run then the initial coins would cover both anyways.

Also, fixed spelling error in the above commit too
`Changing "The Smut Orc Camp" to "The Smut Orc Logging Camp" would get rid of this message. (auto_pre_adv.ash, line 232)`
The Smut Orc Camp was missing the word Logging

## How Has This Been Tested?
started a plumber run. it bought the lucky bucket first then it bought the fire flower.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
