### PR TITLE
Plumber and a few other fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2170,18 +2170,6 @@ boolean doBedtime()
 		}
 		if((my_inebriety() <= inebriety_limit()) && (my_rain() >= 50) && (my_adventures() >= 1))
 		{
-			if(item_amount($item[beer helmet]) == 0)
-			{
-				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
-				if(canYellowRay())
-				{
-					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
-				}
-			}
-			else
-			{
-				auto_log_info("If you have the Frat Warrior Fatigues, rain man an Astronomer? Skinflute?", "blue");
-			}
 			auto_log_info("You have a rain man to cast, please do so before overdrinking and then run me again.", "red");
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_quest_level_4.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_4.ash
@@ -18,8 +18,15 @@ boolean L4_batCave()
 	int batStatus = internalQuestStatus("questL04Bat");
 	if((item_amount($item[Sonar-In-A-Biscuit]) > 0) && (batStatus < 3))
 	{
-		use(1, $item[Sonar-In-A-Biscuit]);
-		return true;
+		if(use(1, $item[Sonar-In-A-Biscuit]))
+		{
+			return true;
+		}
+		else
+		{
+			auto_log_warning("Failed to use [Sonar-In-A-Biscuit] for some reason. refreshing inventory and skipping", "red");
+			cli_execute("refresh inv");
+		}
 	}
 
 	if(batStatus >= 4)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1296,6 +1296,11 @@ boolean acquireMP(int goal, int meat_reserve){
  */
 boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 {
+	//vampyres don't use MP
+	if(my_class() == $class[Vampyre])
+	{
+		return false;
+	}
 
   boolean isMax = (goal == my_maxmp());
 
@@ -1392,6 +1397,13 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
     // Ed doesn't need to heal outside of combat unless on 0 hp
     return false;
   }
+  
+	//vampyres can only be restored using blood bags, which are too valuable to waste on healing HP.
+	//better to make food/drink from them and then rest in your coffin
+	if(my_class() == $class[Vampyre])
+	{
+		return false;
+	}
   
   boolean isMax = (goal == my_maxhp());
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2923,9 +2923,10 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		auto_powerfulGloveNoncombat();
 	}
 
-	// TODO: And we have >400 coins. Or some cutoff.
+	//blooper ink costs 15 coins without which it will error when trying to buy it, so that is the bare minimum we need to check for
+	//However we don't want to waste our early coins on it as they are precious. So require at least 400 coins before buying it.
 	if((numeric_modifier("Combat Rate").to_int() + equipDiff > amt) &&
-	   my_class() == $class[Plumber] && 0 == have_effect($effect[Blooper Inked]))
+	   my_class() == $class[Plumber] && 0 == have_effect($effect[Blooper Inked]) && item_amount($item[coin]) > 400)
 	{
 		retrieve_item(1, $item[blooper ink]);
 		buffMaintain($effect[Blooper Inked], 0, 1, 1);

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -265,6 +265,10 @@ zelda_buyable zelda_nextBuyable()
 	{
 		return zelda_buyableItem($item[bony back shell]);
 	}
+	else if (!possessEquipment($item[bonfire flower]))
+	{
+		return zelda_buyableItem($item[bonfire flower]);
+	}
 
 	zelda_buyable nothing;
 	return nothing;


### PR DESCRIPTION
# Description

I spun off the common issues into their own pull request / branch. left previous branch to deal with the 2adv stuff.

This branch does:

issue 1: trying to use providePlusNonCombat() in plumber with less than 15 coins would produce an error with a stack trace (and probably skipping the rest of the buff function) due to trying to buy blooper ink without enough coins to do so. (requires 15).
Additionally there was a todo there to make the check 400 coins because blooper ink is very wasteful early on the run before you have bought more important things like a scaling damage source.
I added a check for number of coins and set it to 400

issue 2: don't assume success when using sonar-in-a-biscuit

issue 3: don't print overly specific advice instructing the player to do stuff we do automatically anyways, without even enough checks to make sure it is actually applicable.

issue 4: vampyres can't use HP restorers and don't have MP so no need for MP restorers. but they can waste them by trying to use them. don't do so.
Fixes #291 

issue 5: plumbers should get a bonfire flower. it keeps on dying to a boss ghost because it doesn't deal enough fire damage. would also help with smut orcs. its last on the list of things to buy.

## How Has This Been Tested?

Vampyre run, several plumber runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
