### PR TITLE
Trapper quest ore mining

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -7,7 +7,6 @@ auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liber
 auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
 auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
-auto_diceMode	boolean	Equip all available Dice (OCRS) gear. This is probably not FUN.
 auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
 auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
 auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
@@ -44,5 +43,6 @@ auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after
 auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
 auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
 auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
 auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
 auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -15,43 +15,43 @@ any	5	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when
 any	6	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 any	7	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
 any	8	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
-any	9	auto_diceMode	boolean	Equip all available Dice (OCRS) gear. This is probably not FUN.
-any	10	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
-any	11	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
-any	12	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	13	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	14	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	15	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	16	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
-any	17	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	18	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	9	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
+any	10	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
+any	11	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	12	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	13	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	14	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	15	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
+any	16	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	17	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
+any	18	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	19	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	20	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	21	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+any	22	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	23	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	24	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	25	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	26	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	27	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	28	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	29	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	30	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	31	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	32	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	33	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	34	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	37	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	38	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	45	auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
 any	46	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
 any	47	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -191,6 +191,7 @@ void initializeSettings()
 	set_property("auto_skipL12Farm", "false");
 	set_property("auto_L12FarmStage", "0");
 	set_property("choiceAdventure1003", 0);
+	remove_property("auto_minedCells");
 	beehiveConsider();
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -463,14 +463,14 @@ boolean bat_consumption()
 	if(my_class() != $class[Vampyre])
 		return false;
 
-	if(have_outfit("War Hippy Fatigues") && is_accessible($coinmaster[Dimemaster]))
+	if(possessOutfit("War Hippy Fatigues") && is_accessible($coinmaster[Dimemaster]))
 	{
 		sell($item[padl phone].buyer, item_amount($item[padl phone]), $item[padl phone]);
 		sell($item[red class ring].buyer, item_amount($item[red class ring]), $item[red class ring]);
 		sell($item[blue class ring].buyer, item_amount($item[blue class ring]), $item[blue class ring]);
 		sell($item[white class ring].buyer, item_amount($item[white class ring]), $item[white class ring]);
 	}
-	if(have_outfit("Frat Warrior Fatigues") && is_accessible($coinmaster[Quartersmaster]))
+	if(possessOutfit("Frat Warrior Fatigues") && is_accessible($coinmaster[Quartersmaster]))
 	{
 		sell($item[pink clay bead].buyer, item_amount($item[pink clay bead]), $item[pink clay bead]);
 		sell($item[purple clay bead].buyer, item_amount($item[purple clay bead]), $item[purple clay bead]);

--- a/RELEASE/scripts/autoscend/auto_bondmember.ash
+++ b/RELEASE/scripts/autoscend/auto_bondmember.ash
@@ -760,7 +760,7 @@ boolean LM_bond()
 					temp = visit_url("place.php?whichplace=kgb&action=kgb_tab4", false);
 				}
 
