### PR TITLE
pokefam and a few other issues.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -84,16 +84,19 @@ void initializeSettings()
 		{
 			set_property("auto_100familiar", my_familiar());
 		}
-		if(is100FamiliarRun())
+		if(autoForbidFamiliarChange())
 		{
 			set_property("auto_useCubeling", false);
 		}
 	}
 
-	if(!is100FamiliarRun() && auto_have_familiar($familiar[Crimbo Shrub]))
+	if(!autoForbidFamiliarChange($familiar[Crimbo Shrub]))
 	{
-		use_familiar($familiar[Crimbo Shrub]);
-		use_familiar($familiar[none]);
+		//if in 100% crimbo shrub run nothing will be done, it will remain on crimbo shrub.
+		//if not in 100% run and are allowed to switch to shrub then it will switch to shrub and then to none
+		
+		autoUseFamiliar($familiar[Crimbo Shrub]);
+		autoUseFamiliar($familiar[none]);
 	}
 
 	string pool = visit_url("questlog.php?which=3");
@@ -279,7 +282,7 @@ boolean handleFamiliar(string type)
 
 boolean handleFamiliar(familiar fam)
 {
-	if(is100FamiliarRun())
+	if(autoForbidFamiliarChange())
 	{
 		return true;
 	}
@@ -851,7 +854,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(((auto_my_path() == "Picky") || is100FamiliarRun()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
+		if(((auto_my_path() == "Picky") || autoForbidFamiliarChange()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{
@@ -1603,7 +1606,7 @@ boolean doBedtime()
 		return false;
 	}
 	int spleenlimit = spleen_limit();
-	if(is100FamiliarRun())
+	if(autoForbidFamiliarChange())
 	{
 		spleenlimit -= 3;
 	}
@@ -2959,7 +2962,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun())
+	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !autoForbidFamiliarChange($familiar[Machine Elf]))
 	{
 		if(get_property("auto_choice1119") != "")
 		{
@@ -4699,7 +4702,7 @@ boolean LX_phatLootToken()
 
 	if((!possessEquipment($item[Ring of Detect Boring Doors]) || (item_amount($item[Eleven-Foot Pole]) == 0) || (item_amount($item[Pick-O-Matic Lockpicks]) == 0)) && auto_have_familiar($familiar[Gelatinous Cubeling]))
 	{
-		if(!is100FamiliarRun($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
+		if(!autoForbidFamiliarChange($familiar[Gelatinous Cubeling]))
 		{
 			return false;
 		}
@@ -6200,7 +6203,7 @@ void auto_begin()
 	if(my_familiar() == $familiar[Stooper])
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");
-		use_familiar($familiar[none]);
+		autoUseFamiliar($familiar[none]);
 	}
 	dailyEvents();
 	while((my_adventures() > 1) && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !get_property("kingLiberated").to_boolean() && doTasks())

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -321,7 +321,7 @@ void preAdvUpdateFamiliar(location place)
 		famChoice = $familiar[none];
 	}
 
-	if((famChoice != $familiar[none]) && !is100FamiliarRun() && (internalQuestStatus("questL13Final") < 13))
+	if((famChoice != $familiar[none]) && !autoForbidFamiliarChange() && (internalQuestStatus("questL13Final") < 13))
 	{
 		if((famChoice != my_familiar()) && !get_property("kingLiberated").to_boolean())
 		{
@@ -345,7 +345,7 @@ void preAdvUpdateFamiliar(location place)
 				}
 			}
 		}
-		if(wannaHeist && (famChoice != $familiar[none]) && !is100FamiliarRun())
+		if(wannaHeist && (famChoice != $familiar[none]) && !autoForbidFamiliarChange())
 		{
 			use_familiar($familiar[cat burglar]);
 		}

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -11,7 +11,6 @@ void bat_initializeSettings()
 {
 	if(my_path() == "Dark Gyffte")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_cubeItems", false);
 		set_property("auto_getSteelOrgan", false);
 		set_property("auto_grimstoneFancyOilPainting", false);

--- a/RELEASE/scripts/autoscend/auto_bondmember.ash
+++ b/RELEASE/scripts/autoscend/auto_bondmember.ash
@@ -4,7 +4,6 @@ void bond_initializeSettings()
 {
 	if(my_path() == "License to Adventure")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_getBeehive", true);
 		set_property("auto_cubeItems", true);
 		set_property("auto_getStarKey", true);

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -4,7 +4,6 @@ void boris_initializeSettings()
 {
 	if(my_path() == "Avatar of Boris")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_getStarKey", true);

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -696,7 +696,7 @@ boolean LA_cs_communityService()
 
 			if(!get_property("auto_hccsNoConcludeDay").to_boolean())
 			{
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun($familiar[Machine Elf]))
+				if((get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !autoForbidFamiliarChange($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -709,7 +709,7 @@ boolean LA_cs_communityService()
 					return true;
 				}
 
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && !is100FamiliarRun($familiar[Machine Elf]))
+				if((get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && !autoForbidFamiliarChange($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -828,14 +828,9 @@ boolean LA_cs_communityService()
 				set_property("auto_csPuckCounter", get_property("auto_csPuckCounter").to_int() - 1);
 				doFarm = true;
 			}
-			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])))
+			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (!autoForbidFamiliarChange($familiar[Puck Man]) || !autoForbidFamiliarChange($familiar[Ms. Puck Man])))
 			{
-				if(is100familiarRun() && is100familiarRun($familiar[Puck Man]) && is100familiarRun($familiar[Ms. Puck Man]))
-				{}
-				else
-				{
-					doFarm = true;
-				}
+			doFarm = true;
 			}
 
 			if(possessEquipment($item[KoL Con 13 Snowglobe]) && (equipped_item($slot[Off-Hand]) == $item[A Light That Never Goes Out]))
@@ -1016,7 +1011,7 @@ boolean LA_cs_communityService()
 			{
 				missing = 0;
 			}
-			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (!is100familiarRun() || !is100familiarRun($familiar[Puck Man]) || !is100familiarRun($familiar[Ms. Puck Man])))
+			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (!autoForbidFamiliarChange($familiar[Puck Man]) || !autoForbidFamiliarChange($familiar[Ms. Puck Man])))
 			{
 				if(elementalPlanes_access($element[hot]))
 				{
@@ -1081,7 +1076,7 @@ boolean LA_cs_communityService()
 				auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 			}
 
-			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && have_familiar($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11) && !is100FamiliarRun($familiar[XO Skeleton]))
+			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && !autoForbidFamiliarChange($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11))
 			{
 				if((!possessEquipment($item[Fireproof Megaphone]) && !possessEquipment($item[Meteorite Guard])) || !possessEquipment($item[High-Temperature Mining Mask]))
 				{
@@ -2244,7 +2239,7 @@ boolean LA_cs_communityService()
 					autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 					return true;
 				}
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && !is100FamiliarRun($familiar[Machine Elf]))
+				if(!autoForbidFamiliarChange($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -2410,7 +2405,7 @@ boolean LA_cs_communityService()
 			}
 			asdonBuff($effect[Driving Stealthily]);
 
-			if(!is100FamiliarRun($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
+			if(!autoForbidFamiliarChange($familiar[Disgeist]))
 			{
 				# Need 37-41 pounds to save 3 turns. (probably 40)
 				# 74 does not save 6 but 79 does.
@@ -3062,7 +3057,7 @@ void cs_initializeDay(int day)
 			{
 				familiar last = my_familiar();
 				int gift = 1;
-				if(is100FamiliarRun() && (my_familiar() != $familiar[Crimbo Shrub]))
+				if(autoForbidFamiliarChange() && (my_familiar() != $familiar[Crimbo Shrub]))
 				{
 					gift = 2;
 				}
@@ -3331,7 +3326,7 @@ void cs_make_stuff(int curQuest)
 			cli_execute("make " + $item[Staff of the Headmaster\'s Victuals]);
 		}
 
-		if(!have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+		if(!have_familiar($familiar[Machine Elf]) && !autoForbidFamiliarChange())
 		{
 			if(item_amount($item[Handful of Smithereens]) >= 3)
 			{
@@ -4332,9 +4327,9 @@ boolean cs_giant_growth()
 	{
 		fail = false;
 	}
-	if(have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+	if(!autoForbidFamiliarChange($familiar[Machine Elf]))
 	{
-		use_familiar($familiar[Machine Elf]);
+		autoUseFamiliar($familiar[Machine Elf]);
 		fail = false;
 	}
 	if(fail)

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -618,7 +618,7 @@ void consumeStuff()
 		{
 			if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper])
 			{
-				use_familiar($familiar[none]);
+				autoUseFamiliar($familiar[none]);
 			}
 			auto_knapsackAutoConsume("drink", false);
 		}

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -76,22 +76,21 @@ boolean settingFixer()
 	{
 		set_property("auto_delayTimer", 1);
 	}
+	
+	//currently of the depreciated auto_100familiar options, none are in use anywhere
 	if(get_property("auto_100familiar") == "yes")
 	{
 		set_property("auto_100familiar", true);
 	}
 	if(get_property("auto_100familiar") == "no")
 	{
-		set_property("auto_100familiar", false);
-	}
-	if(get_property("auto_100familiar") == "true")
-	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
+		set_property("auto_100familiar", $familiar[none]);
 	}
 	if(get_property("auto_100familiar") == "false")
 	{
 		set_property("auto_100familiar", $familiar[none]);
 	}
+	
 	if(get_property("auto_killingjar") == "done")
 	{
 		set_property("auto_killingjar", "finished");

--- a/RELEASE/scripts/autoscend/auto_digimon.ash
+++ b/RELEASE/scripts/autoscend/auto_digimon.ash
@@ -10,7 +10,6 @@ void digimon_initializeSettings()
 {
 	if(auto_my_path() == "Pocket Familiars")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_getBeehive", false);
 		set_property("auto_getBoningKnife", false);
 		set_property("auto_cubeItems", false);

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -22,7 +22,6 @@ void ed_initializeSettings()
 {
 	if (isActuallyEd())
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_crackpotjar", "done");
 		set_property("auto_cubeItems", false);
 		set_property("auto_day1_dna", "finished");

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -499,7 +499,7 @@ boolean handleBjornify(familiar fam)
 		return false;
 	}
 
-	if(is100FamiliarRun() && (fam == my_familiar()))
+	if(autoForbidFamiliarChange() && (fam == my_familiar()))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -472,7 +472,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 
 	set_property("choiceAdventure970", "0");
 
-	if(is100FamiliarRun($familiar[Reanimated Reanimator]))
+	if(autoForbidFamiliarChange($familiar[Reanimated Reanimator]))
 	{
 		wink = false;
 	}

--- a/RELEASE/scripts/autoscend/auto_highlands.ash
+++ b/RELEASE/scripts/autoscend/auto_highlands.ash
@@ -277,7 +277,7 @@ boolean L9_aBooPeak()
 			lihcface = "-equip lihc face";
 		}
 		string parrot = ", switch exotic parrot, switch mu, switch trick-or-treating tot";
-		if(is100FamiliarRun())
+		if(autoForbidFamiliarChange())
 		{
 			parrot = "";
 		}

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -401,7 +401,7 @@ boolean L12_filthworms()
 
 	if(have_effect($effect[Filthworm Drone Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if((get_property("_xoHugsUsed").to_int() <= 10) && !autoForbidFamiliarChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -409,7 +409,7 @@ boolean L12_filthworms()
 	}
 	else if(have_effect($effect[Filthworm Larva Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if((get_property("_xoHugsUsed").to_int() <= 10) && !autoForbidFamiliarChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -417,7 +417,7 @@ boolean L12_filthworms()
 	}
 	else
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if((get_property("_xoHugsUsed").to_int() <= 10) && !autoForbidFamiliarChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -1058,7 +1058,7 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
 	songboomSetting("meat");
 
-	if(is100FamiliarRun())
+	if(autoForbidFamiliarChange())
 	{
 		addToMaximize("200meat drop");
 	}
@@ -1107,7 +1107,7 @@ boolean L12_themtharHills()
 
 
 	handleFamiliar("meat");
-	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && !is100FamiliarRun($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
+	if((available_amount($item[Li\'l Pirate Costume]) > 0) && !autoForbidFamiliarChange($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
 		autoEquip($item[Li\'l Pirate Costume]);

--- a/RELEASE/scripts/autoscend/auto_mclargehuge.ash
+++ b/RELEASE/scripts/autoscend/auto_mclargehuge.ash
@@ -321,7 +321,7 @@ boolean L8_trapperGroar()
 	//What is our potential +Combat score.
 	//TODO: Use that instead of the Avatar/Hound Dog checks.
 
-	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || is100FamiliarRun($familiar[Jumpsuited Hound Dog])))
+	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || autoForbidFamiliarChange($familiar[Jumpsuited Hound Dog])))
 	{
 		if(L8_trapperExtreme())
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2014.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2014.ash
@@ -46,7 +46,7 @@ boolean dna_startAcquire()
 	}
 	else
 	{
-		if((have_familiar($familiar[Machine Elf])) && is100FamiliarRun($familiar[Machine Elf]))
+		if(!autoForbidFamiliarChange($familiar[Machine Elf]))
 		{
 			familiar bjorn = my_bjorned_familiar();
 			if(bjorn == $familiar[Machine Elf])

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1185,7 +1185,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !is100FamiliarRun() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !autoForbidFamiliarChange($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -1113,7 +1113,7 @@ boolean solveKGBMastermind()
 
 boolean getSpaceJelly()
 {
-	if(is100FamiliarRun($familiar[Space Jellyfish]))
+	if(autoForbidFamiliarChange($familiar[Space Jellyfish]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -148,7 +148,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 	{
 		return false;
 	}
-	if(is100FamiliarRun($familiar[God Lobster]))
+	if(autoForbidFamiliarChange($familiar[God Lobster]))
 	{
 		return false;
 	}
@@ -301,13 +301,13 @@ boolean fantasyRealmToken()
 		}
 	}
 
-	// If we're not allowed to adventure without a familiar
-	if(is100familiarRun() && auto_have_familiar($familiar[Mosquito]))
+	// If we're not allowed to adventure without a familiar due to being in a 100% familiar run.
+	if(is100FamiliarRun())
 	{
 		return false;
 	}
 	set_property("auto_familiarChoice", "none");
-	use_familiar($familiar[none]);
+	autoUseFamiliar($familiar[none]);
 
 	if(possessEquipment($item[FantasyRealm G. E. M.]))
 	{

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -4,7 +4,6 @@ void pete_initializeSettings()
 {
 	if(my_path() == "Avatar of Sneaky Pete")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_peteSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_getStarKey", true);

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -639,7 +639,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && !is100FamiliarRun())
+		if((auto_have_familiar($familiar[warbear drone])) && !autoForbidFamiliarChange())
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -655,12 +655,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Sludgepuppy])) && !autoForbidFamiliarChange())
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Imitation Crab])) && !autoForbidFamiliarChange())
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;
@@ -770,7 +770,7 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(is100FamiliarRun())
+		if(autoForbidFamiliarChange())
 		{
 			addToMaximize("200meat drop");
 		}

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -60,7 +60,7 @@ boolean L13_towerNSContests()
 
 				provideInitiative(400, true);
 
-				if(crowd1Insufficient() && (get_property("sidequestArenaCompleted") == "fratboy"))
+				if(crowd1Insufficient())
 				{
 					cli_execute("concert White-boy Angst");
 				}
@@ -639,7 +639,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && !autoForbidFamiliarChange())
+		if((auto_have_familiar($familiar[warbear drone])) && !is100FamiliarRun())
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -655,12 +655,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && !autoForbidFamiliarChange())
+		else if((auto_have_familiar($familiar[Sludgepuppy])) && !is100FamiliarRun())
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && !autoForbidFamiliarChange())
+		else if((auto_have_familiar($familiar[Imitation Crab])) && !is100FamiliarRun())
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;
@@ -770,7 +770,7 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(autoForbidFamiliarChange())
+		if(is100FamiliarRun())
 		{
 			addToMaximize("200meat drop");
 		}

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -60,7 +60,7 @@ boolean L13_towerNSContests()
 
 				provideInitiative(400, true);
 
-				if(crowd1Insufficient())
+				if(crowd1Insufficient() && (get_property("sidequestArenaCompleted") == "fratboy"))
 				{
 					cli_execute("concert White-boy Angst");
 				}
@@ -639,7 +639,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && !is100FamiliarRun())
+		if((auto_have_familiar($familiar[warbear drone])) && !autoForbidFamiliarChange())
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -655,12 +655,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Sludgepuppy])) && !autoForbidFamiliarChange())
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Imitation Crab])) && !autoForbidFamiliarChange())
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;
@@ -770,7 +770,7 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(is100FamiliarRun())
+		if(autoForbidFamiliarChange())
 		{
 			addToMaximize("200meat drop");
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -807,8 +807,10 @@ boolean instakillable(monster mon);							//Defined in autoscend/auto_util.ash
 int[int] intList();											//Defined in autoscend/auto_list.ash
 int internalQuestStatus(string prop);						//Defined in autoscend/auto_util.ash
 int freeCrafts();											//Defined in autoscend/auto_util.ash
+boolean autoUseFamiliar(familiar target);					//Defined in autoscend/auto_util.ash
 boolean is100FamiliarRun();									//Defined in autoscend/auto_util.ash
-boolean is100FamiliarRun(familiar thisOne);					//Defined in autoscend/auto_util.ash
+boolean autoForbidFamiliarChange();							//Defined in autoscend/auto_util.ash
+boolean autoForbidFamiliarChange(familiar target);			//Defined in autoscend/auto_util.ash
 boolean isBanished(monster enemy);							//Defined in autoscend/auto_util.ash
 boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
squashed together to cleanup some github webgui issues. as well as manual fixes of conflicting filechanges done to upstream

combined records of previous commits:
Commit 1

Egg benedict method was removed as it caused some issue with both is100familiarRun() and is100familiarRun(thisOne) in ways that were difficult to fix without removing that method. Also I checked all files via grep and it was only ever used by paths anyways

is100familiarRun() only explicitly checked for egg benedict to test if you have mosquito too (in case someone used it incorrectly somewhere, which was not the case; this made it somewhat confusing to figure out what it was doing there), and if you do have a mosquito it "caught" this "error" and "corrected" it by marking it as allowing familiar change (which breaks pokefam, as pokefam says you have the familiar, but you can't use familiars in pokefam).

Only if you had egg benedict set and did not have mosquito did it correctly block familiar changing (ie all other avatar paths), in that it simply reached the end of the function and returned true (indicating 100familiar is set to something).

the specific familiar version inherited this problem in a way that couldn't really be fixed without completely doing away with the egg benedict method. As fixing it while maintaining the egg benedict method would introduce other issues.

As such I replaced egg benedict with a path check inside is100familiarRun() function.

=======

Analysis:

Looking at the issues with fantasy realm, part of the problem is that whomever wrote it assumed the function is100familiarRun() does what its name says instead of what it documentation says. this is not a break caused by my changes, but it was already broken before... however, to fix it i require a function that actually does what the name of is100familiarRun() says!
In addition, it also pointlessly repeated the mosquito check (which was already being checked in the function itself previously) resulting in incorrect data in paths like pokefam.

=======

Commit 2:

used find and replace alongside grep to completely replace all instances of
is100FamiliarRun
with
autoForbidFamiliarChange

Now the name is correctly self documenting.
This also frees up the name is100FamiliarRun() for a function that actually does what the name says instead of answering the question of "am i forbidden to change familiar".

Which I will now create, integrate, and go over all instances to see where the previous function was used incorrectly and is in need of switching to this new function.

=======

Commit 3:
created function is100FamiliarRun() which actually answers the question of the name. Modified autoForbidFamiliarChange() to make use of said function. Fixed documentation for both as well as autoForbidFamiliarChange(familiar thisOne)
Also modified the structure of autoForbidFamiliarChange(familiar thisOne) to be clearer. instead of nested ifs use sequential ones to reach the same results but easier to read. now with extra documentation.

Created function autoUseFamiliar(familiar target), it is a wrapper to mafia's use_familiar(familiar target). it adds various checks to ensure proper functionality. it will return true if familiar has been successfully set to target, and false if it failed (either because it tried and failed, or because it realized you are forbidden from doing so).

Fixed fantasyRealmToken() in auto_mr2018.ash by

changing the check for "autoForbidFamiliarChange() + mosquito check" into a check for is100FamiliarRun().
Previously it would not run on any paths which forbid familiars except for pokefam. Now it will run on all paths that forbid familiars.
changing use_familiar($familiar[none]) into autoUseFamiliar($familiar[none]). which will prevent it from erroring out on pokefam path.
Also replaced 2 instances in autoscend.ash and 1 instance of auto_cooking.ash of use_familiar($familiar[none]) into autoUseFamiliar($familiar[none]). which should solve similar errors.

========

Commit 4:
autoForbidFamiliarChange(familiar target) now also checks if you have the familiar called target. Because if you don't actually have a familiar you are obviously forbidden to change to it.

in auto_mr2015.ash in function boolean resolveSixthDMT() I changed !autoForbidFamiliarChange() to !autoForbidFamiliarChange($familiar[Machine Elf]) inside the if function.
This fixes an existing issue where that function would not do machine elf stuff if you were in a 100% run for machine elf.

auto_mclargehuge line 324 doing both a check for "don't have familiar jumpsuited hound dog" and "forbidden to change to jumpsuited hound dog" is redundant since forbidden to change to check already checks if you don't have it. removed the check for whether we have the familiar or not

autoscend.ash
line 87 used correctly
line 93 combined auto_have_familiar($familiar[Crimbo Shrub]) and !autoForbidFamiliarChange() into !autoForbidFamiliarChange($familiar[Crimbo Shrub]). as well as changed use_familiar into autoUseFamiliar. this should prevent any issues with a 100% crimbo shrub run
line 95-96 no changes, but why is it changing to crimbo shrub and then to no familiar?
line 281 used correctly
line 859 no changes. why is pulling key lime pies requiring that you either be in picky or be forbidden to change familiar? This was previously triggered on all avatar paths except west of loathing and pokefam, now it will also be triggered on pokefam.
line 1611 why is being forbidden to change familiar reducing the spleen limit by 3?
line 2965 combined auto_have_familiar($familiar[Machine Elf]) and !autoForbidFamiliarChange() into !autoForbidFamiliarChange($familiar[Machine Elf]) to solve issue if doing 100% run of Machine Elf
line 4743 removed a pocket familiar's specific fix that has been rendered redundant now that autoForbidFamiliarChange correctly handles pocket familiar runs.
line 5808 changed autoForbidFamiliarChange() to is100FamiliarRun(), this is actually another instance where what was wanted is knowing if you are in a 100% familiar run and not the previous documented functionality of said function.

auto_community_service
line 699 removed redundant check for having familiar machine elf, this is already checked by !autoForbidFamiliarChange($familiar[Machine Elf])
line 712 same as line 699
line 833 fixed 100% run issue. it had nested ifs and elses and confusion over what the old function name meant. such that if you were in a 100% run for puck man or ms. puck man it would not use either. the changes reduced the number of lines by 4, so all future line numbers listed in this file are at -4 compared to original file
line 1014 lots of redundant code in if function removed for puck man and ms. puck man
line 1079 removed redundant check for having XO skeleton, since its already checking if you are allowed to change to XO skeleton.
line 2242 removed redundant check for having machine elf and also if allowed to change to machine elf
line 2408 removed redundant check for having disgeist and also if allowed to change to disgeist
line 3060 looks ok. could be trimmed but I am not changing it at the moment
line 3329 looks correct
line 4330 & 4332 fixed error when doing 100% machine elf run.
line 4766 another instance that actually wanted is100FamiliarRun not autoForbidFamiliarChange

auto_island_war
line 399 & 407 & 415 removed redundant check for having XO skeleton and not being forbidden to change to XO skeleton
line 1064 used correctly
line 1127 removed redundant check for having trick or treating tot and also not being forbidden to change to XO skeleton

auto_mr2014 fixed issues caused by previously confusing name. if you had both machine elf and Little Geneticist DNA-Splicing Lab, would error in pokefam, and break 100% runs for other familiars.

Analysis:
searching for instances of autoForbidFamiliarChange to see if there are more instances where it was used incorrectly back when it had a misleading name.

autoscend = fixes & questions above

autoscend_header = just a header, nothing to change

auto_community_service = fixed above

auto_equipment = line 639, I am not sure but I think it should be the new is100FamiliarRun() instead of forbid familiar. Can you bjornify in paths where familiars are forbidden?

auto_heavyrains = used correctly

auto_highlands = used correctly

auto_island_war = fixed above

auto_mclargehuge = fixed above

auto_mr2014 = fixed above

auto_mr2015 = fixed above

auto_mr2017 = used correctly

auto_mr2018 = fixed in previous commits.

auto_pre_adventure = looks correct. although potentially somewhat redundant code. unchanged

auto_tower = used correctly

## How Has This Been Tested?

well, had a pokefam run with it. it solved the mr2018 issues as well as all instances of trying (and failing) to set a familiar.

Lots and lots of other issues with pokefam still remain unsolved (not caused by this branch, they were already pokefam issues before).
Especially the one where it often fails to change equipment so weird errors occur because autoscend is trying to adventure somewhere with equipment it assumes it has (eg, trying to start the war without a war outfit equipped, fail after 53 turns, trying to fight boiler with unstable fulminate without actually equipping it and then fail after 53 turns, etc)

I also had several other runs with it outside of pokefam. several plumber and two hardcore pathless.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
