### PR TITLE
rename is100FamiliarRun to forbidFamChange

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -91,13 +91,13 @@ void initializeSettings()
 		{
 			set_property("auto_100familiar", my_familiar());
 		}
-		if(is100FamiliarRun())
+		if(forbidFamChange())
 		{
 			set_property("auto_useCubeling", false);
 		}
 	}
 
-	if(!is100FamiliarRun() && auto_have_familiar($familiar[Crimbo Shrub]))
+	if(!forbidFamChange() && auto_have_familiar($familiar[Crimbo Shrub]))
 	{
 		use_familiar($familiar[Crimbo Shrub]);
 		use_familiar($familiar[none]);
@@ -345,7 +345,7 @@ boolean handleFamiliar(string type)
 
 boolean handleFamiliar(familiar fam)
 {
-	if(is100FamiliarRun())
+	if(forbidFamChange())
 	{
 		return true;
 	}
@@ -917,7 +917,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(((auto_my_path() == "Picky") || is100FamiliarRun()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
+		if(((auto_my_path() == "Picky") || forbidFamChange()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{
@@ -1675,7 +1675,7 @@ boolean doBedtime()
 		return false;
 	}
 	int spleenlimit = spleen_limit();
-	if(is100FamiliarRun())
+	if(forbidFamChange())
 	{
 		spleenlimit -= 3;
 	}
@@ -2776,7 +2776,7 @@ int auto_freeCombatsRemaining()
 {
 	int count = 0;
 	
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && !forbidFamChange())
 	{
 		count += 5-get_property("_machineTunnelsAdv").to_int();
 	}
@@ -2784,7 +2784,7 @@ int auto_freeCombatsRemaining()
 	{
 		count += 10-get_property("_snojoFreeFights").to_int();
 	}
-	if(auto_have_familiar($familiar[God Lobster]) && !is100FamiliarRun())
+	if(auto_have_familiar($familiar[God Lobster]) && !forbidFamChange())
 	{
 		count += 3-get_property("_godLobsterFights").to_int();
 	}
@@ -2829,7 +2829,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && !is100FamiliarRun())
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && !forbidFamChange())
 	{
 		if(get_property("auto_choice1119") != "")
 		{
@@ -4050,7 +4050,7 @@ boolean LX_phatLootToken()
 
 	if((!possessEquipment($item[Ring of Detect Boring Doors]) || (item_amount($item[Eleven-Foot Pole]) == 0) || (item_amount($item[Pick-O-Matic Lockpicks]) == 0)) && auto_have_familiar($familiar[Gelatinous Cubeling]))
 	{
-		if(!is100FamiliarRun($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
+		if(!forbidFamChange($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
 		{
 			return false;
 		}
@@ -4805,7 +4805,7 @@ boolean doTasks()
 
 	basicAdjustML();
 	powerLevelAdjustment();
-	if (is100FamiliarRun() && my_familiar() == $familiar[none])
+	if (forbidFamChange() && my_familiar() == $familiar[none])
 	{
 		// re-equip a familiar if it's a 100% run just in case something unequipped it
 		// looking at you auto_maximizedConsumeStuff()...

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -319,7 +319,7 @@ void preAdvUpdateFamiliar(location place)
 		famChoice = $familiar[none];
 	}
 
-	if((famChoice != $familiar[none]) && !is100FamiliarRun() && (internalQuestStatus("questL13Final") < 13))
+	if((famChoice != $familiar[none]) && !forbidFamChange() && (internalQuestStatus("questL13Final") < 13))
 	{
 		if((famChoice != my_familiar()) && !get_property("kingLiberated").to_boolean())
 		{
@@ -343,7 +343,7 @@ void preAdvUpdateFamiliar(location place)
 				}
 			}
 		}
-		if(wannaHeist && (famChoice != $familiar[none]) && !is100FamiliarRun())
+		if(wannaHeist && (famChoice != $familiar[none]) && !forbidFamChange())
 		{
 			use_familiar($familiar[cat burglar]);
 		}

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -696,7 +696,7 @@ boolean LA_cs_communityService()
 
 			if(!get_property("auto_hccsNoConcludeDay").to_boolean())
 			{
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !forbidFamChange($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -709,7 +709,7 @@ boolean LA_cs_communityService()
 					return true;
 				}
 
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && !is100FamiliarRun($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && !forbidFamChange($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -830,7 +830,7 @@ boolean LA_cs_communityService()
 			}
 			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])))
 			{
-				if(is100familiarRun() && is100familiarRun($familiar[Puck Man]) && is100familiarRun($familiar[Ms. Puck Man]))
+				if(forbidFamChange() && forbidFamChange($familiar[Puck Man]) && forbidFamChange($familiar[Ms. Puck Man]))
 				{}
 				else
 				{
@@ -1016,7 +1016,7 @@ boolean LA_cs_communityService()
 			{
 				missing = 0;
 			}
-			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (!is100familiarRun() || !is100familiarRun($familiar[Puck Man]) || !is100familiarRun($familiar[Ms. Puck Man])))
+			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (!forbidFamChange() || !forbidFamChange($familiar[Puck Man]) || !forbidFamChange($familiar[Ms. Puck Man])))
 			{
 				if(elementalPlanes_access($element[hot]))
 				{
@@ -1081,7 +1081,7 @@ boolean LA_cs_communityService()
 				auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 			}
 
-			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && have_familiar($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11) && !is100FamiliarRun($familiar[XO Skeleton]))
+			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && have_familiar($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11) && !forbidFamChange($familiar[XO Skeleton]))
 			{
 				if((!possessEquipment($item[Fireproof Megaphone]) && !possessEquipment($item[Meteorite Guard])) || !possessEquipment($item[High-Temperature Mining Mask]))
 				{
@@ -2244,7 +2244,7 @@ boolean LA_cs_communityService()
 					autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 					return true;
 				}
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && !is100FamiliarRun($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && !forbidFamChange($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -2410,7 +2410,7 @@ boolean LA_cs_communityService()
 			}
 			asdonBuff($effect[Driving Stealthily]);
 
-			if(!is100FamiliarRun($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
+			if(!forbidFamChange($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
 			{
 				# Need 37-41 pounds to save 3 turns. (probably 40)
 				# 74 does not save 6 but 79 does.
@@ -3062,7 +3062,7 @@ void cs_initializeDay(int day)
 			{
 				familiar last = my_familiar();
 				int gift = 1;
-				if(is100FamiliarRun() && (my_familiar() != $familiar[Crimbo Shrub]))
+				if(forbidFamChange() && (my_familiar() != $familiar[Crimbo Shrub]))
 				{
 					gift = 2;
 				}
@@ -3331,7 +3331,7 @@ void cs_make_stuff(int curQuest)
 			cli_execute("make " + $item[Staff of the Headmaster\'s Victuals]);
 		}
 
-		if(!have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+		if(!have_familiar($familiar[Machine Elf]) && !forbidFamChange())
 		{
 			if(item_amount($item[Handful of Smithereens]) >= 3)
 			{
@@ -4332,7 +4332,7 @@ boolean cs_giant_growth()
 	{
 		fail = false;
 	}
-	if(have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+	if(have_familiar($familiar[Machine Elf]) && !forbidFamChange())
 	{
 		use_familiar($familiar[Machine Elf]);
 		fail = false;
@@ -4768,7 +4768,7 @@ boolean cs_preTurnStuff(int curQuest)
 		januaryToteAcquire($item[Wad Of Used Tape]);
 	}
 
-	if(is100FamiliarRun())
+	if(forbidFamChange())
 	{
 		if((my_familiar() != $familiar[Puck Man]) && (my_familiar() != $familiar[Ms. Puck Man]))
 		{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -510,7 +510,7 @@ boolean handleBjornify(familiar fam)
 		return false;
 	}
 
-	if(is100FamiliarRun() && (fam == my_familiar()))
+	if(forbidFamChange() && (fam == my_familiar()))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -491,7 +491,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 
 	set_property("choiceAdventure970", "0");
 
-	if(is100FamiliarRun($familiar[Reanimated Reanimator]))
+	if(forbidFamChange($familiar[Reanimated Reanimator]))
 	{
 		wink = false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2014.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2014.ash
@@ -46,7 +46,7 @@ boolean dna_startAcquire()
 	}
 	else
 	{
-		if((have_familiar($familiar[Machine Elf])) && is100FamiliarRun($familiar[Machine Elf]))
+		if((have_familiar($familiar[Machine Elf])) && forbidFamChange($familiar[Machine Elf]))
 		{
 			familiar bjorn = my_bjorned_familiar();
 			if(bjorn == $familiar[Machine Elf])

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1185,7 +1185,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !is100FamiliarRun() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !forbidFamChange() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -1091,7 +1091,7 @@ boolean solveKGBMastermind()
 
 boolean getSpaceJelly()
 {
-	if(is100FamiliarRun($familiar[Space Jellyfish]))
+	if(forbidFamChange($familiar[Space Jellyfish]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -148,7 +148,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 	{
 		return false;
 	}
-	if(is100FamiliarRun($familiar[God Lobster]))
+	if(forbidFamChange($familiar[God Lobster]))
 	{
 		return false;
 	}
@@ -288,7 +288,7 @@ boolean fantasyRealmToken()
 	}
 
 	// If we're not allowed to adventure without a familiar
-	if(is100familiarRun() && auto_have_familiar($familiar[Mosquito]))
+	if(forbidFamChange() && auto_have_familiar($familiar[Mosquito]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -919,7 +919,7 @@ boolean L12_filthworms()
 
 	if(have_effect($effect[Filthworm Drone Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -927,7 +927,7 @@ boolean L12_filthworms()
 	}
 	else if(have_effect($effect[Filthworm Larva Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -935,7 +935,7 @@ boolean L12_filthworms()
 	}
 	else
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !is100FamiliarRun($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -1594,7 +1594,7 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
 	songboomSetting("meat");
 
-	if(is100FamiliarRun())
+	if(forbidFamChange())
 	{
 		addToMaximize("200meat drop");
 	}
@@ -1643,7 +1643,7 @@ boolean L12_themtharHills()
 
 
 	handleFamiliar("meat");
-	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && !is100FamiliarRun($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
+	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && !forbidFamChange($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
 		autoEquip($item[Li\'l Pirate Costume]);

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -706,7 +706,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && !is100FamiliarRun())
+		if((auto_have_familiar($familiar[warbear drone])) && !forbidFamChange())
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -722,12 +722,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Sludgepuppy])) && !forbidFamChange())
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && !is100FamiliarRun())
+		else if((auto_have_familiar($familiar[Imitation Crab])) && !forbidFamChange())
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;
@@ -837,7 +837,7 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(is100FamiliarRun())
+		if(forbidFamChange())
 		{
 			addToMaximize("200meat drop");
 		}

--- a/RELEASE/scripts/autoscend/auto_quest_level_8.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_8.ash
@@ -321,7 +321,7 @@ boolean L8_trapperGroar()
 	//What is our potential +Combat score.
 	//TODO: Use that instead of the Avatar/Hound Dog checks.
 
-	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || is100FamiliarRun($familiar[Jumpsuited Hound Dog])))
+	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || forbidFamChange($familiar[Jumpsuited Hound Dog])))
 	{
 		if(L8_trapperExtreme())
 		{

--- a/RELEASE/scripts/autoscend/auto_quest_level_9.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_9.ash
@@ -312,7 +312,7 @@ boolean L9_aBooPeak()
 			lihcface = "-equip lihc face";
 		}
 		string parrot = ", switch exotic parrot, switch mu, switch trick-or-treating tot";
-		if(is100FamiliarRun())
+		if(forbidFamChange())
 		{
 			parrot = "";
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -134,8 +134,8 @@ boolean loopHandler(string turnSetting, string counterSetting, string abortMessa
 boolean loopHandler(string turnSetting, string counterSetting, int threshold);
 boolean loopHandlerDelay(string counterSetting);
 boolean loopHandlerDelay(string counterSetting, int threshold);
-boolean is100FamiliarRun();
-boolean is100FamiliarRun(familiar thisOne);
+boolean forbidFamChange();
+boolean forbidFamChange(familiar thisOne);
 boolean fightScienceTentacle(string option);
 boolean fightScienceTentacle();
 boolean evokeEldritchHorror(string option);
@@ -869,7 +869,7 @@ string reverse(string s)
 	return ret;
 }
 
-boolean is100FamiliarRun()
+boolean forbidFamChange()
 {
 	// Answers the question "am I not allowed to change my familiar?"
 	// Returns true for paths with no familiars
@@ -892,9 +892,9 @@ boolean is100FamiliarRun()
 	return true;
 }
 
-boolean is100FamiliarRun(familiar thisOne)
+boolean forbidFamChange(familiar thisOne)
 {
-	if(is100FamiliarRun())
+	if(forbidFamChange())
 	{
 		if(get_property("auto_100familiar") == thisOne)
 		{
@@ -1319,7 +1319,7 @@ boolean canYellowRay(monster target)
 	# Use this to determine if it is safe to enter a yellow ray combat.
 
 	// first, do any necessary prep to use a yellow ray
-	if((my_familiar() == $familiar[Crimbo Shrub]) || (!is100FamiliarRun($familiar[Crimbo Shrub]) && auto_have_familiar($familiar[Crimbo Shrub])))
+	if((my_familiar() == $familiar[Crimbo Shrub]) || (!forbidFamChange($familiar[Crimbo Shrub]) && auto_have_familiar($familiar[Crimbo Shrub])))
 	{
 		if(item_amount($item[box of old Crimbo decorations]) == 0)
 		{
@@ -3269,7 +3269,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	if(pass())
 		return result();
 
-	if(doEquips && !is100FamiliarRun())
+	if(doEquips && !forbidFamChange())
 	{
 		familiar resfam = $familiar[none];
 		foreach fam in $familiars[Trick-or-Treating Tot, Mu, Exotic Parrot]

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -817,8 +817,8 @@ boolean instakillable(monster mon);							//Defined in autoscend/auto_util.ash
 int[int] intList();											//Defined in autoscend/auto_list.ash
 int internalQuestStatus(string prop);						//Defined in autoscend/auto_util.ash
 int freeCrafts();											//Defined in autoscend/auto_util.ash
-boolean is100FamiliarRun();									//Defined in autoscend/auto_util.ash
-boolean is100FamiliarRun(familiar thisOne);					//Defined in autoscend/auto_util.ash
+boolean forbidFamChange();									//Defined in autoscend/auto_util.ash
+boolean forbidFamChange(familiar thisOne);					//Defined in autoscend/auto_util.ash
 boolean isBanished(monster enemy);							//Defined in autoscend/auto_util.ash
 boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
rename is100FamiliarRun to forbidFamChange
applies to both is100FamiliarRun() and is100FamiliarRun(familiar thisOne)

# Description

Why it is needed:
*There are some bugs related to people thinking "is100FamiliarRun" actually answers the question "is this a 100% familiar run" instead of what it actually does which determine if you are allowed to change familiar.
*I want to make some pokefam specific improvements to those functions (in a future PR).
*A function that actually answers the question "is this a 100% familiar run" instead of what the current function does is actually needed.

To address those issues we either need to create a new function called "isReally100FamiliarRun" and hope people stop making this reasonable mistake. Or rename the existing function and then reuse its name for the new function. Per discussion in discord we are going to rename this.

However my branch where I worked on it kept on requiring manual refactoring to solve merge conflicts because the rename touches on too many different files, and this function is also used too often in new things (such as whenever a new IOTM familiar is added).

As such, I am first going to do a PR for just the rename (this PR).
After it is merged into beta I will start a new branch for just the bug fixes which will go into a separate PR. This allows people to review it without it constantly breaking and requiring refactoring.