### PR TITLE
workaround for dense liana desync in mafia. need help with code

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1361,7 +1361,7 @@ boolean L11_hiddenCityZones()
 		return true;
 	}
 
-	if ($location[A Massive Ziggurat].turns_spent < 3)
+	if ($location[A Massive Ziggurat].turns_spent < 3 && get_property("lastEncounter") != "Legend of the Temple in the Hidden City")
 	{
 		equipMachete();
 
@@ -1371,10 +1371,7 @@ boolean L11_hiddenCityZones()
 		{
 			handleBjornify($familiar[Grimstone Golem]);
 		}
-		autoAdv(1, $location[A Massive Ziggurat]);
-		handleFamiliar("item");
-		handleBjornify($familiar[El Vibrato Megadrone]);
-		return true;
+		if(autoAdv(1, $location[A Massive Ziggurat])) return true;
 	}
 	return false;
 }


### PR DESCRIPTION
# Description

mdiblasi contacted me on discord, mentioned they are currently stuck at a reproducible infinite loop at the hidden city quest that happened to them on the last 5 plumber runs. they worked around it by manually doing it then running autoscend again.

I first confirmed they are indeed on latest version of mafia and autoscend. Then looking at their logs and their guide screenshot (super helpful) helped me locate the problem.
On day X-1 it cleared all the dense lianas in the city using a machete.
In day X it decided that the massive ziggurat (and only it) is back to having 0 dense lianas again. So it repeatedly tries to adventure there.

Worse, it successfully goes there because going there without the dense lianas triggers an NC successfully. which chooses to skip the NC at no adv cost. So they are repeatedly successfully going to that spot.

I gave them a hacky fix which worked for them which basically checks if the last spot they visited was the NC (which only appears if all the lianas are dead).
So what they are now doing is, instead of infinite loop they are doing
```
adventure 1 turn elsewhere
go to massive ziggurat, wear machete, try to clear it, hit NC, skip adventure
adventure 1 turn elsewhere
go to massive ziggurat, wear machete, try to clear it, hit NC, skip adventure
repeat until the city is cleared
```

I wanted to actually do
```
if ($location[A Massive Ziggurat].turns_spent < 3 && get_property("lastEncounter") == "Legend of the Temple in the Hidden City")
{
 correct mafia wrong state
}
```
but how do you actually modify turns_spent in a zone? also I am worried that doing that would cause a desync. Maybe the answer is to keep internal track of lianas being cleared?

Something like
```
if (get_property("lastEncounter") == "Legend of the Temple in the Hidden City")
{
   set_property("auto_L11_MassiveZigguratDenseLianasClear", true);
}
if(!get_property("auto_L11_MassiveZigguratDenseLianasClear").to_boolean())
{
  adventure in zone to clear them
}
```
and during new run initialize set it to false?
while setting it to false

## How Has This Been Tested?

sent to mdiblasi and it worked for them

Note though that I really don't want to merge it as is. I would rather write a better fix first. maybe when i wake up. because i am about 5 minutes from falling asleep right now

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
