### PR TITLE
Tidy up acquisition of star key

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5254,13 +5254,20 @@ boolean LX_loggingHatchet()
 
 boolean LX_getStarKey()
 {
-	//if we don't want the star key then stop this function
+	//if we don't want the star key then skip this function
 	if(!get_property("auto_getStarKey").to_boolean())
 	{
 		return false;
 	}
+
+	//if already have the star key or already used it, then stop running this function.
+	if(!needStarKey())
+	{
+		set_property("auto_getStarKey", false);
+		return false;
+	}
 	
-	//if we did not progress enough in garbage quest to be able to reach hole in the sky then stop this function
+	//if we did not progress enough in giant garbage quest to reach hole in the sky then skip this function
 	if (internalQuestStatus("questL10Garbage") < 9 || internalQuestStatus("questL11Shen") < 7)
 	{
 		return false;
@@ -5289,14 +5296,7 @@ boolean LX_getStarKey()
 		return true;
 	}
 	
-	//if has the key or already used it then change setting to indicate we don't want to run this function. saves a lot of ifs
-	if(!needStarKey())
-	{
-		set_property("auto_getStarKey", false);
-		return false;
-	}
-	
-	//skip so chart can be pulled at door if: not hardcore, not at the door, have lines, have stars
+	//wait to pull star chart at the door if: not hardcore, not at the door, have lines, have stars
 	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore() && internalQuestStatus("questL13Final") != 5)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5254,46 +5254,44 @@ boolean LX_loggingHatchet()
 
 boolean LX_getStarKey()
 {
-	//if we don't want the star key then skip this function
 	if(!get_property("auto_getStarKey").to_boolean())
 	{
 		return false;
 	}
 
-	//if already have the star key or already used it, then stop running this function.
+	//needStarKey() checks if you own or have used the star key
 	if(!needStarKey())
 	{
 		set_property("auto_getStarKey", false);
 		return false;
 	}
 	
-	//if we did not progress enough in giant garbage quest to reach hole in the sky then skip this function
-	//if shen quest is not far ahead enough also skip. because shen might send us there and it would be a waste of adventures if we already got the star key before he sends us there.
-	if (internalQuestStatus("questL10Garbage") < 9 || internalQuestStatus("questL11Shen") < 7)
+	bool hole_in_sky_unreachable = internalQuestStatus("questL10Garbage") < 9;
+	bool shen_might_request_hole = internalQuestStatus("questL11Shen") < 7;
+	if (hole_in_sky_unreachable || shen_might_request_hole)
 	{
 		return false;
 	}
 	
-	//can we reach the hole in the sky. need rocketship, except in kingdom of exploathing.
+	//kingdom of exploathing does not need rocketship to reach hole in the sky
 	if(item_amount($item[Steam-Powered Model Rocketship]) == 0 && !in_koe())
 	{
 		return false;
 	}
 	
-	//pull a star chart when all following are true: not hardcore. at the door. no chart. no key. key not used.
-	if (!in_hardcore() && internalQuestStatus("questL13Final") == 5 && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
+	bool at_tower_door = internalQuestStatus("questL13Final") == 5;
+	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
 		pullXWhenHaveY($item[Star Chart], 1, 0);
 	}
 	
-	//craft the star key if I have the ingredients for it
 	if((item_amount($item[Richard\'s Star Key]) == 0) && (item_amount($item[Star Chart]) > 0) && (item_amount($item[star]) >= 8) && (item_amount($item[line]) >= 7) && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
 		return create(1, $item[Richard\'s Star Key]);
 	}
 	
-	//wait to pull star chart at the door if: not hardcore, not at the door, have lines, have stars
-	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore() && internalQuestStatus("questL13Final") != 5)
+	//if only star chart is missing and you will pull it at tower door, then you are done for now.
+	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore() && !at_tower_door)
 	{
 		return false;
 	}
@@ -5304,7 +5302,6 @@ boolean LX_getStarKey()
 		return false;
 	}
 
-	//if you have space jellyfish use it, if you don't have it use the best +item familiar
 	if(auto_have_familiar($familiar[Space Jellyfish]))
 	{
 		handleFamiliar($familiar[Space Jellyfish]);
@@ -5322,9 +5319,7 @@ boolean LX_getStarKey()
 		handleFamiliar("item");
 	}
 	
-	//adventure in the hole in the sky to grab components of the star key
-	autoAdv(1, $location[The Hole In The Sky]);
-	return true;
+	return autoAdv(1, $location[The Hole In The Sky]);
 }
 
 boolean L5_haremOutfit()

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5272,12 +5272,6 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
-	//not hardcore, not yet at the door, have all key ingredients except star chart, then skip this function
-	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore() && internalQuestStatus("questL13Final") != 5)
-	{
-		return false;
-	}
-	
 	//pull a star chart when all following are true: not hardcore. at the door. no chart. no key. key not used.
 	if (!in_hardcore() && internalQuestStatus("questL13Final") == 5 && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
@@ -5299,6 +5293,12 @@ boolean LX_getStarKey()
 	if(!needStarKey())
 	{
 		set_property("auto_getStarKey", false);
+		return false;
+	}
+	
+	//skip so chart can be pulled at door if: not hardcore, not at the door, have lines, have stars
+	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore() && internalQuestStatus("questL13Final") != 5)
+	{
 		return false;
 	}
 	

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5289,7 +5289,7 @@ boolean LX_getStarKey()
 	}
 	
 	//if you don't have space jellyfish get an item boosting familiar. If you do then get the space jellyfish
