### PR TITLE
Fixes for the myriad of auto_hippyInstead = true issues.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2295,11 +2295,6 @@ boolean questOverride()
 		}
 	}
 
-	if(get_property("auto_hippyInstead").to_boolean())
-	{
-		set_property("auto_ignoreFlyer", true);
-	}
-
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -11,6 +11,7 @@ void hr_initializeSettings()
 		set_property("auto_mountainmen", "");
 		set_property("auto_ninjasnowmanassassin", "");
 		set_property("auto_orcishfratboyspy", "");
+		set_property("auto_warhippyspy", "");
 
 		set_property("auto_lastthunder", "100");
 		set_property("auto_lastthunderturn", "0");
@@ -58,9 +59,14 @@ boolean routineRainManHandler()
 			return rainManSummon("ninja snowman assassin", true, false);
 		}
 
-		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_orcishfratboyspy") == ""))
+		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_orcishfratboyspy") == "") && !get_property("auto_hippyInstead").to_boolean())
 		{
 			return rainManSummon("orcish frat boy spy", false, false);
+		}
+		
+		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_warhippyspy") == "") && get_property("auto_hippyInstead").to_boolean())
+		{
+			return rainManSummon("war hippy spy", false, false);
 		}
 		
 		if(needStarKey())
@@ -330,6 +336,10 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	{
 		mId = 409;
 	}
+	if(monsterName == "war hippy spy")
+	{
+		mId = 419;
+	}
 	if(monsterName == "morbid skull")
 	{
 		mId = 1269;
@@ -433,6 +443,19 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	{
 		set_property("auto_orcishfratboyspy", "done");
 		if((item_amount($item[beer helmet]) > 0) || (item_amount($item[bejeweled pledge pin]) > 0) || (item_amount($item[distressed denim pants]) > 0))
+		{
+			return false;
+		}
+		if((have_effect($effect[everything looks yellow]) > 0) || (my_lightning() < 5))
+		{
+			return false;
+		}
+	}
+	
+	if(monsterName == "war hippy spy")
+	{
+		set_property("auto_warhippyspy", "done");
+		if((item_amount($item[reinforced beaded headband]) > 0) || (item_amount($item[round purple sunglasses]) > 0) || (item_amount($item[bullet-proof corduroys]) > 0))
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -1421,7 +1421,7 @@ boolean L12_finalizeWar()
 		return false;
 	}
 
-	if (get_property("hippiesDefeated").to_int() < 1000 && get_property("fratsDefeated").to_int() < 1000)
+	if (get_property("hippiesDefeated").to_int() < 1000 && get_property("fratboysDefeated").to_int() < 1000)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -28,9 +28,8 @@ boolean warOutfit(boolean immediate)
 				return false;
 			}
 		}
-		return true;
 	}
-	else
+	if(get_property("auto_hippyInstead").to_boolean())
 	{
 		if(!reallyWarOutfit("war hippy fatigues"))
 		{
@@ -44,8 +43,8 @@ boolean warOutfit(boolean immediate)
 				return false;
 			}
 		}
-		return true;
 	}
+	return true;
 }
 
 boolean haveWarOutfit()
