### PR TITLE
misc

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -226,30 +226,23 @@ void initializeSettings()
 	set_property("auto_doneInitialize", my_ascensions());
 }
 
-boolean auto_unreservedAdvRemaining()
+int auto_advToReserve()
 {
-	// Calculates if we should continue to run the main loop based on how many adv we want to keep.
+	// Calculates how many adventures we should aim to keep in reserve
 	
-	// blank int does not work properly. blank should default to -1
-	if(get_property("auto_save_adv_override") == "")
+	// blank int value does not work. and values lower than -1 are not valid.
+	if(get_property("auto_save_adv_override") == "" || get_property("auto_save_adv_override").to_int() < -1)
 	{
 		set_property("auto_save_adv_override", -1);
 	}
 	
-	// if auto_save_adv_override value is not -1 then use the override
-	if(get_property("auto_save_adv_override") != -1)
+	// if auto_save_adv_override value is 0 or higher then use the override
+	if(get_property("auto_save_adv_override").to_int() > -1)
 	{
-		if(my_adventures() > get_property("auto_save_adv_override").to_int())
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return get_property("auto_save_adv_override").to_int();
 	}
 
-	// automatically calculate adv to reserve at end of day
+	// automatically calculate how many adv to reserve at end of day
 	// free crafting require at least 1 adventure to do.
 	// To enter free fights we need at least 1 adventure remaining. Dying costs an adventure, so we reserve 2 adventures so the user can manually complete the remaining fights even if we lose.
 	// cocktailcrafting and pasta cooking require 2 adventures.
@@ -278,14 +271,17 @@ boolean auto_unreservedAdvRemaining()
 		}
 	}
 	
-	if(my_adventures() > reserveadv)
+	return reserveadv;
+}
+
+boolean auto_unreservedAdvRemaining()
+{
+	// should the main loop continue to run or not, based on how many adv we wish to reserve.
+	if(my_adventures() > auto_advToReserve())
 	{
 		return true;
 	}
-	else
-	{
-		return false;
-	}
+	return false;
 }
 
 boolean handleFamiliar(string type)

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2753,10 +2753,6 @@ string auto_edCombatHandler(int round, string opp, string text)
 	
 	if(canUse($item[chaos butterfly]) && !get_property("chaosButterflyThrown").to_boolean() && !get_property("auto_skipL12Farm").to_boolean())
 	{
-		if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
-		{
-			return useItems($item[chaos butterfly], $item[Time-Spinner]);
-		}
 		return useItem($item[chaos butterfly]);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -548,9 +548,28 @@ string auto_combatHandler(int round, string opp, string text)
 	// Unique Heavy Rains Enemy that Reflects Spells.
 	if(enemy.to_string() == "Gurgle")
 	{
-		if(canUse($skill[Summon Love Stinkbug], false))
+		if(canUse($skill[Summon Love Stinkbug]))
 		{
-			return useSkill($skill[Summon Love Stinkbug], false);
+			return useSkill($skill[Summon Love Stinkbug]);
+		}
+		return "attack with weapon";
+	}
+	
+	// Unique Heavy Rains Enemy that reduces Spells damage to 1 and caps non spell damage at 39 per source and type
+	// Has low enough HP it can be defeated in 10 combat turns using simple melee attacks that deal only physical damage
+	if(enemy.to_string() == "Dr. Aquard")
+	{
+		if(canUse($skill[Curse of Weaksauce]))
+		{
+			return useSkill($skill[Curse of Weaksauce]);
+		}
+		if(canUse($skill[Micrometeorite]))
+		{
+			return useSkill($skill[Micrometeorite]);
+		}
+		if(canUse($skill[Summon Love Stinkbug]))
+		{
+			return useSkill($skill[Summon Love Stinkbug]);
 		}
 		return "attack with weapon";
 	}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -791,9 +791,11 @@ string auto_combatHandler(int round, string opp, string text)
 		{
 			return useSkill($skill[Curse Of Weaksauce]);
 		}
+		//instead of calling the first [Thunder Bird] cast here it leaves it to the handler that immediately follows.
+		//othewise you would need a bunch of protective code testing its viability first to avoid risking infinite loop.
 	}
-	
-	// Heavy rain repeated debuffing over multiple combat rounds using [Thunder Bird] skill.
+	// The heavy rain boss debuffing above and [Thunder Bird] handler below this line rely on being in the current order. do not flip them.
+	// [Thunder Bird] skill handler for Heavy Rain path, perform repeated debuffing over multiple rounds.
 	if(get_property("auto_combatHandlerThunderBird").to_int() > 0 && canUse($skill[Thunder Bird], false))
 	{
 		set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 1);

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -544,35 +544,6 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 	}
 
