### PR TITLE
War farm sidequest

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -181,6 +181,8 @@ void initializeSettings()
 	set_property("auto_replaces", "");
 	set_property("auto_consumeKeyLimePies", true);
 	set_property("auto_skipNuns", "false");
+	set_property("auto_skipL12Farm", "false");
+	set_property("auto_L12FarmStage", "0");
 	set_property("choiceAdventure1003", 0);
 	beehiveConsider();
 
@@ -4926,7 +4928,7 @@ boolean doTasks()
 
 	if(L9_leafletQuest())				return true;
 	if(L7_crypt())						return true;
-	if(fancyOilPainting())			return true;
+	if(fancyOilPainting())				return true;
 
 	if((my_level() >= 7) && (my_daycount() != 2) && LX_freeCombats())
 	{
@@ -4935,7 +4937,7 @@ boolean doTasks()
 
 	if(L8_trapperStart())				return true;
 	if(L8_trapperGround())				return true;
-	if(L8_trapperNinjaLair())				return true;
+	if(L8_trapperNinjaLair())			return true;
 	if(L8_trapperGroar())				return true;
 	if(LX_steelOrgan())					return true;
 	if(L10_plantThatBean())				return true;
@@ -4956,7 +4958,7 @@ boolean doTasks()
 	if(L11_nostrilOfTheSerpent())		return true;
 	if(L11_unlockHiddenCity())			return true;
 	if(L11_hiddenCityZones())			return true;
-	if(ornateDowsingRod())			return true;
+	if(ornateDowsingRod())				return true;
 	if(L11_aridDesert())				return true;
 
 	if (get_property("sidequestNunsCompleted") != "none" && item_amount($item[Half A Purse]) == 1)
@@ -4975,15 +4977,16 @@ boolean doTasks()
 	if(L11_unlockEd())					return true;
 	if(L11_defeatEd())					return true;
 	if(L12_gremlins())					return true;
-	if(L12_sonofaFinish())			return true;
+	if(L12_sonofaFinish())				return true;
 	if(L12_sonofaBeach())				return true;
 	if(L12_filthworms())				return true;
-	if(L12_orchardFinalize())		return true;
-	if(L12_themtharHills())			return true;
+	if(L12_orchardFinalize())			return true;
+	if(L12_themtharHills())				return true;
+	if(L12_farm())						return true;
 	if(L11_getBeehive())				return true;
 	if(L12_finalizeWar())				return true;
 	if(LX_getDigitalKey())				return true;
-	if(LX_getStarKey())				return true;
+	if(LX_getStarKey())					return true;
 	if(L12_lastDitchFlyer())			return true;
 
 	if(!get_property("kingLiberated").to_boolean() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
@@ -4995,9 +4998,9 @@ boolean doTasks()
 		}
 	}
 
-	if (L12_clearBattlefield())		return true;
-	if(LX_koeInvaderHandler())		return true;
-	if(L13_powerLevel())			return true;
+	if (L12_clearBattlefield())			return true;
+	if(LX_koeInvaderHandler())			return true;
+	if(L13_powerLevel())				return true;
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
 	if(L13_sorceressDoor())				return true;

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -992,6 +992,15 @@ string auto_combatHandler(int round, string opp, string text)
 			return useItem($item[Jam Band Flyers]);
 		}
 	}
+	
+	if(canUse($item[chaos butterfly]) && !get_property("chaosButterflyThrown").to_boolean() && !get_property("auto_skipL12Farm").to_boolean())
+	{
+		if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
+		{
+			return useItems($item[chaos butterfly], $item[Time-Spinner]);
+		}
+		return useItem($item[chaos butterfly]);
+	}
 
 	if(item_amount($item[Cocktail Napkin]) > 0)
 	{
@@ -2740,6 +2749,15 @@ string auto_edCombatHandler(int round, string opp, string text)
 			}
 			return useItem($item[Jam Band Flyers]);
 		}
+	}
+	
+	if(canUse($item[chaos butterfly]) && !get_property("chaosButterflyThrown").to_boolean() && !get_property("auto_skipL12Farm").to_boolean())
+	{
+		if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
+		{
+			return useItems($item[chaos butterfly], $item[Time-Spinner]);
+		}
+		return useItem($item[chaos butterfly]);
 	}
 
 	if((enemy == $monster[dirty thieving brigand]) && !contains_text(edCombatState, "curse of fortune"))

--- a/RELEASE/scripts/autoscend/auto_koe.ash
+++ b/RELEASE/scripts/autoscend/auto_koe.ash
@@ -13,6 +13,7 @@ boolean koe_initializeSettings()
 		set_property("auto_holeinthesky", false);
 		set_property("auto_grimstoneOrnateDowsingRod", "false");
 		set_property("auto_paranoia", 3);
