### PR TITLE
Ed fixes/tidying

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ The recommended choices in Valhalla for Actually Ed the Undying are
 
 This code base has changed hands and evolved over years of development. Most of the code was written by people who are no longer playing the game or maintaining it. So, there may be mistakes and learning curves. Please be patient and understanding, this is a hobby for us.
 
-Your ascension may or may not break in spectacular ways! Sorry in advance if that happens! Also, at the moment you will probably have to handle the vast majority of your diet manually. At least, in hardcore standard, anyway.
+Your ascension may or may not break in spectacular ways! Sorry in advance if that happens!
 
 ## Issues?
 
-Please do create github issues for any problems you run in to. I make no promises about how fast
-I'll be to handle them, but I'll try to fix reasonable problems in a reasonable timeframe.
+Please do create github issues for any problems you run in to. We make no promises about how fast
+we'll be to handle them, but we'll try to fix reasonable problems in a reasonable timeframe.
 
 You can also come discuss problems with the script on the [#autoscend channel on the Ascension Speed Society discord server](https://discord.gg/96xZxv3), or just discuss the script in general!
 

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -14,7 +14,7 @@ boolean autoAdv(int num, location loc, string option)
 		return false;
 	}
 
-	set_property("auto_combatHandler", "");
+	remove_property("auto_combatHandler");
 	set_property("auto_diag_round", 0);
 	set_property("nextAdventure", loc);
 	if(option == "")
@@ -22,6 +22,7 @@ boolean autoAdv(int num, location loc, string option)
 		if (isActuallyEd())
 		{
 			option = "auto_edCombatHandler";
+			remove_property("auto_edCombatHandler");
 		} else {
 			option = "auto_combatHandler";
 		}
@@ -151,7 +152,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 		}
 		urlGetFlags /= 2;
 	}
-	if (my_hp() == 0 || have_effect($effect[Beaten Up]) > 0)
+	if ((my_hp() == 0 || have_effect($effect[Beaten Up]) > 0) && !isActuallyEd())
 	{
 		auto_log_warning("Uh oh! Died when starting a combat indirectly.", "red");
 		#Can we just return true here?

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -3179,7 +3179,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
-	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location() && canUse($skill[Fist Of The Mummy], false))
+	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest, The Batrat and Ratbat Burrow, The Boss Bat\'s Lair, Cobb\'s Knob Harem] contains my_location() && canUse($skill[Fist Of The Mummy], false))
 	{
 		return useSkill($skill[Fist Of The Mummy], false);
 	}

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -493,5 +493,18 @@ boolean settingFixer()
 		remove_property("auto_copperhead");
 	}
 
+	if (property_exists("auto_hpAutoRecoveryItems"))
+	{
+		remove_property("auto_hpAutoRecoveryItems");
+	}
+	if (property_exists("auto_hpAutoRecovery"))
+	{
+		remove_property("auto_hpAutoRecovery");
+	}
+	if (property_exists("auto_hpAutoRecoveryTarget"))
+	{
+		remove_property("auto_hpAutoRecoveryTarget");
+	}
+	
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -56,15 +56,6 @@ void ed_initializeSession()
 {
 	if (isActuallyEd())
 	{
-		if(get_property("hpAutoRecoveryItems") != "linen bandages")
-		{
-			set_property("auto_hpAutoRecoveryItems", get_property("hpAutoRecoveryItems"));
-			set_property("auto_hpAutoRecovery", get_property("hpAutoRecovery"));
-			set_property("auto_hpAutoRecoveryTarget", get_property("hpAutoRecoveryTarget"));
-			set_property("hpAutoRecoveryItems", "linen bandages");
-			set_property("hpAutoRecovery", 0.0);
-			set_property("hpAutoRecoveryTarget", 0.1);
-		}
 		// the following settings will affect combat automation
 		// see auto_choice_adv.ash for where and how they are used.
 		backupSetting("choiceAdventure1023", "");
@@ -77,15 +68,7 @@ void ed_terminateSession()
 {
 	if (isActuallyEd())
 	{
-		if(get_property("hpAutoRecoveryItems") == "linen bandages")
-		{
-			set_property("hpAutoRecoveryItems", get_property("auto_hpAutoRecoveryItems"));
-			set_property("hpAutoRecovery", get_property("auto_hpAutoRecovery"));
-			set_property("hpAutoRecoveryTarget", get_property("auto_hpAutoRecoveryTarget"));
-			set_property("auto_hpAutoRecoveryItems", "");
-			set_property("auto_hpAutoRecovery", 0.0);
-			set_property("auto_hpAutoRecoveryTarget", 0.0);
-		}
+		// do nothing.
 	}
 }
 
@@ -1283,6 +1266,30 @@ boolean L1_ed_islandFallback()
 				put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
 			}
 		}
