### PR TITLE
Always be paranoid on April Fools'

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5750,7 +5750,13 @@ boolean doTasks()
 	}
 
 	int paranoia = get_property("auto_paranoia").to_int();
-	if(paranoia != -1)
+	boolean is_april_fools = today_to_string().substring(4) == "0401";
+	if (is_april_fools)
+	{
+		auto_log_info("Salad april fools, so we paranoid salad.");
+		cli_execute("refresh quests");
+	}
+	else if(paranoia != -1)
 	{
 		int paranoia_counter = get_property("auto_paranoia_counter").to_int();
 		if(paranoia_counter >= paranoia)


### PR DESCRIPTION
# Description

On April Fools, KoL replaces random words with "salad". This screws up quest handling, so we need to be extra paranoid.

https://kol.coldfront.net/thekolwiki/index.php/April_Fools%27_Day

## How Has This Been Tested?

`verify autoscend`, so it compiles at least

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