@@ -101,79 +100,96 @@ boolean warAdventure()
 
 boolean L12_getOutfit()
 {
-	if (internalQuestStatus("questL12War") < 0 || internalQuestStatus("questL12War") > 0)
+	if (internalQuestStatus("questL12War") != 0)
 	{
 		return false;
 	}
 
+	// noncombat when adventuring at The Hippy Camp (Verge of War)
+	set_property("choiceAdventure139", "3");	//fight a War Hippy (space) cadet for outfit pieces
+	set_property("choiceAdventure140", "3");	//fight a War Hippy drill sergeant for outfit pieces
+	set_property("choiceAdventure141", "1");	//if wearing [Frat Boy Ensemble] get 50 mysticality
+	set_property("choiceAdventure142", "3");	//if wearing [Frat Warrior Fatigues] start the war or skip adventure
+	
+	// noncombat when adventuring at Orcish Frat House (Verge of War)
+	set_property("choiceAdventure143", "3");	//fight a War Pledgefor outfit pieces
+	set_property("choiceAdventure144", "3");	//fight a Frat Warrior drill sergeant for outfit pieces
+	set_property("choiceAdventure145", "1");	//if wearing [Filthy Hippy Disguise] get 50 muscle
+	set_property("choiceAdventure146", "3");	//if wearing [War Hippy Fatigues] start the war or skip adventure
+
+	// if you already have the war outfit we don't need to do anything now
 	if (haveWarOutfit())
 	{
 		return false;
 	}
-
-	set_property("choiceAdventure143", "3");
-	set_property("choiceAdventure144", "3");
-	set_property("choiceAdventure145", "1");
-	set_property("choiceAdventure146", "1");
-
-	if((get_property("auto_orcishfratboyspy") == "done") && !in_hardcore())
+	
+	//heavy rains softcore pull handling
+	if(!in_hardcore() && (auto_my_path() == "Heavy Rains"))
 	{
-		pullXWhenHaveY($item[Beer Helmet], 1, 0);
-		pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);
-		pullXWhenHaveY($item[Distressed Denim Pants], 1, 0);
-	}
-
-	if(!in_hardcore() && (auto_my_path() != "Heavy Rains"))
-	{
-		pullXWhenHaveY($item[Beer Helmet], 1, 0);
-		pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);
-		pullXWhenHaveY($item[Distressed Denim Pants], 1, 0);
-	}
-
-	if(possessEquipment($item[Beer Helmet]) && possessEquipment($item[Distressed Denim Pants]) && possessEquipment($item[Bejeweled Pledge Pin]))
-	{
-		set_property("choiceAdventure139", "3");
-		set_property("choiceAdventure140", "3");
-		return true;
-	}
-
-	if (possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
-	{
-		autoOutfit("filthy hippy disguise");
-		if(my_lightning() >= 5)
+		//TODO add hippies support here and in heavy rains file for copying hippy spy instead.
+		if(get_property("auto_hippyInstead").to_boolean())
 		{
-			autoAdv(1, $location[Wartime Frat House]);
-			return true;
+			pullXWhenHaveY($item[Reinforced Beaded Headband], 1, 0);
+			pullXWhenHaveY($item[Round Purple Sunglasses], 1, 0);
+			pullXWhenHaveY($item[Bullet-proof Corduroys], 1, 0);			
 		}
-
-		if(in_hardcore())
-		{
-			autoAdv(1, $location[Wartime Frat House]);
-			return true;
-		}
-
-		if(!canYellowRay())
+		// auto_orcishfratboyspy indicates that rainman was already used to copy an orcish frat boy in heavy rains. if it failed to YR pull missing items
+		if((get_property("auto_orcishfratboyspy") == "done") && !get_property("auto_hippyInstead").to_boolean())
 		{
 			pullXWhenHaveY($item[Beer Helmet], 1, 0);
 			pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);
 			pullXWhenHaveY($item[Distressed Denim Pants], 1, 0);
-			return true;
 		}
+	}
 
-		//We should probably have some kind of backup solution here
+	//softcore pull handling for all other paths
+	if(!in_hardcore() && (auto_my_path() != "Heavy Rains"))
+	{
+		if(get_property("auto_hippyInstead").to_boolean())
+		{
+			pullXWhenHaveY($item[Reinforced Beaded Headband], 1, 0);
+			pullXWhenHaveY($item[Round Purple Sunglasses], 1, 0);
+			pullXWhenHaveY($item[Bullet-proof Corduroys], 1, 0);			
+		}
+		if(!get_property("auto_hippyInstead").to_boolean())
+		{
+			pullXWhenHaveY($item[Beer Helmet], 1, 0);
+			pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);
+			pullXWhenHaveY($item[Distressed Denim Pants], 1, 0);
+		}
+	}
+
+	// if you have war outfit now then you just pulled it. so this time we return true as something changed
+	if(haveWarOutfit())
+	{
+		return true;
+	}
+	// if you reached this point you are either in hardcore or are in softcore but ran out of pulls
+	// if really in softcore and out of pulls then returning false here lets you skip it until tomorrow
+	if(!in_hardcore())
+	{
 		return false;
 	}
