### PR TITLE
Fam3

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -97,7 +97,7 @@ void initializeSettings()
 		}
 	}
 
-	if(!forbidFamChange() && auto_have_familiar($familiar[Crimbo Shrub]))
+	if(!forbidFamChange($familiar[Crimbo Shrub]))
 	{
 		use_familiar($familiar[Crimbo Shrub]);
 		use_familiar($familiar[none]);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2834,7 +2834,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && !forbidFamChange())
+	if(!in_koe() && get_property("_machineTunnelsAdv").to_int() < 5 && !forbidFamChange($familiar[Machine Elf]))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -11,7 +11,6 @@ void bat_initializeSettings()
 {
 	if(my_path() == "Dark Gyffte")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_cubeItems", false);
 		set_property("auto_getSteelOrgan", false);
 		set_property("auto_grimstoneFancyOilPainting", false);

--- a/RELEASE/scripts/autoscend/auto_bondmember.ash
+++ b/RELEASE/scripts/autoscend/auto_bondmember.ash
@@ -4,7 +4,6 @@ void bond_initializeSettings()
 {
 	if(my_path() == "License to Adventure")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_getBeehive", true);
 		set_property("auto_wandOfNagamar", false);
 		set_property("choiceAdventure1258", 2);

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -4,7 +4,6 @@ void boris_initializeSettings()
 {
 	if(my_path() == "Avatar of Boris")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_grimstoneOrnateDowsingRod", false);

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -82,11 +82,7 @@ boolean settingFixer()
 	}
 	if(get_property("auto_100familiar") == "no")
 	{
-		set_property("auto_100familiar", false);
-	}
-	if(get_property("auto_100familiar") == "true")
-	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
+		set_property("auto_100familiar", $familiar[none]);
 	}
 	if(get_property("auto_100familiar") == "false")
 	{

--- a/RELEASE/scripts/autoscend/auto_digimon.ash
+++ b/RELEASE/scripts/autoscend/auto_digimon.ash
@@ -10,7 +10,6 @@ void digimon_initializeSettings()
 {
 	if(auto_my_path() == "Pocket Familiars")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_getBeehive", false);
 		set_property("auto_getBoningKnife", false);
 		set_property("auto_cubeItems", false);

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -22,7 +22,6 @@ void ed_initializeSettings()
 {
 	if (isActuallyEd())
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_crackpotjar", "done");
 		set_property("auto_cubeItems", false);
 		set_property("auto_day1_dna", "finished");

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1185,7 +1185,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !forbidFamChange() && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !forbidFamChange($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -287,8 +287,8 @@ boolean fantasyRealmToken()
 		}
 	}
 
-	// If we're not allowed to adventure without a familiar
-	if(forbidFamChange() && auto_have_familiar($familiar[Mosquito]))
+	// If we're not allowed to adventure without a familiar due to being in a 100% familiar run.
+	if(is100FamRun())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -4,7 +4,6 @@ void pete_initializeSettings()
 {
 	if(my_path() == "Avatar of Sneaky Pete")
 	{
-		set_property("auto_100familiar", $familiar[Egg Benedict]);
 		set_property("auto_peteSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_grimstoneOrnateDowsingRod", false);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -873,7 +873,7 @@ boolean is100FamRun()
 {
 	// answers the question of "is this a 100% familiar run"
 	
-	if(get_property("auto_100familiar") == $familiar[none])
+	if(get_property("auto_100familiar").to_familiar() == $familiar[none])
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -877,10 +877,6 @@ boolean is100FamRun()
 	{
 		return false;
 	}
-	if(get_property("auto_100familiar") == "")
-	{
-		return false;
-	}
 	
 	// if you reached this line, then it means that auto_100familiar is set to some specific familiar.
 	return true;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -135,7 +135,7 @@ boolean loopHandler(string turnSetting, string counterSetting, int threshold);
 boolean loopHandlerDelay(string counterSetting);
 boolean loopHandlerDelay(string counterSetting, int threshold);
 boolean forbidFamChange();
-boolean forbidFamChange(familiar thisOne);
+boolean forbidFamChange(familiar target);
 boolean fightScienceTentacle(string option);
 boolean fightScienceTentacle();
 boolean evokeEldritchHorror(string option);
@@ -869,18 +869,10 @@ string reverse(string s)
 	return ret;
 }
 
-boolean forbidFamChange()
+boolean is100FamRun()
 {
-	// Answers the question "am I not allowed to change my familiar?"
-	// Returns true for paths with no familiars
-	if(get_property("auto_100familiar") == $familiar[Egg Benedict])
-	{
-		if(have_familiar($familiar[Mosquito]))
-		{
-			return false;
-		}
-	}
-
+	// answers the question of "is this a 100% familiar run"
+	
 	if(get_property("auto_100familiar") == $familiar[none])
 	{
 		return false;
@@ -889,22 +881,53 @@ boolean forbidFamChange()
 	{
 		return false;
 	}
+	
+	// if you reached this line, then it means that auto_100familiar is set to some specific familiar.
 	return true;
 }
 
-boolean forbidFamChange(familiar thisOne)
+boolean forbidFamChange()
 {
-	if(forbidFamChange())
+	// answers the question "am I forbidden to change familiar?"
+	// an answer of true means you cannot change familiar, either due to path or due to being 100% run.
+	// an answer of false means you are allowed to change familiar
+	
+	//paths in which you cannot use a familiar as a familiar (in pokefam familiars are used as something else)
+	if($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, License to Adventure, Pocket Familiars, Dark Gyffte] contains auto_my_path())
 	{
-		if(get_property("auto_100familiar") == thisOne)
-		{
-			return false;
-		}
 		return true;
 	}
-	return false;
+	
+	// If you are not in a specific path that forbids familiars, then the question is whether or not you are in a 100% run. If you are in such a run then changing familiar is forbidden.
+	return is100FamRun();
 }
 
+boolean forbidFamChange(familiar target)
+{
+	// answers the question of "am I forbidden to change familiar to a familiar named target"
+	// Returns false means you are allowed to change familiar to familiar target. because double negatives.
+	// Returns true means you are forbidden to change familiar to familiar target
+
+	// if you don't have a familiar, you can't change to it.
+	if(!auto_have_familiar(target))
+	{
+		return true;
+	}
+
+	// You are allowed to change to a familiar if it is also the goal of the current 100% run.
+	if(get_property("auto_100familiar") == target)
+	{
+		return false;
+	}
+	else if(forbidFamChange())
+	{
+		// checks path and 100% runs for diferent familiar than target
+		return true;
+	}
+	
+	// if you reached this point, then auto_100familiar must not be set to anything, you are allowed to change familiar.
+	return false;
+}
 
 boolean setAdvPHPFlag()
 {

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -833,8 +833,9 @@ boolean instakillable(monster mon);							//Defined in autoscend/auto_util.ash
 int[int] intList();											//Defined in autoscend/auto_list.ash
 int internalQuestStatus(string prop);						//Defined in autoscend/auto_util.ash
 int freeCrafts();											//Defined in autoscend/auto_util.ash
+boolean is100FamRun();										//Defined in autoscend/auto_util.ash
 boolean forbidFamChange();									//Defined in autoscend/auto_util.ash
-boolean forbidFamChange(familiar thisOne);					//Defined in autoscend/auto_util.ash
+boolean forbidFamChange(familiar target);					//Defined in autoscend/auto_util.ash
 boolean isBanished(monster enemy);							//Defined in autoscend/auto_util.ash
 boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

Creates function is100FamRun and uses it to fix fantasyrealm not being used in paths that forbid familiar.
Fixes up the logic of forbidFamChange to be correct, solving its issues in pokefam.
corrected machine elf and crimbo shrub not being in a 100% run even when they are the target of such a run.

## How Has This Been Tested?

Passed validation.
I don't actually own a crimbo shrub nor a machine elf so I cannot test their fixes.

The original commits were tested in pokefam with fantasyrealm and fixed some issues there.
I also ran said original commits through many different runs on different paths and did not see any issue caused by it.

This is not the original commit though. I manually copy pasted pertinent functions / lines into beta and made sure they are compatible with current beta.

Since current beta has slightly different spelling on those functions than the original commit I had to change it where appropriate. Such changes would be caught when validating (and indeed I had missed one such instance at first and then caught it this way). So I don't think this is actually a problem.

Just in case though. I am using this in my current runs. Specifically:
part of a plumber run.
part of a sneaky pete run
part of a max skill ed run
part of a 0 skill ed run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
