### PR TITLE
More choiceAdventureScript fixes.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -21,6 +21,28 @@ void main(int choice, string page)
 				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 			}
 			break;
+		case 1310: // Granted a Boon (God Lobster)
+			int goal = get_property("_auto_lobsterChoice").to_int();
+			string search = "I'd like part of your regalia.";
+			if(goal == 2)
+			{
+				search = "I'd like a blessing.";
+			}
+			else if(goal == 3)
+			{
+				search = "I'd like some experience.";
+			}
+
+			int choice = 0;
+			foreach idx, str in available_choice_options()
+			{
+				if(contains_text(str,search))
+				{
+					choice = idx;
+				}
+			}
+			run_choice(choice);
+			break;
 		case 1340: // Is There A Doctor In The House? (Lil' Doctor Bag™)
 			auto_log_info("Accepting doctor quest, it's our job!");
 			run_choice(1);

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -108,6 +108,7 @@ boolean pantogramPants()
 {
 	return pantogramPants(my_primestat(), $element[cold], 1, 2, 1);
 }
+
 boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int misc)
 {
 	if(!is_unrestricted($item[Portable Pantogram]))
@@ -248,7 +249,6 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 
 }
 
-
 boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int loveEffect, boolean equivocator, int giftItem)
 {
 	return loveTunnelAcquire(enforcer, statItem, engineer, loveEffect, equivocator, giftItem, "");
@@ -280,7 +280,6 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
-//	set_property("_auto_loveTunnelDone", true);
 
 	string temp = visit_url("place.php?whichplace=town_wrong");
 	if(!(contains_text(temp, "townwrong_tunnel")))
@@ -288,34 +287,16 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 		return false;
 	}
 
-	#string temp = visit_url("place.php?whichplace=town_wrong&action=townwrong_tunnel");
-	set_location($location[The Tunnel of L.O.V.E.]);
-	cli_execute("auto_pre_adv");
-	temp = visit_url("place.php?whichplace=town_wrong&action=townwrong_tunnel");
-	if(contains_text(temp, "Come back tomorrow!"))
-	{
-		set_property("_loveTunnelUsed", true);
-		auto_log_warning("Already visited L.O.V.E. Tunnel. Can't be visiting again.", "red");
-		temp = visit_url("choice.php?pwd=&whichchoice=1222&option=2");
-		return false;
-	}
-
-	temp = visit_url("choice.php?pwd=&whichchoice=1222&option=1");
-
-	if(enforcer || engineer || equivocator)
-	{
-		set_property("auto_disableAdventureHandling", true);
-	}
+	backupSetting("choiceAdventure1222", "1"); // The Tunnel of L.O.V.E.
 
 	if(enforcer)
 	{
-		autoAdvBypass("choice.php?pwd=&whichchoice=1223&option=1", option);
+		backupSetting("choiceAdventure1223", "1"); // L.O.V. Entrance - Fight Enforcer
 	}
 	else
 	{
-		string temp = visit_url("choice.php?pwd=&whichchoice=1223&option=2");
+		backupSetting("choiceAdventure1223", "2"); // L.O.V. Entrance - Skip Enforcer
 	}
-
 
 	int statValue = 4;
 	if(statItem == $stat[none])
@@ -348,55 +329,52 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 		}
 	}
 
-	temp = visit_url("choice.php?pwd=&whichchoice=1224&option=" + statValue);
-#1		Cardigan,			LOV Eardigan	Shirt - 25% Muscle Stats, 8-12HP Regen, +25ML, End of Day
-#2		Epaulettes,			LOV Epaulettes	Back  - 25% Myst Stats, 4-6MP Regen, -3MPCombatSkills, End of Day
-#3		Earrings			LOV Earrings	Acc   - 25% Moxie Stats, +3 PrismRes, +50% Meat, End of Day
-#4		Nothing
-
+	backupSetting("choiceAdventure1224", to_string(statValue)); // L.O.V. Equipment Room
+	#1		Cardigan,			LOV Eardigan	Shirt - 25% Muscle Stats, 8-12HP Regen, +25ML, End of Day
+	#2		Epaulettes,			LOV Epaulettes	Back  - 25% Myst Stats, 4-6MP Regen, -3MPCombatSkills, End of Day
+	#3		Earrings			LOV Earrings	Acc   - 25% Moxie Stats, +3 PrismRes, +50% Meat, End of Day
+	#4		Nothing
 
 	if(engineer)
 	{
-		autoAdvBypass("choice.php?pwd=&whichchoice=1225&option=1", option);
+		backupSetting("choiceAdventure1225", "1"); // L.O.V. Engine Room - Fight Engineer
 	}
 	else
 	{
-		string temp = visit_url("choice.php?pwd=&whichchoice=1225&option=2");
+		backupSetting("choiceAdventure1225", "2"); // L.O.V. Engine Room - Skip Engineer
 	}
 
