### PR TITLE
some fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2327,7 +2327,7 @@ boolean L13_towerNSNagamar()
 	}
 	
 	//hunt for bear verb orgy
-	if (item_amount($item[Wand of Nagamar]) == 0 && internalQuestStatus("questL13Final") == 12)
+	if (item_amount($item[Wand of Nagamar]) == 0 && internalQuestStatus("questL13Final") == 12 && !in_koe())
 	{
 		return autoAdv($location[The VERY Unquiet Garves]);
 	}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1440,9 +1440,9 @@ string auto_combatHandler(int round, string opp, string text)
 			{
 				return useSkill($skill[Northern Explosion], false);
 			}
-			else
+			else if($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class())
 			{
-				auto_log_warning("None of our preferred skills available. Engaging in Fisticuffs.", "red");
+				auto_log_warning("None of our preferred [cold] skills available against smut orcs. Engaging in Fisticuffs.", "red");
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/auto_macguffin.ash
+++ b/RELEASE/scripts/autoscend/auto_macguffin.ash
@@ -1479,15 +1479,22 @@ boolean L11_mauriceSpookyraven()
 
 		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
 
-		autoAdv(1, $location[The Haunted Boiler Room]);
-
-		if(item_amount($item[wine bomb]) == 1)
+		if(equipped_amount($item[Unstable Fulminate]) == 1)
 		{
-			visit_url("place.php?whichplace=manor4&action=manor4_chamberwall");
+			autoAdv(1, $location[The Haunted Boiler Room]);
 		}
-		return true;
+		else
+		{
+			abort("Tried to adventure in [Haunted Boiler Room] without an [Unstable Fulminate] equipped! Aborting to avoid wasting turns...");
+		}
 	}
 
+	if(item_amount($item[wine bomb]) == 1)
+	{
+		visit_url("place.php?whichplace=manor4&action=manor4_chamberwall");
+		return true;
+	}
+	
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/auto_macguffin.ash
+++ b/RELEASE/scripts/autoscend/auto_macguffin.ash
@@ -1336,7 +1336,14 @@ boolean L11_mauriceSpookyraven()
 	if(item_amount($item[wine bomb]) == 1)
 	{
 		visit_url("place.php?whichplace=manor4&action=manor4_chamberwall");
-		return true;
+		if (internalQuestStatus("questL11Manor") == 3)
+		{
+			return true;
+		}
+		else
+		{
+			abort("Tried to use the wine bomb but it somehow failed?");
+		}
 	}
 
 	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || (my_class() == $class[Avatar of Boris]) || (auto_my_path() == "Way of the Surprising Fist") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
@@ -1482,19 +1489,13 @@ boolean L11_mauriceSpookyraven()
 		if(equipped_amount($item[Unstable Fulminate]) == 1)
 		{
 			autoAdv(1, $location[The Haunted Boiler Room]);
+			return true;
 		}
 		else
 		{
 			abort("Tried to adventure in [Haunted Boiler Room] without an [Unstable Fulminate] equipped! Aborting to avoid wasting turns...");
 		}
 	}
-
-	if(item_amount($item[wine bomb]) == 1)
-	{
-		visit_url("place.php?whichplace=manor4&action=manor4_chamberwall");
-		return true;
-	}
-	
 	return false;
 }
 


### PR DESCRIPTION
# Description

there are multiple different bugs (and more are occasionally introduced) that can cause autoscend to fail to equip the unstable fulminate before trying to adventure in the haunted boiler room. When that happens, it would waste over 50 adventures there before aborting with the message of having spent too many turns there.
Now there is a last second check to immediately abort if it tries to adventure in that zone without the unstable fulminate, preventing that loss of adventures.

Also the warning for not being able to acquire cold damage for smut orcs is clearer now and only shows up for the 6 core classes (since avatar paths have their own handling).

## How Has This Been Tested?

hardcore Kingdom of Exploathing run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
