### PR TITLE
free combats improvements

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2807,30 +2807,29 @@ int auto_freeCombatsRemaining(boolean print_remaining_fights)
 	//under level 13 we wan to get max XP. level 14+ we already missed the insta karma, no need to hold back anymore.
 	boolean powerlevel = my_level() != 13 || get_property("auto_disregardInstantKarma").to_boolean();
 	int count = 0;
-	int temp = 0;
 	
 	debugPrint("Remaining Free Fights:");
 	if(!in_koe() && canChangeToFamiliar($familiar[Machine Elf]))
 	{
-		temp = 5-get_property("_machineTunnelsAdv").to_int();
+		int temp = 5-get_property("_machineTunnelsAdv").to_int();
 		count += temp;
 		debugPrint("Machine Elf = " + temp);
 	}
 	if(snojoFightAvailable())
 	{
-		temp = 10-get_property("_snojoFreeFights").to_int();
+		int temp = 10-get_property("_snojoFreeFights").to_int();
 		count += temp;
 		debugPrint("Snojo = " + temp);
 	}
 	if(canChangeToFamiliar($familiar[God Lobster]) && powerlevel)
 	{
-		temp = 3-get_property("_godLobsterFights").to_int();
+		int temp = 3-get_property("_godLobsterFights").to_int();
 		count += temp;
 		debugPrint("God Lobster = " + temp);
 	}
 	if(neverendingPartyRemainingFreeFights() > 0)
 	{
-		temp = neverendingPartyRemainingFreeFights();
+		int temp = neverendingPartyRemainingFreeFights();
 		count += temp;
 		debugPrint("Neverending Party = " + temp);
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2795,18 +2795,19 @@ int auto_freeCombatsRemaining()
 	return auto_freeCombatsRemaining(false);
 }
 
