### PR TITLE
Fixing/removing workarounds we had for (now fixed) mafia issues.

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -17,10 +17,10 @@ auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; t
 auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
 auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-auto_blacklistFamiliar	string	A semi-colon separate string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Ashton Kutcher (ignores Soda Bread).
-auto_limitConsume	boolean	When false, will not eat or drink anything automatically.
+auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
 auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
 auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -25,10 +25,10 @@ any	15	auto_floundryChoice	string	Force floundry usage. Must use the item name (
 any	16	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
 any	17	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 any	18	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	19	auto_blacklistFamiliar	string	A semi-colon separate string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
 any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Ashton Kutcher (ignores Soda Bread).
-any	22	auto_limitConsume	boolean	When false, will not eat or drink anything automatically.
+any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
 any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
 any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19953; // Detect when a fight follows a choice. WHen automating with adv1 or adventure, automate that fight.
+since r19979; // If you can recover HP or MP with a restorative, it is not banned in your path
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -413,7 +413,7 @@ boolean acquireMilkOfMagnesiumIfUnused(boolean useAdv)
 
 boolean consumeMilkOfMagnesiumIfUnused()
 {
-	if(get_property("_milkOfMagnesiumUsed").to_boolean())
+	if(get_property("_milkOfMagnesiumUsed").to_boolean() || item_amount($item[Milk Of Magnesium]) < 1)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -46,9 +46,6 @@ void ed_initializeSettings()
 		set_property("auto_edCombatRoundCount", 0);
 
 		set_property("choiceAdventure1002", 1);
-		remove_property("choiceAdventure1023");
-		remove_property("choiceAdventure1024");
-		set_property("edDefeatAbort", "4"); // we have to set this stupidly high to stop mafia interrupting us.
 		set_property("desertExploration", 100);
 		set_property("nsTowerDoorKeysUsed", "Boris's key,Jarlsberg's key,Sneaky Pete's key,Richard's star key,skeleton key,digital key");
 		set_property("auto_delayHauntedKitchen", true);
@@ -68,6 +65,11 @@ void ed_initializeSession()
 			set_property("hpAutoRecovery", 0.0);
 			set_property("hpAutoRecoveryTarget", 0.1);
 		}
+		// the following settings will affect combat automation
+		// see auto_choice_adv.ash for where and how they are used.
+		backupSetting("choiceAdventure1023", "");
+		backupSetting("choiceAdventure1024", "");
+		backupSetting("edDefeatAbort", "3");
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -561,35 +561,7 @@ boolean handleBjornify(familiar fam)
 
 void equipBaseline()
 {
-	if(my_daycount() == 1)
-	{
-		if(have_familiar($familiar[grimstone golem]))
-		{
-			if(get_property("_grimFairyTaleDropsCrown").to_int() >= 1)
-			{
-				handleBjornify($familiar[El Vibrato Megadrone]);
-			}
-		}
-		else
-		{
-			handleBjornify($familiar[El Vibrato Megadrone]);
-		}
-	}
-	if(my_daycount() == 2)
-	{
-		handleBjornify($familiar[El Vibrato Megadrone]);
-	}
-
-	if(get_property("auto_diceMode").to_boolean())
-	{
-		autoEquip($slot[acc1], $item[Dice Ring]);
-		autoEquip($slot[acc2], $item[Dice Belt Buckle]);
-		autoEquip($slot[acc3], $item[Dice Sunglasses]);
-		autoEquip($slot[hat], $item[Dice-Print Do-Rag]);
-		autoEquip($slot[back], $item[Dice-Shaped Backpack]);
-		autoEquip($slot[pants], $item[Dice-Print Pajama Pants]);
-		autoEquip($slot[familiar], $item[Kill Screen]);
-	}
+	equipMaximizedGear();
 }
 
 void ensureSealClubs()

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -153,7 +153,6 @@ void handleKingLiberation()
 	{
 		restoreSetting("kingLiberatedScript");
 		restoreSetting("afterAdventureScript");
-		restoreSetting("betweenAdventureScript");
 		restoreSetting("betweenBattleScript");
 		restoreSetting("counterScript");
 	}

--- a/RELEASE/scripts/autoscend/auto_quest_level_10.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_10.ash
@@ -72,13 +72,6 @@ boolean L10_airship()
 		buffMaintain($effect[Gummed Shoes], 0, 1, 1);
 	}
 
