### PR TITLE
Procrastinate adventuring in zones that Shen snakes might appear in

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4429,8 +4429,7 @@ boolean LX_getStarKey()
 	}
 	
 	boolean hole_in_sky_unreachable = internalQuestStatus("questL10Garbage") < 9;
-	// TODO: Clean up logic
-	boolean shen_might_request_hole = internalQuestStatus("questL11Shen") < 7;
+	boolean shen_might_request_hole = shenShouldDelayZone($location[The Hole in the Sky]);
 	if (hole_in_sky_unreachable || shen_might_request_hole)
 	{
 		return false;
@@ -4462,12 +4461,6 @@ boolean LX_getStarKey()
 	if(!zone_isAvailable($location[The Hole In The Sky]))
 	{
 		auto_log_warning("The Hole In The Sky is not available, we have to do something else...", "red");
-		return false;
-	}
-
-	if (shenShouldDelayZone($location[The Hole in the Sky]))
-	{
-		auto_log_debug("Delaying Hole in the Sky in case of Shen.");
 		return false;
 	}
 
@@ -4844,7 +4837,6 @@ boolean doTasks()
 		auto_log_info("You can also disable this feature: set auto_shenSkipLastLevel=999.", "blue");
 
 		auto_log_warning("This feature is super experimental. Please report any issues.", "red");
-		// TODO: provide manual override to disable in case I've screwed up something
 		set_property("auto_shenStarted", my_daycount());
 	}
 

--- a/RELEASE/scripts/autoscend/auto_quest_level_10.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_10.ash
@@ -272,6 +272,12 @@ boolean L10_topFloor()
 		return false;
 	}
 
+	if (shenShouldDelayZone($location[The Castle in the Clouds in the Sky (Top Floor)]))
+	{
+		auto_log_debug("Delaying Top Floor in case of Shen.");
+		return false;
+	}
+
 	auto_log_info("Castle Top Floor", "blue");
 	set_property("choiceAdventure680", 1); // Mercy adventure: Are you a Man or a Mouse?
 	if(item_amount($item[Drum \'n\' Bass \'n\' Drum \'n\' Bass Record]) > 0)
@@ -360,6 +366,12 @@ boolean L10_holeInTheSkyUnlock()
 		// we force auto_holeinthesky to true in L11_shenCopperhead() as Ed if Shen sends us to the Hole in the Sky
 		// as otherwise the zone isn't required at all for Ed.
 		set_property("auto_holeinthesky", false);
+		return false;
+	}
+
+	if (shenShouldDelayZone($location[The Castle in the Clouds in the Sky (Top Floor)]))
+	{
+		auto_log_debug("Delaying unlocking Hole in the Sky in case of Shen.");
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_quest_level_4.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_4.ash
@@ -70,11 +70,21 @@ boolean L4_batCave()
 			autoAdv($location[The Beanbat Chamber]);
 			return true;
 		}
+		if (shenShouldDelayZone($location[The Batrat and Ratbat Burrow]))
+		{
+			auto_log_debug("Delaying Batrat Burrow in case of Shen.");
+			return false;
+		}
 		autoAdv($location[The Batrat and Ratbat Burrow]);
 		return true;
 	}
 	if(batStatus >= 1)
 	{
+		if (shenShouldDelayZone($location[The Batrat and Ratbat Burrow]))
+		{
+			auto_log_debug("Delaying Batrat Burrow in case of Shen.");
+			return false;
+		}
 		bat_formBats();
 		autoAdv($location[The Batrat and Ratbat Burrow]);
 		return true;

--- a/RELEASE/scripts/autoscend/auto_quest_level_8.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_8.ash
@@ -250,6 +250,12 @@ boolean L8_trapperNinjaLair()
 			return false;
 		}
 
+		if (shenShouldDelayZone($location[Lair of the Ninja Snowmen]))
+		{
+			auto_log_debug("Delaying Lair of the Ninja Snowmen in case of Shen.");
+			return false;
+		}
+
 		handleFamiliar("item");
 		asdonBuff($effect[Driving Obnoxiously]);
 		if(!providePlusCombat(25))

--- a/RELEASE/scripts/autoscend/auto_quest_level_9.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_9.ash
@@ -81,6 +81,13 @@ boolean L9_chasmBuild()
 		return false;
 	}
 
+	if (shenShouldDelayZone($location[The Smut Orc Logging Camp]))
+	{
+		auto_log_debug("Delaying Logging Camp in case of Shen.");
+		return false;
+	}
+
+
 	auto_log_info("Chasm time", "blue");
 
 	if(item_amount($item[fancy oil painting]) > 0)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -92,6 +92,12 @@ boolean L10_ground();
 boolean L10_topFloor();
 boolean L10_holeInTheSkyUnlock();
 boolean LX_getStarKey();
+
+int shenItemsReturned();												//Defined in autoscend/auto_quest_level_11.ash
+boolean[location] shenSnakeLocations(int day, int n_items_returned);	//Defined in autoscend/auto_quest_level_11.ash
+boolean[location] shenZonesToAvoidBecauseMaybeSnake();					//Defined in autoscend/auto_quest_level_11.ash
+boolean shenShouldDelayZone(location loc);								//Defined in autoscend/auto_quest_level_11.ash
+
 boolean L11_palindome();
 boolean L11_hiddenCity();
 boolean L11_hiddenTavernUnlock();


### PR DESCRIPTION
# Description

Since each Shen snake requires 4-6 adventures in a zone after Shen asks
us to go there, this could save at least 10 adventures per ascension.

There are two obvious reasons this hasn't been done previously:

1. Low-IOTM or low-skill accounts might need those early zones to level
   up to unlock later quests. If we skip those early zones, they'll run
   out of tasks to complete.

2. Accounts without solid combat suites might need those early zones to
   level up to not die in higher-level zones. If we skip those early
   zones, they'll be weaker and die more.

This commit handles the running-out-of-tasks issue by, after running out
of tasks to do, allowing ourselves to adventure in zones with potential
snakes awaiting. This is implemented similarly to the powerlevelling
code, using the property "auto_shenSkipLastLevel".

This commit does not handle issue 2, and I'm hoping it's not a big deal.

Fixes #314

## How Has This Been Tested?

Mostly `validate` and manually inspecting the output of certain utility functions. Nothing end-to-end. Please don't approve or merge.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
