### PR TITLE
familiar functions changes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2784,7 +2784,7 @@ int auto_freeCombatsRemaining()
 	{
 		count += 10-get_property("_snojoFreeFights").to_int();
 	}
-	if(auto_have_familiar($familiar[God Lobster]) && canChangeFamiliar())
+	if(canChangeFamiliar($familiar[God Lobster]))
 	{
 		count += 3-get_property("_godLobsterFights").to_int();
 	}
@@ -4055,7 +4055,7 @@ boolean LX_phatLootToken()
 
 	if((!possessEquipment($item[Ring of Detect Boring Doors]) || (item_amount($item[Eleven-Foot Pole]) == 0) || (item_amount($item[Pick-O-Matic Lockpicks]) == 0)) && auto_have_familiar($familiar[Gelatinous Cubeling]))
 	{
-		if(canChangeToFamiliar($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
+		if(canChangeToFamiliar($familiar[Gelatinous Cubeling]))
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2776,7 +2776,7 @@ int auto_freeCombatsRemaining()
 {
 	int count = 0;
 	
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
+	if(!in_koe() && canChangeToFamiliar($familiar[Machine Elf]))
 	{
 		count += 5-get_property("_machineTunnelsAdv").to_int();
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -91,13 +91,13 @@ void initializeSettings()
 		{
 			set_property("auto_100familiar", my_familiar());
 		}
-		if(forbidFamChange())
+		if(!canChangeFamiliar())
 		{
 			set_property("auto_useCubeling", false);
 		}
 	}
 
-	if(!forbidFamChange($familiar[Crimbo Shrub]))
+	if(canChangeToFamiliar($familiar[Crimbo Shrub]))
 	{
 		use_familiar($familiar[Crimbo Shrub]);
 		use_familiar($familiar[none]);
@@ -345,7 +345,7 @@ boolean handleFamiliar(string type)
 
 boolean handleFamiliar(familiar fam)
 {
-	if(forbidFamChange())
+	if(!canChangeFamiliar())
 	{
 		return true;
 	}
@@ -917,7 +917,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(((auto_my_path() == "Picky") || forbidFamChange()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
+		if(((auto_my_path() == "Picky") || !canChangeFamiliar()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{
@@ -1675,7 +1675,7 @@ boolean doBedtime()
 		return false;
 	}
 	int spleenlimit = spleen_limit();
-	if(forbidFamChange())
+	if(!canChangeFamiliar())
 	{
 		spleenlimit -= 3;
 	}
@@ -2776,7 +2776,7 @@ int auto_freeCombatsRemaining()
 {
 	int count = 0;
 	
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && !forbidFamChange())
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
 	{
 		count += 5-get_property("_machineTunnelsAdv").to_int();
 	}
@@ -2784,7 +2784,7 @@ int auto_freeCombatsRemaining()
 	{
 		count += 10-get_property("_snojoFreeFights").to_int();
 	}
-	if(auto_have_familiar($familiar[God Lobster]) && !forbidFamChange())
+	if(auto_have_familiar($familiar[God Lobster]) && canChangeFamiliar())
 	{
 		count += 3-get_property("_godLobsterFights").to_int();
 	}
@@ -2834,7 +2834,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(!in_koe() && get_property("_machineTunnelsAdv").to_int() < 5 && !forbidFamChange($familiar[Machine Elf]))
+	if(!in_koe() && get_property("_machineTunnelsAdv").to_int() < 5 && canChangeToFamiliar($familiar[Machine Elf]))
 	{
 		if(get_property("auto_choice1119") != "")
 		{
@@ -4055,7 +4055,7 @@ boolean LX_phatLootToken()
 
 	if((!possessEquipment($item[Ring of Detect Boring Doors]) || (item_amount($item[Eleven-Foot Pole]) == 0) || (item_amount($item[Pick-O-Matic Lockpicks]) == 0)) && auto_have_familiar($familiar[Gelatinous Cubeling]))
 	{
-		if(!forbidFamChange($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
+		if(canChangeToFamiliar($familiar[Gelatinous Cubeling]) && (auto_my_path() != "Pocket Familiars"))
 		{
 			return false;
 		}
@@ -4810,7 +4810,7 @@ boolean doTasks()
 
 	basicAdjustML();
 	powerLevelAdjustment();
-	if (forbidFamChange() && my_familiar() == $familiar[none])
+	if (!canChangeFamiliar() && my_familiar() == $familiar[none])
 	{
 		// re-equip a familiar if it's a 100% run just in case something unequipped it
 		// looking at you auto_maximizedConsumeStuff()...

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2784,7 +2784,7 @@ int auto_freeCombatsRemaining()
 	{
 		count += 10-get_property("_snojoFreeFights").to_int();
 	}
-	if(canChangeFamiliar($familiar[God Lobster]))
+	if(canChangeToFamiliar($familiar[God Lobster]))
 	{
 		count += 3-get_property("_godLobsterFights").to_int();
 	}

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -320,7 +320,7 @@ void preAdvUpdateFamiliar(location place)
 		famChoice = $familiar[none];
 	}
 
-	if((famChoice != $familiar[none]) && !forbidFamChange() && (internalQuestStatus("questL13Final") < 13))
+	if((famChoice != $familiar[none]) && canChangeFamiliar() && (internalQuestStatus("questL13Final") < 13))
 	{
 		if((famChoice != my_familiar()) && !get_property("kingLiberated").to_boolean())
 		{
@@ -344,7 +344,7 @@ void preAdvUpdateFamiliar(location place)
 				}
 			}
 		}
-		if(wannaHeist && (famChoice != $familiar[none]) && !forbidFamChange())
+		if(wannaHeist && (famChoice != $familiar[none]) && canChangeFamiliar())
 		{
 			use_familiar($familiar[cat burglar]);
 		}

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -344,7 +344,7 @@ void preAdvUpdateFamiliar(location place)
 				}
 			}
 		}
-		if(wannaHeist && (famChoice != $familiar[none]) && canChangeFamiliar())
+		if(wannaHeist && (famChoice != $familiar[none]) && canChangeToFamiliar($familiar[Cat Burglar]))
 		{
 			use_familiar($familiar[cat burglar]);
 		}

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -696,7 +696,7 @@ boolean LA_cs_communityService()
 
 			if(!get_property("auto_hccsNoConcludeDay").to_boolean())
 			{
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !forbidFamChange($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && canChangeToFamiliar($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -709,7 +709,7 @@ boolean LA_cs_communityService()
 					return true;
 				}
 
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && !forbidFamChange($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && canChangeToFamiliar($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -830,7 +830,7 @@ boolean LA_cs_communityService()
 			}
 			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])))
 			{
-				if(forbidFamChange() && forbidFamChange($familiar[Puck Man]) && forbidFamChange($familiar[Ms. Puck Man]))
+				if(!canChangeFamiliar() && !canChangeToFamiliar($familiar[Puck Man]) && !canChangeToFamiliar($familiar[Ms. Puck Man]))
 				{}
 				else
 				{
@@ -1016,7 +1016,7 @@ boolean LA_cs_communityService()
 			{
 				missing = 0;
 			}
-			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (!forbidFamChange() || !forbidFamChange($familiar[Puck Man]) || !forbidFamChange($familiar[Ms. Puck Man])))
+			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (canChangeFamiliar() || canChangeToFamiliar($familiar[Puck Man]) || canChangeToFamiliar($familiar[Ms. Puck Man])))
 			{
 				if(elementalPlanes_access($element[hot]))
 				{
@@ -1081,7 +1081,7 @@ boolean LA_cs_communityService()
 				auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 			}
 
-			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && have_familiar($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11) && !forbidFamChange($familiar[XO Skeleton]))
+			if(elementalPlanes_access($element[hot]) && have_skills($skills[Meteor Lore, Snokebomb]) && have_familiar($familiar[XO Skeleton]) && (my_mp() > mp_cost($skill[Snokebomb])) && (get_property("_snokebombUsed").to_int() < 3) && (get_property("_macrometeoriteUses").to_int() < 10) && (get_property("_xoHugsUsed").to_int() < 11) && canChangeToFamiliar($familiar[XO Skeleton]))
 			{
 				if((!possessEquipment($item[Fireproof Megaphone]) && !possessEquipment($item[Meteorite Guard])) || !possessEquipment($item[High-Temperature Mining Mask]))
 				{
@@ -2244,7 +2244,7 @@ boolean LA_cs_communityService()
 					autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 					return true;
 				}
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && !forbidFamChange($familiar[Machine Elf]))
+				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && canChangeToFamiliar($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -2410,7 +2410,7 @@ boolean LA_cs_communityService()
 			}
 			asdonBuff($effect[Driving Stealthily]);
 
-			if(!forbidFamChange($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
+			if(canChangeToFamiliar($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
 			{
 				# Need 37-41 pounds to save 3 turns. (probably 40)
 				# 74 does not save 6 but 79 does.
@@ -3062,7 +3062,7 @@ void cs_initializeDay(int day)
 			{
 				familiar last = my_familiar();
 				int gift = 1;
-				if(forbidFamChange() && (my_familiar() != $familiar[Crimbo Shrub]))
+				if(!canChangeFamiliar() && (my_familiar() != $familiar[Crimbo Shrub]))
 				{
 					gift = 2;
 				}
@@ -3331,7 +3331,7 @@ void cs_make_stuff(int curQuest)
 			cli_execute("make " + $item[Staff of the Headmaster\'s Victuals]);
 		}
 
-		if(!have_familiar($familiar[Machine Elf]) && !forbidFamChange())
+		if(!have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
 		{
 			if(item_amount($item[Handful of Smithereens]) >= 3)
 			{
@@ -4332,7 +4332,7 @@ boolean cs_giant_growth()
 	{
 		fail = false;
 	}
-	if(have_familiar($familiar[Machine Elf]) && !forbidFamChange())
+	if(have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
 	{
 		use_familiar($familiar[Machine Elf]);
 		fail = false;
@@ -4768,7 +4768,7 @@ boolean cs_preTurnStuff(int curQuest)
 		januaryToteAcquire($item[Wad Of Used Tape]);
 	}
 
-	if(forbidFamChange())
+	if(!canChangeFamiliar())
 	{
 		if((my_familiar() != $familiar[Puck Man]) && (my_familiar() != $familiar[Ms. Puck Man]))
 		{

--- a/RELEASE/scripts/autoscend/auto_community_service.ash
+++ b/RELEASE/scripts/autoscend/auto_community_service.ash
@@ -828,14 +828,9 @@ boolean LA_cs_communityService()
 				set_property("auto_csPuckCounter", get_property("auto_csPuckCounter").to_int() - 1);
 				doFarm = true;
 			}
-			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])))
+			if(((item_amount($item[Power Pill]) < 2) || (item_amount($item[Yellow Pixel]) < pixelsNeed)) && (canChangeToFamiliar($familiar[Puck Man]) || canChangeToFamiliar($familiar[Ms. Puck Man])))
 			{
-				if(!canChangeFamiliar() && !canChangeToFamiliar($familiar[Puck Man]) && !canChangeToFamiliar($familiar[Ms. Puck Man]))
-				{}
-				else
-				{
-					doFarm = true;
-				}
+				doFarm = true;
 			}
 
 			if(possessEquipment($item[KoL Con 13 Snowglobe]) && (equipped_item($slot[Off-Hand]) == $item[A Light That Never Goes Out]))
@@ -1016,7 +1011,7 @@ boolean LA_cs_communityService()
 			{
 				missing = 0;
 			}
-			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (have_familiar($familiar[Puck Man]) || have_familiar($familiar[Ms. Puck Man])) && (canChangeFamiliar() || canChangeToFamiliar($familiar[Puck Man]) || canChangeToFamiliar($familiar[Ms. Puck Man])))
+			if((missing > (item_amount($item[Miniature Power Pill]) + item_amount($item[Power Pill]))) && (canChangeToFamiliar($familiar[Puck Man]) || canChangeToFamiliar($familiar[Ms. Puck Man])))
 			{
 				if(elementalPlanes_access($element[hot]))
 				{
@@ -2244,7 +2239,7 @@ boolean LA_cs_communityService()
 					autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 					return true;
 				}
-				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 2) && canChangeToFamiliar($familiar[Machine Elf]))
+				if(get_property("_machineTunnelsAdv").to_int() < 2 && canChangeToFamiliar($familiar[Machine Elf]))
 				{
 					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
@@ -2410,7 +2405,7 @@ boolean LA_cs_communityService()
 			}
 			asdonBuff($effect[Driving Stealthily]);
 
-			if(canChangeToFamiliar($familiar[Disgeist]) && have_familiar($familiar[Disgeist]))
+			if(canChangeToFamiliar($familiar[Disgeist]))
 			{
 				# Need 37-41 pounds to save 3 turns. (probably 40)
 				# 74 does not save 6 but 79 does.
@@ -4332,7 +4327,7 @@ boolean cs_giant_growth()
 	{
 		fail = false;
 	}
-	if(have_familiar($familiar[Machine Elf]) && canChangeFamiliar())
+	if(canChangeToFamiliar($familiar[Machine Elf]))
 	{
 		use_familiar($familiar[Machine Elf]);
 		fail = false;

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -510,7 +510,7 @@ boolean handleBjornify(familiar fam)
 		return false;
 	}
 
-	if(forbidFamChange() && (fam == my_familiar()))
+	if(!canChangeFamiliar() && (fam == my_familiar()))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_heavyrains.ash
+++ b/RELEASE/scripts/autoscend/auto_heavyrains.ash
@@ -491,7 +491,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 
 	set_property("choiceAdventure970", "0");
 
-	if(forbidFamChange($familiar[Reanimated Reanimator]))
+	if(!canChangeToFamiliar($familiar[Reanimated Reanimator]))
 	{
 		wink = false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2014.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2014.ash
@@ -46,7 +46,7 @@ boolean dna_startAcquire()
 	}
 	else
 	{
-		if((have_familiar($familiar[Machine Elf])) && forbidFamChange($familiar[Machine Elf]))
+		if((have_familiar($familiar[Machine Elf])) && !canChangeToFamiliar($familiar[Machine Elf]))
 		{
 			familiar bjorn = my_bjorned_familiar();
 			if(bjorn == $familiar[Machine Elf])

--- a/RELEASE/scripts/autoscend/auto_mr2014.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2014.ash
@@ -46,7 +46,7 @@ boolean dna_startAcquire()
 	}
 	else
 	{
-		if((have_familiar($familiar[Machine Elf])) && !canChangeToFamiliar($familiar[Machine Elf]))
+		if(!canChangeToFamiliar($familiar[Machine Elf]))
 		{
 			familiar bjorn = my_bjorned_familiar();
 			if(bjorn == $familiar[Machine Elf])

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1185,7 +1185,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && !forbidFamChange($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && canChangeToFamiliar($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
 		if(get_property("auto_choice1119") != "")
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2017.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2017.ash
@@ -1091,7 +1091,7 @@ boolean solveKGBMastermind()
 
 boolean getSpaceJelly()
 {
-	if(forbidFamChange($familiar[Space Jellyfish]))
+	if(!canChangeToFamiliar($familiar[Space Jellyfish]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -148,7 +148,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 	{
 		return false;
 	}
-	if(forbidFamChange($familiar[God Lobster]))
+	if(!canChangeToFamiliar($familiar[God Lobster]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -873,7 +873,7 @@ boolean L12_filthworms()
 
 	if(have_effect($effect[Filthworm Drone Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -881,7 +881,7 @@ boolean L12_filthworms()
 	}
 	else if(have_effect($effect[Filthworm Larva Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -889,7 +889,7 @@ boolean L12_filthworms()
 	}
 	else
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && !forbidFamChange($familiar[XO Skeleton]))
+		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -1548,7 +1548,7 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
 	songboomSetting("meat");
 
-	if(forbidFamChange())
+	if(!canChangeFamiliar())
 	{
 		addToMaximize("200meat drop");
 	}
@@ -1595,7 +1595,7 @@ boolean L12_themtharHills()
 
 
 	handleFamiliar("meat");
-	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && !forbidFamChange($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
+	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
 		autoEquip($item[Li\'l Pirate Costume]);

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -873,7 +873,7 @@ boolean L12_filthworms()
 
 	if(have_effect($effect[Filthworm Drone Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
+		if(get_property("_xoHugsUsed").to_int() <= 10 && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -881,7 +881,7 @@ boolean L12_filthworms()
 	}
 	else if(have_effect($effect[Filthworm Larva Stench]) > 0)
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
+		if(get_property("_xoHugsUsed").to_int() <= 10 && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -889,7 +889,7 @@ boolean L12_filthworms()
 	}
 	else
 	{
-		if(auto_have_familiar($familiar[XO Skeleton]) && (get_property("_xoHugsUsed").to_int() <= 10) && canChangeToFamiliar($familiar[XO Skeleton]))
+		if(get_property("_xoHugsUsed").to_int() <= 10 && canChangeToFamiliar($familiar[XO Skeleton]))
 		{
 			handleFamiliar($familiar[XO Skeleton]);
 		}
@@ -1595,7 +1595,7 @@ boolean L12_themtharHills()
 
 
 	handleFamiliar("meat");
-	if(auto_have_familiar($familiar[Trick-or-Treating Tot]) && (available_amount($item[Li\'l Pirate Costume]) > 0) && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
+	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
 		autoEquip($item[Li\'l Pirate Costume]);

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -706,7 +706,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && canChangeFamiliar())
+		if(canChangeToFamiliar($familiar[warbear drone]))
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -722,12 +722,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && canChangeFamiliar())
+		else if(canChangeToFamiliar($familiar[Sludgepuppy]))
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && canChangeFamiliar())
+		else if(canChangeToFamiliar($familiar[Imitation Crab]))
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -706,7 +706,7 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if((auto_have_familiar($familiar[warbear drone])) && !forbidFamChange())
+		if((auto_have_familiar($familiar[warbear drone])) && canChangeFamiliar())
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -722,12 +722,12 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if((auto_have_familiar($familiar[Sludgepuppy])) && !forbidFamChange())
+		else if((auto_have_familiar($familiar[Sludgepuppy])) && canChangeFamiliar())
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
 		}
-		else if((auto_have_familiar($familiar[Imitation Crab])) && !forbidFamChange())
+		else if((auto_have_familiar($familiar[Imitation Crab])) && canChangeFamiliar())
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 2;
@@ -837,7 +837,7 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(forbidFamChange())
+		if(!canChangeFamiliar())
 		{
 			addToMaximize("200meat drop");
 		}

--- a/RELEASE/scripts/autoscend/auto_quest_level_8.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_8.ash
@@ -321,7 +321,7 @@ boolean L8_trapperGroar()
 	//What is our potential +Combat score.
 	//TODO: Use that instead of the Avatar/Hound Dog checks.
 
-	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || forbidFamChange($familiar[Jumpsuited Hound Dog])))
+	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || !canChangeToFamiliar($familiar[Jumpsuited Hound Dog])))
 	{
 		if(L8_trapperExtreme())
 		{

--- a/RELEASE/scripts/autoscend/auto_quest_level_8.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_8.ash
@@ -321,7 +321,7 @@ boolean L8_trapperGroar()
 	//What is our potential +Combat score.
 	//TODO: Use that instead of the Avatar/Hound Dog checks.
 
-	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !auto_have_familiar($familiar[Jumpsuited Hound Dog]) || !canChangeToFamiliar($familiar[Jumpsuited Hound Dog])))
+	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !canChangeToFamiliar($familiar[Jumpsuited Hound Dog])))
 	{
 		if(L8_trapperExtreme())
 		{

--- a/RELEASE/scripts/autoscend/auto_quest_level_9.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_9.ash
@@ -312,7 +312,7 @@ boolean L9_aBooPeak()
 			lihcface = "-equip lihc face";
 		}
 		string parrot = ", switch exotic parrot, switch mu, switch trick-or-treating tot";
-		if(forbidFamChange())
+		if(!canChangeFamiliar())
 		{
 			parrot = "";
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1336,7 +1336,7 @@ boolean canYellowRay(monster target)
 	# Use this to determine if it is safe to enter a yellow ray combat.
 
 	// first, do any necessary prep to use a yellow ray
-	if((my_familiar() == $familiar[Crimbo Shrub]) || (canChangeToFamiliar($familiar[Crimbo Shrub]) && auto_have_familiar($familiar[Crimbo Shrub])))
+	if(canChangeToFamiliar($familiar[Crimbo Shrub]))
 	{
 		if(item_amount($item[box of old Crimbo decorations]) == 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -909,7 +909,7 @@ boolean canChangeToFamiliar(familiar target)
 	}
 
 	// You are allowed to change to a familiar if it is also the goal of the current 100% run.
-	if(get_property("auto_100familiar") == target)
+	if(get_property("auto_100familiar").to_familiar() == target)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -134,8 +134,6 @@ boolean loopHandler(string turnSetting, string counterSetting, string abortMessa
 boolean loopHandler(string turnSetting, string counterSetting, int threshold);
 boolean loopHandlerDelay(string counterSetting);
 boolean loopHandlerDelay(string counterSetting, int threshold);
-boolean forbidFamChange();
-boolean forbidFamChange(familiar target);
 boolean fightScienceTentacle(string option);
 boolean fightScienceTentacle();
 boolean evokeEldritchHorror(string option);
@@ -882,47 +880,47 @@ boolean is100FamRun()
 	return true;
 }
 
-boolean forbidFamChange()
+boolean canChangeFamiliar()
 {
-	// answers the question "am I forbidden to change familiar?"
-	// an answer of true means you cannot change familiar, either due to path or due to being 100% run.
-	// an answer of false means you are allowed to change familiar
+	// answers the question "am I allowed to change familiar?" in the general sense
 	
 	//paths in which you cannot use a familiar as a familiar (in pokefam familiars are used as something else)
 	if($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, License to Adventure, Pocket Familiars, Dark Gyffte] contains auto_my_path())
 	{
-		return true;
+		return false;
 	}
 	
-	// If you are not in a specific path that forbids familiars, then the question is whether or not you are in a 100% run. If you are in such a run then changing familiar is forbidden.
-	return is100FamRun();
+	if(is100FamRun())
+	{
+		return false;
+	}
+	
+	return true;
 }
 
-boolean forbidFamChange(familiar target)
+boolean canChangeToFamiliar(familiar target)
 {
-	// answers the question of "am I forbidden to change familiar to a familiar named target"
-	// Returns false means you are allowed to change familiar to familiar target. because double negatives.
-	// Returns true means you are forbidden to change familiar to familiar target
+	// answers the question of "am I allowed to change familiar to a familiar named target"
 
 	// if you don't have a familiar, you can't change to it.
 	if(!auto_have_familiar(target))
 	{
-		return true;
+		return false;
 	}
 
 	// You are allowed to change to a familiar if it is also the goal of the current 100% run.
 	if(get_property("auto_100familiar") == target)
 	{
-		return false;
-	}
-	else if(forbidFamChange())
-	{
-		// checks path and 100% runs for diferent familiar than target
 		return true;
+	}
+	else if(!canChangeFamiliar())
+	{
+		// checks path limitations, as well as 100% runs for a diferent familiar than target
+		return false;
 	}
 	
 	// if you reached this point, then auto_100familiar must not be set to anything, you are allowed to change familiar.
-	return false;
+	return true;
 }
 
 boolean setAdvPHPFlag()
@@ -1338,7 +1336,7 @@ boolean canYellowRay(monster target)
 	# Use this to determine if it is safe to enter a yellow ray combat.
 
 	// first, do any necessary prep to use a yellow ray
-	if((my_familiar() == $familiar[Crimbo Shrub]) || (!forbidFamChange($familiar[Crimbo Shrub]) && auto_have_familiar($familiar[Crimbo Shrub])))
+	if((my_familiar() == $familiar[Crimbo Shrub]) || (canChangeToFamiliar($familiar[Crimbo Shrub]) && auto_have_familiar($familiar[Crimbo Shrub])))
 	{
 		if(item_amount($item[box of old Crimbo decorations]) == 0)
 		{
@@ -3288,7 +3286,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	if(pass())
 		return result();
 
-	if(doEquips && !forbidFamChange())
+	if(doEquips && canChangeFamiliar())
 	{
 		familiar resfam = $familiar[none];
 		foreach fam in $familiars[Trick-or-Treating Tot, Mu, Exotic Parrot]

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -834,8 +834,8 @@ int[int] intList();											//Defined in autoscend/auto_list.ash
 int internalQuestStatus(string prop);						//Defined in autoscend/auto_util.ash
 int freeCrafts();											//Defined in autoscend/auto_util.ash
 boolean is100FamRun();										//Defined in autoscend/auto_util.ash
-boolean forbidFamChange();									//Defined in autoscend/auto_util.ash
-boolean forbidFamChange(familiar target);					//Defined in autoscend/auto_util.ash
+boolean canChangeFamiliar();								//Defined in autoscend/auto_util.ash
+boolean canChangeToFamiliar(familiar target);				//Defined in autoscend/auto_util.ash
 boolean isBanished(monster enemy);							//Defined in autoscend/auto_util.ash
 boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
replaced forbidFamChange() with canChangeFamiliar()
replaced forbidFamChange(familiar target) with canChangeToFamiliar(familiar target)
This is not a rename, but an inversion of the logic from asking a negative to asking a positive. 
Adjusted the functions to have inverted logic.
Adjusted all instances in which it is used to invert the logic. (by adding or removing ! as appropriate)

## How Has This Been Tested?

Validated autoscend.ash

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