-	if (isActuallyEd() && $location[The Penultimate Fantasy Airship].turns_spent < 1)
-	{
-		// temp workaround for mafia bug.
-		// see https://kolmafia.us/showthread.php?24767-Quest-tracking-preferences-change-request(s)&p=156733&viewfull=1#post156733
-		visit_url("place.php?whichplace=beanstalk");
-	}
-
 	autoAdv(1, $location[The Penultimate Fantasy Airship]);
 	handleFamiliar("item");
 	return true;

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1825,9 +1825,8 @@ boolean L11_talismanOfNam()
 
 boolean L11_palindome()
 {
-	if (!possessEquipment($item[Talisman O\' Namsilat]) || internalQuestStatus("questL11Palindome") > 5)
+	if (internalQuestStatus("questL11Palindome") < 0 || internalQuestStatus("questL11Palindome") > 5)
 	{
-		// mafia doesn't set questL11Palindome to started until you adventure in the Palindome
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_quest_level_4.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_4.ash
@@ -8,7 +8,7 @@ boolean L4_batCave()
 	}
 
 	auto_log_info("In the bat hole!", "blue");
-	visit_url("place.php?whichplace=bathole"); // ensure quest status is updated.
+
 	if(considerGrimstoneGolem(true))
 	{
 		handleBjornify($familiar[Grimstone Golem]);
@@ -33,7 +33,7 @@ boolean L4_batCave()
 	{
 		if (item_amount($item[Enchanted Bean]) == 0 && internalQuestStatus("questL10Garbage") < 2 && !isActuallyEd())
 		{
-			autoAdv(1, $location[The Beanbat Chamber]);
+			autoAdv($location[The Beanbat Chamber]);
 			return true;
 		}
 		council();
@@ -51,7 +51,7 @@ boolean L4_batCave()
 		addToMaximize("10meat");
 		int batskinBelt = item_amount($item[Batskin Belt]);
 		auto_change_mcd(4); // get the pants from the Boss Bat.
-		autoAdv(1, $location[The Boss Bat\'s Lair]);
+		autoAdv($location[The Boss Bat\'s Lair]);
 		# DIGIMON remove once mafia tracks this
 		if(item_amount($item[Batskin Belt]) != batskinBelt)
 		{
@@ -64,16 +64,16 @@ boolean L4_batCave()
 		bat_formBats();
 		if (item_amount($item[Enchanted Bean]) == 0 && internalQuestStatus("questL10Garbage") < 2 && !isActuallyEd())
 		{
-			autoAdv(1, $location[The Beanbat Chamber]);
+			autoAdv($location[The Beanbat Chamber]);
 			return true;
 		}
-		autoAdv(1, $location[The Batrat and Ratbat Burrow]);
+		autoAdv($location[The Batrat and Ratbat Burrow]);
 		return true;
 	}
 	if(batStatus >= 1)
 	{
 		bat_formBats();
-		autoAdv(1, $location[The Batrat and Ratbat Burrow]);
+		autoAdv($location[The Batrat and Ratbat Burrow]);
 		return true;
 	}
 
@@ -95,6 +95,6 @@ boolean L4_batCave()
 	}
 
 	bat_formBats();
-	autoAdv(1, $location[Guano Junction]);
+	autoAdv($location[Guano Junction]);
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_quest_level_9.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_9.ash
@@ -235,7 +235,7 @@ boolean L9_aBooPeak()
 		return false;
 	}
 	
-	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire1.gif"))
+	if (get_property("booPeakLit").to_boolean())
 	{
 		return false;
 	}
@@ -538,12 +538,7 @@ boolean L9_twinPeak()
 		return false;
 	}
 
-	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire2.gif"))
-	{
-		return false;
-	}
-
-	if(get_property("twinPeakProgress").to_int() >= 15)
+	if (get_property("twinPeakProgress").to_int() >= 15)
 	{
 		return false;
 	}
@@ -767,7 +762,7 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	if(contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
+	if (get_property("oilPeakLit").to_boolean())
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean needJar = ((oilProgress & 4) == 0);
@@ -877,8 +872,9 @@ boolean L9_highLandlord()
 		return false;
 	}
 
-	if (internalQuestStatus("questL09Topping") < 2)
+	if (internalQuestStatus("questL09Topping") == 1)
 	{
+		auto_log_info("Visiting the Highland Lord's tower <ominous music plays>", "blue");
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");
 		set_property("auto_grimstoneFancyOilPainting", false);
 		return true;
@@ -888,10 +884,9 @@ boolean L9_highLandlord()
 	if(L9_aBooPeak())			return true;
 	if(L9_oilPeak())			return true;
 
-	buffer peaks = visit_url("place.php?whichplace=highlands");
-	if (peaks.contains_text("fire1.gif") && peaks.contains_text("fire2.gif") && peaks.contains_text("fire3.gif"))
+	if (internalQuestStatus("questL09Topping") == 3)
 	{
-		auto_log_info("Highlord Done", "blue");
+		auto_log_info("Aw, sweet, dude! You totally lit all the signal fires!", "blue");
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");
 		council();
 		return true;


### PR DESCRIPTION
# Description

This is mostly fixing/removing workarounds we had for mafia issues that have been fixed recently.
See https://kolmafia.us/showthread.php?24767-Quest-tracking-preferences-change-request(s)

Also fixes an issue with Ed aborting after dying a 3rd time in the same combat (my fault not mafia's) and equipBaseline basically doing nothing (again my fault, I removed the non-maximizer code).

I also changed the check for using milk of magnesium to check we have one before we try to blindly use it as the periodic error it threw annoyed me.

## How Has This Been Tested?

Done some HC Ed. Just finished day 1 of a new run which tested the choiceAdventureScript handling successfully.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