+
+		// TODO: Malibu Stacey - move all this to a more central location after refactor
+		if (item_amount($item[filthy knitted dread sack]) > 1 && equipped_amount($item[filthy knitted dread sack]) == 0) {
+			// keep one for starting the war (and general wearing until we have something better)
+			auto_autosell(item_amount($item[filthy knitted dread sack]) - 1, $item[filthy knitted dread sack]);
+		} else if (item_amount($item[filthy knitted dread sack]) > 0 && equipped_amount($item[filthy knitted dread sack]) == 1) {
+			// have one equipped, just sell any others.
+			auto_autosell(item_amount($item[filthy knitted dread sack]), $item[filthy knitted dread sack]);
+		}
+
+		if (item_amount($item[hemp string]) > 1 && equipped_amount($item[hemp string]) == 0) {
+			// keep one for the Bonerdagon necklace.
+			auto_autosell(item_amount($item[hemp string]) - 1, $item[hemp string]);
+		} else if (item_amount($item[hemp string]) > 0 && equipped_amount($item[hemp string]) == 1) {
+			// have one equipped, just sell any others.
+			auto_autosell(item_amount($item[hemp string]), $item[hemp string]);
+		}
+
+		// autosell some other useless stuff as we can use the meat to buy MP from doc galaktik.
+		// Ed doesn't need any of this stuff as he starts with the Staff of Ed and can use it until the level 11 quest
+		foreach it in $items[hippy bongo, filthy pestle, double-barreled sling] {
+			auto_autosell(item_amount(it), it);
+		}
+
 		return retVal;
 	}
 	set_property("auto_needLegs", true);

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1,7 +1,7 @@
 script "auto_post_adv.ash";
 import<autoscend.ash>
 
-void handlePostAdventure()
+void main()
 {
 	if(limit_mode() == "spelunky")
 	{
@@ -227,7 +227,7 @@ void handlePostAdventure()
 				buffMaintain($effect[Bounty of Renenutet], 10, 1, 10);
 			}
 
-			if (my_level() < 13 && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && (!($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob] contains my_location()) || have_skill($skill[More Legs])) && my_location() != $location[The Smut Orc Logging Camp])
+			if ((my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean()) && my_level() > 3 && !get_property("auto_needLegs").to_boolean() && !($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Smut Orc Logging Camp] contains my_location()))
 			{
 				buffMaintain($effect[Blessing of Serqet], 10, 1, 10);
 			}
@@ -1049,9 +1049,4 @@ void handlePostAdventure()
 	}
 
 	auto_log_info("Post Adventure done, beep.", "purple");
-}
-
-void main()
-{
-	handlePostAdventure();
 }

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1,13 +1,10 @@
 script "auto_pre_adv.ash";
 import<autoscend.ash>
 
-void handlePreAdventure()
+void main()
 {
-	handlePreAdventure(my_location());
-}
 
-void handlePreAdventure(location place)
-{
+	location place = my_location();
 	if((equipped_item($slot[familiar]) == $item[none]) && (my_familiar() != $familiar[none]) && (auto_my_path() == "Heavy Rains"))
 	{
 		abort("Familiar has no equipment, WTF");
@@ -46,11 +43,6 @@ void handlePreAdventure(location place)
 	if(get_floundry_locations() contains place)
 	{
 		buffMaintain($effect[Baited Hook], 0, 1, 1);
-	}
-
-	if((my_mp() < 30) && ((my_mp()+20) < my_maxmp()) && (item_amount($item[Psychokinetic Energy Blob]) > 0))
-	{
-		use(1, $item[Psychokinetic Energy Blob]);
 	}
 
 	if((get_property("_bittycar") == "") && (item_amount($item[Bittycar Meatcar]) > 0))
@@ -319,6 +311,16 @@ void handlePreAdventure(location place)
 		}
 	}
 
