### PR TITLE
plumber desert tracking is broken in latest mafia.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -210,6 +210,13 @@ boolean L11_aridDesert()
 	{
 		string temp = visit_url("place.php?whichplace=desertbeach", false);
 	}
+	
+	// TODO: Mafia currently (r20019) does not properly track desert exploration progress in plumber
+	// Not sure if this fix can do exact progress, but when I visited that page it corrected my explortion to 100 and quest progress to done so it will prevent adv loss at least
+	if(in_zelda() && get_property("desertExploration").to_int() < 100)
+	{
+		string discard = visit_url("place.php?whichplace=desertbeach");
+	}
 
 	if(get_property("desertExploration").to_int() >= 100)
 	{


### PR DESCRIPTION
# Description

Workaround for Mafia bug
https://kolmafia.us/showthread.php?24888-mafia-not-tracking-desert-progress-in-plumber&p=157035#post157035

wastes lots of adv in there without this fix.

## How Has This Been Tested?

validates.
calling it from ash to confirm it visit the correct spot
when I manually visited that page earlier it correct my desert exploration from 43 to 100
it will be days before i can fully test it in the wild. but i think this needs merging now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
