### PR TITLE
redoing the unstable fulminate fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -65,12 +65,23 @@ boolean autoEquip(item it)
 
 // specifically intended for forcing something in to a specific slot,
 // instead of just forcing it to be equipped in general
-// made for Antique Machete, mainly
+// mostly for the Antique Machete and unstable fulminate
 boolean autoForceEquip(slot s, item it)
 {
 	if(!possessEquipment(it) || !auto_can_equip(it))
 	{
 		return false;
+	}
+	if($slot[off-hand] == s)
+	{
+		if (weapon_hands(equipped_item($slot[weapon])) > 1)
+		{
+			removeFromMaximize("+equip " + equipped_item($slot[weapon]));
+			equip($slot[weapon], $item[none]);
+		}
+		removeFromMaximize("-equip " + it);
+		addToMaximize("-off-hand, 1hand");
+		return equip($slot[off-hand], it);
 	}
 	if(equip(s, it))
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -308,7 +308,10 @@ void handlePreAdventure(location place)
 		{
 			abort("Tried to charge a WineBomb but don't have one.");
 		}
-		autoEquip($slot[off-hand], $item[Unstable Fulminate]);
+		if(!autoForceEquip($slot[off-hand], $item[Unstable Fulminate]))
+		{
+			abort("Tried to adventure in [The Haunted Boiler Room] without an [Unstable Fulminate]");
+		}
 	}
 
 	if(place == $location[The Black Forest])

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -308,9 +308,14 @@ void handlePreAdventure(location place)
 		{
 			abort("Tried to charge a WineBomb but don't have one.");
 		}
-		if(!autoForceEquip($slot[off-hand], $item[Unstable Fulminate]))
+		if(equipped_amount($item[Unstable Fulminate]) == 0)
 		{
-			abort("Tried to adventure in [The Haunted Boiler Room] without an [Unstable Fulminate]");
+			auto_log_warning("Tried to adventure in [The Haunted Boiler Room] without an [Unstable Fulminate]... correcting", "red");
+			autoForceEquip($slot[off-hand], $item[Unstable Fulminate]);
+			if(equipped_amount($item[Unstable Fulminate]) == 0)
+			{
+				abort("Correction failed, please report this. Manually get the [wine bomb] then run me again");
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1495,33 +1495,23 @@ boolean L11_mauriceSpookyraven()
 
 	if (possessEquipment($item[Unstable Fulminate]) && internalQuestStatus("questL11Manor") < 3)
 	{
-		if(weapon_hands(equipped_item($slot[weapon])) > 1)
-		{
-			autoEquip($slot[weapon], $item[none]);
-		}
-		auto_log_info("Now we mix and heat it up.", "blue");
+		auto_MaxMLToCap(auto_convertDesiredML(82), true);
+		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
 
 		if((auto_my_path() == "Picky") && (item_amount($item[gumshoes]) > 0))
 		{
 			auto_change_mcd(0);
 			autoEquip($slot[acc2], $item[gumshoes]);
 		}
-
-		if(!autoEquip($item[Unstable Fulminate]))
-		{
-			abort("Unstable Fulminate was not equipped. Please report this and include the following: Equipped items and if you have or don't have an Unstable Fulminate. For now, get the wine bomb manually, and run again.");
-		}
-
+		
 		if(monster_level_adjustment() < 57)
 		{
 			buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
 		}
-
-		auto_MaxMLToCap(auto_convertDesiredML(82), true);
-
-		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
-
-		return autoAdv(1, $location[The Haunted Boiler Room]);
+		
+		//unstable fulminate is being forcibly equipped in auto_pre_adv.ash
+		auto_log_info("Now we mix and heat it up.", "blue");
+		return autoAdv(1, $location[The Haunted Boiler Room]);	
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1509,7 +1509,11 @@ boolean L11_mauriceSpookyraven()
 			buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
 		}
 		
-		//unstable fulminate is being forcibly equipped in auto_pre_adv.ash
+		if(!autoForceEquip($slot[off-hand], $item[Unstable Fulminate]))
+		{
+			abort("Unstable Fulminate was not equipped. Please report this and include the following: Equipped items and if you have or don't have an Unstable Fulminate. For now, get the wine bomb manually, and run again.");
+		}
+		
 		auto_log_info("Now we mix and heat it up.", "blue");
 		return autoAdv(1, $location[The Haunted Boiler Room]);	
 	}


### PR DESCRIPTION
# Description

Redoing the unstable fulminate fix. I handled incorrectly earlier, it seemed fine because it was catching an instance where maximize was failing. But I didn't notice that the way I handled it would "catch" all attempts to adventure there, as it triggers before the maximizer.

This should be done correctly this time. I managed to adventure with it and complete the wine bomb. Additionally I think the new implementation is more robust and will solve other instances where it fails to equip the unstable fulminate.

## How Has This Been Tested?

vampyre softcore run, used the unstable fulminate with it to make the wine bomb.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
