### PR TITLE
Sometimes the only choices you have are bad ones. But you still have to choose...

### DIFF
--- a/BUILD/settings/action.dat
+++ b/BUILD/settings/action.dat
@@ -1,1 +1,2 @@
 auto_interrupt	boolean	Cause script to stop before starting next turn action (instead of trying to abort midturn).
+auto_debugging	boolean	Will cause the script to stop after one adventure (by setting auto_interrupt = true).

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -4,6 +4,7 @@
 # variable timing, number, variable name, variable type, description
 
 action	0	auto_interrupt	boolean	Cause script to stop before starting next turn action (instead of trying to abort midturn).
+action	1	auto_debugging	boolean	Will cause the script to stop after one adventure (by setting auto_interrupt = true).
 
 any	0	auto_skipNEPOverride	boolean	If true, will not use the Neverending Party even if mafia says it is available.
 any	1	auto_newbieOverride	boolean	Did you fight a crate? Ugh... Report it please, but if you want the script to try again, set this to true and it'll override it. Once.
@@ -29,7 +30,7 @@ any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If
 any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Ashton Kutcher (ignores Soda Bread).
 any	22	auto_limitConsume	boolean	When false, will not eat or drink anything automatically.
 any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat. If you set it to "disabled" it will revert to the old equipment system, for now.
+any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
 any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
 any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.

--- a/RELEASE/relay/autoscend_quests.txt
+++ b/RELEASE/relay/autoscend_quests.txt
@@ -42,9 +42,8 @@
 42	_auto_lastABooCycleFix	integer	POST	Tracker to prevent us infinitely looping on A-Boo Peak
 43	_auto_witchessBattles	integer	POST	Tracker for Witchess Combats (yes, this is actually needed).
 44	auto_combatDirective	string	ANY	State of overloading of combat behaviors.
-45	auto_copperhead	integer	ANY	Tracks the first 3 choice options when being a waiter at Copperhead (1|2|4)
-46	auto_needLegs	boolean	PRE	In Ed, do we require getting legs before trying to Ka farm?
-47	auto_getSteelOrgan	boolean	ANY	Are we trying to get a Steel Organ this ascension?
-48	auto_hccsTurnSave	boolean	ANY	In HCCS: Should we ignore pixel farming?
-49	auto_maxCandyPrice	integer	ANY	Max allowable price per candy for Rethinking Candy (default 2500)
-50	auto_hccsNoConcludeDay	boolean	ANY	In HCCS: When true, reduce how many daily end-of-day things we do.
+45	auto_needLegs	boolean	PRE	In Ed, do we require getting legs before trying to Ka farm?
+46	auto_getSteelOrgan	boolean	ANY	Are we trying to get a Steel Organ this ascension?
+47	auto_hccsTurnSave	boolean	ANY	In HCCS: Should we ignore pixel farming?
+48	auto_maxCandyPrice	integer	ANY	Max allowable price per candy for Rethinking Candy (default 2500)
+49	auto_hccsNoConcludeDay	boolean	ANY	In HCCS: When true, reduce how many daily end-of-day things we do.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19891; // Fix checking for duplicate function to do exact match on parameters
+since r19953; // Detect when a fight follows a choice. WHen automating with adv1 or adventure, automate that fight.
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -126,7 +126,6 @@ void initializeSettings()
 	set_property("auto_combatHandler", "");
 	set_property("auto_cookie", -1);
 	set_property("auto_copies", "");
-	set_property("auto_copperhead", 0);
 	set_property("auto_crackpotjar", "");
 	set_property("auto_cubeItems", true);
 	set_property("auto_dakotaFanning", false);