-	else
+	
+	// if outfit could not be pulled and have a [Filthy Hippy Disguise] outfit then wear it and adventure in Frat House to get war outfit
+	if (!get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
 	{
-		if(!in_hardcore())
-		{
-			pullXWhenHaveY($item[Filthy Knitted Dread Sack], 1, 0);
-			pullXWhenHaveY($item[Filthy Corduroys], 1, 0);
-		}
-		if(L12_preOutfit())
-		{
-			return true;
-		}
+		autoOutfit("filthy hippy disguise");
+		autoAdv(1, $location[Wartime Frat House]);
+		return true;
+	}
+	
+	// if outfit could not be pulled and have a [Frat Boy Ensemble] outfit then wear it and adventure in Hippy Camp to get war outfit
+	if (get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[orcish baseball cap]) && possessEquipment($item[orcish frat-paddle]) && possessEquipment($item[orcish cargo shorts]))
+	{
+		autoOutfit("frat Boy Ensemble");
+		autoAdv(1, $location[Wartime Hippy Camp]);
+		return true;
+	}
+	
+	if(L12_preOutfit())
+	{
+		return true;
 	}
 	return false;
 }
@@ -184,23 +200,35 @@ boolean L12_preOutfit()
 	{
 		return false;
 	}
+	
+	// in softcore you will pull the war outfit, no need to get pre outfit
 	if(!in_hardcore())
 	{
 		return false;
 	}
+	
 	if(my_level() < 9)
 	{
 		return false;
 	}
-	if (possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
-	{
-		return false;
-	}
+	
 	if(haveWarOutfit())
 	{
 		return false;
 	}
-
+	
+	// if siding with frat and already own [filthy hippy disguise] outfit needed to get the frat boy war outfit
+	if (!get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
+	{
+		return false;
+	}
+	
+	// if siding with hippies and already own [frat boy ensemble] outfit needed to get the hippy war outfit
+	if (get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[orcish baseball cap]) && possessEquipment($item[orcish frat-paddle]) && possessEquipment($item[orcish cargo shorts]))
+	{
+		return false;
+	}
+	
 	if (isActuallyEd())
 	{
 		if(!canYellowRay() && (my_level() < 12))
@@ -213,7 +241,6 @@ boolean L12_preOutfit()
 	{
 		return false;
 	}
-	auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
 
 	if((my_class() == $class[Gelatinous Noob]) && auto_have_familiar($familiar[Robortender]))
 	{
@@ -223,15 +250,35 @@ boolean L12_preOutfit()
 		}
 	}
 
-	if(my_level() < 12)
+	// if we want to do war on the fratboy side, then we need to adventure in hippy camp for [filthy hippy disguise] outfit to then adventure in frat house for frat war outfit
+	if(!get_property("auto_hippyInstead").to_boolean())
 	{
-		autoAdv(1, $location[Hippy Camp]);
+		auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
+		if(my_level() < 12)
+		{
+			autoAdv(1, $location[Hippy Camp]);
+		}
+		else
+		{
+			autoAdv(1, $location[Wartime Hippy Camp]);
+		}
 	}
-	else
+
+	// if we want to do war on the hippy side, then we need to adventure in orcish frat house for [frat boy ensemble] outfit to then adventure in hippy camp for hippy war outfit
+	if(get_property("auto_hippyInstead").to_boolean())
 	{
-		autoAdv(1, $location[Wartime Hippy Camp]);
+		auto_log_info("Trying to acquire a frat boy ensemble", "blue");
+		if(my_level() < 12)
+		{
+			autoAdv(1, $location[Frat House]);
+		}
+		else
+		{
+			autoAdv(1, $location[Wartime Frat House]);
+		}
 	}
-	return true;
+	
+	return true;	//the above ifs cover all possibilities so we had to have adventured somewhere just now. either frat house or hippy camp
 }
 
 boolean L12_startWar()
