### PR TITLE
Avatar of Pete and Boris changes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4884,8 +4884,6 @@ boolean doTasks()
 	# This function buys missing skills in general, not just for Picky.
 	# It should be moved.
 	picky_buyskills();
-	boris_buySkills();
-	pete_buySkills();
 	awol_buySkills();
 	awol_useStuff();
 	theSource_buySkills();
@@ -4914,6 +4912,8 @@ boolean doTasks()
 
 	//Early adventure options that we probably want
 	if(dna_startAcquire())				return true;
+	if(LM_boris())						return true;
+	if(LM_pete())						return true;
 	if(LM_jello())						return true;
 	if(LM_fallout())					return true;
 	if(LM_groundhog())					return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -276,6 +276,12 @@ int auto_advToReserve()
 		{
 			reserveadv = max(2, reserveadv);
 		}
+		
+		//sneaky pete specific check. Mixologist lets you spend 2 adv on crafting. cocktail magic makes crafting free.
+		if(auto_have_skill($skill[Mixologist]) && !auto_have_skill($skill[Cocktail Magic]))
+		{
+			reserveadv = max(2, reserveadv);
+		}
 	}
 	
 	return reserveadv;
@@ -4907,7 +4913,7 @@ boolean doTasks()
 	//Early adventure options that we probably want
 	if(dna_startAcquire())				return true;
 	if(LM_boris())						return true;
-	if(LM_pete())						return true;
+	pete_buySkills();
 	if(LM_jello())						return true;
 	if(LM_fallout())					return true;
 	if(LM_groundhog())					return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4884,6 +4884,8 @@ boolean doTasks()
 	# This function buys missing skills in general, not just for Picky.
 	# It should be moved.
 	picky_buyskills();
+	boris_buySkills();
+	pete_buySkills();
 	awol_buySkills();
 	awol_useStuff();
 	theSource_buySkills();
@@ -4912,14 +4914,12 @@ boolean doTasks()
 
 	//Early adventure options that we probably want
 	if(dna_startAcquire())				return true;
-	if(LM_boris())						return true;
-	pete_buySkills();
 	if(LM_jello())						return true;
 	if(LM_fallout())					return true;
 	if(LM_groundhog())					return true;
 	if(LM_digimon())					return true;
 	if(LM_majora())						return true;
-	if(LM_batpath()) return true;
+	if(LM_batpath()) 					return true;
 	if(doHRSkills())					return true;
 
 	if(auto_my_path() != "Community Service")

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -1,9 +1,44 @@
 script "auto_boris.ash"
 
+boolean in_boris()
+{
+	return auto_my_path() == "Avatar of Boris";
+}
+
+boolean borisAdjustML()
+{
+	//set target ML boosts for boris.
+	
+	if(my_buffedstat($stat[muscle]) < 30)
+	{
+		return auto_change_mcd(0);
+	}
+	
+	boolean strong = auto_have_skill($skill[Barrel Chested]);
+	
+	if(!strong)
+	{
+		auto_change_mcd(0);
+	}
+	else
+	{
+		auto_change_mcd(11);
+	}
+	
+	//Overconfident is an intrinsic +30 ML. By the time you are strong enough to use it it can be turned on and left on
+	if(strong && my_buffedstat($stat[muscle]) > 100 && have_skill($skill[Pep Talk]) && have_effect($effect[Overconfident]) == 0)
+	{
+		use_skill(1, $skill[Pep Talk]);
+	}
+	
+	return true;
+}
+
 void boris_initializeSettings()
 {
-	if(my_path() == "Avatar of Boris")
+	if(in_boris())
 	{
+		Print("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_grimstoneOrnateDowsingRod", false);
@@ -17,12 +52,9 @@ void boris_initializeSettings()
 	}
 }
 
-
-
-
 void boris_initializeDay(int day)
 {
-	if(my_path() != "Avatar of Boris")
+	if(!in_boris())
 	{
 		return;
 	}
@@ -76,19 +108,20 @@ void boris_initializeDay(int day)
 	}
 }
 
