### PR TITLE
that was backwards

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -1862,11 +1862,11 @@ boolean L12_farm()
 	int want_to_farm = 0;
 	if(auto_warSide() == "hippy")
 	{
-		want_to_farm = (plan>>5)&1;
+		want_to_farm = (plan>>0)&1;
 	}
 	else
 	{
-		want_to_farm = (plan>>0)&1;
+		want_to_farm = (plan>>5)&1;
 	}
 	if(want_to_farm == 0)
 	{


### PR DESCRIPTION
Hippy and fratboy were inverted when checking the plan result field.
As a result they were both checking whether the plan was to do arena instead of dooks.

## How Has This Been Tested?

tested it in a fratboy plumber run where it initially wanted to do dooks before i corrected it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
