### PR TITLE
MCD, zeppelin protestors, and a few misc things

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5264,6 +5264,7 @@ void auto_begin()
 	backupSetting("autoSatisfyWithNPCs", true);
 	backupSetting("removeMalignantEffects", false);
 	backupSetting("autoAntidote", 0);
+	backupSetting("dontStopForCounters", true);
 
 	backupSetting("kingLiberatedScript", "scripts/autoscend/auto_king.ash");
 	backupSetting("afterAdventureScript", "scripts/autoscend/auto_post_adv.ash");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5275,7 +5275,7 @@ void auto_begin()
 	backupSetting("battleAction", "custom combat script");
 
 	backupSetting("choiceAdventure1107", 1);
-	backupSetting("choiceAdventure330", 1);
+	backupSetting("choiceAdventure330", 1);		//haunted billiards room NC shark chum
 
 	if(get_property("counterScript") != "")
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4244,7 +4244,7 @@ boolean LX_handleSpookyravenFirstFloor()
 	{
 		abort("Have Lady Spookyraven's Necklace but did not give it to her....");
 	}
-
+	
 	if(hasSpookyravenLibraryKey())
 	{
 		auto_log_info("Well, we need writing desks", "blue");
@@ -4252,7 +4252,7 @@ boolean LX_handleSpookyravenFirstFloor()
 		set_property("choiceAdventure888", "4");
 		set_property("choiceAdventure889", "5");
 		set_property("choiceAdventure163", "4");
-		autoAdv(1, $location[The Haunted Library]);
+		if(autoAdv(1, $location[The Haunted Library])) return true;
 	}
 	else if(item_amount($item[Spookyraven Billiards Room Key]) == 1)
 	{
@@ -4291,11 +4291,8 @@ boolean LX_handleSpookyravenFirstFloor()
 		if(!possessEquipment($item[Pool Cue]) && !possessEquipment(staffOfFats) && !possessEquipment(staffOfFatsEd) && !possessEquipment(staffOfEd) && !in_tcrs())
 		{
 			auto_log_info("Well, I need a pool cueball...", "blue");
-			backupSetting("choiceAdventure330", 1);
 			providePlusNonCombat(25, true);
-			autoAdv(1, $location[The Haunted Billiards Room]);
-			restoreSetting("choiceAdventure330");
-			return true;
+			if(autoAdv(1, $location[The Haunted Billiards Room])) return true;
 		}
 
 		auto_log_info("Looking at the billiards room: 14 <= " + expectPool + " <= 18", "green");
@@ -4344,10 +4341,8 @@ boolean LX_handleSpookyravenFirstFloor()
 		}
 
 		auto_log_info("It's billiards time!", "blue");
-		backupSetting("choiceAdventure330", 1);
 		providePlusNonCombat(25, true);
-		autoAdv(1, $location[The Haunted Billiards Room]);
-		restoreSetting("choiceAdventure330");
+		if(autoAdv(1, $location[The Haunted Billiards Room])) return true;
 	}
 	else
 	{
@@ -4366,10 +4361,9 @@ boolean LX_handleSpookyravenFirstFloor()
 			}
 		}
 
-		autoAdv(1, $location[The Haunted Kitchen]);
-		handleFamiliar("item");
+		if(autoAdv(1, $location[The Haunted Kitchen])) return true;
 	}
-	return true;
+	return false;
 }
 
 boolean LX_handleSpookyravenNecklace()
@@ -5281,6 +5275,7 @@ void auto_begin()
 	backupSetting("battleAction", "custom combat script");
 
 	backupSetting("choiceAdventure1107", 1);