-				if(!have_outfit("Knob Goblin Harem Girl Disguise"))
+				if(!possessOutfit("Knob Goblin Harem Girl Disguise"))
 				{
 					if(!acquireMP(160, 0))
 					{

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -4,6 +4,90 @@ import<autoscend.ash>
 void main(int choice, string page)
 {
 	switch (choice) {
+		case 15: // Yeti Nother Hippy (The eXtreme Slope)
+			if (possessEquipment($item[eXtreme mittens])) {
+				if (possessEquipment($item[eXtreme scarf])) {
+					run_choice(3); // get 200 Meat.
+				} else {
+					run_choice(2); // get eXtreme scarf
+				}
+			} else {
+				run_choice(1); // get eXtreme mittens
+			}
+			break;
+		case 16: // Saint Beernard (The eXtreme Slope)
+			if (possessEquipment($item[snowboarder pants])) {
+				if (possessEquipment($item[eXtreme scarf])) {
+					run_choice(3); // get 200 Meat.
+				} else {
+					run_choice(2); // get eXtreme scarf
+				}
+			} else {
+				run_choice(1); // get snowboarder pants
+			}
+			break;
+		case 17: // Generic Teen Comedy Snowboarding Adventure (The eXtreme Slope)
+			if (possessEquipment($item[eXtreme mittens])) {
+				if (possessEquipment($item[snowboarder pants])) {
+					run_choice(3); // get 200 Meat.
+				} else {
+					run_choice(2); // get snowboarder pants
+				}
+			} else {
+				run_choice(1); // get eXtreme mittens
+			}
+			break;
+		case 18: // A Flat Miner (Itznotyerzitz Mine)
+			if (possessEquipment($item[miner\'s pants])) {
+				if (possessEquipment($item[7-Foot Dwarven mattock])) {
+					run_choice(3); // get 100 Meat.
+				} else {
+					run_choice(2); // get 7-Foot Dwarven mattock
+				}
+			} else {
+				run_choice(1); // get miner's pants
+			}
+			break;
+		case 19: // 100% Legal (Itznotyerzitz Mine)
+			if (possessEquipment($item[miner\'s helmet])) {
+				if (possessEquipment($item[miner\'s pants])) {
+					run_choice(3); // get 100 Meat.
+				} else {
+					run_choice(2); // get miner's pants
+				}
+			} else {
+				run_choice(1); // get miner's helmet
+			}
+			break;
+		case 20: // See You Next Fall (Itznotyerzitz Mine)
+			if (possessEquipment($item[miner\'s helmet])) {
+				if (possessEquipment($item[7-Foot Dwarven mattock])) {
+					run_choice(3); // get 100 Meat.
+				} else {
+					run_choice(2); // get 7-Foot Dwarven mattock
+				}
+			} else {
+				run_choice(1); // get miner's helmet
+			}
+			break;
+		case 556: // More Locker Than Morlock (Itznotyerzitz Mine)
+			if (!possessOutfit("Mining Gear")) {
+				run_choice(1); // get an outfit piece
+			} else {
+				run_choice(2); // skip
+			}
+			break;
+		case 575: // Duffel on the Double (The eXtreme Slope)
+			if (!possessOutfit("eXtreme Cold-Weather Gear")) {
+				run_choice(1); // get an outfit piece
+			} else {
+				if (isActuallyEd()) { // add other paths which don't want to waste spleen (if any) here.
+					run_choice(3); // skip
+				} else {
+					run_choice(4); // Lucky Pill. (Clover for 1 spleen, worth?)
+				}
+			}
+			break;
 		case 1023: // Like a Bat Into Hell (Actually Ed the Undying)
 			run_choice(1); // Enter the Underworld
 			auto_log_info("Ed died in combat " + get_property("_edDefeats").to_int() + " time(s)", "blue");
@@ -20,6 +104,12 @@ void main(int choice, string page)
 				auto_log_info("Ed died in combat for reals!");
 				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 			}
+			break;
+		case 1082: // The "Rescue" (post-Cake Lord in Madness Bakery)
+			run_choice(1);
+			break;
+		case 1083: // Cogito Ergot Sum (post-post-Cake Lord in Madness Bakery)
+			run_choice(1);
 			break;
 		case 1310: // Granted a Boon (God Lobster)
 			int goal = get_property("_auto_lobsterChoice").to_int();

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1,11 +1,5 @@
 script "autoscend/auto_equipment.ash";
 
-void equipBaseline();
-void equipRollover();
-void ensureSealClubs();
-void makeStartingSmiths();
-int equipmentAmount(item equipment);
-
 string getMaximizeSlotPref(slot s)
 {
 	return "_auto_maximize_equip_" + s.to_string();
@@ -99,7 +93,7 @@ boolean autoForceEquip(item it)
 
 boolean autoOutfit(string toWear)
 {
-	if(!have_outfit(toWear))
+	if(!possessOutfit(toWear, true))
 	{
 		return false;
 	}
@@ -383,88 +377,6 @@ void equipOverrides()
 	}
 }
 
-void makeStartingSmiths()
-{
-	if(!auto_have_skill($skill[Summon Smithsness]))
-	{
-		return;
-	}
-
-	if(item_amount($item[Lump of Brituminous Coal]) == 0)
-	{
-		if(my_mp() < (3 * mp_cost($skill[Summon Smithsness])))
-		{
-			auto_log_warning("You don't have enough MP for initialization, it might be ok but probably not.", "red");
-		}
-		use_skill(3, $skill[Summon Smithsness]);
-	}
-
-	if(knoll_available())
-	{
-		buyUpTo(1, $item[maiden wig]);
-	}
-
-	switch(my_class())
-	{
-	case $class[Seal Clubber]:
-		if(!possessEquipment($item[Meat Tenderizer is Murder]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[seal-clubbing club]);
-		}
-		if(!possessEquipment($item[Vicar\'s Tutu]) && (item_amount($item[Lump of Brituminous Coal]) > 0) && knoll_available())
-		{
-			buy(1, $item[Frilly Skirt]);
-			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Frilly Skirt]);
-		}
-		break;
-	case $class[Turtle Tamer]:
-		if(!possessEquipment($item[Work is a Four Letter Sword]))
-		{
-			buyUpTo(1, $item[Sword Hilt]);
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[sword hilt]);
-		}
-		if(!possessEquipment($item[Ouija Board\, Ouija Board]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[turtle totem]);
-		}
-		break;
-	case $class[Sauceror]:
-		if(!possessEquipment($item[Saucepanic]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Saucepan]);
-		}
-		if(!possessEquipment($item[A Light that Never Goes Out]) && (item_amount($item[Lump of Brituminous Coal]) > 0))
-		{
-			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Third-hand Lantern]);
-		}
-		break;
-	case $class[Pastamancer]:
-		if(!possessEquipment($item[Hand That Rocks the Ladle]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Pasta Spoon]);
-		}
-		break;
-	case $class[Disco Bandit]:
-		if(!possessEquipment($item[Frankly Mr. Shank]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Disco Ball]);
-		}
-		break;
-	case $class[Accordion Thief]:
-		if(!possessEquipment($item[Shakespeare\'s Sister\'s Accordion]))
-		{
-			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Stolen Accordion]);
-		}
-		break;
-	}
-
-	if(knoll_available() && !possessEquipment($item[Hairpiece on Fire]) && (item_amount($item[lump of Brituminous Coal]) > 0))
-	{
-		autoCraft("smith", 1, $item[lump of Brituminous coal], $item[maiden wig]);
-	}
-	buffMaintain($effect[Merry Smithsness], 0, 1, 10);
-}
-
 int equipmentAmount(item equipment)
 {
 	if(equipment == $item[none])
@@ -496,6 +408,32 @@ int equipmentAmount(item equipment)
 boolean possessEquipment(item equipment)
 {
 	return equipmentAmount(equipment) > 0;
+}
+
+boolean possessOutfit(string outfitToCheck, boolean checkCanEquip) {
+	// have_outfit will report false if you're wearing some of the items
+	// it will only report true if you have all in inventory or are wearing the whole thing
+	// hence this now exists.
+	if (count(outfit_pieces(outfitToCheck)) == 0) {
+		auto_log_warning(outfitToCheck + " is not a valid outfit!");
+		return false;
+	}
+	
+	foreach key, piece in outfit_pieces(outfitToCheck) {
+		if (!possessEquipment(piece))
+		{
+			return false;
+		}
+		if(checkCanEquip && !can_equip(piece))
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+boolean possessOutfit(string outfitToCheck) {
+	return possessOutfit(outfitToCheck, false);	
 }
 
 boolean handleBjornify(familiar fam)

--- a/RELEASE/scripts/autoscend/auto_mr2013.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2013.ash
@@ -14,3 +14,85 @@ void handleJar()
 		}
 	}
 }
+
+void makeStartingSmiths()
+{
+	if(!auto_have_skill($skill[Summon Smithsness]))
+	{
+		return;
+	}
+
+	if(item_amount($item[Lump of Brituminous Coal]) == 0)
+	{
+		if(my_mp() < (3 * mp_cost($skill[Summon Smithsness])))
+		{
+			auto_log_warning("You don't have enough MP for initialization, it might be ok but probably not.", "red");
+		}
+		use_skill(3, $skill[Summon Smithsness]);
+	}
+
+	if(knoll_available())
+	{
+		buyUpTo(1, $item[maiden wig]);
+	}
+
+	switch(my_class())
+	{
+	case $class[Seal Clubber]:
+		if(!possessEquipment($item[Meat Tenderizer is Murder]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[seal-clubbing club]);
+		}
+		if(!possessEquipment($item[Vicar\'s Tutu]) && (item_amount($item[Lump of Brituminous Coal]) > 0) && knoll_available())
+		{
+			buy(1, $item[Frilly Skirt]);
+			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Frilly Skirt]);
+		}
+		break;
+	case $class[Turtle Tamer]:
+		if(!possessEquipment($item[Work is a Four Letter Sword]))
+		{
+			buyUpTo(1, $item[Sword Hilt]);
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[sword hilt]);
+		}
+		if(!possessEquipment($item[Ouija Board\, Ouija Board]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[turtle totem]);
+		}
+		break;
+	case $class[Sauceror]:
+		if(!possessEquipment($item[Saucepanic]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Saucepan]);
+		}
+		if(!possessEquipment($item[A Light that Never Goes Out]) && (item_amount($item[Lump of Brituminous Coal]) > 0))
+		{
+			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Third-hand Lantern]);
+		}
+		break;
+	case $class[Pastamancer]:
+		if(!possessEquipment($item[Hand That Rocks the Ladle]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Pasta Spoon]);
+		}
+		break;
+	case $class[Disco Bandit]:
+		if(!possessEquipment($item[Frankly Mr. Shank]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Disco Ball]);
+		}
+		break;
+	case $class[Accordion Thief]:
+		if(!possessEquipment($item[Shakespeare\'s Sister\'s Accordion]))
+		{
+			autoCraft("smith", 1, $item[lump of Brituminous coal], $item[Stolen Accordion]);
+		}
+		break;
+	}
+
+	if(knoll_available() && !possessEquipment($item[Hairpiece on Fire]) && (item_amount($item[lump of Brituminous Coal]) > 0))
+	{
+		autoCraft("smith", 1, $item[lump of Brituminous coal], $item[maiden wig]);
+	}
+	buffMaintain($effect[Merry Smithsness], 0, 1, 10);
+}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -74,13 +74,6 @@ void main()
 		}
 	}
 
-	//This has a post combat scenario, let us just handle it.
-	if(last_monster() == $monster[Cake Lord])
-	{
-		run_choice(1);
-		run_choice(1);
-	}
-
 	if((get_property("lastEncounter") == "Daily Briefing") && (auto_my_path() == "License to Adventure"))
 	{
 		set_property("_auto_bondBriefing", "started");

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -443,30 +443,30 @@ boolean warOutfit(boolean immediate)
 
 	if(!get_property("auto_hippyInstead").to_boolean())
 	{
-		if(!reallyWarOutfit("frat warrior fatigues"));
+		if(!reallyWarOutfit("Frat Warrior Fatigues"));
 		{
 			foreach it in $items[Beer Helmet, Distressed Denim Pants, Bejeweled Pledge Pin]
 			{
 				take_closet(closet_amount(it), it);
 			}
-			if(!reallyWarOutfit("frat warrior fatigues"))
+			if(!reallyWarOutfit("Frat Warrior Fatigues"))
 			{
-				abort("Do not have frat warrior fatigues and don't know why....");
+				abort("Do not have Frat Warrior Fatigues and don't know why....");
 				return false;
 			}
 		}
 	}
 	else
 	{
-		if(!reallyWarOutfit("war hippy fatigues"))
+		if(!reallyWarOutfit("War Hippy Fatigues"))
 		{
 			foreach it in $items[Reinforced Beaded Headband, Bullet-proof Corduroys, Round Purple Sunglasses]
 			{
 				take_closet(closet_amount(it), it);
 			}
-			if(!reallyWarOutfit("war hippy fatigues"))
+			if(!reallyWarOutfit("War Hippy Fatigues"))
 			{
-				abort("Do not have war hippy fatigues and don't know why....");
+				abort("Do not have War Hippy Fatigues and don't know why....");
 				return false;
 			}
 		}
@@ -474,29 +474,21 @@ boolean warOutfit(boolean immediate)
 	return true;
 }
 
-boolean haveWarOutfit()
+boolean haveWarOutfit(boolean canWear)
 {
 	if(!get_property("auto_hippyInstead").to_boolean())
 	{
-		foreach it in $items[Beer Helmet, Distressed Denim Pants, Bejeweled Pledge Pin]
-		{
-			if(available_amount(it) == 0)
-			{
-				return false;
-			}
-		}
+		return possessOutfit("Frat Warrior Fatigues", canWear);
 	}
 	else
 	{
-		foreach it in $items[Reinforced Beaded Headband, Bullet-proof Corduroys, Round Purple Sunglasses]
-		{
-			if(available_amount(it) == 0)
-			{
-				return false;
-			}
-		}
+		return possessOutfit("War Hippy Fatigues", canWear);
 	}
 	return true;
+}
+
+boolean haveWarOutfit() {
+	return haveWarOutfit(false);
 }
 
 boolean warAdventure()
@@ -597,16 +589,16 @@ boolean L12_getOutfit()
 	}
 	
 	// if outfit could not be pulled and have a [Filthy Hippy Disguise] outfit then wear it and adventure in Frat House to get war outfit
-	if (!get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
+	if (!get_property("auto_hippyInstead").to_boolean() && possessOutfit("Filthy Hippy Disguise"))
 	{
-		autoOutfit("filthy hippy disguise");
+		autoOutfit("Filthy Hippy Disguise");
 		return autoAdv(1, $location[Wartime Frat House]);
 	}
 	
 	// if outfit could not be pulled and have a [Frat Boy Ensemble] outfit then wear it and adventure in Hippy Camp to get war outfit
-	if (get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[orcish baseball cap]) && possessEquipment($item[orcish frat-paddle]) && possessEquipment($item[orcish cargo shorts]))
+	if (get_property("auto_hippyInstead").to_boolean() && possessOutfit("Frat Boy Ensemble"))
 	{
-		autoOutfit("frat Boy Ensemble");
+		autoOutfit("Frat Boy Ensemble");
 		return autoAdv(1, $location[Wartime Hippy Camp]);
 	}
 	
@@ -640,14 +632,14 @@ boolean L12_preOutfit()
 		return false;
 	}
 	
-	// if siding with frat and already own [filthy hippy disguise] outfit needed to get the frat boy war outfit
-	if (!get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[filthy knitted dread sack]) && possessEquipment($item[filthy corduroys]))
+	// if siding with frat and already own [Filthy Hippy Disguise] outfit needed to get the frat boy war outfit
+	if (!get_property("auto_hippyInstead").to_boolean() && possessOutfit("Filthy Hippy Disguise"))
 	{
 		return false;
 	}
 	
-	// if siding with hippies and already own [frat boy ensemble] outfit needed to get the hippy war outfit
-	if (get_property("auto_hippyInstead").to_boolean() && possessEquipment($item[orcish baseball cap]) && possessEquipment($item[orcish frat-paddle]) && possessEquipment($item[orcish cargo shorts]))
+	// if siding with hippies and already own [Frat Boy Ensemble] outfit needed to get the hippy war outfit
+	if (get_property("auto_hippyInstead").to_boolean() && possessOutfit("Frat Boy Ensemble"))
 	{
 		return false;
 	}
@@ -687,7 +679,7 @@ boolean L12_preOutfit()
 			adventure_status = autoAdv(1, $location[Wartime Hippy Camp]);
 		}
 	}
