### PR TITLE
shen softblock check should be before powerleveling

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5196,6 +5196,14 @@ boolean doTasks()
 
 	if (L12_clearBattlefield())			return true;
 	if(LX_koeInvaderHandler())			return true;
+	
+	if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished")
+	{
+		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
+		set_property("auto_shenSkipLastLevel", my_level());
+		return true;
+	}
+	
 	if(L13_powerLevel())				return true;
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
@@ -5203,14 +5211,6 @@ boolean doTasks()
 	if(L13_towerNSTower())				return true;
 	if(L13_towerNSNagamar())			return true;
 	if(L13_towerNSFinal())				return true;
-
-	if(my_level() > get_property("auto_shenSkipLastLevel").to_int())
-	{
-		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
-		set_property("auto_shenSkipLastLevel", my_level());
-		return true;
-	}
-
 
 	if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
 	{


### PR DESCRIPTION
If you run out of other things to do. Do not delay logging camp for shen.
Was previously checking this after the powerlevel to level 13 function instead of before.

## How Has This Been Tested?

In hardcore ed, i was delaying it and boss bat. I made the change then ran it and it stopped delaying logging camp.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