-boolean boris_buySkills()
+void boris_buySkills()
 {
-	if(my_class() != $class[Avatar of Boris])
+	if(!in_boris())
 	{
-		return false;
+		return;
 	}
 	if(my_level() <= get_property("auto_borisSkills").to_int())
 	{
-		return false;
+		return;
 	}
+	//if you have these 3 skills then you have all skills
 	if(have_skill($skill[Bifurcating Blow]) && have_skill($skill[Banishing Shout]) && have_skill($skill[Gourmand]))
 	{
-		return false;
+		return;
 	}
 
 	int possBorisPoints = 0;
@@ -106,6 +139,8 @@ boolean boris_buySkills()
 			skillPoints = skillPoints - 1;
 			int tree = 1;
 
+			//skills are listed in reverse order. from last to first to buy.
+			//Correct Boris strat is super easy. get all feasting, then all shouting, then fighting last.
 			if(!have_skill($skill[Bifurcating Blow]))
 			{
 				tree = 1;
@@ -134,6 +169,19 @@ boolean boris_buySkills()
 			{
 				tree = 1;
 			}
+			if(!have_skill($skill[Broadside]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[[11002]Ferocity]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Cleave]))
+			{
+				tree = 1;
+			}
+			
 			if(!have_skill($skill[Banishing Shout]))
 			{
 				tree = 2;
@@ -154,22 +202,6 @@ boolean boris_buySkills()
 			{
 				tree = 2;
 			}
-			if(!have_skill($skill[Gourmand]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Barrel Chested]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[More to Love]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Hungry Eyes]))
-			{
-				tree = 3;
-			}
 			if(!have_skill($skill[Song of Solitude]))
 			{
 				tree = 2;
@@ -189,6 +221,23 @@ boolean boris_buySkills()
 			if(!have_skill($skill[Intimidating Bellow]))
 			{
 				tree = 2;
+			}
+			
+			if(!have_skill($skill[Gourmand]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Barrel Chested]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[More to Love]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Hungry Eyes]))
+			{
+				tree = 3;
 			}
 			if(!have_skill($skill[Heroic Belch]))
 			{
@@ -215,36 +264,9 @@ boolean boris_buySkills()
 				tree = 3;
 			}
 
-			if(!have_skill($skill[Broadside]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[[11002]Ferocity]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Cleave]))
-			{
-				tree = 1;
-			}
-
 			visit_url("da.php?pwd&whichtree=" + tree + "&action=borisskill");
 		}
 	}
 
 	set_property("auto_borisSkills", my_level());