-	// fighting for hippies, adventure in orcish frat house for [frat boy ensemble] outfit to then adventure in hippy camp for hippy war outfit
+	// fighting for hippies, adventure in orcish frat house for [Frat Boy Ensemble] outfit to then adventure in hippy camp for hippy war outfit
 	else
 	{
 		auto_log_info("Trying to acquire a frat boy ensemble", "blue");
@@ -724,7 +716,7 @@ boolean L12_startWar()
 		return false;
 	}
 
-	if (!haveWarOutfit() || my_basestat($stat[Mysticality]) < 70 || my_basestat($stat[Moxie]) < 70)
+	if (!haveWarOutfit(true))
 	{
 		return false;
 	}
@@ -1514,7 +1506,7 @@ boolean L12_themtharHills()
 
 	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 	{
-		outfit("frat warrior fatigues");
+		outfit("Frat Warrior Fatigues");
 		cli_execute("concert 2");
 	}
 
@@ -1882,7 +1874,7 @@ boolean L12_clearBattlefield()
 {
 	if(in_koe())
 	{
-		if (internalQuestStatus("questL12HippyFrat") < 2 && get_property("hippiedDefeated").to_int() < 333 && get_property("fratboysDefeated").to_int() < 333 && can_equip($item[Distressed denim pants]) && can_equip($item[beer helmet]) && can_equip($item[bejeweled pledge pin]))
+		if (internalQuestStatus("questL12HippyFrat") < 2 && get_property("hippiedDefeated").to_int() < 333 && get_property("fratboysDefeated").to_int() < 333 && possessOutfit("Frat Warrior Fatigues", true))
 		{
 			handleFamiliar("item");
 			if(haveWarOutfit())
@@ -1995,7 +1987,7 @@ boolean L12_finalizeWar()
 		return false;
 	}
 
-	if(have_outfit("War Hippy Fatigues"))
+	if(possessOutfit("War Hippy Fatigues"))
 	{
 		auto_log_info("Getting dimes.", "blue");
 		foreach it in $items[padl phone, red class ring, blue class ring, white class ring]
@@ -2014,7 +2006,7 @@ boolean L12_finalizeWar()
 			}
 		}
 	}
