### PR TITLE
fix for freecombats aborting when it shouldn't

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2806,6 +2806,11 @@ int auto_freeCombatsRemaining()
 
 boolean LX_freeCombats()
 {
+	if(auto_freeCombatsRemaining() == 0)
+	{
+		return false;
+	}
+	
 	if(my_inebriety() > inebriety_limit())
 	{
 		return false;


### PR DESCRIPTION
# Description

Fix for auto free combats aborting when you have 1 adv left but no free combats.

## How Has This Been Tested?

`validate autoscend.ash`

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