-	temp = visit_url("choice.php?pwd=&whichchoice=1226&option=" + loveEffect);
-#1	Lovebotamy					+10 stats per fight
-#2	Open Heart Surgery			+10 familiar weight (50 adventures)
-#3	Wandering Eye Surgery		+50% item drops (50 adventures)
-#4	Nothing
+	backupSetting("choiceAdventure1226", to_string(loveEffect)); // L.O.V. Emergency Room
+	#1	Lovebotamy					+10 stats per fight
+	#2	Open Heart Surgery			+10 familiar weight (50 adventures)
+	#3	Wandering Eye Surgery		+50% item drops (50 adventures)
+	#4	Nothing
 
 	if(equivocator)
 	{
-		autoAdvBypass("choice.php?pwd=&whichchoice=1227&option=1", option);
+		backupSetting("choiceAdventure1227", "1"); // L.O.V. Elbow Room - Fight Equivocator
 	}
 	else
 	{
-		string temp = visit_url("choice.php?pwd=&whichchoice=1227&option=2");
+		backupSetting("choiceAdventure1227", "2"); // L.O.V. Elbow Room - Skip Equivocator
 	}
 
-	temp = visit_url("choice.php?pwd=&whichchoice=1228&option=" + giftItem);
-#1		Boomerang			LOV Enamorang (combat item) stagger, consumed (15 turn later copy?)
-#2		Toy Dart Gun		LOV Emotionizer (usable self/others)
-#3		Chocolate			LOV Extraterrestrial Chocolate (+3/2/1 advs, independent chocolate?)
-#4		Flowers				LOV Echinacea Bouquet (Spleen). (stats + small hp/mp, 1 toxicity)
-#5		Plush Elephant		LOV Elephant (Shield, DR+10)
-#6		Toast? Only with Space Jellyfish?
-#7		Nothing
-	if(enforcer || engineer || equivocator)
-	{
-		set_property("auto_disableAdventureHandling", false);
-		cli_execute("auto_post_adv");
-	}
+	backupSetting("choiceAdventure1228", to_string(giftItem));
+	#1		Boomerang			LOV Enamorang (combat item) stagger, consumed (15 turn later copy?)
+	#2		Toy Dart Gun		LOV Emotionizer (usable self/others)
+	#3		Chocolate			LOV Extraterrestrial Chocolate (+3/2/1 advs, independent chocolate?)
+	#4		Flowers				LOV Echinacea Bouquet (Spleen). (stats + small hp/mp, 1 toxicity)
+	#5		Plush Elephant		LOV Elephant (Shield, DR+10)
+	#6		Toast? Only with Space Jellyfish?
+	#7		Nothing
+
+	boolean retval = autoAdv($location[The Tunnel of L.O.V.E.]);
+
 	if(item_amount($item[LOV Extraterrestrial Chocolate]) > 0)
 	{
 		use(1, $item[LOV Extraterrestrial Chocolate]);
 	}
-	return true;
+	return retval;
 }
 
 boolean kgbWasteClicks()

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -197,30 +197,8 @@ boolean godLobsterCombat(item it, int goal, string option)
 	}
 	else
 	{
+		set_property("_auto_lobsterChoice", to_string(goal));
 		autoAdv(1, $location[Noob Cave], option);
-		temp = visit_url("main.php");
-
-		string search = "I'd like part of your regalia.";
-		if(goal == 2)
-		{
-			search = "I'd like a blessing.";
-		}
-		else if(goal == 3)
-		{
-			search = "I'd like some experience.";
-		}
-
-		int choice = 0;
-		foreach idx, str in available_choice_options()
-		{
-			if(contains_text(str,search))
-			{
-				choice = idx;
-			}
-		}
-		backupSetting("choiceAdventure1310", choice);
-		temp = visit_url("choice.php?pwd=&whichchoice=1310&option=" + choice, true);
-		restoreSetting("choiceAdventure1310");
 	}
 
 	set_property("auto_disableAdventureHandling", false);

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1521,15 +1521,7 @@ boolean L11_mauriceSpookyraven()
 
 		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
 
-		if(equipped_amount($item[Unstable Fulminate]) == 1)
-		{
-			autoAdv(1, $location[The Haunted Boiler Room]);
-			return true;
-		}
-		else
-		{
-			abort("Tried to adventure in [Haunted Boiler Room] without an [Unstable Fulminate] equipped! Aborting to avoid wasting turns...");
-		}
+		return autoAdv(1, $location[The Haunted Boiler Room]);
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -1,6 +1,6 @@
 script "auto_quest_level_13.ash"
 
-boolean L13_towerNSEntrance()
+boolean L13_powerLevel()
 {
 	// this function is exceptionally badly named. It powerlevels to 13 and nothing else. Should be refactored.
 	if(internalQuestStatus("questL13Final") < 0)


### PR DESCRIPTION
# Description

- fixes for God Lobster post-combat choice abort and Tunnel of L.O.V.E handling (doesn't use choiceAdventureScript since it's not necessary. Technically neither should the God Lobster).
- also fix a missing function rename from PR #284 

## How Has This Been Tested?

Tested the LOV handling on my regular account with some copy & paste shenanigans.
God Lobster change is 100% untested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