@@ -5383,9 +5382,7 @@ boolean auto_tavern()
 	boolean maximized = false;
 	foreach loc in locations
 	{
-		auto_interruptCheck();
 		//Sleaze is the only one we don't care about
-
 		if (possessEquipment($item[Kremlin\'s Greatest Briefcase]))
 		{
 			string mod = string_modifier($item[Kremlin\'s Greatest Briefcase], "Modifiers");
@@ -6177,7 +6174,7 @@ void auto_begin()
 
 	backupSetting("kingLiberatedScript", "scripts/autoscend/auto_king.ash");
 	backupSetting("afterAdventureScript", "scripts/autoscend/auto_post_adv.ash");
-	backupSetting("betweenAdventureScript", "scripts/autoscend/auto_pre_adv.ash");
+	backupSetting("choiceAdventureScript", "scripts/autoscend/auto_choice_adv.ash");
 	backupSetting("betweenBattleScript", "scripts/autoscend/auto_pre_adv.ash");
 
 	backupSetting("hpAutoRecovery", -1);

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -19,17 +19,23 @@ boolean autoAdv(int num, location loc, string option)
 	set_property("nextAdventure", loc);
 	if(option == "")
 	{
-		option = "auto_combatHandler";
+		if (isActuallyEd())
+		{
+			option = "auto_edCombatHandler";
+		} else {
+			option = "auto_combatHandler";
+		}
 	}
+
 	if (isActuallyEd())
 	{
-		return autoEdAdv(num, loc, option);
+		ed_handleAdventureServant(loc);
 	}
+
 	if(auto_my_path() == "Pocket Familiars")
 	{
 		return digimon_autoAdv(num, loc, option);
 	}
-
 
 	boolean retval = false;
 
@@ -48,7 +54,7 @@ boolean autoAdv(int num, location loc, string option)
 	}
 	else
 	{
-		retval = adv1(loc, 0, option);
+		retval = adv1(loc, -1, option);
 	}
 	if(auto_my_path() == "One Crazy Random Summer")
 	{
@@ -62,10 +68,7 @@ boolean autoAdv(int num, location loc, string option)
 			}
 		}
 	}
-	if(get_property("lastEncounter") == "Using the Force")
-	{
-		run_choice(get_property("_auto_saberChoice").to_int());
-	}
+
 	return retval;
 }
 
@@ -93,11 +96,6 @@ boolean autoAdvBypass(string url, location loc)
 	return autoAdvBypass(url, loc, "");
 }
 
-#boolean autoAdvBypass(string[int] url, location loc)
-#{
-#	return autoAdvBypass(url, loc, "");
-#}
-
 boolean autoAdvBypass(string url, location loc, string option)
 {
 	string[int] urlConvert;
@@ -124,11 +122,16 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	cli_execute("auto_pre_adv");
 	if(option == "")
 	{
-		option = "auto_combatHandler";
+		if (isActuallyEd())
+		{
+			option = "auto_edCombatHandler";
+		} else {
+			option = "auto_combatHandler";
+		}
 	}
 	if (isActuallyEd())
 	{
-		ed_preAdv(1, loc, option);
+		ed_handleAdventureServant(loc);
 	}
 
 	auto_log_info("About to start a combat indirectly at " + loc + "... (" + count(url) + ") accesses required.", "blue");
@@ -164,11 +167,6 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	{
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 
-		if (isActuallyEd())
-		{
-				auto_runEdCombat(option, false);
-				return true;
-		}
 		if(option != "autoscend_null") // && (option != ""))
 		{
 			if(get_auto_attack() == 0)

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -1,0 +1,37 @@
+script "auto_choice_adv.ash";
+import<autoscend.ash>
+
+void main(int choice, string page)
+{
+	switch (choice) {
+		case 1023: // Like a Bat Into Hell (Actually Ed the Undying)
+			run_choice(1); // Enter the Underworld
+			auto_log_info("Ed died in combat " + get_property("_edDefeats").to_int() + " time(s)", "blue");
+			ed_shopping(); // "free" trip to the Underworld, may as well go shopping!
+			visit_url("place.php?whichplace=edunder&action=edunder_leave");
+			break;
+		case 1024:  // Like a Bat out of Hell (Actually Ed the Undying)
+			if (get_property("_edDefeats").to_int() < get_property("edDefeatAbort").to_int()) {
+				// resurrecting is still free.
+				run_choice(1, false); // UNDYING!
+			} else {
+				// resurrecting will cost Ka
+				run_choice(2); // Accept the cold embrace of death (Return to the Pyramid)
+				auto_log_info("Ed died in combat for reals!");
+				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
+			}
+			break;
+		case 1340: // Is There A Doctor In The House? (Lil' Doctor Bag™)
+			auto_log_info("Accepting doctor quest, it's our job!");
+			run_choice(1);
+			break;
+		case 1342: // Torpor (Dark Gyffte)
+			bat_reallyPickSkills(20);
+			break;
+		case 1387: // Using the Force (Fourth of May Cosplay Saber)
+			run_choice(get_property("_auto_saberChoice").to_int());
+			break;
+		default:
+			break;
+	}
+}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2507,7 +2507,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location())
 	{
-		if (my_mp() < mp_cost($skill[Fist Of The Mummy]))
+		if (my_mp() < mp_cost($skill[Fist Of The Mummy]) && get_property("_edDefeats").to_int() < 2)
 		{
 			foreach it in $items[Holy Spring Water, Spirit Beer, Sacramental Wine]
 			{

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -6,7 +6,6 @@ script "auto_cooking.ash"
 
 boolean acquireMilkOfMagnesiumIfUnused(boolean useAdv);
 boolean consumeMilkOfMagnesiumIfUnused(boolean useAdv);
-int autoDailySpecialPrice();
 boolean autoEat(int howMany, item toEat);
 boolean autoEat(int howMany, item toEat, boolean silent);
 boolean autoDrink(int howMany, item toDrink);
@@ -259,46 +258,6 @@ boolean autoDrinkCafe(int howmany, int id)
 		handleTracker(name, "auto_drunken");
 	}
 	return true;
-}
-
-int autoDailySpecialPrice()
-{
-	//this function provides the purchase price for the daily special item in chez snootie or gnomish microbrewery.
-
-	//check for known items whose autosell price is hidden due to being marked nodiscard
-	switch(daily_special())
-	{
-		//chez snootie
-		case $item[banana]: return 3;
-		case $item[banana cream pie]: return 30;
-		case $item[fiery wing]: return 96;
-		case $item[forbidden sausage]: return 46;
-		case $item[ghost cucumber]: return 225;
-		case $item[laser-broiled pear]: return 465;
-		
-		//gnomish microbrewery
-		case $item[banana daiquiri]: return 30;
-		case $item[bungle in the jungle]: return 75;
-		case $item[especially salty dog]: return 462;
-	}
-
-	//if an item has an autosell price, the cost to buy it from chez snootie or gnomish microbrewery is 3 times the autosell value
-	if (autosell_price(daily_special()) > 0)
-	{
-		return 3*autosell_price(daily_special());
-	}
-	
-	//this function should not be called if you do not have access to a daily special (for example, knoll sign). But just in case
-	if (daily_special() == $item[none])
-	{
-		auto_log_warning("for some reason auto_cooking.ash called function autoDailySpecialPrice() even though no daily special item is available to you from chez snootie or gnomish microbrewery", "orange");
-		return 100;
-	}
-
-	//if an item does not have an autosell price and is not a known item, assume the price is 100 and print a warning asking the user to report this
-	auto_log_warning("Autoscend can not determine the price of the daily special at chez snnotie or gnomish microbrewery and will guess it costs 100 meat", "orange");
-	auto_log_warning("Please report this warning. file auto_cooking.ash function autoDailySpecialPrice() item " + daily_special(), "orange");
-	return 100;
 }
 
 boolean autoEatCafe(int howmany, int id)
@@ -998,7 +957,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	// Add daily special
 	if (daily_special() != $item[none] && canConsume(daily_special()))
 	{
-		int daily_special_limit = 1 + min(my_meat()/autoDailySpecialPrice(), organLeft()/organCost(daily_special()));
+		int daily_special_limit = 1 + min(my_meat()/get_property("_dailySpecialPrice").to_int(), organLeft()/organCost(daily_special()));
 		for (int i=0; i < daily_special_limit; i++)
 		{
 			int n = count(actions);

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -481,5 +481,17 @@ boolean settingFixer()
 		remove_property("auto_legacyConsumeStuff");
 	}
 
+	if (property_exists("betweenAdventureScript"))
+	{
+		auto_log_debug("betweenAdventureScript might be an old mafia property that was renamed but it does nothing now.");
+		remove_property("betweenAdventureScript");
+	}
+
+	if (property_exists("auto_copperhead"))
+	{
+		auto_log_debug("Mafia added tracking for the Copperhead Club non-combat so this is no longer necesssary.");
+		remove_property("auto_copperhead");
+	}
+
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_digimon.ash
+++ b/RELEASE/scripts/autoscend/auto_digimon.ash
@@ -144,7 +144,7 @@ boolean digimon_autoAdv(int num, location loc, string option)
 
 			if($ints[89, 890, 891, 892, 893, 894, 895, 896, 897, 898, 899, 900, 901, 902, 903, 914] contains choice)
 			{
-				return adv1(loc, 0, option);
+				return adv1(loc, -1, option);
 			}
 
 			temp = visit_url("choice.php?pwd=" + my_hash() + "&whichchoice=" + choice + "&option=" + get_property("choiceAdventure" + choice).to_int());

--- a/RELEASE/scripts/autoscend/auto_giant_trash.ash
+++ b/RELEASE/scripts/autoscend/auto_giant_trash.ash
@@ -7,14 +7,6 @@ boolean L10_plantThatBean()
 		return false;
 	}
 
-	if (isActuallyEd())
-	{
-		// no bean needed as Ed, just climb the beanstalk to progress the quest
-		visit_url("place.php?whichplace=beanstalk");
-		cli_execute("refresh quests");
-		return true;
-	}
-
 	auto_log_info("Planting me magic bean!", "blue");
 	string page = visit_url("place.php?whichplace=plains");
 	if(contains_text(page, "place.php?whichplace=beanstalk"))
@@ -78,6 +70,13 @@ boolean L10_airship()
 		buffMaintain($effect[Snow Shoes], 0, 1, 1);
 		buffMaintain($effect[Fishy\, Oily], 0, 1, 1);
 		buffMaintain($effect[Gummed Shoes], 0, 1, 1);
+	}
+
+	if (isActuallyEd() && $location[The Penultimate Fantasy Airship].turns_spent < 1)
+	{
+		// temp workaround for mafia bug.
+		// see https://kolmafia.us/showthread.php?24767-Quest-tracking-preferences-change-request(s)&p=156733&viewfull=1#post156733
+		visit_url("place.php?whichplace=beanstalk");
 	}
 
 	autoAdv(1, $location[The Penultimate Fantasy Airship]);

--- a/RELEASE/scripts/autoscend/auto_highlands.ash
+++ b/RELEASE/scripts/autoscend/auto_highlands.ash
@@ -258,7 +258,17 @@ boolean L9_aBooPeak()
 
 	auto_log_info("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
 	boolean clueCheck = ((clueAmt > 0) || (get_property("auto_aboopending").to_int() != 0));
-	if(clueCheck && (get_property("booPeakProgress").to_int() > 2))
+	if (get_property("auto_abooclover").to_boolean() && get_property("booPeakProgress").to_int() >= 30 && booCloversOk)
+	{
+		cloverUsageInit();
+		autoAdvBypass(296, $location[A-Boo Peak]);
+		if(cloverUsageFinish())
+		{
+			set_property("auto_abooclover", false);
+		}
+		return true;
+	}
+	else if (clueCheck && (get_property("booPeakProgress").to_int() > 2))
 	{
 		boolean doThisBoo = false;
 
@@ -479,16 +489,6 @@ boolean L9_aBooPeak()
 		equipBaseline();
 		handleFamiliar("item");
 		handleBjornify(priorBjorn);
-	}
-	else if(get_property("auto_abooclover").to_boolean() && (get_property("booPeakProgress").to_int() >= 30) && booCloversOk)
-	{
-		cloverUsageInit();
-		autoAdvBypass(296, $location[A-Boo Peak]);
-		if(cloverUsageFinish())
-		{
-			set_property("auto_abooclover", false);
-		}
-		return true;
 	}
 	else
 	{

--- a/RELEASE/scripts/autoscend/auto_macguffin.ash
+++ b/RELEASE/scripts/autoscend/auto_macguffin.ash
@@ -1690,7 +1690,7 @@ boolean L11_shenCopperhead()
 			int behindtheStacheOption = 4;
 			if (item_amount($item[priceless diamond]) > 0 || item_amount($item[Red Zeppelin Ticket]) > 0 || (internalQuestStatus("questL11Shen") == 6 && item_amount($item[unnamed cocktail]) > 0))
 			{
-				if (get_property("auto_copperhead").to_int() != 3)
+				if (get_property("copperheadClubHazard") != "lantern")
 				{
 					// got priceless diamond or zeppelin ticket so lets burn the place down (and make Flamin' Whatsisnames)
 					behindtheStacheOption = 3;
@@ -1698,7 +1698,7 @@ boolean L11_shenCopperhead()
 			}
 			else
 			{
-				if (get_property("auto_copperhead").to_int() != 2)
+				if (get_property("copperheadClubHazard") != "ice")
 				{
 					// knock over the ice bucket & try for the priceless diamond.
 					behindtheStacheOption = 2;
@@ -1715,22 +1715,6 @@ boolean L11_shenCopperhead()
 		if (maximizeContains("-10ml"))
 		{
 			removeFromMaximize("-10ml");
-		}
-		if (get_property("lastEncounter") == "Behind the 'Stache")
-		{
-			// store which of the 3 zone changing options we have active so we don't waste Crappy Waiter Disguises
-			switch (get_property("choiceAdventure855").to_int())
-			{
-			case 1:
-				set_property("auto_copperhead", 1);
-				break;
-			case 2:
-				set_property("auto_copperhead", 2);
-				break;
-			case 3:
-				set_property("auto_copperhead", 3);
-				break;
-			}
 		}
 		return retval;
 	}

--- a/RELEASE/scripts/autoscend/auto_mclargehuge.ash
+++ b/RELEASE/scripts/autoscend/auto_mclargehuge.ash
@@ -364,9 +364,12 @@ boolean L8_trapperGroar()
 			auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
 			if (item_amount($item[Groar\'s Fur]) == 0 && item_amount($item[Winged Yeti Fur]) == 0)
 			{
-				addToMaximize("5meat");
+				addToMaximize("2000cold resistance 5max");
+				// mafia bug screws us here if we don't already have the 5 cold res. auto_pre_adv will not be called and this will infinite loop
+				equipMaximizedGear(); // remove this once https://kolmafia.us/showthread.php?24764-betweenBattleScript-and-afterAdventureScrinever-gets-called is fixed.
 				//If this returns false, we might have finished already, can we check this?
 				autoAdv(1, $location[Mist-shrouded Peak]);
+				removeFromMaximize("2000cold resistance 5max");
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -100,25 +100,6 @@ void handlePostAdventure()
 		return;
 	}
 
-	if(choice_follows_fight())
-	{
-		// make sure last_choice is updated
-		visit_url("main.php");
-		switch(last_choice())
-		{
-			case 1340: // Is There A Doctor In The House?
-				auto_log_info("Accepting doctor quest, it's our job!");
-				run_choice(1);
-				break;
-			case 1342: // Torpor
-				bat_reallyPickSkills(20);
-				break;
-			default:
-				auto_log_warning("Unrecognized unhandled choice after combat " + last_choice(), "red");
-				break;
-		}
-	}
-
 	if(!get_property("_ballInACupUsed").to_boolean() && (item_amount($item[Ball-In-A-Cup]) > 0))
 	{
 		use(1, $item[Ball-In-A-Cup]);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -470,7 +470,6 @@ void handlePreAdventure(location place)
 		// Last minute MCD alterations if Limit set, otherwise trust maximizer
 		if(get_property("auto_MLSafetyLimit") != "")
 		{
-			auto_change_mcd(0);
 			auto_setMCDToCap();
 		}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -6430,6 +6430,11 @@ void auto_interruptCheck()
 		restoreAllSettings();
 		abort("auto_interrupt detected and aborting, auto_interrupt disabled.");
 	}
+	else if (get_property("auto_debugging").to_boolean())
+	{
+		set_property("auto_interrupt", true);
+		auto_log_info("auto_debugging detected, auto_interrupt enabled.");
+	}
 }
 
 element currentFlavour()
@@ -6862,17 +6867,13 @@ boolean auto_setMCDToCap()
 	// Don't try to set the MCD if in KoE
 	if(!in_koe())
 	{
-		if(($strings[Marmot, Opossum, Platypus] contains my_sign()) && (11 <= remainingMLToCap()))
-		{
-			auto_change_mcd(11);
-		}
-		else if(10 <= remainingMLToCap())
-		{
-			auto_change_mcd(10);
-		}
-		else if(10 > remainingMLToCap())
+		if (current_mcd() > remainingMLToCap())
 		{
 			auto_change_mcd(remainingMLToCap());
+		}
+		else
+		{
+			auto_change_mcd(11);
 		}
 	}
 
@@ -6900,13 +6901,6 @@ boolean UrKelCheck(int UrKelToML, int UrKelUpperLimit, int UrKelLowerLimit)
 //		Ur-kel's may need new entries in this case due to its variance
 boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 {
-
-// Turn Off MCD first if not in KoE, so we can maximize our ML within constraints.
-	if(!in_koe() && !($locations[The Boss Bat\'s Lair, Haert of the Cyrpt, Throne Room] contains my_location()))
-	{
-		auto_change_mcd(0);
-	}
-
 	void tryEffects(boolean [effect] effects)
 	{
 		foreach eff in effects

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -400,7 +400,6 @@ boolean canOde(item toDrink); //Defined in autoscend/auto_cooking.ash
 boolean canSimultaneouslyAcquire(int[item] needed);			//Defined in autoscend/auto_util.ash
 boolean clear_property_if(string setting, string cond);		//Defined in autoscend/auto_util.ash
 boolean autoDrink(int howMany, item toDrink);					//Defined in autoscend/auto_cooking.ash
-int autoDailySpecialPrice();									//Defined in autoscend/auto_cooking.ash
 boolean autoEat(int howMany, item toEat);						//Defined in autoscend/auto_cooking.ash
 boolean autoEat(int howMany, item toEat, boolean silent);		//Defined in autoscend/auto_cooking.ash
 boolean auto_knapsackAutoConsume(string type, boolean simulate);	//Defined in autoscend/auto_cooking.ash
@@ -538,16 +537,13 @@ boolean zataraClanmate(string who);							//Defined in autoscend/auto_clan.ash
 boolean zataraAvailable();									//Defined in autoscend/auto_clan.ash
 boolean zataraSeaside(string who);							//Defined in autoscend/auto_clan.ash
 boolean isActuallyEd();										//Defined in auto_ascend/auto_edTheUndying.ash
-void auto_runEdCombat(string option, boolean skipFirstFight);	//Defined in autoscend/auto_edTheUndying.ash
-void auto_runEdCombat(string option);	//Defined in autoscend/auto_edTheUndying.ash
-boolean autoEdAdv(int num, location loc, string option);		//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_doResting();										//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_eatStuff();										//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeDay(int day);								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSession();								//Defined in autoscend/auto_edTheUndying.ash
 void ed_initializeSettings();								//Defined in autoscend/auto_edTheUndying.ash
 boolean ed_needShop();										//Defined in autoscend/auto_edTheUndying.ash
-boolean ed_preAdv(int num, location loc, string option);	//Defined in autoscend/auto_edTheUndying.ash
+void ed_handleAdventureServant(location loc);	//Defined in autoscend/auto_edTheUndying.ash
 void ed_terminateSession();									//Defined in autoscend/auto_edTheUndying.ash
 effect[int] effectList();									//Defined in autoscend/auto_list.ash
 boolean elementalPlanes_access(element ele);				//Defined in autoscend/auto_elementalPlanes.ash


### PR DESCRIPTION
I'm putting this up for testing if anyone else wants to give it a go. The choiceAdventureScript stuff looks good now in Actually Ed the Undying runs but you will require r19953 or later of mafia.
I haven't tested if Torpor still works in Dark Gyffte nor if the Force Saber & Lil Doctor Bag handling is as expected (and I can't actually test those 2 as I don't have any IotMs on my test account).

# Description

- add auto_choice_adv.ash and set choiceAdventureScript to it so we handle choice adventures dynamically if they don't have a choice set (fixes Ed runs with updated mafia).
- various changes/removals to fix Ed runs in combination with above as we no longer need to manually handle running combat & resurrecting as Ed.
- pre-emptively move handling for Using the Force, Lil' Doctor Bag quest popup and Torpor to auto_choice_adv.ash (needs testing)
- add auto_debugging which sets auto_interrupt after the interrupt check has run so you can run one adventure at a time for debugging purposes.
- remove auto_copperhead, replace with new mafia property copperheadClubHazard which does the same thing but automatically.
- remove autoDailySpecialPrice, replace with new mafia property _dailySpecialPrice
- ensure we use a clover to grab A-boo Clues
- workaround issue with Mist-Shrouded Peak where we're relying on Cold Res from equipment to allow us to adventure there to make sure we actually equip the equipment so we don't infinite loop failing to adventure.
- fix all the spam turning the MCD up and down before every adventure because it slows our runs down and is unnecessary server hits. Only change the MCD if a different setting is required.

Fixes #27 

## How Has This Been Tested?

Running a HC Ed run as I write this.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