-	return true;
-}
-
-
-boolean LM_boris()
-{
-	if(my_path() != "Avatar of Boris")
-	{
-		return false;
-	}
-
-	boris_buySkills();
-
-	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -2,12 +2,16 @@ script "auto_boris.ash"
 
 boolean in_boris()
 {
-	return auto_my_path() == "Avatar of Boris";
+	return my_class() == $class[Avatar of Boris];
 }
 
 boolean borisAdjustML()
 {
 	//set target ML boosts for boris.
+	if(!in_boris())
+	{
+		return false;
+	}
 	
 	if(my_buffedstat($stat[muscle]) < 30)
 	{
@@ -38,7 +42,7 @@ void boris_initializeSettings()
 {
 	if(in_boris())
 	{
-		Print("Initializing Avatar of Boris settings", "blue");
+		auto_log_info("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
 		set_property("auto_grimstoneOrnateDowsingRod", false);

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -274,3 +274,15 @@ void boris_buySkills()
 
 	set_property("auto_borisSkills", my_level());
 }
+
+boolean LM_boris()
+{
+	if(!in_boris())
+	{
+		return false;
+	}
+
+	boris_buySkills();
+
+	return false;
+}

--- a/RELEASE/scripts/autoscend/auto_mr2015.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2015.ash
@@ -115,7 +115,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Protection, Glamour, Vigor];		break;
 		}
 	}
-	else if(my_path() == "Avatar of Boris")
+	else if(in_boris())
 	{
 		switch(my_daycount())
 		{
@@ -236,7 +236,7 @@ boolean auto_mayoItems()
 	}
 
 	boolean[item] mayos;
-	if(my_path() == "Avatar of Boris")
+	if(in_boris())
 	{
 		switch(my_daycount())
 		{

--- a/RELEASE/scripts/autoscend/auto_mr2016.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2016.ash
@@ -77,7 +77,7 @@ boolean snojoFightAvailable()
 		standard[2] = "Muscle";
 		standard[3] = "Moxie";
 
-		if((my_path() == "Avatar of Boris") && (possessEquipment($item[Boris\'s Helm]) || possessEquipment($item[Boris\'s Helm (Askew)])))
+		if(in_boris() && (possessEquipment($item[Boris\'s Helm]) || possessEquipment($item[Boris\'s Helm (Askew)])))
 		{
 			standard[0] = "Muscle";
 			standard[1] = "Mysticality";

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -84,7 +84,7 @@ boolean januaryToteAcquire(item it)
 
 	if(choice == 2)
 	{
-		if((auto_my_path() == "Way of the Surprising Fist") || (my_class() == $class[Avatar Of Boris]))
+		if((auto_my_path() == "Way of the Surprising Fist") || in_boris())
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -198,7 +198,7 @@ boolean auto_sausageGoblin(location loc, string option)
 	
 	// can't equip kramko sausage grinder during certain paths, return false in those paths
 	
-	if (auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Avatar of Boris")
+	if (auto_my_path() == "Way of the Surprising Fist" || in_boris())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -67,7 +67,7 @@ void main()
 		uneffect($effect[Scarysauce]);
 	}
 
-	if(my_path() == $class[Avatar of Boris])
+	if(in_boris())
 	{
 		if((have_effect($effect[Song of Solitude]) == 0) && (have_effect($effect[Song of Battle]) == 0))
 		{

--- a/RELEASE/scripts/autoscend/auto_quest_level_11.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_11.ash
@@ -1217,7 +1217,7 @@ boolean L11_hiddenCityZones()
 	boolean needRelocate = (get_property("relocatePygmyJanitor").to_int() != my_ascensions());
 	boolean needMatches = (get_property("hiddenTavernUnlock").to_int() != my_ascensions());
 
-	if (!in_hardcore() || my_class() == $class[Avatar of Boris] || auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Pocket Familiars")
+	if (!in_hardcore() || in_boris() || auto_my_path() == "Way of the Surprising Fist" || auto_my_path() == "Pocket Familiars")
 	{
 		needMachete = false;
 	}
@@ -1481,7 +1481,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || (my_class() == $class[Avatar of Boris]) || (auto_my_path() == "Way of the Surprising Fist") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || in_boris() || (auto_my_path() == "Way of the Surprising Fist") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -69,19 +69,20 @@ void pete_initializeDay(int day)
 	}
 }
 
-boolean pete_buySkills()
+void pete_buySkills()
 {
 	if(my_class() != $class[Avatar of Sneaky Pete])
 	{
-		return false;
+		return;
 	}
 	if(my_level() <= get_property("auto_peteSkills").to_int())
 	{
-		return false;
+		return;
 	}
-	if(have_skill($skill[Natural Dancer]) && have_skill($skill[Flash Headlight]) && have_skill($skill[Walk Away From Explosion]) && (my_level() > 12))
+	//if you have those 3 skills then you have all skills.
+	if(have_skill($skill[Natural Dancer]) && have_skill($skill[Flash Headlight]) && have_skill($skill[Walk Away From Explosion]))
 	{
-		return false;
+		return;
 	}
 
 	string page = visit_url("da.php?place=gate3");
@@ -93,6 +94,7 @@ boolean pete_buySkills()
 
 		while(skillPoints > 0)
 		{
+			//skills are listed in inverse order. The first listed skill is the last skill to buy.
 			skillPoints = skillPoints - 1;
 			int tree = 1;
 
@@ -101,18 +103,6 @@ boolean pete_buySkills()
 				tree = 2;
 			}
 			if(!have_skill($skill[Biker Swagger]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Riding Tall]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Check Mirror]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Easy Riding]))
 			{
 				tree = 2;
 			}
@@ -198,6 +188,18 @@ boolean pete_buySkills()
 				tree = 1;
 			}
 
+			if(!have_skill($skill[Riding Tall]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Check Mirror]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Easy Riding]))
+			{
+				tree = 2;
+			}
 			if(!have_skill($skill[Peel Out]))
 			{
 				tree = 2;
@@ -279,18 +281,4 @@ boolean pete_buySkills()
 	}
 
 	set_property("auto_peteSkills", my_level());
-	return true;
-}
-
-
-boolean LM_pete()
-{
-	if(my_path() != "Avatar of Sneaky Pete")
-	{
-		return false;
-	}
-
-	pete_buySkills();
-
-	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -282,3 +282,15 @@ void pete_buySkills()
 
 	set_property("auto_peteSkills", my_level());
 }
+
+boolean LM_pete()
+{
+	if(my_path() != "Avatar of Sneaky Pete")
+	{
+		return false;
+	}
+
+	pete_buySkills();
+
+	return false;
+}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3694,6 +3694,7 @@ boolean auto_have_familiar(familiar fam)
 
 boolean basicAdjustML()
 {
+	if(in_boris()) return borisAdjustML();
 	if (in_zelda())
 	{
 		// We don't get many stats from combat - no point running ML.

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -312,8 +312,10 @@ int auto_advToReserve();									//Defined in autoscend.ash
 boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
 boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash
+boolean LM_boris();											//Defined in autoscend/auto_boris.ash
 boolean LM_fallout();										//Defined in autoscend/auto_fallout.ash
 boolean LM_jello();											//Defined in autoscend/auto_jellonewbie.ash
+boolean LM_pete();											//Defined in autoscend/auto_sneakypete.ash
 boolean LX_ghostBusting();									//Defined in autoscend/auto_mr2016.ash
 boolean LX_theSource();										//Defined in autoscend/auto_theSource.ash
 familiar[int] List();										//Defined in autoscend/auto_list.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -312,7 +312,6 @@ int auto_advToReserve();									//Defined in autoscend.ash
 boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
 boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash
-boolean LM_boris();											//Defined in autoscend/auto_boris.ash
 boolean LM_fallout();										//Defined in autoscend/auto_fallout.ash
 boolean LM_jello();											//Defined in autoscend/auto_jellonewbie.ash
 boolean LX_ghostBusting();									//Defined in autoscend/auto_mr2016.ash
@@ -415,7 +414,9 @@ boolean tcrs_loadCafeDrinks(int[int] cafe_backmap, float[int] adv, int[int] ineb
 boolean tcrs_maximize_with_items(string maximizerString);	//Defined in autoscend/auto_tcrs.ash
 boolean in_koe();											//Defined in autoscend/auto_koe.ash
 boolean in_zelda();											//Defined in autoscend/auto_zelda.ash
-boolean boris_buySkills();									//Defined in autoscend/auto_boris.ash
+boolean in_boris();											//Defined in autoscend/auto_boris.ash
+boolean borisAdjustML();									//Defined in autoscend/auto_boris.ash
+void boris_buySkills();										//Defined in autoscend/auto_boris.ash
 void boris_initializeDay(int day);							//Defined in autoscend/auto_boris.ash
 void boris_initializeSettings();							//Defined in autoscend/auto_boris.ash
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -315,7 +315,6 @@ boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash
 boolean LM_boris();											//Defined in autoscend/auto_boris.ash
 boolean LM_fallout();										//Defined in autoscend/auto_fallout.ash
 boolean LM_jello();											//Defined in autoscend/auto_jellonewbie.ash
-boolean LM_pete();											//Defined in autoscend/auto_sneakypete.ash
 boolean LX_ghostBusting();									//Defined in autoscend/auto_mr2016.ash
 boolean LX_theSource();										//Defined in autoscend/auto_theSource.ash
 familiar[int] List();										//Defined in autoscend/auto_list.ash
@@ -901,7 +900,7 @@ boolean ocrs_postHelper();									//Defined in autoscend/auto_summerfun.ash
 void oldPeoplePlantStuff();									//Defined in autoscend/auto_floristfriar.ash
 boolean organsFull();										//Defined in autoscend/auto_util.ash
 boolean ovenHandle();										//Defined in autoscend/auto_util.ash
-boolean pete_buySkills();									//Defined in autoscend/auto_sneakypete.ash
+void pete_buySkills();										//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeDay(int day);							//Defined in autoscend/auto_sneakypete.ash
 void pete_initializeSettings();								//Defined in autoscend/auto_sneakypete.ash
 boolean picky_buyskills();									//Defined in autoscend/auto_picky.ash


### PR DESCRIPTION
Tweaked skill purchase order to be more helpful for low skill players. (high skill gets them all anyways).
Custom ML management for boris. Including when to use overconfidence.
Also added in_boris() and used it.

## How Has This Been Tested?

Ash calls.
1 new account doing HC pete
1 new account doing HC boris
ran it on other paths too to see that nothing unexpected happened.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
