### PR TITLE
[plumber] Fix failures at Haunted Bedroom and Bat Hole

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2565,6 +2565,9 @@ boolean LX_spookyBedroomCombat()
 {
 	set_property("auto_disableAdventureHandling", true);
 
+	zelda_equipTool($stat[moxie]);
+	equipMaximizedGear();
+
 	autoAdv(1, $location[The Haunted Bedroom]);
 	if(contains_text(visit_url("main.php"), "choice.php"))
 	{

--- a/RELEASE/scripts/autoscend/auto_quest_level_4.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_4.ash
@@ -57,6 +57,9 @@ boolean L4_batCave()
 		{
 			auto_badassBelt(); // mafia doesn't make this any more even if autoCraft = true for some random reason so lets do it manually.
 		}
+		// TODO: Mafia currently does not advance the quest tracker when the Plumber boss is defeated.
+		// This breaks that infinite loop, while "refresh quests" apparently doesn't. Who knows?
+		visit_url("place.php?whichplace=bathole");
 		return true;
 	}
 	if(batStatus >= 2)


### PR DESCRIPTION
# Description

* Haunted Bedroom was skipping the pre-adventure handler and so adventuring without equipping a plumber tool.

* In Plumber runs, we were infinite-looping at the Bat Hole, trying to adventure in the Lair after defeating the Boss Bat-equivalent. This was because Mafia wasn't updating the quest tracking property when we beat the substitute boss in Plumber. I fixed this by visit_url-ing the Bat Hole after adventuring in the Boss Bat's zone. This is definitely an upstream Mafia bug, though. Ah well.

## How Has This Been Tested?

Both were tested via observing the crash locally, re-running to confirm that the bug persisted through restarts, adding the change, and confirming that the bug disappeared. This should avoid a false positive, where the bug wasn't actually fixed by my code but I assumed it was because hey, it cleared up after I ran my code.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