@@ -256,12 +303,11 @@ boolean L12_startWar()
 		return false;
 	}
 
-	auto_log_info("Must save the ferret!!", "blue");
-	warOutfit(false);
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
 		handleBjornify($familiar[Grimstone Golem]);
 	}
+	
 	buffMaintain($effect[Snow Shoes], 0, 1, 1);
 	buffMaintain($effect[Become Superficially Interested], 0, 1, 1);
 	providePlusNonCombat(25);
@@ -271,11 +317,21 @@ boolean L12_startWar()
 		use_skill(1, $skill[Incredible Self-Esteem]);
 	}
 
-	autoAdv(1, $location[Wartime Hippy Camp]);
-	set_property("choiceAdventure142", "3");
-	if(contains_text(get_property("lastEncounter"), "Blockin\' Out the Scenery"))
+	// set noncombats to value needed to start the war
+	set_property("choiceAdventure142", "3");	//if wearing [Frat Warrior Fatigues] start the war or skip adventure
+	set_property("choiceAdventure146", "3");	//if wearing [War Hippy Fatigues] start the war or skip adventure
+
+	// wear the appropriate war outfit based on auto_hippyInstead
+	warOutfit(false);
+
+	// start the war when siding with frat boys
+	if(!get_property("auto_hippyInstead").to_boolean())
 	{
-		if(!get_property("auto_hippyInstead").to_boolean())
+		auto_log_info("Must save the ferret!!", "blue");
+		autoAdv(1, $location[Wartime Hippy Camp]);
+		
+		//if war started accept side quests for junkyard, concert, and lighthouse
+		if(contains_text(get_property("lastEncounter"), "Blockin\' Out the Scenery"))
 		{
 			visit_url("bigisland.php?action=junkman&pwd");
 			visit_url("bigisland.php?place=concert&pwd");
@@ -283,6 +339,22 @@ boolean L12_startWar()
 			visit_url("bigisland.php?place=lighthouse&action=pyro&pwd=");
 		}
 	}
+	
+	// start the war when siding with hippies
+	if(get_property("auto_hippyInstead").to_boolean())
+	{
+		auto_log_info("Must save the goldfish!!", "blue");
+		autoAdv(1, $location[Wartime Frat House]);
+		
+		//if war started accept side quests for farm, nuns, and orchard
+		if(contains_text(get_property("lastEncounter"), "Fratacombs"))
+		{
+			visit_url("bigisland.php?place=farm&action=farmer&pwd=");
+			visit_url("bigisland.php?place=nunnery");
+			visit_url("bigisland.php?place=orchard&action=stand&pwd=");
+		}
+	}
+		
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -29,7 +29,7 @@ boolean warOutfit(boolean immediate)
 			}
 		}
 	}