+	backupSetting("choiceAdventure330", 1);
 
 	if(get_property("counterScript") != "")
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1944,7 +1944,6 @@ boolean doBedtime()
 	}
 	else if((my_daycount() <= 2) && (freeCrafts() > 0) && my_adventures() > 0)
 	{
-		backupSetting("requireBoxServants", "false");
 		// Check for rapid prototyping
 		while((freeCrafts() > 0) && (item_amount($item[Scrumptious Reagent]) > 0) && (item_amount($item[Cranberries]) > 0) && (item_amount($item[Cranberry Cordial]) < 2) && have_skill($skill[Advanced Saucecrafting]))
 		{
@@ -1955,7 +1954,6 @@ boolean doBedtime()
 		{
 			cli_execute("make " + $item[Milk Of Magnesium]);
 		}
-		restoreSetting("requireBoxServants");
 	}
 
 	dna_bedtime();

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -496,4 +496,11 @@ void main()
 	}
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");
+	
+	//to avoid constant flipping on the MCD. change it right before adventuring
+	int mcd_target = get_property("auto_mcd_target").to_int();
+	if(current_mcd() != mcd_target)
+	{
+		change_mcd(mcd_target);
+	}
 }

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1622,7 +1622,7 @@ boolean L11_mauriceSpookyraven()
 
 boolean L11_redZeppelin()
 {
-	if (internalQuestStatus("questL11Shen") < 8)
+	if (internalQuestStatus("questL11Shen") < 8 && my_level() != get_property("auto_powerLevelLastLevel").to_int())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_quest_level_5.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_5.ash
@@ -70,9 +70,8 @@ boolean L5_haremOutfit()
 	bat_formBats();
 
 	auto_log_info("Looking for some sexy lingerie!", "blue");
-	autoAdv(1, $location[Cobb\'s Knob Harem]);
-	handleFamiliar("item");
-	return true;
+	if(autoAdv(1, $location[Cobb\'s Knob Harem])) return true;
+	return false;
 }
 
 boolean L5_goblinKing()

--- a/RELEASE/scripts/autoscend/auto_quest_level_5.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_5.ash
@@ -70,8 +70,7 @@ boolean L5_haremOutfit()
 	bat_formBats();
 
 	auto_log_info("Looking for some sexy lingerie!", "blue");
-	if(autoAdv(1, $location[Cobb\'s Knob Harem])) return true;
-	return false;
+	return autoAdv(1, $location[Cobb\'s Knob Harem]);
 }
 
 boolean L5_goblinKing()

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -882,9 +882,6 @@ boolean is100FamRun()
 
 boolean pathAllowsFamiliar()
 {
-	//does the current path allows you to use familiar?
-	
-	//classes is preferred to string because that way mafia will return an error if you misspelled the class name.
 	if($classes[
 	Ed, 
 	Avatar of Boris,
@@ -3756,7 +3753,7 @@ boolean auto_change_mcd(int mcd)
 	return auto_change_mcd(mcd, false);
 }
 
-boolean auto_change_mcd(int mcd, boolean immediatly)
+boolean auto_change_mcd(int mcd, boolean immediately)
 {
 	if (in_koe()) return false;
 
@@ -3801,7 +3798,7 @@ boolean auto_change_mcd(int mcd, boolean immediatly)
 	{
 		return true;
 	}
-	if(immediatly)
+	if(immediately)
 	{
 		return change_mcd(next);
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3744,6 +3744,11 @@ boolean basicAdjustML()
 
 boolean auto_change_mcd(int mcd)
 {
+	return auto_change_mcd(mcd, false);
+}
+
+boolean auto_change_mcd(int mcd, boolean immediatly)
+{
 	if (in_koe()) return false;
 
 	int best = 10;
@@ -3774,7 +3779,7 @@ boolean auto_change_mcd(int mcd)
 		best = 11;
 	}
 
-	if(my_level() >= 13 && !get_property("auto_disregardInstantKarma").to_boolean())
+	if(my_level() == 13 && !get_property("auto_disregardInstantKarma").to_boolean())
 	{
 		if((get_property("questL12War") == "finished") || (get_property("sidequestArenaCompleted") != "none") || (get_property("flyeredML").to_int() >= 10000) || get_property("auto_ignoreFlyer").to_boolean())
 		{
@@ -3787,7 +3792,13 @@ boolean auto_change_mcd(int mcd)
 	{
 		return true;
 	}
-	return change_mcd(next);
+	if(immediatly)
+	{
+		return change_mcd(next);
+	}
+	//for non immediate changes we still return true because the setting was set to be changed later.
+	set_property("auto_mcd_target", next);
+	return true;
 }
 
 boolean evokeEldritchHorror(string option)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3798,12 +3798,13 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 	{
 		return true;
 	}
+	
+	set_property("auto_mcd_target", next);
 	if(immediately)
 	{
 		return change_mcd(next);
 	}
-	//for non immediate changes we still return true because the setting was set to be changed later.
-	set_property("auto_mcd_target", next);
+	//for non immediate changes we still return true because the mafia setting was changed and MCD will be changed later.
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -880,12 +880,31 @@ boolean is100FamRun()
 	return true;
 }
 
+boolean pathAllowsFamiliar()
+{
+	//paths in which you cannot use a familiar
+	//pokefam converts your familiars into pokefam, they are not actually familiars in that path and cannot be used as such.
+	if($strings[
+	Actually Ed the Undying, 
+	Avatar of Boris,
+	Avatar of Jarlsberg,
+	Avatar of Sneaky Pete,
+	License to Adventure,
+	Pocket Familiars,
+	Dark Gyffte
+	] contains auto_my_path())
+	{
+		return false;
+	}
+	
+	return true;
+}
+
 boolean canChangeFamiliar()
 {
 	// answers the question "am I allowed to change familiar?" in the general sense
 	
-	//paths in which you cannot use a familiar as a familiar (in pokefam familiars are used as something else)
-	if($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, License to Adventure, Pocket Familiars, Dark Gyffte] contains auto_my_path())
+	if(!pathAllowsFamiliar())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -882,16 +882,25 @@ boolean is100FamRun()
 
 boolean pathAllowsFamiliar()
 {
-	//paths in which you cannot use a familiar
-	//pokefam converts your familiars into pokefam, they are not actually familiars in that path and cannot be used as such.
-	if($strings[
-	Actually Ed the Undying, 
+	//does the current path allows you to use familiar?
+	
+	//classes is preferred to string because that way mafia will return an error if you misspelled the class name.
+	if($classes[
+	Ed, 
 	Avatar of Boris,
 	Avatar of Jarlsberg,
 	Avatar of Sneaky Pete,
+	Vampyre
+	] contains my_class())
+	{
+		return false;
+	}
+	
+	//path check for cases where the path bans familairs and does not use a unique class.
+	//since pokefam converts your familiars into pokefam, they are not actually familiars in that path and cannot be used as familiars.
+	if($strings[
 	License to Adventure,
-	Pocket Familiars,
-	Dark Gyffte
+	Pocket Familiars
 	] contains auto_my_path())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3778,7 +3778,7 @@ boolean auto_change_mcd(int mcd, boolean immediatly)
 	{
 		best = 11;
 	}
-
+	//under level 13 we want to level up. level 14+ we already missed the instant karma, no point in holding back anymore.
 	if(my_level() == 13 && !get_property("auto_disregardInstantKarma").to_boolean())
 	{
 		if((get_property("questL12War") == "finished") || (get_property("sidequestArenaCompleted") != "none") || (get_property("flyeredML").to_int() >= 10000) || get_property("auto_ignoreFlyer").to_boolean())

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -464,7 +464,7 @@ boolean auto_barrelPrayers();									//Defined in autoscend/auto_mr2015.ash
 void auto_begin();											//Defined in autoscend.ash
 item auto_bestBadge();										//Defined in autoscend/auto_mr2016.ash
 boolean auto_change_mcd(int mcd);								//Defined in autoscend/auto_util.ash
-boolean auto_change_mcd(int mcd, boolean immediatly);			//Defined in autoscend/auto_util.ash
+boolean auto_change_mcd(int mcd, boolean immediately);			//Defined in autoscend/auto_util.ash
 string auto_combatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash
 boolean auto_doPrecinct();									//Defined in autoscend/auto_mr2016.ash
 string auto_edCombatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -846,6 +846,7 @@ int[int] intList();											//Defined in autoscend/auto_list.ash
 int internalQuestStatus(string prop);						//Defined in autoscend/auto_util.ash
 int freeCrafts();											//Defined in autoscend/auto_util.ash
 boolean is100FamRun();										//Defined in autoscend/auto_util.ash
+boolean pathAllowsFamiliar();								//Defined in autoscend/auto_util.ash
 boolean canChangeFamiliar();								//Defined in autoscend/auto_util.ash
 boolean canChangeToFamiliar(familiar target);				//Defined in autoscend/auto_util.ash
 boolean isBanished(monster enemy);							//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -464,6 +464,7 @@ boolean auto_barrelPrayers();									//Defined in autoscend/auto_mr2015.ash
 void auto_begin();											//Defined in autoscend.ash
 item auto_bestBadge();										//Defined in autoscend/auto_mr2016.ash
 boolean auto_change_mcd(int mcd);								//Defined in autoscend/auto_util.ash
+boolean auto_change_mcd(int mcd, boolean immediatly);			//Defined in autoscend/auto_util.ash
 string auto_combatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash
 boolean auto_doPrecinct();									//Defined in autoscend/auto_mr2016.ash
 string auto_edCombatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash


### PR DESCRIPTION
# Description

1. pathAllowsFamiliar() created. this allows us to replace auto_have_familiar($familiar[mosquito]) checks. And do it better since the former gives misleading results in pokefam. This will be useful for correcting PR#177

2. mob of zepplin protestors block on waiting for shen to be done made into a soft block rather than a hard block. If there is nothing else left to do then it will be done suboptimally. Partially fixes #319 

3. Don't flip flop on MCD setting so much. alter its desired target figure then finally set it once in pre adventure just before we go adventuring somewhere.
included an option to change it immediately but looking at the various places it is called I don't see any where we would want to.

4. backup and then enable mafia setting for not auto aborting automation when counters expire.

5. fix for mafia setting for requireBoxServants not being restored (we were doing a backup of the setting twice. first the real value, then the value we set in the first backup.


## How Has This Been Tested?

test.ash which imports autoscend.ash then calls and prints specific functions and what they are doing.

Zeppelin protestors latest version of the fix is currently untested.

Rest have been tested for 2 days on 5 accounts doing different paths.
softcore plumber
hardcore ed
hardcore pete
hardcore boris
casual

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