+	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {
+		equip($slot[Pants], $item[None]);
+		put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+		if (is_wearing_outfit("Filthy Hippy Disguise")) {
+			abort("Tried to adventure in the Hippy Camp as Actually Ed the Undying wearing the Filthy Hippy Disguise (this is bad).");
+		} else {
+			auto_log_info("Took off the Filthy Hippy Disguise before adventuring in the Hippy Camp so we don't waste adventures on non-combats.");
+		}
+	}
+
 	if(place == $location[The Black Forest])
 	{
 		autoEquip($slot[acc3], $item[Blackberry Galoshes]);
@@ -452,11 +454,15 @@ void handlePreAdventure(location place)
 		uneffect($effect[Driving Recklessly]);
 		uneffect($effect[Ur-Kel\'s Aria of Annoyance]);
 
-		if((purgeML) && item_amount($item[soft green echo eyedrop antidote]) > 5)
+		if(purgeML && item_amount($item[soft green echo eyedrop antidote]) > 5)
 		{
 			uneffect($effect[Drescher\'s Annoying Noise]);
 			uneffect($effect[Pride of the Puffin]);
 			uneffect($effect[Ceaseless Snarling]);
+			uneffect($effect[Blessing of Serqet]);
+		}
+		else if (purgeML && isActuallyEd() && (item_amount($item[ancient cure-all]) > 0 || item_amount($item[soft green echo eyedrop antidote]) > 0))
+		{
 			uneffect($effect[Blessing of Serqet]);
 		}
 	}
@@ -506,12 +512,9 @@ void handlePreAdventure(location place)
 		auto_log_warning("We don't have a lot of MP but we are chugging along anyway", "red");
 	}
 	groundhogAbort(place);
-	if(my_inebriety() > inebriety_limit()) abort("You are overdrunk. Stop it.");
+	if (my_inebriety() > inebriety_limit()) {
+		abort("You are overdrunk. Stop it.");
+	}
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");
-}
-
-void main()
-{
-	handlePreAdventure();
 }

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -393,6 +393,10 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
       restored_amount += numeric_modifier("Bonus Resting HP");
     }
 
+    if (isActuallyEd() && metadata.name != "linen bandages") {
+      restored_amount = 0;
+    }
+
     return restored_amount;
   }
 
@@ -1392,10 +1396,16 @@ boolean acquireHP(int goal, int meat_reserve){
   */
 boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
 
-  if (isActuallyEd() && my_hp() > 0)
-  {
-    // Ed doesn't need to heal outside of combat unless on 0 hp
-    return false;
+  if (isActuallyEd()) {
+    if (my_hp() > 0) {
+      // Ed doesn't need to heal outside of combat unless on 0 hp
+      return false;
+    } else {
+      // handle situations where acquireHP() has been called and passed though to here
+      // so goal = my_maxhp(). This is exceptionally wasteful for Ed as it will burn all his linen bandages
+      // and then all his Ka replacing his linen bandages. Ed only needs 1 HP to adventure.
+      goal = 1;
+    }
   }
   
 	//vampyres can only be restored using blood bags, which are too valuable to waste on healing HP.
@@ -1424,7 +1434,7 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
       retrieve_item(1, $item[super deluxe mushroom]);
       use(1, $item[super deluxe mushroom]);
 		}
-	}
+  }
 	else
 	{
 		__restore("hp", goal, meat_reserve, useFreeRests);

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -393,7 +393,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
       restored_amount += numeric_modifier("Bonus Resting HP");
     }
 
-    if (isActuallyEd() && metadata.name != "linen bandages") {
+    if (isActuallyEd() && !($items[linen bandages, silk bandages, cotton bandages] contains metadata.name.to_item())) {
       restored_amount = 0;
     }
 
@@ -1434,7 +1434,7 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
       retrieve_item(1, $item[super deluxe mushroom]);
       use(1, $item[super deluxe mushroom]);
 		}
-  }
+	}
 	else
 	{
 		__restore("hp", goal, meat_reserve, useFreeRests);


### PR DESCRIPTION
# Description

Major issue fixed is Ed's combat tracking wasn't being reset. This leads to failing to do the nuns as we don't use Curse of Fortune in any combat at Themthar Hills after the first. It also breaks using his other skills like banish/YR more than once per day (yeah this was an oversight by me when I did the choiceAdventureScript changes).

Minor fixes are
- Restoring HP out of combat works for Ed. You'll see why I fixed this in the next PR I put up but it means we should no longer abort when you get Zerg Rush in Sonofa Beach or some other non-combat which puts you on 0 HP.
- should also no longer abort if losing initiative in places we handle with `autoAdvBypass` (such as the Tavern cellar)
- Don't use Blessing of Serqet in the Hippy Camp at all, this just ends up wasting adventures due to our jump chance being much lower so the meagre amount of stats per combat we get from running it are wasted regardless. Also make it obey `auto_disregardInstantKarma`
- Sell a bunch of stuff when Ka farming at the Hippy Camp as meat = MP which saves us spending Ka on Ed's MP restores (which means we get upgrades faster which means we spend fewer turns farming Ka for upgrades).
- Use Fist of the Mummy instead of Storm of the Scarab in more locations to save MP. There are likely more places this can apply.
- Removed some unnecessary function declarations from auto_pre_adv.ash and auto_post_adv.ash

Fixes #163 

## How Has This Been Tested?

Finished one full HC Ed run, on day 2 of a second at the moment.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