-	if(have_outfit("Frat Warrior Fatigues"))
+	if(possessOutfit("Frat Warrior Fatigues"))
 	{
 		auto_log_info("Getting quarters.", "blue");
 		foreach it in $items[pink clay bead, purple clay bead, green clay bead, communications windchimes]
@@ -2070,7 +2062,7 @@ boolean L12_finalizeWar()
 		}
 	}
 
-	if(have_outfit("War Hippy Fatigues"))
+	if(possessOutfit("War Hippy Fatigues"))
 	{
 		while($coinmaster[Dimemaster].available_tokens >= 5)
 		{
@@ -2086,7 +2078,7 @@ boolean L12_finalizeWar()
 		}
 	}
 
-	if(have_outfit("Frat Warrior Fatigues"))
+	if(possessOutfit("Frat Warrior Fatigues"))
 	{
 		while($coinmaster[Quartersmaster].available_tokens >= 5)
 		{

--- a/RELEASE/scripts/autoscend/auto_quest_level_5.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_5.ash
@@ -22,8 +22,7 @@ boolean L5_getEncryptionKey()
 	}
 
 	auto_log_info("Looking for the knob.", "blue");
-	autoAdv(1, $location[The Outskirts of Cobb\'s Knob]);
-	return true;
+	return autoAdv($location[The Outskirts of Cobb\'s Knob]);
 }
 
 boolean L5_findKnob()
@@ -50,7 +49,7 @@ boolean L5_haremOutfit()
 	{
 		return false;
 	}
-	if(have_outfit("knob goblin harem girl disguise"))
+	if (possessOutfit("Knob Goblin Harem Girl Disguise"))
 	{
 		return false;
 	}
@@ -70,7 +69,7 @@ boolean L5_haremOutfit()
 	bat_formBats();
 
 	auto_log_info("Looking for some sexy lingerie!", "blue");
-	autoAdv(1, $location[Cobb\'s Knob Harem]);
+	autoAdv($location[Cobb\'s Knob Harem]);
 	handleFamiliar("item");
 	return true;
 }
@@ -93,23 +92,23 @@ boolean L5_goblinKing()
 	{
 		return false;
 	}
-	if(!have_outfit("Knob Goblin Harem Girl Disguise"))
+	if(!possessOutfit("Knob Goblin Harem Girl Disguise"))
 	{
 		return false;
 	}
 
 	auto_log_info("Death to the gobbo!!", "blue");
-	if(!autoOutfit("knob goblin harem girl disguise"))
+	if(!autoOutfit("Knob Goblin Harem Girl Disguise"))
 	{
 		abort("Could not put on Knob Goblin Harem Girl Disguise, aborting");
 	}
 	buffMaintain($effect[Knob Goblin Perfume], 0, 1, 1);
 	if(have_effect($effect[Knob Goblin Perfume]) == 0)
 	{
-		autoAdv(1, $location[Cobb\'s Knob Harem]);
+		autoAdv($location[Cobb\'s Knob Harem]);
 		if(contains_text(get_property("lastEncounter"), "Cobb's Knob lab key"))
 		{
-			autoAdv(1, $location[Cobb\'s Knob Harem]);
+			autoAdv($location[Cobb\'s Knob Harem]);
 		}
 		return true;
 	}
@@ -138,7 +137,7 @@ boolean L5_goblinKing()
 	{
 		auto_change_mcd(10); // get the Crown from the Goblin King.
 	}
-	autoAdv(1, $location[Throne Room]);
+	autoAdv($location[Throne Room]);
 
 	if((item_amount($item[Crown of the Goblin King]) > 0) || (item_amount($item[Glass Balls of the Goblin King]) > 0) || (item_amount($item[Codpiece of the Goblin King]) > 0) || (get_property("questL05Goblin") == "finished") || in_zelda())
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -78,6 +78,7 @@ boolean L8_trapperGround();
 boolean L8_trapperNinjaLair();
 boolean L8_trapperExtreme();
 boolean L8_trapperGroar();
+boolean L8_trapperQuest();
 boolean L9_chasmBuild();
 boolean L9_highLandlord();
 boolean L9_aBooPeak();
@@ -239,6 +240,8 @@ boolean dailyEvents();
 //Do we have a some item either equipped or in inventory (not closet or hagnk\'s.
 boolean possessEquipment(item equipment);		//Defined in autoscend/auto_equipment.ash
 int equipmentAmount(item equipment); // Defined in autoscend/auto_equipment.ash
+boolean possessOutfit(string outfit, boolean checkCanEquip); // Defined in autoscend/auto_equipment.ash
+boolean possessOutfit(string outfit); // Defined in autoscend/auto_equipment.ash
 
 //Do Bjorn stuff
 boolean handleBjornify(familiar fam);			//Defined in autoscend/auto_equipment.ash


### PR DESCRIPTION
So I should preface this with the statement that I'm **not** looking for reviews of this yet as there's a fair bit of refactoring I want to do to this code to make it cleaner and more maintainable first. You'll probably notice that from looking at the code. It has evolved over time as I've fixed various issues with it so there's quite a lot of repetition and redundancy in its current state.

This is being posted to gather feedback on testing that it does what it's supposed to do.

I've had this in the works for a while (see my comment on #8 from the end of _September_ last year) and it kept getting sidelined until Easter weekend when I got some time to focus on it and give it a proper test (blame KoE, Crimbo and just generally life for constantly getting in the way).

I tested it a load in aftercore before letting it loose in a HC Ed run which resulted in the following when hunting for chrome ore for the trapper:
![itznotyerzitzmine](https://user-images.githubusercontent.com/50261170/79310768-50e94f00-7eb1-11ea-996e-a3bffe7c7551.png)
It went to the left of the first chrome ore it hit above the loadstone before going to the right to hit the second hence the asbestos ore there.

As the comment in `auto_testMining()` says, you can test it in aftercore with the following command
`ash import <autoscend.ash> auto_testMining($item[insert ore type]);`

If you want to see it in action in-run, `set auto_mineForOres = true` on the CLI or use our relay manager to set that & it will attempt to run unless you have a better way of getting the ores when you hit the trapper quest.

Thanks in advance.