+		set_property("auto_skipL12Farm", "true");
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -1590,10 +1590,7 @@ boolean L12_farm()
 			{
 				return true;
 			}
-			else
-			{
-				set_property("auto_L12FarmStage", "1");
-			}
+			set_property("auto_L12FarmStage", "1");
 		}
 		if(get_property("auto_L12FarmStage").to_int() == 1)
 		{
@@ -1601,10 +1598,7 @@ boolean L12_farm()
 			{
 				return true;
 			}
-			else
-			{
-				set_property("auto_L12FarmStage", "2");
-			}
+			set_property("auto_L12FarmStage", "2");
 		}
 		if(get_property("auto_L12FarmStage").to_int() == 2)
 		{
@@ -1612,10 +1606,7 @@ boolean L12_farm()
 			{
 				return true;
 			}
-			else
-			{
-				set_property("auto_L12FarmStage", "3");
-			}
+			set_property("auto_L12FarmStage", "3");
 		}
 		if(get_property("auto_L12FarmStage").to_int() == 3)
 		{
@@ -1623,10 +1614,7 @@ boolean L12_farm()
 			{
 				return true;
 			}
-			else
-			{
-				set_property("auto_L12FarmStage", "4");
-			}
+			set_property("auto_L12FarmStage", "4");
 		}
 		if(get_property("auto_L12FarmStage").to_int() == 4)
 		{
@@ -1636,10 +1624,7 @@ boolean L12_farm()
 			{
 				return true;
 			}
-			else
-			{
-				abort("Failed to turn in L12 Farm sidequest. please finish it manually and run me again");
-			}
+			abort("Failed to turn in L12 Farm sidequest. please finish it manually and run me again");
 		}
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -80,6 +80,7 @@ int spleen_left();
 int stomach_left();
 int fullness_left();
 int inebriety_left();
+boolean canPull(item it);
 void pullAll(item it);
 void pullAndUse(item it, int uses);
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);
@@ -4313,6 +4314,47 @@ boolean in_ronin()
 	return !can_interact();
 }
 