-	if(get_property("auto_hippyInstead").to_boolean())
+	else
 	{
 		if(!reallyWarOutfit("war hippy fatigues"))
 		{
@@ -109,13 +109,11 @@ boolean L12_getOutfit()
 	set_property("choiceAdventure139", "3");	//fight a War Hippy (space) cadet for outfit pieces
 	set_property("choiceAdventure140", "3");	//fight a War Hippy drill sergeant for outfit pieces
 	set_property("choiceAdventure141", "1");	//if wearing [Frat Boy Ensemble] get 50 mysticality
-	set_property("choiceAdventure142", "3");	//if wearing [Frat Warrior Fatigues] start the war or skip adventure
 	
 	// noncombat when adventuring at Orcish Frat House (Verge of War)
 	set_property("choiceAdventure143", "3");	//fight a War Pledgefor outfit pieces
 	set_property("choiceAdventure144", "3");	//fight a Frat Warrior drill sergeant for outfit pieces
 	set_property("choiceAdventure145", "1");	//if wearing [Filthy Hippy Disguise] get 50 muscle
-	set_property("choiceAdventure146", "3");	//if wearing [War Hippy Fatigues] start the war or skip adventure
 
 	// if you already have the war outfit we don't need to do anything now
 	if (haveWarOutfit())
@@ -151,7 +149,7 @@ boolean L12_getOutfit()
 			pullXWhenHaveY($item[Round Purple Sunglasses], 1, 0);
 			pullXWhenHaveY($item[Bullet-proof Corduroys], 1, 0);			
 		}
-		if(!get_property("auto_hippyInstead").to_boolean())
+		else
 		{
 			pullXWhenHaveY($item[Beer Helmet], 1, 0);
 			pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);
@@ -175,16 +173,14 @@ boolean L12_getOutfit()
 	if (!get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
 	{
 		autoOutfit("filthy hippy disguise");
-		autoAdv(1, $location[Wartime Frat House]);
-		return true;
+		return autoAdv(1, $location[Wartime Frat House]);
 	}
 	
 	// if outfit could not be pulled and have a [Frat Boy Ensemble] outfit then wear it and adventure in Hippy Camp to get war outfit
 	if (get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[orcish baseball cap]) && possessEquipment($item[orcish frat-paddle]) && possessEquipment($item[orcish cargo shorts]))
 	{
 		autoOutfit("frat Boy Ensemble");
-		autoAdv(1, $location[Wartime Hippy Camp]);
-		return true;
+		return autoAdv(1, $location[Wartime Hippy Camp]);
 	}
 	
 	if(L12_preOutfit())
@@ -250,11 +246,11 @@ boolean L12_preOutfit()
 		}
 	}
 
-	// if we want to do war on the fratboy side, then we need to adventure in hippy camp for [filthy hippy disguise] outfit to then adventure in frat house for frat war outfit
+	// fighting for fratboys, adventure in hippy camp for [filthy hippy disguise] outfit to then adventure in frat house for frat war outfit
 	if(!get_property("auto_hippyInstead").to_boolean())
 	{
 		auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
-		if(my_level() < 12)
+		if(internalQuestStatus("questL12War") > -1)
 		{
 			autoAdv(1, $location[Hippy Camp]);
 		}
@@ -263,12 +259,11 @@ boolean L12_preOutfit()
 			autoAdv(1, $location[Wartime Hippy Camp]);
 		}
 	}
-
-	// if we want to do war on the hippy side, then we need to adventure in orcish frat house for [frat boy ensemble] outfit to then adventure in hippy camp for hippy war outfit
-	if(get_property("auto_hippyInstead").to_boolean())
+	// fighting for hippies, adventure in orcish frat house for [frat boy ensemble] outfit to then adventure in hippy camp for hippy war outfit
+	else
 	{
 		auto_log_info("Trying to acquire a frat boy ensemble", "blue");
-		if(my_level() < 12)
+		if(internalQuestStatus("questL12War") > -1)
 		{
 			autoAdv(1, $location[Frat House]);
 		}
@@ -308,8 +303,6 @@ boolean L12_startWar()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 	
-	buffMaintain($effect[Snow Shoes], 0, 1, 1);
-	buffMaintain($effect[Become Superficially Interested], 0, 1, 1);
 	providePlusNonCombat(25);
 
 	if((my_path() != "Dark Gyffte") && (my_mp() > 50) && have_skill($skill[Incredible Self-Esteem]) && !get_property("_incredibleSelfEsteemCast").to_boolean())
@@ -330,29 +323,19 @@ boolean L12_startWar()
 		auto_log_info("Must save the ferret!!", "blue");
 		autoAdv(1, $location[Wartime Hippy Camp]);
 		
-		//if war started accept side quests for junkyard, concert, and lighthouse
-		if(contains_text(get_property("lastEncounter"), "Blockin\' Out the Scenery"))
+		//if war started, accept flyer quest for fratboys.
+		//this is only started here and only for frat.
+		//move this to dedicated function that can start it for both sides as appropriate
+		if(internalQuestStatus("questL12War") == 1)
 		{
-			visit_url("bigisland.php?action=junkman&pwd");
-			visit_url("bigisland.php?place=concert&pwd");
-			visit_url("bigisland.php?place=lighthouse&action=pyro&pwd=");
-			visit_url("bigisland.php?place=lighthouse&action=pyro&pwd=");
+			visit_url("bigisland.php?place=concert&pwd");	
 		}
 	}
