### PR TITLE
War3 missing stuff from previous commit

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -6043,7 +6043,6 @@ boolean doTasks()
 	if(L12_gremlins())					return true;
 	if(L12_sonofaFinish())			return true;
 	if(L12_sonofaBeach())				return true;
-	if(L12_orchardStart())			return true;
 	if(L12_filthworms())				return true;
 	if(L12_orchardFinalize())		return true;
 	if(L12_themtharHills())			return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2285,19 +2285,6 @@ boolean doBedtime()
 	return false;
 }
 
-boolean questOverride()
-{
-	if(get_property("semirareCounter").to_int() == 0)
-	{
-		if(get_property("semirareLocation") != "")
-		{
-			set_property("semirareLocation", "");
-		}
-	}
-
-	return false;
-}
-
 boolean L13_towerNSNagamar()
 {
 	if (!get_property("auto_wandOfNagamar").to_boolean() && internalQuestStatus("questL13Final") != 12)
@@ -5733,7 +5720,6 @@ boolean doTasks()
 	}
 
 	print_header();
-	questOverride();
 
 	auto_interruptCheck();
 
@@ -6212,7 +6198,6 @@ void auto_begin()
 
 	ed_initializeSession();
 	bat_initializeSession();
-	questOverride();
 
 	if(my_daycount() > 1)
 	{

--- a/RELEASE/scripts/autoscend/auto_island_war.ash
+++ b/RELEASE/scripts/autoscend/auto_island_war.ash
@@ -341,26 +341,6 @@ boolean L12_startWar()
 	return true;
 }
 
-boolean L12_orchardStart()
-{
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestOrchardCompleted") != "none")
-	{
-		return false;
-	}
-	if (in_tcrs() || in_koe())
-	{
-		return false;
-	}
-	if((get_property("hippiesDefeated").to_int() < 64) && !get_property("auto_hippyInstead").to_boolean())
-	{
-		return false;
-	}
-
-	warOutfit(true);
-	visit_url("bigisland.php?place=orchard&action=stand&pwd=");
-	return true;
-}
-
 boolean L12_filthworms()
 {
 	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestOrchardCompleted") != "none")
@@ -536,7 +516,25 @@ boolean L12_gremlins()
 
 	if(item_amount($item[molybdenum magnet]) == 0)
 	{
-		abort("We don't have the molybdenum magnet but should... please get it and rerun the script");
+		//if fighting for frat immediately grab it
+		if(!get_property("auto_hippyInstead").to_boolean())
+		{
+			warOutfit(true);
+			visit_url("bigisland.php?action=junkman&pwd");
+		}
+		
+		//if fighting for hippies grab magnet when enough fratboys killed
+		if(get_property("auto_hippyInstead").to_boolean() && (get_property("fratboysDefeated").to_int() >= 192))
+		{
+			warOutfit(true);
+			visit_url("bigisland.php?action=junkman&pwd");
+		}
+		
+		//if still don't have magnet something went wrong
+		if(item_amount($item[molybdenum magnet]) == 0)
+		{
+			abort("We don't have the molybdenum magnet but should... please get it and rerun the script");
+		}
 	}
 
 	if(auto_my_path() == "Disguises Delimit")

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -125,7 +125,6 @@ boolean L12_sonofaBeach();
 boolean L12_sonofaFinish();
 boolean L12_gremlins();
 boolean L12_orchardFinalize();
-boolean L12_orchardStart();
 boolean L12_finalizeWar();
 boolean L13_sorceressDoor();
 boolean L13_towerNSEntrance();
@@ -136,7 +135,6 @@ boolean L13_towerNSNagamar();
 boolean L13_towerNSFinal();
 boolean L13_ed_councilWarehouse();
 boolean L13_ed_towerHandler();
-boolean questOverride();
 
 string autoscend_current_version();
 string autoscend_previous_version();


### PR DESCRIPTION
I made a mistake when rebasing the previous war branch (the one that got merged upstream already) and lost a few commits in the process.

This pull is for the missing stuff:
1. orchard fix. function to accept the quest is pointless for frat and harms the hippies
2. junkyard fix. added code to the quest handler function to start the quest if needed for both hippies and fratboys. note that current lass/beta includes a removal of a hacky unreliable code to start it for only frat, so at the moment lass/beta does not start it for either side. instead aborting and asking the player to manually acquire the magnet then rerun.
3. quest override function removed, the sole remaining thing in it is addressing a long solved mafia issue

all of it has already been thoroughly tested before being lost. so it can be merged

manually rebuilt it into this branch to handle CRLF git bug being resolved by a recent commit