+boolean canPull(item it)
+{
+	if(in_hardcore())
+	{
+		return false;
+	}
+	if(it == $item[none])
+	{
+		return false;
+	}
+	if(!is_unrestricted(it))
+	{
+		return false;
+	}
+	if(pulls_remaining() == 0)
+	{
+		return false;
+	}
+	
+	if(storage_amount(it) > 0)
+	{
+		return true;
+	}
+
+	int meat = my_storage_meat();
+	if(can_interact())
+	{
+		meat = max(meat, my_meat() - 5000);
+	}
+	int curPrice = auto_mall_price(it);
+	if (curPrice >= 20000)
+	{
+		return false;
+	}
+	else if (curPrice < meat)
+	{
+		return true;
+	}
+	
+	return false;
+}
 
 void pullAll(item it)
 {

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -113,18 +113,31 @@ boolean L11_unlockEd();
 boolean L11_defeatEd();
 boolean L11_getBeehive();
 boolean L11_fistDocuments();
-boolean L12_lastDitchFlyer();
-boolean L12_flyerBackup();
-boolean L12_flyerFinish();
-boolean L12_preOutfit();
-boolean L12_getOutfit();
-boolean L12_startWar();
-boolean L12_filthworms();
-boolean L12_sonofaBeach();
-boolean L12_sonofaFinish();
-boolean L12_gremlins();
-boolean L12_orchardFinalize();
-boolean L12_finalizeWar();
+string auto_warSide();										//Defined in autoscend/auto_quest_level_12.ash
+int auto_warSideQuestsDone();								//Defined in autoscend/auto_quest_level_12.ash
+int auto_warEnemiesRemaining();								//Defined in autoscend/auto_quest_level_12.ash
+int auto_warKillsPerBattle();								//Defined in autoscend/auto_quest_level_12.ash
+int auto_warKillsPerBattle(int sidequests);					//Defined in autoscend/auto_quest_level_12.ash
+int auto_warTotalBattles(int plan, int remaining);			//Defined in autoscend/auto_quest_level_12.ash
+int auto_warTotalBattles(int plan);							//Defined in autoscend/auto_quest_level_12.ash
+boolean warAdventure();										//Defined in autoscend/auto_quest_level_12.ash
+boolean haveWarOutfit();									//Defined in autoscend/auto_quest_level_12.ash
+boolean warOutfit();										//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_sonofaPrefix();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_themtharHills();								//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_farm();											//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_lastDitchFlyer();								//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_flyerBackup();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_flyerFinish();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_preOutfit();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_getOutfit();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_startWar();										//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_filthworms();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_sonofaBeach();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_sonofaFinish();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_gremlins();										//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_orchardFinalize();								//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_finalizeWar();									//Defined in autoscend/auto_quest_level_12.ash
 boolean L13_powerLevel();
 boolean L13_sorceressDoor();
 boolean L13_towerNSContests();
@@ -267,7 +280,6 @@ boolean useCocoon();
 
 
 //Large pile dump.
-boolean L12_sonofaPrefix();									//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
 boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash
 boolean LM_boris();											//Defined in autoscend/auto_boris.ash
@@ -526,7 +538,6 @@ int doNumberology(string goal, boolean doIt);				//Defined in autoscend/auto_uti
 int doNumberology(string goal, boolean doIt, string option);//Defined in autoscend/auto_util.ash
 int doNumberology(string goal, string option);				//Defined in autoscend/auto_util.ash
 boolean doTasks();											//Defined in autoscend.ash
-boolean L12_themtharHills();									//Defined in autoscend.ash
 boolean isSpeakeasyDrink(item drink); //Defined in autoscend/auto_clan.ash
 boolean canDrinkSpeakeasyDrink(item drink); //Defined in autoscend/auto_clan.ash
 boolean drinkSpeakeasyDrink(item drink);					//Defined in autoscend/auto_clan.ash
@@ -940,9 +951,6 @@ int whitePixelCount();										//Defined in autoscend/auto_util.ash
 boolean careAboutDrops(monster mon);						//Defined in autoscend/auto_util.ash
 boolean volcano_bunkerJob();								//Defined in autoscend/auto_elementalPlanes.ash
 boolean volcano_lavaDogs();									//Defined in autoscend/auto_elementalPlanes.ash
-boolean warAdventure();										//Defined in autoscend.ash
-boolean haveWarOutfit();									//Defined in autoscend.ash
-boolean warOutfit();										//Defined in autoscend.ash
 item whatHiMein();											//Defined in autoscend/auto_util.ash
 effect whatStatSmile();										//Defined in autoscend/auto_util.ash
 void woods_questStart();									//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -115,9 +115,13 @@ boolean L11_getBeehive();
 boolean L11_fistDocuments();
 string auto_warSide();										//Defined in autoscend/auto_quest_level_12.ash
 int auto_warSideQuestsDone();								//Defined in autoscend/auto_quest_level_12.ash
+int auto_warSideQuestsState();								//Defined in autoscend/auto_quest_level_12.ash
 int auto_warEnemiesRemaining();								//Defined in autoscend/auto_quest_level_12.ash
 int auto_warKillsPerBattle();								//Defined in autoscend/auto_quest_level_12.ash
 int auto_warKillsPerBattle(int sidequests);					//Defined in autoscend/auto_quest_level_12.ash
+int auto_warAdvReqCB();										//Defined in autoscend/auto_quest_level_12.ash
+int auto_warAdvReqFarm();									//Defined in autoscend/auto_quest_level_12.ash
+int auto_warPlan();											//Defined in autoscend/auto_quest_level_12.ash
 int auto_warTotalBattles(int plan, int remaining);			//Defined in autoscend/auto_quest_level_12.ash
 int auto_warTotalBattles(int plan);							//Defined in autoscend/auto_quest_level_12.ash
 boolean warAdventure();										//Defined in autoscend/auto_quest_level_12.ash
@@ -125,6 +129,7 @@ boolean haveWarOutfit();									//Defined in autoscend/auto_quest_level_12.ash
 boolean warOutfit();										//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_sonofaPrefix();									//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_themtharHills();								//Defined in autoscend/auto_quest_level_12.ash
+boolean LX_chaosButterfly();								//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_farm();											//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_lastDitchFlyer();								//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_flyerBackup();									//Defined in autoscend/auto_quest_level_12.ash
@@ -891,6 +896,7 @@ float provideMysticality(int amt, boolean doEquips, boolean speculative); //Defi
 boolean provideMysticality(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
 float provideMoxie(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean provideMoxie(int amt, boolean doEquips); //Defined in autoscend/auto_util.ash
+boolean canPull(item it);									//Defined in autoscend/auto_util.ash
 void pullAll(item it);										//Defined in autoscend/auto_util.ash
 void pullAndUse(item it, int uses);							//Defined in autoscend/auto_util.ash
 boolean pullXWhenHaveY(item it, int howMany, int whenHave);	//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

Farm sidequest handling for L12 war quest.

## How Has This Been Tested?

Plumber softcore as hippy, when I applied this patch to this run the war already started, but all i did in it was spend 1 turn in the orchard. had a chaos butterfly in inventory already and it correctly performed the sidequest

plumber softcore as fratboy

Vampyre softcore as fratboy, 0 skill 0 iotm. did find a bug. fixed below.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