-	
 	// start the war when siding with hippies
-	if(get_property("auto_hippyInstead").to_boolean())
+	else
 	{
 		auto_log_info("Must save the goldfish!!", "blue");
 		autoAdv(1, $location[Wartime Frat House]);
-		
-		//if war started accept side quests for farm, nuns, and orchard
-		if(contains_text(get_property("lastEncounter"), "Fratacombs"))
-		{
-			visit_url("bigisland.php?place=farm&action=farmer&pwd=");
-			visit_url("bigisland.php?place=nunnery");
-			visit_url("bigisland.php?place=orchard&action=stand&pwd=");
-		}
 	}
 		
 	return true;

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -124,15 +124,15 @@ boolean L12_getOutfit()
 	//heavy rains softcore pull handling
 	if(!in_hardcore() && (auto_my_path() == "Heavy Rains"))
 	{
-		//TODO add hippies support here and in heavy rains file for copying hippy spy instead.
-		if(get_property("auto_hippyInstead").to_boolean())
+		// auto_warhippyspy indicates rainman was already used to copy a war hippy spy in heavy rains. if it failed to YR pull missing items
+		if(get_property("auto_warhippyspy") == "done" && get_property("auto_hippyInstead").to_boolean())
 		{
 			pullXWhenHaveY($item[Reinforced Beaded Headband], 1, 0);
 			pullXWhenHaveY($item[Round Purple Sunglasses], 1, 0);
 			pullXWhenHaveY($item[Bullet-proof Corduroys], 1, 0);			
 		}
-		// auto_orcishfratboyspy indicates that rainman was already used to copy an orcish frat boy in heavy rains. if it failed to YR pull missing items
-		if((get_property("auto_orcishfratboyspy") == "done") && !get_property("auto_hippyInstead").to_boolean())
+		// auto_orcishfratboyspy indicates rainman was already used to copy an orcish frat boy in heavy rains. if it failed to YR pull missing items
+		if(get_property("auto_orcishfratboyspy") == "done" && !get_property("auto_hippyInstead").to_boolean())
 		{
 			pullXWhenHaveY($item[Beer Helmet], 1, 0);
 			pullXWhenHaveY($item[Bejeweled Pledge Pin], 1, 0);

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -60,7 +60,7 @@ boolean L13_towerNSContests()
 
 				provideInitiative(400, true);
 
-				if(crowd1Insufficient())
+				if(crowd1Insufficient() && (get_property("sidequestArenaCompleted") == "fratboy"))
 				{
 					cli_execute("concert White-boy Angst");
 				}


### PR DESCRIPTION
# Description

Lots of issues with the island war when fighting for the hippies.
worse offenders are:
1. it pulls frat outfit
2. if you manually pulled hippy outfit, it wears it then adventures in hippy camp to start the war for 52 turns before realizing something is wrong.

Fixes #167
probably fixes a few other open issues too

## How Has This Been Tested?
all testing thus far was in mafia r19898, which predates the NC handling change by mafia.

main account = has tons of IOTMs and all skills permed.
side account = has very few permed skills and zero IOTMs

So far I have tested:

main account, softcore plumber on hippies side, I manually fought all the way until the arena and got the hippy band fliers before deciding to start writing this update.
It successfully flyered for the hippies and then fought until the man. Did not actually start combat with the man but that is a bug that predates my patch. I am not too sure how to fix it actually since that code is weird.

main account, hardcore pathless turtle tamer, fighting for frat, I ran a full ascension (2 day). Carefully monitoring this quest. No issues at all were noticed, showing I didn't break anything on the already working frat side for hardcore. (unless I maybe softcore or heavy rains, future things to test)

main account, hardcore pathless, seal clubber, fighting for hippies.

side accounts. casual pathless sauceror fighting for hippies... with almost no skills and 0 IOTMs.

main account, hardcore pathless, seal clubber, fighting for fratboys

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