-	// Unique Heavy Rains Enemy that Reflects Spells.
-	if(enemy.to_string() == "Gurgle")
-	{
-		if(canUse($skill[Summon Love Stinkbug]))
-		{
-			return useSkill($skill[Summon Love Stinkbug]);
-		}
-		return "attack with weapon";
-	}
-	
-	// Unique Heavy Rains Enemy that reduces Spells damage to 1 and caps non spell damage at 39 per source and type
-	// Has low enough HP it can be defeated in 10 combat turns using simple melee attacks that deal only physical damage
-	if(enemy.to_string() == "Dr. Aquard")
-	{
-		if(canUse($skill[Curse of Weaksauce]))
-		{
-			return useSkill($skill[Curse of Weaksauce]);
-		}
-		if(canUse($skill[Micrometeorite]))
-		{
-			return useSkill($skill[Micrometeorite]);
-		}
-		if(canUse($skill[Summon Love Stinkbug]))
-		{
-			return useSkill($skill[Summon Love Stinkbug]);
-		}
-		return "attack with weapon";
-	}
-
 	if (enemy == $monster[The Invader] && canUse($skill[Weapon of the Pastalord], false))
 	{
 		return useSkill($skill[Weapon of the Pastalord], false);
@@ -763,10 +734,10 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 	}
 
-	//Heavy Rain Boss debuffing
-	if($monsters[Big Wisnaqua, The Aquaman, The Big Wisniewski, The Man, The Rain King] contains enemy)
+	//Heavy Rain boss debuff & Stunning
+	if($monsters[Big Wisnaqua, The Aquaman, The Rain King] contains enemy)
 	{
-		//Against bosses set how many [Thunder Bird] we want to cast during round 1
+		//During round 1 against late bosses set how many [Thunder Bird] we plan to cast during this combat
 		if(round == 1 && get_property("auto_combatHandlerThunderBird").to_int() == 0)
 		{
 			int targetThunderBird = 3;
@@ -782,24 +753,122 @@ string auto_combatHandler(int round, string opp, string text)
 			{
 				targetThunderBird++;
 			}
-			targetThunderBird = min(my_thunder(), targetThunderBird);
 			set_property("auto_combatHandlerThunderBird", targetThunderBird);
 		}
 	
-		//if enemy ML is too high then they cannot be staggered, and at that point curse of weaksauce is less useful as it reduces by a fixed amount.
-		if(canUse($skill[Curse Of Weaksauce]) && my_mp() >= 30 && auto_have_skill($skill[Itchy Curse Finger]) && monster_level_adjustment() <= 150)
+		//These bosses are actually stunable. unless their ML is over 150
+		if(monster_level_adjustment() > 150)		//not stunable
 		{
-			return useSkill($skill[Curse Of Weaksauce]);
+			//30% debuff each crayon shavings, making each 1 superior to 2 casts of [Thunder Bird]
+			if(item_amount($item[crayon shavings]) > 1 && auto_have_skill($skill[Ambidextrous Funkslinging]))
+			{
+				set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 4);
+				return "item " + $item[crayon shavings] + ", " + $item[crayon shavings];
+			}
+			if(item_amount($item[crayon shavings]) > 0)
+			{
+				set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 2);
+				return "item " + $item[crayon shavings];
+			}
 		}
-		//instead of calling the first [Thunder Bird] cast here it leaves it to the handler that immediately follows.
-		//othewise you would need a bunch of protective code testing its viability first to avoid risking infinite loop.
+		else		//stunable
+		{
+			if(canUse($skill[Micrometeorite]))
+			{
+				//stun and delevel 10% (or theoretically up to 25% if it was not used constantly)
+				set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 1);
+				return useSkill($skill[Micrometeorite]);
+			}
+			if(canUse($skill[Curse Of Weaksauce]) && my_mp() >= 50 && auto_have_skill($skill[Itchy Curse Finger]))
+			{
+				//every round delevel 3% of original attack value
+				return useSkill($skill[Curse Of Weaksauce]);
+			}
+			if(canUse($skill[Thunderstrike]) && my_thunder() >= 5)
+			{
+				//Once per combat multiround stun ability that does not delevel
+				return useSkill($skill[Thunderstrike]);
+			}
+			if(canUse($skill[Curse Of Weaksauce]) && my_mp() >= 50)
+			{
+				//rely on thunderstrike stun if you do not have [Itchy Curse Finger]
+				return useSkill($skill[Curse Of Weaksauce]);
+			}
+		}
+		
+		//once done with stunnning, use [Thunder Bird] which debuffs but does not stun.
+		if(my_thunder() == 0 && get_property("auto_combatHandlerThunderBird").to_int() > 0)
+		{
+			set_property("auto_combatHandlerThunderBird", 0);
+		}
+		if(get_property("auto_combatHandlerThunderBird").to_int() > 0 && canUse($skill[Thunder Bird], false))
+		{
+			set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 1);
+			return useSkill($skill[Thunder Bird], false);
+		}
 	}
