### PR TITLE
[plumber] Be smarter about when to fight scaling monsters

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5910,9 +5910,10 @@ boolean doTasks()
 		acquireHP();
 	}
 
+	boolean weak_and_zelda = in_zelda() && !zelda_canDealScalingDamage();
 	if(my_daycount() == 1)
 	{
-		if((my_adventures() < 10) && (my_level() >= 7) && (my_hp() > 0))
+		if((my_adventures() < 10) && (my_level() >= 7) && (my_hp() > 0) && !weak_and_zelda)
 		{
 			fightScienceTentacle();
 			if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))
@@ -5921,7 +5922,7 @@ boolean doTasks()
 			}
 		}
 	}
-	else if((my_level() >= 9) && (my_hp() > 0))
+	else if((my_level() >= 9) && (my_hp() > 0) && !weak_and_zelda)
 	{
 		fightScienceTentacle();
 		if(my_mp() > (2 * mp_cost($skill[Evoke Eldritch Horror])))

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -471,6 +471,10 @@ boolean canDrink(item toDrink)
 	{
 		return false;
 	}
+	if (my_class() == $class[Avatar of Jarlsberg])
+	{
+		return contains_text(craft_type(toDrink), "Jarlsberg's Kitchen");
+	}
 	if((auto_my_path() == "Nuclear Autumn") && (toDrink.inebriety != 1))
 	{
 		return false;
@@ -525,6 +529,10 @@ boolean canEat(item toEat)
 	if(!auto_is_valid(toEat))
 	{
 		return false;
+	}
+	if (my_class() == $class[Avatar of Jarlsberg])
+	{
+		return contains_text(craft_type(toEat), "Jarlsberg's Kitchen");
 	}
 	if((auto_my_path() == "Nuclear Autumn") && (toEat.fullness != 1))
 	{

--- a/RELEASE/scripts/autoscend/auto_macguffin.ash
+++ b/RELEASE/scripts/autoscend/auto_macguffin.ash
@@ -562,11 +562,15 @@ boolean L11_aridDesert()
 
 boolean L11_wishForBaaBaaBuran()
 {
-	if(!get_property("auto_useWishes").to_boolean() && canGenieCombat())
+	if (!canGenieCombat() || canEat($item[fortune cookie]))
+	{
+		return false;
+	}
+	if(!get_property("auto_useWishes").to_boolean())
 	{
 		auto_log_warning("Skipping wishing for Baa'baa'bu'ran because auto_useWishes=false", "red");
 	}
-	if (get_property("auto_useWishes").to_boolean() && canGenieCombat())
+	else
 	{
 		auto_log_info("I'm sorry we don't already have stone wool. You might even say I'm sheepish. Sheep wish.", "blue");
 		handleFamiliar("item");

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -169,6 +169,12 @@ boolean godLobsterCombat(item it, int goal, string option)
 		return false;
 	}
 
+	// Avoid fighting the lobster when we are in our pajamas.
+	if (in_zelda() && !zelda_equippedHammer() && !zelda_equippedFlower() && !zelda_equippedBoots())
+	{
+		return false;
+	}
+
 	familiar last = my_familiar();
 	item lastGear = equipped_item($slot[familiar]);
 
@@ -180,6 +186,8 @@ boolean godLobsterCombat(item it, int goal, string option)
 		equip($slot[familiar], it);
 	}
 
+	// TODO: Disabling adventure handling means we do not swap out equipment,
+	// which means sometimes we fight the god lobster in our pajamas and die.
 	set_property("auto_disableAdventureHandling", true);
 
 	string temp = visit_url("main.php?fightgodlobster=1");

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -316,25 +316,55 @@ int zelda_ppCost(skill sk)
 
 boolean zelda_canDealScalingDamage()
 {
-	// TODO: When mafia tracks costumes, account for level 3 basic attacks
-	if(my_maxpp() < 2)
-	{
-		return false;
-	}
+	item[stat] items_lv1 = {
+		$stat[moxie]: $item[work boots],
+		$stat[mysticality]: $item[[10462]fire flower],
+		$stat[muscle]: $item[hammer],
+	};
 
-	if(auto_have_skill($skill[[25006]Multi-Bounce]))
-	{
-		return true;
-	}
+	item[stat] items_lv2 = {
+		$stat[moxie]: $item[fancy boots],
+		$stat[mysticality]: $item[bonfire flower],
+		$stat[muscle]: $item[heavy hammer],
+	};
 
-	if(auto_have_skill($skill[[25004]Fireball Barrage]) && zelda_haveFlower())
-	{
-		return true;
-	}
+	// These attacks deal scaling damage at level 1.
+	skill[stat] attacks_2pp = {
+		$stat[moxie]: $skill[[25006]Multi-Bounce],
+		$stat[mysticality]: $skill[[25004]Fireball Barrage],
+		$stat[muscle]: $skill[[25002]Ultra Smash],
+	};
 
-	if(auto_have_skill($skill[[25002]Ultra Smash]) && zelda_haveHammer())
+	// These attacks deal scaling damage at level 3.
+	skill[stat] attacks_free = {
+		$stat[moxie]: $skill[Jump Attack],
+		$stat[mysticality]: $skill[Fireball Toss],
+		$stat[muscle]: $skill[Hammer Smash],
+	};
+
+	// This is a pretty rough guesstimate.
+	int expected_scaler_hp = my_buffedstat(my_primestat());
+
+	foreach st in $stats[]
 	{
-		return true;
+		int level = 0;
+		if (possessEquipment(items_lv2[st]))
+		{
+			level = 2;
+		}
+		else if (possessEquipment(items_lv1[st]))
+		{
+			level = 1;
+		}
+		else continue;
+
+		// Discard stats that are wildly lower than our max stat.
+		if (expected_scaler_hp >= 2 * my_buffedstat(st)) continue;
+
+		level += to_int(zelda_costume() == st);
+
+		if ((my_maxpp() >= 2) && have_skill(attacks_2pp[st])) return true;
+		if (level >= 3 && have_skill(attacks_free[st])) return true;
 	}
 
 	return false;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1133,7 +1133,9 @@ boolean LM_batpath(); // Defined in autoscend/auto_batpath.ash
 boolean zelda_initializeSettings(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_haveHammer(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_haveFlower(); // Defined in autoscend/auto_zelda.ash
+boolean zelda_equippedHammer(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_equippedFlower(); // Defined in autoscend/auto_zelda.ash
+boolean zelda_equippedBoots(); // Defined in autoscend/auto_zelda.ash
 int zelda_numBadgesBought(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_buySkill(skill sk); // Defined in autoscend/auto_zelda.ash
 boolean zelda_buyEquipment(item it); // Defined in autoscend/auto_zelda.ash


### PR DESCRIPTION
# Description

People really like manually eating Diabolic Pizza Cube pies in Plumber, because it gives them boatloads of muscle stats and helps them hit high levels very quickly. Unfortunately, autoscend really likes using moxie and mysticality mode in Plumber, and our weak little moxie- and mysticality-based attacks, even if they *technically* scale with our stats, are unable to scratch monsters that are scaling with our BRUTE STRENGTH because we are boasting absolutely insane stat ratios like 50 moxie/50 mysticality/700 muscle.

This fixes a few issues with how we decide whether we feel comfortable fighting scaling monsters in Plumber.

* First, we calculate the expected HP of the scaling fight, and do not consider, say, scaling Moxie attacks when our Moxie is much lower than our Muscle.
* Second, we now notice if we've got a base attack that scales because we've got the costume. With our current purchase plan, this is not a functional change. Oh well.

## How Has This Been Tested?

Seemed to not want to use scaling fights early in the run, but use them later in the run. Tested the function directly at a few points and printf-debugged all intermediate steps, and they seemed correct.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
