### PR TITLE
fix infinite loop for hardcore at pre-war outfit with no summons

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -250,7 +250,7 @@ boolean L12_preOutfit()
 	if(!get_property("auto_hippyInstead").to_boolean())
 	{
 		auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
-		if(internalQuestStatus("questL12War") > -1)
+		if(internalQuestStatus("questL12War") == -1)
 		{
 			autoAdv(1, $location[Hippy Camp]);
 		}
@@ -263,7 +263,7 @@ boolean L12_preOutfit()
 	else
 	{
 		auto_log_info("Trying to acquire a frat boy ensemble", "blue");
-		if(internalQuestStatus("questL12War") > -1)
+		if(internalQuestStatus("questL12War") == -1)
 		{
 			autoAdv(1, $location[Frat House]);
 		}


### PR DESCRIPTION
fix to getting frat boy ensemble and filthy hippy disguise before the war quest started for hardcore players without any summoning ability.

## How Has This Been Tested?

Sent a copy of it to someone on discord who was having the issue and it solved it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