-	// The heavy rain boss debuffing above and [Thunder Bird] handler below this line rely on being in the current order. do not flip them.
-	// [Thunder Bird] skill handler for Heavy Rain path, perform repeated debuffing over multiple rounds.
-	if(get_property("auto_combatHandlerThunderBird").to_int() > 0 && canUse($skill[Thunder Bird], false))
+
+	// Heavy Rains Final Boss. strips you of positive effects every time it hits you. Capped at 40 damage per source per element.
+	if(enemy.to_string() == "The Rain King")
 	{
-		set_property("auto_combatHandlerThunderBird", get_property("auto_combatHandlerThunderBird").to_int() - 1);
-		return useSkill($skill[Thunder Bird], false);
+		if(get_property("auto_rain_king_combat") == "attack")
+		{
+			if(canUse($skill[Lunging Thrust-Smack], false))
+			{
+				return useSkill($skill[Lunging Thrust-Smack], false);
+			}
+			if(canUse($skill[Thrust-Smack], false))
+			{
+				return useSkill($skill[Thrust-Smack], false);
+			}
+			if(canUse($skill[Lunge Smack], false))
+			{
+				return useSkill($skill[Lunge Smack], false);
+			}
+			return "attack with weapon";
+		}
+		if(get_property("auto_rain_king_combat") == "saucestorm" && canUse($skill[Saucestorm], false))
+		{
+			return useSkill($skill[Saucestorm], false);
+		}
+		if(get_property("auto_rain_king_combat") == "weapon_of_the_pastalord" && canUse($skill[Weapon of the Pastalord], false))
+		{
+			return useSkill($skill[Weapon of the Pastalord], false);
+		}
+		if(get_property("auto_rain_king_combat") == "turtleini" && canUse($skill[Turtleini], false))
+		{
+			return useSkill($skill[Turtleini], false);
+		}
+		abort("I am not sure how to finish this battle");
+	}
+	
+	// Unique Heavy Rains Enemy that Reflects Spells.
+	if(enemy.to_string() == "Gurgle")
+	{
+		if(canUse($skill[Summon Love Stinkbug]))
+		{
+			return useSkill($skill[Summon Love Stinkbug]);
+		}
+		return "attack with weapon";
+	}
+	
+	// Unique Heavy Rains Enemy that reduces Spells damage to 1 and caps non spell damage at 39 per source and type
+	// Has low enough HP it can be defeated in 10 combat turns using simple melee attacks that deal only physical damage
+	if(enemy.to_string() == "Dr. Aquard")
+	{
+		if(canUse($skill[Curse of Weaksauce]))
+		{
+			return useSkill($skill[Curse of Weaksauce]);
+		}
+		if(canUse($skill[Micrometeorite]))
+		{
+			return useSkill($skill[Micrometeorite]);
+		}
+		if(canUse($skill[Summon Love Stinkbug]))
+		{
+			return useSkill($skill[Summon Love Stinkbug]);
+		}
+		return "attack with weapon";
 	}
 
 	if((my_location() == $location[The Battlefield (Frat Uniform)]) && (enemy == $monster[gourmet gourami]))

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -3326,12 +3326,9 @@ void cs_make_stuff(int curQuest)
 			cli_execute("make " + $item[Staff of the Headmaster\'s Victuals]);
 		}
 
-		if(!have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
+		if(!canChangeToFamiliar($familiar[Machine Elf]) && item_amount($item[Handful of Smithereens]) >= 3)
 		{
-			if(item_amount($item[Handful of Smithereens]) >= 3)
-			{
-				cli_execute("make 3 " + $item[Louder Than Bomb]);
-			}
+			cli_execute("make 3 " + $item[Louder Than Bomb]);
 		}
 
 		if((item_amount($item[Scrumptious Reagent]) >= 5) && have_skill($skill[Advanced Saucecrafting]))

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -606,6 +606,8 @@ void equipRollover()
 		to_max += ",0.3fites";
 	if(auto_have_familiar($familiar[Trick-or-Treating Tot]))
 		to_max += ",switch Trick-or-Treating Tot";
+	if(auto_have_familiar($familiar[Left-Hand Man]))
+		to_max += ",switch Left-Hand Man";
 
 	maximize(to_max, false);
 

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -40,8 +40,19 @@ boolean routineRainManHandler()
 	{
 		return false;
 	}
-#	if(my_rain() > (92 - (12 * my_daycount())))
+	
+	boolean want_to_rainman = false;
 	if((my_rain() > (92 - (7 * (my_daycount() - 1)))) && (have_effect($effect[ultrahydrated]) == 0))
+	{
+		want_to_rainman = true;
+	}
+	//stomach and liver are full, and 1 adv is left before we are done for the day
+	if(my_adventures() == (1 + auto_advToReserve()) && my_rain() >= 50 && my_fullness() == fullness_limit() && my_inebriety() == inebriety_limit())
+	{
+		want_to_rainman = true;
+	}
+	
+	if(want_to_rainman)
 	{
 		if(get_property("auto_mountainmen") == "")
 		{

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -554,3 +554,222 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink)
 {
 	return rainManSummon(monsterName, copy, wink, "");
 }
+
+boolean L13_towerFinalHeavyRains()
+{
+	//Prepare for and defeat the final boss for Heavy Rains run. Which has special rules for engagement.
+	if (internalQuestStatus("questL13Final") != 11)
+	{
+		return false;
+	}
+	
+	//use a damage dealing familiar
+	if(canChangeToFamiliar($familiar[warbear drone]))			//old event item. still farmable. up to 6 attacks per round
+	{
+		use_familiar($familiar[Warbear Drone]);
+		//TODO does rain king stripping at begining of combat remove familiar equipment? if yes remove the part below
+		pullXWhenHaveY($item[warbear drone codes], 1, 0);
+		if(possessEquipment($item[warbear drone codes]))
+		{
+			equip($item[warbear drone codes]);
+		}
+	}
+	else if(canChangeToFamiliar($familiar[Sludgepuppy]))		//IOTM derivative, infinitely farmable. attacks 3 times per round
+	{
+		use_familiar($familiar[Sludgepuppy]);
+	}
+	else if(canChangeToFamiliar($familiar[Imitation Crab]))		//cheap, easily acquired. attacks 2 times per round
+	{
+		use_familiar($familiar[Imitation Crab]);
+	}
+	else if(canChangeToFamiliar($familiar[Angry Goat]))			//super cheap. high chance to attack each round.
+	{
+		use_familiar($familiar[Angry Goat]);
+	}
+	
+	//buff up before the boss
+	//buffMaintain($effect[Benetton's Medley of Diversity], 0, 1, 1);		//15 prismatic weapon dmg. TODO: implemented in buffMaintain
+	buffMaintain($effect[Dirge of Dreadfulness], 0, 1, 1);					//12 spooky weapon dmg
+	effectAblativeArmor(true);					//Unimportant effects protect your important one from being removed.
+	
+	//Calculate melee/ranged damage. Each element is capped at 40. assume you will be able to deal 40 physical damage.
+	cli_execute("outfit Birthday Suit");			//Need to get naked so we can check our stats properly.
+	maximize("prismatic damage, +weapon, +offhand", false);
+
+	int hot_dmg = min(40,numeric_modifier("hot damage"));
+	int cold_dmg = min(40,numeric_modifier("cold damage"));
+	int stench_dmg = min(40,numeric_modifier("stench damage"));
+	int sleaze_dmg = min(40,numeric_modifier("sleaze damage"));
+	int spooky_dmg = min(40,numeric_modifier("spooky damage"));
+	if(auto_have_skill($skill[Cold Shoulder]))
+	{
+		cold_dmg = min(40, (5+cold_dmg));
+	}
+	
+	//lunging thrust smack as a seal clubber with a club triples elemental damage. this applies to damage that does not come from weapon, excluding cold shoulder.
+	boolean want_club = false;
+	if(my_class() == $class[Seal Clubber] && auto_have_skill($skill[Lunging Thrust-Smack]))
+	{
+		maximize("prismatic damage, +weapon, +offhand, +club", false);
+		int club_hot_dmg = min(40,(3*numeric_modifier("hot damage")));
+		int club_cold_dmg = min(40,(3*numeric_modifier("cold damage")));
+		int club_stench_dmg = min(40,(3*numeric_modifier("stench damage")));
+		int club_sleaze_dmg = min(40,(3*numeric_modifier("sleaze damage")));
+		int club_spooky_dmg = min(40,(3*numeric_modifier("spooky damage")));
+		
+		if(auto_have_skill($skill[Cold Shoulder]))
+		{
+			club_cold_dmg = min(40, (5+club_cold_dmg));
+		}
+
+		if((hot_dmg + cold_dmg + stench_dmg + sleaze_dmg + spooky_dmg) < (club_hot_dmg + club_cold_dmg + club_stench_dmg + club_sleaze_dmg + club_spooky_dmg))
+		{
+			want_club = true;
+			hot_dmg = club_hot_dmg;
+			cold_dmg = club_cold_dmg;
+			stench_dmg = club_stench_dmg;
+			sleaze_dmg = club_sleaze_dmg;
+			spooky_dmg = club_spooky_dmg;
+		}
+	}
+	
+	int attack_dmg = 40 + min(40,hot_dmg) + min(40,cold_dmg) + min(40,stench_dmg) + min(40,sleaze_dmg) + min(40,spooky_dmg);
+	
+	//check magic damage
+	boolean spell_extra_element = false;
+	if(item_amount($item[Rain-Doh green lantern]) > 0 || item_amount($item[meteorb]) > 0 || item_amount($item[snow mobile]) > 0)
+	{
+		spell_extra_element = true;
+	}
+	else foreach it in $items[Rain-Doh green lantern, meteorb, snow mobile]
+	{
+		if(creatable_amount(it) > 0)
+		{
+			create(1, it);
+			spell_extra_element = true;
+			break;
+		}
+	}
+
+	int	spell_dmg = 0;
+	string best_spell = "";
+	if(auto_have_skill($skill[Saucestorm]))
+	{
+		if(80>spell_dmg)
+		{
+			best_spell = "saucestorm";
+			spell_dmg = max(80,spell_dmg);
+		}
+		//IIRC hot and cold extra elements don't work for saucestorm, so only want green lantern. TODO verify
+		if(item_amount($item[Rain-Doh green lantern]) > 0 && 120>spell_dmg)
+		{
+			best_spell = "saucestorm";
+			spell_dmg = max(120,spell_dmg);
+		}
+	}
+	if(auto_have_skill($skill[Weapon of the Pastalord]) && auto_have_skill($skill[Flavour of Magic]))
+	{
+		if(80>spell_dmg)
+		{
+			best_spell = "weapon_of_the_pastalord";
+			spell_dmg = max(80,spell_dmg);
+		}
+		if(spell_extra_element && 120>spell_dmg)
+		{
+			best_spell = "weapon_of_the_pastalord";
+			spell_dmg = max(120,spell_dmg);
+		}
+	}
+	if(auto_have_skill($skill[Turtleini]))
+	{
+		if(120>spell_dmg)
+		{
+			best_spell = "turtleini";
+			spell_dmg = max(120,spell_dmg);
+		}
+		if(spell_extra_element && 160>spell_dmg)
+		{
+			//how does [Turtleini] get affected by extra elements? I am guessing it increases it to 160. TODO verify
+			best_spell = "turtleini";
+			spell_dmg = max(160,spell_dmg);
+		}
+	}
+	
+	boolean plan_on_spells = false;
+	if(attack_dmg < spell_dmg)
+	{
+		plan_on_spells = true;
+	}
+	
+	//final dressup for the boss
+	if(plan_on_spells)
+	{
+		set_property("auto_rain_king_combat", best_spell);
+		if(spell_extra_element)
+		{
+			maximize("spell damage percent, +weapon", false);
+			if(item_amount($item[Rain-Doh green lantern]) > 0)
+			{
+				equip($slot[off-hand], $item[Rain-Doh green lantern]);
+			}
+			else if(item_amount($item[meteorb]) > 0)
+			{
+				equip($slot[off-hand], $item[meteorb]);
+			}
+			else if(item_amount($item[snow mobile]) > 0)
+			{
+				equip($slot[off-hand], $item[snow mobile]);
+			}
+		}
+		else
+		{
+			maximize("spell damage percent, +weapon, +offhand", false);
+		}
+	}
+	else
+	{
+		set_property("auto_rain_king_combat", "attack");
+		if(want_club)
+		{
+			maximize("prismatic damage, +weapon, +offhand, +club", false);
+		}
+		else
+		{
+			maximize("prismatic damage, +weapon, +offhand", false);
+		}
+	}
+	
+	//Rain King strips all equipment other than weapon and offhand.
+	//Stripped equipment can only provide you with -ML which is applied before the stripping
+	buyUpTo(3, $item[water wings for babies]);
+	maximize("-ml, -weapon, -offhand", false);
+	
+	//Fight!
+	acquireHP();
+	set_property("auto_disableAdventureHandling", true);
+	autoAdvBypass("place.php?whichplace=nstower&action=ns_10_sorcfight", $location[Noob Cave]);
+	set_property("auto_disableAdventureHandling", false);
+	if(last_monster() != $monster[The Rain King])
+	{
+		abort("Failed to start the battle with The Rain King");
+	}
+	if(have_effect($effect[Beaten Up]) > 0)
+	{
+		abort("The Rain King beat me up! please finish him off manually");
+	}
+	if(get_property("auto_stayInRun").to_boolean())
+	{
+		abort("User wanted to stay in run (auto_stayInRun), we are done.");
+	}
+	else
+	{
+		visit_url("place.php?whichplace=nstower&action=ns_11_prism");
+		if(get_property("kingLiberated") == "true")
+		{
+			abort("All done. King Ralph has been freed");
+		}
+		abort("Tried to break prism but failed");
+	}
+	abort("How did I reach this line? I should have fought [The Rain King]");
+	return false;
+}

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -302,8 +302,7 @@ boolean fantasyRealmToken()
 
 	//This does not appear to check that we no longer need to adventure there...
 
-	autoAdv(1, $location[The Bandit Crossroads]);
-	return true;
+	return autoAdv(1, $location[The Bandit Crossroads]);
 }
 
 boolean songboomSetting(string goal)

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -108,7 +108,6 @@ int auto_warKillsPerBattle(int sidequests)
 	int kills = 2**sidequests;
 		
 	// Avatar of Sneaky Pete has a motorbike mod that gives +3 kills/battle.
-	// TODO find correct spelling of mafia property for Rocket Launcher, I am currently guessing its spelling
 	if(get_property("peteMotorbikeCowling") == "Rocket Launcher")
 	{
 		kills += 3;

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -970,11 +970,14 @@ boolean L13_towerNSTower()
 
 boolean L13_towerNSFinal()
 {
-	if (internalQuestStatus("questL13Final") < 11 || internalQuestStatus("questL13Final") > 11)
+	//state 11 means ready to fight sorceress. state 12 means lost to her due to lack of wand thus unlocking bear verb orgy
+	if (internalQuestStatus("questL13Final") < 11 || internalQuestStatus("questL13Final") > 12)
 	{
 		return false;
 	}
-	if(get_property("auto_wandOfNagamar").to_boolean())
+	//wand acquisition function is called before this function, it turns this propery to false once a wand is acquired.
+	//it is also false on all paths that don't want a wand. Thus if it is true it means we do want a wand but didn't get one yet.
+	if(get_property("auto_wandOfNagamar").to_boolean() && internalQuestStatus("questL13Final") == 11)
 	{
 		auto_log_warning("We do not have a Wand of Nagamar but appear to need one. We must lose to the Sausage first...", "red");
 	}

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -975,6 +975,7 @@ boolean L13_towerNSFinal()
 	{
 		return false;
 	}
+	
 	//wand acquisition function is called before this function, it turns this propery to false once a wand is acquired.
 	//it is also false on all paths that don't want a wand. Thus if it is true it means we do want a wand but didn't get one yet.
 	if(get_property("auto_wandOfNagamar").to_boolean() && internalQuestStatus("questL13Final") == 11)
@@ -982,18 +983,22 @@ boolean L13_towerNSFinal()
 		auto_log_warning("We do not have a Wand of Nagamar but appear to need one. We must lose to the Sausage first...", "red");
 	}
 
-	//Only if the final boss does not unbuff us...
-	if($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Bees Hate You, Bugbear Invasion, Community Service, Heavy Rains, The Source, Way of the Surprising Fist, Zombie Slayer] contains auto_my_path())
+	if(auto_my_path() == "Heavy Rains")
 	{
-		if(auto_my_path() == "The Source")
-		{
-			acquireMP(200, 0);
-		}
+		return L13_towerFinalHeavyRains();
 	}
-	else
+	
+	if(auto_my_path() == "The Source")
 	{
+		acquireMP(200, 0);
+	}
+	
+	if(!($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Bees Hate You, Bugbear Invasion, Community Service, The Source, Way of the Surprising Fist, Zombie Slayer] contains auto_my_path()))
+	{
+		//Only if the final boss does not unbuff us...
 		cli_execute("scripts/autoscend/auto_post_adv.ash");
 	}
+	
 	if(my_class() == $class[Turtle Tamer])
 	{
 		autoEquip($item[Ouija Board\, Ouija Board]);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7141,7 +7141,6 @@ boolean is_superlikely(string encounterName)
 
 }
 
-
 // Function to Predict how many turns we will get from an AT buff
 int auto_predictAccordionTurns()
 {
@@ -7170,4 +7169,120 @@ int auto_predictAccordionTurns()
 	}
 
 	return CurrentBestTurns;
+}
+
+boolean hasTTBlessing()
+{
+	//do you currently have a turtle blessing active? or if not turtle tamer then the buff?
+	
+	foreach eff in $effects[
+	Blessing of the War Snapper,
+	Grand Blessing of the War Snapper,
+	Glorious Blessing of the War Snapper,
+	Blessing of She-Who-Was,
+	Grand Blessing of She-Who-Was,
+	Glorious Blessing of She-Who-Was,
+	Blessing of the Storm Tortoise,
+	Grand Blessing of the Storm Tortoise,
+	Glorious Blessing of the Storm Tortoise,
+	Disdain of the War Snapper,
+	Disdain of She-Who-Was,
+	Disdain of the Storm Tortoise
+	]
+	{
+		if(have_effect(eff) > 0)
+		{
+			return true;
+		}
+	}
+	
+	return false;	
+}
+
+void effectAblativeArmor(boolean passive_dmg_allowed)
+{
+	//when facing a boss that has a buff stripping mechanic that is limited on how many can be stripped per round.
+	//then load up on as many reasonable buffs as you can taking cost into account.
+	//avoid potentially undesireable effects such as +ML.
+	//I am pretty sure non combat skills that give an effect count.
+	//but I am labeling them seperate from buffs in case we ever need to split this function.
+	
+	//if you have something that reduces the cost of casting buffs, wear it now.
+	maximize("-mana cost", false);
+	
+	//Passive damage
+	if(passive_dmg_allowed)
+	{
+		buffMaintain($effect[Spiky Shell], 0, 1, 1);					//8 MP
+		buffMaintain($effect[Jalape&ntilde;o Saucesphere], 0, 1, 1);	//5 MP
+		buffMaintain($effect[Scarysauce], 0, 1, 1);						//10 MP
+	}
+	
+	//1MP Non-Combat skills from each class
+	buffMaintain($effect[Seal Clubbing Frenzy], 0, 1, 1);
+	buffMaintain($effect[Patience of the Tortoise], 0, 1, 1);
+	buffMaintain($effect[Pasta Oneness], 0, 1, 1);
+	buffMaintain($effect[Saucemastery], 0, 1, 1);
+	buffMaintain($effect[Disco State of Mind], 0, 1, 1);
+	buffMaintain($effect[Mariachi Mood], 0, 1, 1);
+
+	//Seal clubber Non-Combat skills
+	buffMaintain($effect[Blubbered Up], 0, 1, 1);						//7 MP
+	buffMaintain($effect[Rage of the Reindeer], 0, 1, 1);				//10 MP
+	buffMaintain($effect[A Few Extra Pounds], 0, 1, 1);					//10 MP
+	//free intrisic, does it work as ablative armor? TODO add support for it in buffMaintain
+	if(have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
+	{
+		use_skill(1, $skill[Iron Palm Technique]);
+	}						
+	
+	//Turtle Tamer Non-Combat skills
+	if(!hasTTBlessing())
+	{
+		buffMaintain($effect[Blessing of the War Snapper], 0, 1, 1);	//15 MP. other blessings too expensive.
+	}
+	
+	//Pastamancer Non-Combat skills
+	buffMaintain($effect[Springy Fusilli], 0, 1, 1);					//10 MP
+	buffMaintain($effect[Shield of the Pastalord], 0, 1, 1);			//20 MP
+	buffMaintain($effect[Leash of Linguini], 0, 1, 1);					//12 MP
+	
+	//Sauceror Non-Combat skills
+	buffMaintain($effect[Sauce Monocle], 0, 1, 1);						//20 MP
+
+	//Disco Bandit Non-Combat skills
+	buffMaintain($effect[Disco Fever], 0, 1, 1);						//10 MP
+	
+	//Turtle Tamer Buffs
+	buffMaintain($effect[Ghostly Shell], 0, 1, 1);						//6 MP
+	buffMaintain($effect[Tenacity of the Snapper], 0, 1, 1);			//8 MP
+	buffMaintain($effect[Empathy], 0, 1, 1);							//15 MP
+	buffMaintain($effect[Reptilian Fortitude], 0, 1, 1);				//8 MP
+	buffMaintain($effect[Astral Shell], 0, 1, 1);						//10 MP
+	buffMaintain($effect[Jingle Jangle Jingle], 0, 1, 1);				//5 MP
+	buffMaintain($effect[Curiosity of Br'er Tarrypin], 0, 1, 1);		//5 MP
+	
+	//Sauceror Buffs
+	buffMaintain($effect[Elemental Saucesphere], 0, 1, 1);				//10 MP
+	buffMaintain($effect[Antibiotic Saucesphere], 0, 1, 1);				//15 MP
+	
+	//Accordion Thief Buffs. We are not shrugging so it will only apply new ones if we have space for them
+	buffMaintain($effect[The Moxious Madrigal], 0, 1, 1);				//2 MP
+	buffMaintain($effect[The Magical Mojomuscular Melody], 0, 1, 1);	//3 MP
+	buffMaintain($effect[Cletus's Canticle of Celerity], 0, 1, 1);		//4 MP
+	buffMaintain($effect[Power Ballad of the Arrowsmith], 0, 1, 1);		//5 MP
+	buffMaintain($effect[Polka of Plenty], 0, 1, 1);					//7 MP
+	
+	//Mutually exclusive effects
+	if(have_effect($effect[Musk of the Moose]) == 0 && have_effect($effect[Hippy Stench]) == 0)
+	{
+		buffMaintain($effect[Smooth Movements], 0, 1, 1);				//10 MP
+	}
+	if(have_effect($effect[Smooth Movements]) == 0 && have_effect($effect[Fresh Scent]) == 0)
+	{
+		buffMaintain($effect[Musk of the Moose], 0, 1, 1);				//10 MP
+	}	
+	
+	//TODO facial expressions, need to check you are not wearing one first and which ones you have
+	//Maybe just not do facial expressions? too much complexity for a singular effect.
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7208,7 +7208,7 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//but I am labeling them seperate from buffs in case we ever need to split this function.
 	
 	//if you have something that reduces the cost of casting buffs, wear it now.
-	maximize("-mana cost", false);
+	maximize("-mana cost, -tie", false);
 	
 	//Passive damage
 	if(passive_dmg_allowed)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -302,6 +302,7 @@ boolean useCocoon();
 
 //Large pile dump.
 int auto_freeCombatsRemaining();							//Defined in autoscend.ash
+int auto_advToReserve();									//Defined in autoscend.ash
 boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
 boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -825,6 +825,7 @@ void hr_doBedtime();										//Defined in autoscend/auto_heavyrains.ash
 boolean hr_handleFamiliar(familiar fam);					//Defined in autoscend/auto_heavyrains.ash
 void hr_initializeDay(int day);								//Defined in autoscend/auto_heavyrains.ash
 void hr_initializeSettings();								//Defined in autoscend/auto_heavyrains.ash
+boolean L13_towerFinalHeavyRains();							//Defined in autoscend/auto_heavyrains.ash
 boolean in_ronin();											//Defined in autoscend/auto_util.ash
 int inebriety_left();										//Defined in autoscend/auto_util.ash
 void initializeDay(int day);								//Defined in autoscend.ash
@@ -1183,6 +1184,8 @@ boolean auto_canForceNextNoncombat();  // Defined in autoscend/auto_util.ash
 boolean auto_forceNextNoncombat(); // Defined in autoscend/auto_util.ash
 boolean auto_haveQueuedForcedNonCombat(); // Defined in autoscend/auto_util.ash
 boolean is_superlikely(string encounterName); // Defined in autoscend/auto_util.ash
+boolean hasTTBlessing();									 // Defined in autoscend/auto_util.ash
+void effectAblativeArmor(boolean passive_dmg_allowed);		 // Defined in autoscend/auto_util.ash
 
 //Record from autoscend/auto_zone.ash
 record generic_t


### PR DESCRIPTION
# Description

1. in a recent merge i copied the chaos butterfly handling code into ed combat handling. However ed cannot funksling, removed that bit of redundant code.

2. Dr. Aquard (in heavy rains path) is a puzzle boss
Fixes #194

3. gurgle (in heavy rains) was set to have summon love stinkbugs cast repeatedly against it. but it is a 1 time per battle spell. also improved handling

4. Thunder bird (heavy rains delevel skill) when unlocked, would be used 5 times against a boss, then another 5 times, then another 5 times... until 31 turns pass and you lose because you only deleveled and never tried dealing damage. Now it only uses it a specified amount of times and then stops. also improved handling.

5. commit baa56e8
issue #198 subissue 3 + discord reported issue with reserved adv
To address #198 I needed to split the function that determines if we are done for the day into 2.
one that calculates how many adv we want to keep, and one to determine if we reached that point.
When doing so I noticed I forgot a .to_int() in one spot which I believe is the cause of the discord reported issue (it was very lacking in details so I can't be sure)

6. commit 17ca00a
issue #198 subissue 1
https://kol.coldfront.net/thekolwiki/index.php/The_Rain_King
Special handling added. 

7. commit a6304ae
actually fight sorceress after acquiring wand of nagamar via bear verb orgy.

8. add left-hand man (farmiliar that can equip an offhand item for you) switching in overnight maximizer string for more rollover adv

## How Has This Been Tested?

Main account (tons of IOTMs, max skills)
Ending of a softcore heavy rains sauceror run. Specifically tested trouble points
day 1 (of expected 2) of heavy rains softcore sauceror run.

Alt account (0 IOTMs, max ed skill points, few permed skills)
day 2 & 3 (of expected 4) of hardcore ed run

Testing accounts (0 IOTMs, 0 skill)
2 days of a long hardcore ed run
2 days of a long hardcore sneaky pete run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