-int auto_freeCombatsRemaining(boolean log_for_debug)
+int auto_freeCombatsRemaining(boolean print_remaining_fights)
 {
 
 	void debugPrint(string msg)
 	{
-	  if (!log_for_debug) return;
+	  if (!print_remaining_fights) return;
 	  print(msg, "red");
 	}
 
+	//under level 13 we wan to get max XP. level 14+ we already missed the insta karma, no need to hold back anymore.
+	boolean powerlevel = my_level() != 13 || get_property("auto_disregardInstantKarma").to_boolean();
 	int count = 0;
 	int temp = 0;
-	boolean powerlevel = my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean();
 	
 	debugPrint("Remaining Free Fights:");
 	if(!in_koe() && canChangeToFamiliar($familiar[Machine Elf]))

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2407,13 +2407,7 @@ boolean LX_attemptPowerLevel()
 	handleFamiliar("stat");
 	addToMaximize("100 exp");
 
-	if(snojoFightAvailable() && (auto_my_path() == "Pocket Familiars"))
-	{
-		autoAdv(1, $location[The X-32-F Combat Training Snowman]);
-		return true;
-	}
-
-	if(LX_freeCombats())
+	if(LX_freeCombats(true))
 	{
 		return true;
 	}
@@ -2798,37 +2792,74 @@ boolean LX_getDigitalKey()
 
 int auto_freeCombatsRemaining()
 {
+	return auto_freeCombatsRemaining(false);
+}
+
+int auto_freeCombatsRemaining(boolean log_for_debug)
+{
+
+	void debugPrint(string msg)
+	{
+	  if (!log_for_debug) return;
+	  print(msg, "red");
+	}
+
 	int count = 0;
+	int temp = 0;
+	boolean powerlevel = my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean();
 	
+	debugPrint("Remaining Free Fights:");
 	if(!in_koe() && canChangeToFamiliar($familiar[Machine Elf]))
 	{
-		count += 5-get_property("_machineTunnelsAdv").to_int();
+		temp = 5-get_property("_machineTunnelsAdv").to_int();
+		count += temp;
+		debugPrint("Machine Elf = " + temp);
 	}
 	if(snojoFightAvailable())
 	{
-		count += 10-get_property("_snojoFreeFights").to_int();
+		temp = 10-get_property("_snojoFreeFights").to_int();
+		count += temp;
+		debugPrint("Snojo = " + temp);
 	}
-	if(canChangeToFamiliar($familiar[God Lobster]))
+	if(canChangeToFamiliar($familiar[God Lobster]) && powerlevel)
 	{
-		count += 3-get_property("_godLobsterFights").to_int();
+		temp = 3-get_property("_godLobsterFights").to_int();
+		count += temp;
+		debugPrint("God Lobster = " + temp);
 	}
-	if(neverendingPartyAvailable())
+	if(neverendingPartyRemainingFreeFights() > 0)
 	{
-		count += 10-get_property("_neverendingPartyFreeTurns").to_int();
+		temp = neverendingPartyRemainingFreeFights();
+		count += temp;
+		debugPrint("Neverending Party = " + temp);
 	}
 	if(get_property("_eldritchTentacleFought").to_boolean() == false)
 	{
 		count++;
+		debugPrint("Tent Tentacle = 1");
 	}
 	if(auto_have_skill($skill[Evoke Eldritch Horror]) && get_property("_eldritchHorrorEvoked").to_boolean() == false)
 	{
 		count++;
+		debugPrint("Evoke Eldritch = 1");
 	}
 	
 	return count;
 }
 
 boolean LX_freeCombats()
+{
+	if(my_level() != 13 || get_property("auto_disregardInstantKarma").to_boolean())
+	{
+		return LX_freeCombats(true);
+	}
+	else
+	{
+		return LX_freeCombats(false);
+	}
+}
+
+boolean LX_freeCombats(boolean powerlevel)
 {
 	if(auto_freeCombatsRemaining() == 0)
 	{
@@ -2848,25 +2879,29 @@ boolean LX_freeCombats()
 	
 	if(my_adventures() < 2)
 	{
-		auto_log_warning("Too few adventures to safely automate free combats.", "red");
-		auto_log_warning("If we lose your last adv on a free combat the remaining free combats are wasted.", "red");
-		abort("Please perform the remaining free combats manually.");
+		auto_freeCombatsRemaining(true);
+		auto_log_warning("Too few adventures to safely automate free combats", "red");
+		auto_log_warning("If we lose your last adv on a free combat the remaining free combats are wasted", "red");
+		abort("Please perform the remaining free combats manually then run me again");
 	}
 
-	if((auto_my_path() != "Disguises Delimit") && neverendingPartyCombat())
+	if(neverendingPartyRemainingFreeFights() > 0)
 	{
-		return true;
+		if(powerlevel)
+		{
+			if(neverendingPartyPowerlevel()) return true;
+		}
+		else
+		{
+			if(neverendingPartyCombat()) return true;
+		}
 	}
+	
+	boolean adv_done = false;
 
 	if(!in_koe() && get_property("_machineTunnelsAdv").to_int() < 5 && canChangeToFamiliar($familiar[Machine Elf]))
 	{
-		if(get_property("auto_choice1119") != "")
-		{
-			set_property("choiceAdventure1119", get_property("auto_choice1119"));
-		}
-		set_property("auto_choice1119", get_property("choiceAdventure1119"));
-		set_property("choiceAdventure1119", 1);
-
+		backupSetting("choiceAdventure1119", 1);
 
 		familiar bjorn = my_bjorned_familiar();
 		if(bjorn == $familiar[Machine Elf])
@@ -2874,35 +2909,38 @@ boolean LX_freeCombats()
 			handleBjornify($familiar[Grinning Turtle]);
 		}
 		handleFamiliar($familiar[Machine Elf]);
-		autoAdv(1, $location[The Deep Machine Tunnels]);
+		adv_done = autoAdv(1, $location[The Deep Machine Tunnels]);
 		if(bjorn == $familiar[Machine Elf])
 		{
 			handleBjornify(bjorn);
 		}
 
-		set_property("choiceAdventure1119", get_property("auto_choice1119"));
-		set_property("auto_choice1119", "");
+		restoreSetting("choiceAdventure1119");
 		handleFamiliar("item");
 		loopHandlerDelayAll();
-		return true;
+		if(adv_done) return true;
 	}
 
 	if(snojoFightAvailable())
 	{
-		handleFamiliar($familiar[Ms. Puck Man]);
-		autoAdv(1, $location[The X-32-F Combat Training Snowman]);
-		handleFamiliar("item");
-		if(get_property("_auto_digitizeDeskCounter").to_int() > 2)
-		{
-			set_property("_auto_digitizeDeskCounter", get_property("_auto_digitizeDeskCounter").to_int() - 1);
-		}
+		adv_done = autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 		loopHandlerDelayAll();
-		return true;
+		if(adv_done) return true;
 	}
 
-	if(((my_level() < 13) || (get_property("auto_disregardInstantKarma").to_boolean())) && godLobsterCombat())
+	if(powerlevel)
 	{
-		return true;
+		if(godLobsterCombat()) return true;
+	}
+	
+	if(get_property("_eldritchTentacleFought").to_boolean() == false)
+	{
+		if(fightScienceTentacle()) return true;
+	}
+	
+	if(auto_have_skill($skill[Evoke Eldritch Horror]) && get_property("_eldritchHorrorEvoked").to_boolean() == false)
+	{
+		if(evokeEldritchHorror()) return true;
 	}
 
 	return false;
@@ -5026,10 +5064,7 @@ boolean doTasks()
 
 	if(snojoFightAvailable() && (my_daycount() == 2) && (get_property("snojoMoxieWins").to_int() == 10))
 	{
-		handleFamiliar($familiar[Ms. Puck Man]);
-		autoAdv(1, $location[The X-32-F Combat Training Snowman]);
-		handleFamiliar("item");
-		return true;
+		return autoAdv(1, $location[The X-32-F Combat Training Snowman]);
 	}
 
 	if(resolveSixthDMT())			return true;

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -1187,13 +1187,7 @@ boolean resolveSixthDMT()
 {
 	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && canChangeToFamiliar($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
 	{
-		if(get_property("auto_choice1119") != "")
-		{
-			set_property("choiceAdventure1119", get_property("auto_choice1119"));
-		}
-		set_property("auto_choice1119", get_property("choiceAdventure1119"));
-		set_property("choiceAdventure1119", 1);
-
+		backupSetting("choiceAdventure1119", 1);
 
 		familiar bjorn = my_bjorned_familiar();
 		if(bjorn == $familiar[Machine Elf])
@@ -1206,9 +1200,8 @@ boolean resolveSixthDMT()
 		{
 			handleBjornify(bjorn);
 		}
-
-		set_property("choiceAdventure1119", get_property("auto_choice1119"));
-		set_property("auto_choice1119", "");
+		
+		restoreSetting("choiceAdventure1119");
 		handleFamiliar("item");
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -770,6 +770,28 @@ boolean neverendingPartyCombat(stat st, boolean hardmode, string option, boolean
 	return neverendingPartyCombat($effect[none], hardmode, option, powerlevelling);
 }
 
+int neverendingPartyRemainingFreeFights()
+{
+	//Returns how many free fights do you have remaining in neverending party?
+	
+	if(!neverendingPartyAvailable())
+	{
+		return 0;
+	}
+	//if path randomizes names then the free fights are not free
+	if(auto_my_path() == "Disguises Delimit" || auto_my_path() == "One Crazy Random Summer")
+	{
+		return 0;
+	}
+	//daily pass users do not get free fights
+	if(get_property("_neverendingPartyToday").to_boolean())
+	{
+		return 0;
+	}
+	//mafia counts how many times you fought there for free, not how many free fights remain.
+	return 10 - get_property("_neverendingPartyFreeTurns").to_int();
+}
+
 boolean neverendingPartyAvailable()
 {
 	if(!get_property("neverendingPartyAlways").to_boolean() && !get_property("_neverendingPartyToday").to_boolean())
@@ -803,7 +825,6 @@ boolean neverendingPartyAvailable()
 	}
 	if(get_property("auto_skipNEPOverride").to_boolean())
 	{
-		auto_log_warning("NEP access disabled. This can be turned on in the Relay by setting auto_skipNEPOverride = false", "red");
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -852,9 +852,8 @@ boolean loopHandlerDelay(string counterSetting, int threshold)
 boolean loopHandlerDelayAll()
 {
 	boolean boo = loopHandlerDelay("_auto_lastABooCycleFix");
-	boolean desk = loopHandlerDelay("_auto_digitizeDeskCounter");
 	boolean digitize = loopHandlerDelay("_auto_digitizeAssassinCounter");
-	return boo || desk || digitize;
+	return boo || digitize;
 }
 
 string reverse(string s)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -309,7 +309,7 @@ boolean useCocoon();
 
 //Large pile dump.
 int auto_freeCombatsRemaining();							//Defined in autoscend.ash
-int auto_freeCombatsRemaining(boolean log_for_debug);		//Defined in autoscend.ash
+int auto_freeCombatsRemaining(boolean print_remaining_fights);		//Defined in autoscend.ash
 int auto_advToReserve();									//Defined in autoscend.ash
 boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -37,6 +37,7 @@ boolean LX_bitchinMeatcar();
 boolean LX_meatMaid();
 boolean LX_craftAcquireItems();
 boolean LX_freeCombats();
+boolean LX_freeCombats(boolean powerlevel);
 boolean LX_dolphinKingMap();
 boolean LX_steelOrgan();
 boolean resolveSixthDMT();
@@ -308,6 +309,7 @@ boolean useCocoon();
 
 //Large pile dump.
 int auto_freeCombatsRemaining();							//Defined in autoscend.ash
+int auto_freeCombatsRemaining(boolean log_for_debug);		//Defined in autoscend.ash
 int auto_advToReserve();									//Defined in autoscend.ash
 boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
@@ -663,6 +665,7 @@ boolean neverendingPartyCombat(stat st);					//Defined in autoscend/auto_mr2018.
 boolean neverendingPartyCombat(effect eff);					//Defined in autoscend/auto_mr2018.ash
 boolean neverendingPartyCombat();							//Defined in autoscend/auto_mr2018.ash
 boolean neverendingPartyPowerlevel();					//Defined in autoscend/auto_mr2018.ash
+int neverendingPartyRemainingFreeFights();					//Defined in autoscend/auto_mr2018.ash
 boolean neverendingPartyAvailable();						//Defined in autoscend/auto_mr2018.ash
 string auto_latteDropName(location l); // Defined in autoscend/auto_mr2018.ash
 boolean auto_latteDropAvailable(location l); // Defined in autoscend/auto_mr2018.ash


### PR DESCRIPTION
# Description

Free combats on rollover multiple bugs fixed and multiple improvements.
Fixed aborting mid rollover prep due to having free fights remaining.
Fixed NEP fighting an 11th dude and using an adventure when trying to free combat
Fixed NEP using non powerleveling function when you want to powerlevel.
Added debuging output to free fights related functions and auto call it when it fails
fixed OCRS spending adventures in NEP
fixed hardcoding ms. puck man as snojo familiar
removed code for writing desk tricks that kol now blocks
don't assume success in snojo and machine elf tunnels
don't silently block subsequent free fights if one mysteriously fails

## How Has This Been Tested?

Mostly through direct ash calls. But also running it on my main account that has free combats.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.