### PR TITLE
[plumber] Always equip plumber combat tool before Ed fight

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -223,35 +223,14 @@ void main()
 		if ((is_ghost_in_zone(place) && !skip_equipping_flower)
 			|| (place == $location[The Smut Orc Logging Camp] && possessEquipment($item[frosty button])))
 		{
-			if (possessEquipment($item[bonfire flower]))
-			{
-				autoEquip($item[bonfire flower]);
-			}
-			else if (possessEquipment($item[[10462]fire flower]))
-			{
-				autoEquip($item[[10462]fire flower]);
-			}
-			else if (item_amount($item[coin]) >= 20)
-			{
-				// 20 coins to avoid doing clever re-routing? Yes please!
-				retrieve_item(1, $item[[10462]fire flower]);
-				autoEquip($item[[10462]fire flower]);
-			}
-			else
+			if(!zelda_equipTool($stat[mysticality]))
 			{
 				abort("I'm scared to adventure in a zone with ghosts without a fire flower. Please fight a bit and buy me a fire flower.");
 			}
 		}
 		else
 		{
-			if (possessEquipment($item[fancy boots]))
-			{
-				autoEquip($slot[acc3], $item[fancy boots]);
-			}
-			else if (possessEquipment($item[work boots]))
-			{
-				autoEquip($slot[acc3], $item[work boots]);
-			}
+			zelda_equipTool($stat[moxie]);
 		}
 
 		// It is dangerous out there! Take this!

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -2284,6 +2284,12 @@ boolean L11_defeatEd()
 		autoForceEquip($item[low-pressure oxygen tank]);
 	}
 
+	zelda_equipTool($stat[moxie]);
+
+	// When we disable adventure handling, we also disable the maximizer that
+	// would normally happen in pre-adventure.
+	equipMaximizedGear();
+
 	acquireHP();
 	auto_log_info("Time to waste all of Ed's Ka Coins :(", "blue");
 

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -397,3 +397,34 @@ boolean zelda_skillValid(skill sk)
 	return true;
 }
 
+boolean zelda_equipTool(stat st)
+{
+	if (!in_zelda()) return false;
+
+	boolean equipWithFallback(item to_equip, item fallback_to_equip)
+	{
+		if (possessEquipment(to_equip) && autoEquip(to_equip))
+		{
+			return true;
+		}
+		else if (possessEquipment(fallback_to_equip))
+		{
+			return autoEquip(fallback_to_equip);
+		}
+		else if (item_amount($item[coin]) >= 20)
+		{
+			// 20 coins to avoid doing clever re-routing? Yes please!
+			retrieve_item(1, fallback_to_equip);
+			return autoEquip(fallback_to_equip);
+		}
+		return false;
+	}
+
+	switch (st)
+	{
+		case $stat[muscle]: return equipWithFallback($item[heavy hammer], $item[hammer]);
+		case $stat[mysticality]: return equipWithFallback($item[bonfire flower], $item[[10462]fire flower]);
+		case $stat[moxie]: return equipWithFallback($item[fancy boots], $item[work boots]);
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1172,6 +1172,7 @@ boolean zelda_buyStuff(); // Defined in autoscend/auto_zelda.ash
 int zelda_ppCost(skill sk); // Defined in autoscend/auto_zelda.ash
 boolean zelda_canDealScalingDamage(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_skillValid(skill sk); // Defined in autoscend/auto_zelda.ash
+boolean zelda_equipTool(stat st); // Defined in autoscend/auto_zelda.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash
 void resetFlavour(); // Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

Ed fighting disables the standard pre-adventure handling, so calls to autoEquip() never happen and the pre-adventure code that would normally force-equip Plumber tools never gets called. This adds a utility function for equipping Plumber tools, calls it before fighting Ed, calls `equipMaximized()` before fighting Ed, and refactors the existing pre-adventure Plumber code to use this utility function.

This also fixes a long-standing bug where we wouldn't equip lots of stuff we intended to equip before fighting Ed.

Relevant to #325 

## How Has This Been Tested?

An automated run ran into the above Ed crash. I made the listed changes and re-ran autoscend. It equipped the fancy boots and defeated Ed. So I have tested this for about two minutes total, but it seems promising.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