-	if(!auto_have_familiar($familiar[Space Jellyfish])
+	if(!auto_have_familiar($familiar[Space Jellyfish]))
 	{
 		handleFamiliar("item");
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5289,12 +5289,7 @@ boolean LX_getStarKey()
 	//craft the star key if I have the ingredients for it
 	if((item_amount($item[Richard\'s Star Key]) == 0) && (item_amount($item[Star Chart]) > 0) && (item_amount($item[star]) >= 8) && (item_amount($item[line]) >= 7) && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
-		visit_url("shop.php?pwd&whichshop=starchart&action=buyitem&quantity=1&whichrow=141");
-		if(item_amount($item[Richard\'s Star Key]) == 0)
-		{
-			cli_execute("make richard's star key");
-		}
-		return true;
+		return create(1, $item[Richard\'s Star Key]);
 	}
 	
 	//wait to pull star chart at the door if: not hardcore, not at the door, have lines, have stars

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5304,12 +5304,8 @@ boolean LX_getStarKey()
 		return false;
 	}
 
-	//if you don't have space jellyfish get an item boosting familiar. If you do then get the space jellyfish
-	if(!auto_have_familiar($familiar[Space Jellyfish]))
-	{
-		handleFamiliar("item");
-	}
-	else
+	//if you have space jellyfish use it, if you don't have it use the best +item familiar
+	if(auto_have_familiar($familiar[Space Jellyfish]))
 	{
 		handleFamiliar($familiar[Space Jellyfish]);
 		if(item_amount($item[Star Chart]) == 0)
@@ -5320,6 +5316,10 @@ boolean LX_getStarKey()
 		{
 			set_property("choiceAdventure1221", 2 + (my_ascensions() % 2));
 		}
+	}
+	else
+	{
+		handleFamiliar("item");
 	}
 	
 	//adventure in the hole in the sky to grab components of the star key

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-tem_amount($item[Star]) >= 8) && (item_amount($item[Line])script "autoscend.ash";
+script "autoscend.ash";
 since r19891; // Fix checking for duplicate function to do exact match on parameters
 /***
 	autoscend_header.ash must be first import

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -198,12 +198,9 @@ void initializeSettings()
 
 	eudora_initializeSettings();
 	hr_initializeSettings();
-	picky_initializeSettings();
 	awol_initializeSettings();
 	theSource_initializeSettings();
-	standard_initializeSettings();
 	florist_initializeSettings();
-	ocrs_initializeSettings();
 	ed_initializeSettings();
 	boris_initializeSettings();
 	jello_initializeSettings();
@@ -215,7 +212,6 @@ void initializeSettings()
 	majora_initializeSettings();
 	glover_initializeSettings();
 	bat_initializeSettings();
-	tcrs_initializeSettings();
 	koe_initializeSettings();
 	zelda_initializeSettings();
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5266,8 +5266,8 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
-	bool hole_in_sky_unreachable = internalQuestStatus("questL10Garbage") < 9;
-	bool shen_might_request_hole = internalQuestStatus("questL11Shen") < 7;
+	boolean hole_in_sky_unreachable = internalQuestStatus("questL10Garbage") < 9;
+	boolean shen_might_request_hole = internalQuestStatus("questL11Shen") < 7;
 	if (hole_in_sky_unreachable || shen_might_request_hole)
 	{
 		return false;
@@ -5279,7 +5279,7 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
-	bool at_tower_door = internalQuestStatus("questL13Final") == 5;
+	boolean at_tower_door = internalQuestStatus("questL13Final") == 5;
 	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
 		pullXWhenHaveY($item[Star Chart], 1, 0);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5268,12 +5268,13 @@ boolean LX_getStarKey()
 	}
 	
 	//if we did not progress enough in giant garbage quest to reach hole in the sky then skip this function
+	//if shen quest is not far ahead enough also skip. because shen might send us there and it would be a waste of adventures if we already got the star key before he sends us there.
 	if (internalQuestStatus("questL10Garbage") < 9 || internalQuestStatus("questL11Shen") < 7)
 	{
 		return false;
 	}
 	
-	//kingdom of exploathing specific
+	//can we reach the hole in the sky. need rocketship, except in kingdom of exploathing.
 	if(item_amount($item[Steam-Powered Model Rocketship]) == 0 && !in_koe())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -141,7 +141,7 @@ void initializeSettings()
 	set_property("auto_forceTavern", false);
 	set_property("auto_funTracker", "");
 	set_property("auto_getBoningKnife", false);
-	set_property("auto_getStarKey", false);
+	set_property("auto_getStarKey", true);
 	set_property("auto_getSteelOrgan", get_property("auto_alwaysGetSteelOrgan").to_boolean());
 	set_property("auto_gnasirUnlocked", false);
 	set_property("auto_grimstoneFancyOilPainting", true);
@@ -5281,19 +5281,19 @@ boolean LX_getStarKey()
 		return false;
 	}
 
-	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7))
+	//softcore stop adventuring in hole in the sky if you have everything but the star chart. The chart will be pulled in auto_tower.ash
+	if((item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7) && !in_hardcore())
 	{
-		if(!in_hardcore())
-		{
-			set_property("auto_getStarKey", false);
-			return false;
-		}
+		set_property("auto_getStarKey", false);
+		return false;
 	}
-	else
+	
+	//if you don't have space jellyfish get an item boosting familiar. If you do then get the space jellyfish
+	if(!auto_have_familiar($familiar[Space Jellyfish])
 	{
 		handleFamiliar("item");
 	}
-	if(auto_have_familiar($familiar[Space Jellyfish]))
+	else
 	{
 		handleFamiliar($familiar[Space Jellyfish]);
 		if(item_amount($item[Star Chart]) == 0)

--- a/RELEASE/scripts/autoscend/auto_awol.ash
+++ b/RELEASE/scripts/autoscend/auto_awol.ash
@@ -6,9 +6,6 @@ boolean awol_initializeSettings()
 	{
 		set_property("auto_awolLastSkill", 0);
 		set_property("auto_getBeehive", true);
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_wandOfNagamar", true);
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -19,7 +19,6 @@ void bat_initializeSettings()
 		set_property("auto_paranoia", 10);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
-		set_property("auto_getStarKey", true);
 		set_property("auto_bat_desiredForm", "");
 	}
 }

--- a/RELEASE/scripts/autoscend/auto_bondmember.ash
+++ b/RELEASE/scripts/autoscend/auto_bondmember.ash
@@ -6,11 +6,6 @@ void bond_initializeSettings()
 	{
 		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_getBeehive", true);
-		set_property("auto_cubeItems", true);
-		set_property("auto_getStarKey", true);
-		set_property("auto_grimstoneOrnateDowsingRod", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_useCubeling", true);
 		set_property("auto_wandOfNagamar", false);
 		set_property("choiceAdventure1258", 2);
 		set_property("choiceAdventure1261", 1);

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -7,9 +7,7 @@ void boris_initializeSettings()
 		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 

--- a/RELEASE/scripts/autoscend/auto_digimon.ash
+++ b/RELEASE/scripts/autoscend/auto_digimon.ash
@@ -14,10 +14,8 @@ void digimon_initializeSettings()
 		set_property("auto_getBeehive", false);
 		set_property("auto_getBoningKnife", false);
 		set_property("auto_cubeItems", false);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_hippyInstead", true);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_ignoreFlyer", true);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);

--- a/RELEASE/scripts/autoscend/auto_fallout.ash
+++ b/RELEASE/scripts/autoscend/auto_fallout.ash
@@ -6,11 +6,7 @@ void fallout_initializeSettings()
 	{
 		set_property("auto_cubeItems", false);
 		set_property("auto_getBeehive", true);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_useCubeling", true);
-		set_property("auto_wandOfNagamar", true);
 
 		if(item_amount($item[Deck of Every Card]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_glover.ash
+++ b/RELEASE/scripts/autoscend/auto_glover.ash
@@ -21,14 +21,9 @@ void glover_initializeSettings()
 	{
 		set_property("auto_getBeehive", true);
 		set_property("auto_getBoningKnife", true);
-		set_property("auto_cubeItems", true);
 		set_property("auto_dakotaFanning", true);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_ignoreFlyer", true);
-		set_property("auto_useCubeling", true);
-		set_property("auto_wandOfNagamar", true);
 		set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 16);
 
 		//Buy Crude Oil Congealer and um... A-Boo Glues.

--- a/RELEASE/scripts/autoscend/auto_groundhog.ash
+++ b/RELEASE/scripts/autoscend/auto_groundhog.ash
@@ -4,12 +4,7 @@ void groundhog_initializeSettings()
 {
 	if(auto_my_path() == "Live. Ascend. Repeat.")
 	{
-		set_property("auto_cubeItems", true);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_useCubeling", true);
-		set_property("auto_wandOfNagamar", true);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -62,20 +62,16 @@ boolean routineRainManHandler()
 		{
 			return rainManSummon("orcish frat boy spy", false, false);
 		}
-
+		
 		if(needStarKey())
 		{
-			boolean result = rainManSummon("skinflute", true, false);
-			if(!result)
+			if(item_amount($item[star]) < 8 && item_amount($item[line]) < 7)
 			{
-				if((item_amount($item[star chart]) == 0) && (item_amount($item[richard\'s star key]) == 0))
-				{
-					return rainManSummon("the astronomer", false, false);
-				}
+				return rainManSummon("skinflute", true, false);
 			}
-			else
+			else if((item_amount($item[star chart]) == 0))
 			{
-				return true;
+				return rainManSummon("the astronomer", false, false);
 			}
 		}
 		if(needDigitalKey())

--- a/RELEASE/scripts/autoscend/auto_jellonewbie.ash
+++ b/RELEASE/scripts/autoscend/auto_jellonewbie.ash
@@ -13,8 +13,6 @@ void jello_initializeSettings()
 	if(my_path() == "Gelatinous Noob")
 	{
 		set_property("auto_cubeItems", false);
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -9,7 +9,6 @@ boolean koe_initializeSettings()
 {
 	if(in_koe())
 	{
-		set_property("auto_getStarKey", true);
 		set_property("auto_bruteForcePalindome", in_hardcore());
 		set_property("auto_holeinthesky", false);
 		set_property("auto_grimstoneOrnateDowsingRod", "false");

--- a/RELEASE/scripts/autoscend/auto_majora.ash
+++ b/RELEASE/scripts/autoscend/auto_majora.ash
@@ -7,12 +7,7 @@ void majora_initializeSettings()
 	{
 		set_property("auto_getBeehive", true);
 		set_property("auto_getBoningKnife", true);
-		set_property("auto_cubeItems", true);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_useCubeling", true);
-		set_property("auto_wandOfNagamar", true);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_picky.ash
+++ b/RELEASE/scripts/autoscend/auto_picky.ash
@@ -1,16 +1,6 @@
 script "picky.ash"
 # Code here is supplementary handlers and specialized handlers
 
-void picky_initializeSettings()
-{
-	if(my_path() == "Picky")
-	{
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_wandOfNagamar", true);
-	}
-}
-
 void picky_pulls()
 {
 	if(my_path() == "Picky")

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -7,9 +7,7 @@ void pete_initializeSettings()
 		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_peteSkills", -1);
 		set_property("auto_cubeItems", false);
-		set_property("auto_getStarKey", true);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 	}

--- a/RELEASE/scripts/autoscend/auto_standard.ash
+++ b/RELEASE/scripts/autoscend/auto_standard.ash
@@ -61,15 +61,3 @@ void standard_dnaPotions()
 		}
 	}
 }
-
-
-void standard_initializeSettings()
-{
-	if(auto_my_path() == "Standard")
-	{
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_wandOfNagamar", true);
-		set_property("auto_useCubeling", true);
-	}
-}

--- a/RELEASE/scripts/autoscend/auto_summerfun.ash
+++ b/RELEASE/scripts/autoscend/auto_summerfun.ash
@@ -1,14 +1,4 @@
 script "auto_summerfun.ash"
-boolean ocrs_initializeSettings()
-{
-	if(my_path() == "One Crazy Random Summer")
-	{
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_wandOfNagamar", true);
-	}
-	return true;
-}
 
 boolean ocrs_postHelper()
 {

--- a/RELEASE/scripts/autoscend/auto_tcrs.ash
+++ b/RELEASE/scripts/autoscend/auto_tcrs.ash
@@ -5,17 +5,6 @@ boolean in_tcrs()
 	return my_path() == "36" || my_path() == "Two Crazy Random Summer";
 }
 
-boolean tcrs_initializeSettings()
-{
-	if(in_tcrs())
-	{
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
-		set_property("auto_wandOfNagamar", true);
-	}
-	return true;
-}
-
 float tcrs_expectedAdvPerFill(string quality)
 {
 	switch(quality)

--- a/RELEASE/scripts/autoscend/auto_theSource.ash
+++ b/RELEASE/scripts/autoscend/auto_theSource.ash
@@ -12,8 +12,6 @@ boolean theSource_initializeSettings()
 	{
 #		set_property("auto_lastSpoon", 0);
 		set_property("auto_getBeehive", true);
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_wandOfNagamar", false);
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_tower.ash
+++ b/RELEASE/scripts/autoscend/auto_tower.ash
@@ -417,23 +417,6 @@ boolean L13_sorceressDoor()
 		return false;
 	}
 
-	if (item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
-	{
-		if(my_rain() < 50)
-		{
-			pullXWhenHaveY($item[Star Chart], 1, 0);
-		}
-	}
-
-	if((item_amount($item[Richard\'s Star Key]) == 0) && (item_amount($item[Star Chart]) > 0) && (item_amount($item[star]) >= 8) && (item_amount($item[line]) >= 7))
-	{
-		visit_url("shop.php?pwd&whichshop=starchart&action=buyitem&quantity=1&whichrow=141");
-		if(item_amount($item[Richard\'s Star Key]) == 0)
-		{
-			cli_execute("make richard's star key");
-		}
-	}
-
 	if (item_amount($item[white pixel]) >= 30 && item_amount($item[Digital Key]) == 0)
 	{
 		if (in_koe())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4625,11 +4625,6 @@ boolean needStarKey()
 	{
 		return false;
 	}
-	if((item_amount($item[Star Chart]) > 0) && (item_amount($item[Star]) >= 8) && (item_amount($item[Line]) >= 7))
-	{
-		return false;
-	}
-
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -10,8 +10,6 @@ boolean zelda_initializeSettings()
 	if(in_zelda())
 	{
 		set_property("auto_getBeehive", true);
-		set_property("auto_getStarKey", true);
-		set_property("auto_holeinthesky", true);
 		set_property("auto_wandOfNagamar", false);
 		set_property("auto_useCubeling", true);
 		// TODO: Remove when quest handling is correct.

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -372,7 +372,6 @@ int estimatedTurnsLeft();									//Defined in autoscend/auto_util.ash
 boolean summonMonster();									//Defined in autoscend/auto_util.ash
 boolean summonMonster(string option);						//Defined in autoscend/auto_util.ash
 boolean in_tcrs();											//Defined in autoscend/auto_tcrs.ash
-boolean tcrs_initializeSettings();							//Defined in autoscend/auto_tcrs.ash
 float tcrs_expectedAdvPerFill(string quality);				//Defined in autoscend/auto_tcrs.ash
 boolean tcrs_loadCafeDrinks(int[int] cafe_backmap, float[int] adv, int[int] inebriety);	//Defined in autoscend/auto_tcrs.ash
 boolean tcrs_maximize_with_items(string maximizerString);	//Defined in autoscend/auto_tcrs.ash
@@ -857,7 +856,6 @@ element ns_hedge2();										//Defined in autoscend/auto_util.ash
 element ns_hedge3();										//Defined in autoscend/auto_util.ash
 int numPirateInsults();										//Defined in autoscend/auto_util.ash
 monster ocrs_helper(string page);							//Defined in autoscend/auto_combat.ash
-boolean ocrs_initializeSettings();							//Defined in autoscend/auto_summerfun.ash
 boolean ocrs_postCombatResolve();							//Defined in autoscend/auto_summerfun.ash
 boolean ocrs_postHelper();									//Defined in autoscend/auto_summerfun.ash
 void oldPeoplePlantStuff();									//Defined in autoscend/auto_floristfriar.ash
@@ -867,7 +865,6 @@ boolean pete_buySkills();									//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeDay(int day);							//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeSettings();								//Defined in autoscend/auto_sneakypete.ash
 boolean picky_buyskills();									//Defined in autoscend/auto_picky.ash
-void picky_initializeSettings();							//Defined in autoscend/auto_picky.ash
 void picky_pulls();											//Defined in autoscend/auto_picky.ash
 void picky_startAscension();								//Defined in autoscend/auto_picky.ash
 skill preferredLibram();									//Defined in autoscend/auto_util.ash
@@ -921,7 +918,6 @@ void shrugAT(effect anticipated);							//Defined in autoscend/auto_util.ash
 boolean snojoFightAvailable();								//Defined in autoscend/auto_mr2016.ash
 int solveCookie();											//Defined in autoscend/auto_util.ash
 int spleen_left();											//Defined in autoscend/auto_util.ash
-void standard_initializeSettings();							//Defined in autoscend/auto_standard.ash
 boolean startArmorySubQuest();								//Defined in autoscend/auto_util.ash
 boolean startGalaktikSubQuest();							//Defined in autoscend/auto_util.ash
 boolean startMeatsmithSubQuest();							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

auto_getStarKey is set to false in initializeSettings().
Then every path will re-set it to the appropriate value for that path... which is true for every path other than ed.
This meant that pathless and standard ending up not acquiring the star key, even though they need it.

There is also already a check to change it to false if its not actually needed in auto_tower.ash, so it should default to true.

Also fixed up the function to get the star key a bit. It had some minor additional issues.

## How Has This Been Tested?

Currently doing a pathless hardcore turtle tamer with it. It set auto_getStarKey correctly to true on initialization.
The corrections to the function for getting the star key itself will be tested tomorrow. don't merge until they are tested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
