### PR TITLE
L13_powerLevel() reworked

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -6,6 +6,7 @@ auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks d
 auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
 auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
+auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
 auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
 auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
 auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -14,46 +14,47 @@ any	4	auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunB
 any	5	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
 any	6	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 any	7	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
-any	8	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
-any	9	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
-any	10	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
-any	11	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	12	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	13	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	14	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	15	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
-any	16	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	17	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	18	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	19	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	20	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	21	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	22	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	23	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	24	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	25	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	26	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	27	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	28	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	29	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	30	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	31	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	32	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	33	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	34	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	37	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	38	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	45	auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
-any	46	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	47	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	8	auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
+any	9	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
+any	10	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
+any	11	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
+any	12	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	13	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	14	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	15	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	16	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
+any	17	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	18	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
+any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	46	auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
+any	47	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	48	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4980,7 +4980,12 @@ boolean doTasks()
 	
 	if(LX_getDigitalKey()) 				return true;
 	if(LX_getStarKey()) 				return true;
-	if(L13_startQuest())				return true;
+	
+	if (my_level() < 13)
+	{
+		if(LX_attemptPowerLevel()) return true;
+	}
+	
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
 	if(L13_sorceressDoor())				return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2447,7 +2447,6 @@ boolean LX_attemptPowerLevel()
 	LX_attemptPowerLevelTheSource();
 
 	//scaling damage zones
-	if(LX_melvignShirt()) return true;		// If you do not have torso awaregness do it first. If you have that skill do thinknerd last.
 	if(elementalPlanes_access($element[stench]) && auto_have_skill($skill[Summon Smithsness]) && (get_property("auto_beatenUpCount").to_int() == 0))
 	{
 		if(autoAdv($location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice])) return true;
@@ -2472,15 +2471,8 @@ boolean LX_attemptPowerLevel()
 	{
 		if(neverendingPartyPowerlevel()) return true;
 	}
-	if(internalQuestStatus("questM22Shirt") > -1)	//do we have access to [The Thinknerd Warehouse]?
-	{
-		if(autoAdv($location[The Thinknerd Warehouse])) return true;		//powerlevel in thinknerd warehouse
-	}
-	else
-	{
-		//try to gain access to thinknerd warehouse. Be willing to spend wish or adv
-		if(LX_unlockThinknerdWarehouse(true)) return true;
-	}
+	//do not use the scaling zone [The Thinknerd Warehouse] here.
+	//it has low stat caps on the scaling, resulting in <30 substats per adv
 
 	// use spare clovers to powerlevel
 	int cloverLimit = get_property("auto_wandOfNagamar").to_boolean() ? 1 : 0;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2420,7 +2420,6 @@ boolean LX_attemptPowerLevel()
 	set_property("auto_powerLevelAdvCount", get_property("auto_powerLevelAdvCount").to_int() + 1);
 	set_property("auto_powerLevelLastAttempted", my_turncount());
 	set_property("auto_powerLevelLastLevel", my_level());
-	set_property("auto_newbieOverride", true);
 	
 	handleFamiliar("stat");
 	addToMaximize("100 exp");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2388,18 +2388,28 @@ boolean powerLevelAdjustment()
 
 boolean LX_melvignShirt()
 {
-	if(internalQuestStatus("questM22Shirt") < 0)
+	//Do the quest [The Shirt Off His Lack of Back] to get the skill [Torso Awaregness] from melvign the gnome.	
+	
+	if(hasTorso())
 	{
 		return false;
 	}
 	if(get_property("questM22Shirt") == "finished")
 	{
+		//is it actually possible to finish the quest and not have torso awareness? if not then this can be delted.
 		return false;
 	}
+	if(internalQuestStatus("questM22Shirt") < 0)	//if quest has not started
+	{
+		if(!LX_unlockThinknerdWarehouse(false))		//if failed to start the quest without spending adv or wish
+		{
+			return false;
+		}
+	}
+	
 	if(item_amount($item[Professor What Garment]) == 0)
 	{
-		autoAdv($location[The Thinknerd Warehouse]);
-		return true;
+		return autoAdv($location[The Thinknerd Warehouse]);
 	}
 	string temp = visit_url("place.php?whichplace=mountains&action=mts_melvin", false);
 	return true;
@@ -2409,170 +2419,122 @@ boolean LX_attemptPowerLevel()
 {
 	set_property("auto_powerLevelAdvCount", get_property("auto_powerLevelAdvCount").to_int() + 1);
 	set_property("auto_powerLevelLastAttempted", my_turncount());
-
+	set_property("auto_powerLevelLastLevel", my_level());
+	set_property("auto_newbieOverride", true);
+	
 	handleFamiliar("stat");
 	addToMaximize("100 exp");
-
-	if(LX_freeCombats(true))
+	
+	auto_log_warning("I need to powerlevel", "red");
+	int delay = get_property("auto_powerLevelTimer").to_int();
+	if(delay == 0)
 	{
+		delay = 10;
+	}
+	wait(delay);
+
+	if(LX_freeCombats(true)) return true;
+	
+	if(chateaumantegna_available() && haveFreeRestAvailable() && auto_my_path() != "The Source")
+	{
+		doFreeRest();
+		cli_execute("scripts/autoscend/auto_post_adv.ash");
+		loopHandlerDelayAll();
 		return true;
 	}
+	
+	//The Source path specific powerleveling
+	LX_attemptPowerLevelTheSource();
 
-	if(!hasTorso())
-	{
-		// We need to acquire a letter from Melvign...
-		if(LX_melvignShirt())
-		{
-			return true;
-		}
-	}
-
-	if(auto_my_path() == "The Source")
-	{
-		if (get_property("lastSecondFloorUnlock").to_int() == my_ascensions())
-		{
-			if(get_property("barrelShrineUnlocked").to_boolean())
-			{
-				if(cloversAvailable() == 0)
-				{
-					handleBarrelFullOfBarrels(false);
-					string temp = visit_url("barrel.php");
-					temp = visit_url("choice.php?whichchoice=1099&pwd=&option=2");
-					handleBarrelFullOfBarrels(false);
-					return true;
-				}
-				stat myStat = my_primestat();
-				if(my_basestat(myStat) >= 148)
-				{
-					return false;
-				}
-				else if(my_basestat(myStat) >= 125)
-				{
-					//Should probably prefer to check what equipment failures we may be having.
-					if((my_basestat($stat[Muscle]) < my_basestat(myStat)) && (my_basestat($stat[Muscle]) < 70))
-					{
-						myStat = $stat[Muscle];
-					}
-					if((my_basestat($stat[Mysticality]) < my_basestat(myStat)) && (my_basestat($stat[Mysticality]) < 70))
-					{
-						myStat = $stat[Mysticality];
-					}
-					if((my_basestat($stat[Moxie]) < my_basestat(myStat)) && (my_basestat($stat[Moxie]) < 70))
-					{
-						myStat = $stat[Moxie];
-					}
-				}
-				//Else, default to mainstat.
-
-				//Determine where to go for clover stats, do not worry about clover failures
-				location whereTo = $location[none];
-				switch(myStat)
-				{
-				case $stat[Muscle]:			whereTo = $location[The Haunted Gallery];				break;
-				case $stat[Mysticality]:	whereTo = $location[The Haunted Bathroom];				break;
-				case $stat[Moxie]:			whereTo = $location[The Haunted Ballroom];				break;
-				}
-
-				if (whereTo == $location[The Haunted Ballroom] && internalQuestStatus("questM21Dance") > 3)
-				{
-					use(item_amount($item[ten-leaf clover]), $item[ten-leaf clover]);
-					LX_spookyBedroomCombat();
-					return true;
-				}
-				if(cloversAvailable() > 0)
-				{
-					cloverUsageInit();
-				}
-				autoAdv(1, whereTo);
-				cloverUsageFinish();
-				return true;
-			}
-			//Banish mahogant, elegant after gown only. (Harold\'s Bell?)
-			LX_spookyBedroomCombat();
-			return true;
-		}
-	}
-
+	//scaling damage zones
+	if(LX_melvignShirt()) return true;		// If you do not have torso awaregness do it first. If you have that skill do thinknerd last.
 	if(elementalPlanes_access($element[stench]) && auto_have_skill($skill[Summon Smithsness]) && (get_property("auto_beatenUpCount").to_int() == 0))
 	{
-		autoAdv(1, $location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice]);
+		if(autoAdv($location[Uncle Gator\'s Country Fun-Time Liquid Waste Sluice])) return true;
 	}
-	else if(elementalPlanes_access($element[spooky]))
+	if(elementalPlanes_access($element[spooky]))
 	{
-		autoAdv(1, $location[The Deep Dark Jungle]);
+		if(autoAdv($location[The Deep Dark Jungle])) return true;
 	}
-	else if(elementalPlanes_access($element[cold]))
+	if(elementalPlanes_access($element[cold]))
 	{
-		autoAdv(1, $location[VYKEA]);
+		if(autoAdv($location[VYKEA])) return true;
 	}
-	else if(elementalPlanes_access($element[sleaze]))
+	if(elementalPlanes_access($element[sleaze]))
 	{
-		autoAdv(1, $location[Sloppy Seconds Diner]);
+		if(autoAdv($location[Sloppy Seconds Diner])) return true;
 	}
-	else if (elementalPlanes_access($element[hot]))
+	if (elementalPlanes_access($element[hot]))
 	{
-		autoAdv(1, $location[The SMOOCH Army HQ]);
+		if(autoAdv($location[The SMOOCH Army HQ])) return true;
 	}
-	else if (neverendingPartyAvailable())
+	if (neverendingPartyAvailable())
 	{
-		neverendingPartyPowerlevel();
+		if(neverendingPartyPowerlevel()) return true;
+	}
+	if(internalQuestStatus("questM22Shirt") > -1)	//do we have access to [The Thinknerd Warehouse]?
+	{
+		if(autoAdv($location[The Thinknerd Warehouse])) return true;		//powerlevel in thinknerd warehouse
 	}
 	else
 	{
-		// burn all spare clovers after level 12 if we need to powerlevel.
-		int cloverLimit = get_property("auto_wandOfNagamar").to_boolean() ? 1 : 0;
-		if (my_level() >= 12 && internalQuestStatus("questL12War") > 1 && cloversAvailable() > cloverLimit)
-		{
-			//Determine where to go for clover stats, do not worry about clover failures
-			location whereTo = $location[none];
-			switch (my_primestat())
-			{
-				case $stat[Muscle]:
-					whereTo = $location[The Haunted Gallery];
-					break;
-				case $stat[Mysticality]:
-					whereTo = $location[The Haunted Bathroom];
-					break;
-				case $stat[Moxie]:
-					whereTo = $location[The Haunted Ballroom];
-					break;
-			}
-
-			cloverUsageInit();
-			boolean retval = autoAdv(1, whereTo);
-			cloverUsageFinish();
-			return retval;
-		}
-
-		// optimal levelling if you have no IotMs with scaling monsters
-		if (internalQuestStatus("questM21Dance") > 3)
-		{
-			switch (my_primestat())
-			{
-				case $stat[Muscle]:
-					set_property("louvreDesiredGoal", "4"); // get Muscle stats
-					break;
-				case $stat[Mysticality]:
-					set_property("louvreDesiredGoal", "5"); // get Myst stats
-					break;
-				case $stat[Moxie]:
-					set_property("louvreDesiredGoal", "6"); // get Moxie stats
-					break;
-			}
-			if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield])))
-			{
-				set_property("choiceAdventure89", "2"); // fight the snake knight (as Ed)
-			}
-			else
-			{
-				set_property("choiceAdventure89", "6"); // ignore the NC & banish it for 10 adv
-			}
-			providePlusNonCombat(25);
-			return autoAdv($location[The Haunted Gallery]);
-		}
-		return false;
+		//try to gain access to thinknerd warehouse. Be willing to spend wish or adv
+		if(LX_unlockThinknerdWarehouse(true)) return true;
 	}
-	return true;
+
+	// use spare clovers to powerlevel
+	int cloverLimit = get_property("auto_wandOfNagamar").to_boolean() ? 1 : 0;
+	if(my_level() >= 12 && internalQuestStatus("questL12War") > 1 && cloversAvailable() > cloverLimit)
+	{
+		//Determine where to go for clover stats, do not worry about clover failures
+		location whereTo = $location[none];
+		switch (my_primestat())
+		{
+			case $stat[Muscle]:
+				whereTo = $location[The Haunted Gallery];
+				break;
+			case $stat[Mysticality]:
+				whereTo = $location[The Haunted Bathroom];
+				break;
+			case $stat[Moxie]:
+				whereTo = $location[The Haunted Ballroom];
+				break;
+		}
+
+		cloverUsageInit();
+		boolean adv_spent = autoAdv(whereTo);
+		cloverUsageFinish();
+		if(adv_spent) return true;
+	}
+
+	// [Haunted Gallery] is the optimal powerleveling spot if you have no scaling monsters nor clovers left.
+	if (internalQuestStatus("questM21Dance") > 3)
+	{
+		switch (my_primestat())
+		{
+			case $stat[Muscle]:
+				set_property("louvreDesiredGoal", "4"); // get Muscle stats
+				break;
+			case $stat[Mysticality]:
+				set_property("louvreDesiredGoal", "5"); // get Myst stats
+				break;
+			case $stat[Moxie]:
+				set_property("louvreDesiredGoal", "6"); // get Moxie stats
+				break;
+		}
+		if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield])))
+		{
+			set_property("choiceAdventure89", "2"); // fight the snake knight (as Ed)
+		}
+		else
+		{
+			set_property("choiceAdventure89", "6"); // ignore the NC & banish it for 10 adv
+		}
+		providePlusNonCombat(25);
+		if(autoAdv($location[The Haunted Gallery])) return true;
+	}
+	
+	return false;
 }
 
 boolean LX_spookyBedroomCombat()
@@ -3363,15 +3325,6 @@ boolean LX_craftAcquireItems()
 		use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
 	}
 
-	if(get_property("questM22Shirt") == "unstarted")
-	{
-		januaryToteAcquire($item[Letter For Melvign The Gnome]);
-		if(possessEquipment($item[Makeshift Garbage Shirt]))
-		{
-			string temp = visit_url("inv_equip.php?pwd&which=2&action=equip&whichitem=" + to_int($item[Makeshift Garbage Shirt]));
-		}
-	}
-
 	if((get_property("lastGoofballBuy").to_int() != my_ascensions()) && (internalQuestStatus("questL03Rat") >= 0))
 	{
 		visit_url("place.php?whichplace=woods");
@@ -3576,17 +3529,6 @@ boolean LX_craftAcquireItems()
 			int choice = 1 + to_int(it) - to_int($item[Meteortarboard]);
 			string temp = visit_url("inv_use.php?pwd=&which=3&whichitem=9516");
 			temp = visit_url("choice.php?pwd=&whichchoice=1264&option=" + choice);
-		}
-	}
-
-	if(item_amount($item[Letter For Melvign The Gnome]) > 0)
-	{
-		use(1, $item[Letter For Melvign The Gnome]);
-		if(get_property("questM22Shirt") == "unstarted")
-		{
-			auto_log_warning("Mafia did not register using the Melvign letter...", "red");
-			cli_execute("refresh inv");
-			set_property("questM22Shirt", "started");
 		}
 	}
 
@@ -5029,6 +4971,7 @@ boolean doTasks()
 	if (L12_clearBattlefield())			return true;
 	if(LX_koeInvaderHandler())			return true;
 	
+	//release the softblock on quests that are waiting for shen quest
 	if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished")
 	{
 		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
@@ -5036,7 +4979,17 @@ boolean doTasks()
 		return true;
 	}
 	
-	if(L13_powerLevel())				return true;
+	//release the softblock on various quests that await optimal conditions.
+	if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
+	{
+		auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
+		set_property("auto_powerLevelLastLevel", my_level());
+		return true;
+	}
+	
+	if(LX_getDigitalKey()) 				return true;
+	if(LX_getStarKey()) 				return true;
+	if(L13_startQuest())				return true;
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
 	if(L13_sorceressDoor())				return true;

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -205,88 +205,30 @@ boolean LX_getStarKey()
 	return autoAdv(1, $location[The Hole In The Sky]);
 }
 
-boolean L13_powerLevel()
+boolean L13_startQuest()
 {
-	// this function is exceptionally badly named. It powerlevels to 13 and nothing else. Should be refactored.
-	if(internalQuestStatus("questL13Final") < 0)
+	// start final quest for the naughty sorceress. If needed power level to reach level 13
+	
+	if(internalQuestStatus("questL13Final") > -1)
 	{
-		if(my_level() < 13)
+		return false;
+	}
+	
+	//start quest if level 13+
+	if(my_level() > 12)
+	{
+		council(); // Log council output
+		if(internalQuestStatus("questL13Final") > -1)
 		{
-			auto_log_warning("I seem to need to power level, or something... waaaa.", "red");
-			# lx_attemptPowerLevel is before. We need to merge all of this into that....
-			set_property("auto_newbieOverride", true);
-
-			if(needDigitalKey())
-			{
-				woods_questStart();
-				if(LX_getDigitalKey())
-				{
-					return true;
-				}
-			}
-			if(needStarKey())
-			{
-				if(zone_isAvailable($location[The Hole In The Sky]))
-				{
-					if(LX_getStarKey())
-					{
-						return true;
-					}
-				}
-			}
-			if(!hasTorso())
-			{
-				if(LX_melvignShirt())
-				{
-					return true;
-				}
-			}
-
-			int delay = get_property("auto_powerLevelTimer").to_int();
-			if(delay == 0)
-			{
-				delay = 10;
-			}
-			wait(delay);
-
-			if(haveAnyIotmAlternativeRestSiteAvailable() && haveFreeRestAvailable() && auto_my_path() != "The Source")
-			{
-				doFreeRest();
-				cli_execute("scripts/autoscend/auto_post_adv.ash");
-				loopHandlerDelayAll();
-				return true;
-			}
-
-			if(!LX_attemptPowerLevel())
-			{
-				if(get_property("auto_powerLevelAdvCount").to_int() >= 10)
-				{
-					auto_log_warning("The following error message is probably wrong, you just need to powerlevel to 13 most likely.", "red");
-					if((item_amount($item[Rock Band Flyers]) > 0) || (item_amount($item[Jam Band Flyers]) > 0))
-					{
-						abort("Need more flyer ML but don't know where to go :(");
-					}
-					else
-					{
-						abort("I am lost, please forgive me. I feel underleveled.");
-					}
-				}
-			}
 			return true;
 		}
 		else
 		{
-			if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
-			{
-				auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
-				set_property("auto_powerLevelLastLevel", my_level());
-				return true;
-			}
-			council(); // Log council output
-			abort("Some sidequest is not done for some raisin. Some sidequest is missing, or something is missing, or something is not not something. We don't know what to do.");
+			abort("I am unable to start the final quest for some reason");
 		}
 	}
-	return false;
+	// if we reached this point under level 13 then we need to level up.
+	return LX_attemptPowerLevel();
 }
 
 boolean L13_towerNSContests()

--- a/RELEASE/scripts/autoscend/auto_quest_level_13.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_13.ash
@@ -205,32 +205,6 @@ boolean LX_getStarKey()
 	return autoAdv(1, $location[The Hole In The Sky]);
 }
 
-boolean L13_startQuest()
-{
-	// start final quest for the naughty sorceress. If needed power level to reach level 13
-	
-	if(internalQuestStatus("questL13Final") > -1)
-	{
-		return false;
-	}
-	
-	//start quest if level 13+
-	if(my_level() > 12)
-	{
-		council(); // Log council output
-		if(internalQuestStatus("questL13Final") > -1)
-		{
-			return true;
-		}
-		else
-		{
-			abort("I am unable to start the final quest for some reason");
-		}
-	}
-	// if we reached this point under level 13 then we need to level up.
-	return LX_attemptPowerLevel();
-}
-
 boolean L13_towerNSContests()
 {
 	if (internalQuestStatus("questL13Final") < 0 || internalQuestStatus("questL13Final") > 3)

--- a/RELEASE/scripts/autoscend/auto_theSource.ash
+++ b/RELEASE/scripts/autoscend/auto_theSource.ash
@@ -246,3 +246,74 @@ boolean theSource_oracle()
 
 	return false;
 }
+
+boolean LX_attemptPowerLevelTheSource()
+{
+	if(my_path() != "The Source")
+	{
+		return false;
+	}
+	if (get_property("lastSecondFloorUnlock").to_int() != my_ascensions())
+	{
+		return false;
+	}
+
+	if(get_property("barrelShrineUnlocked").to_boolean())
+	{
+		if(cloversAvailable() == 0)
+		{
+			handleBarrelFullOfBarrels(false);
+			string temp = visit_url("barrel.php");
+			temp = visit_url("choice.php?whichchoice=1099&pwd=&option=2");
+			handleBarrelFullOfBarrels(false);
+			return true;
+		}
+		stat myStat = my_primestat();
+		if(my_basestat(myStat) >= 148)
+		{
+			return false;
+		}
+		else if(my_basestat(myStat) >= 125)
+		{
+			//Should probably prefer to check what equipment failures we may be having.
+			if((my_basestat($stat[Muscle]) < my_basestat(myStat)) && (my_basestat($stat[Muscle]) < 70))
+			{
+				myStat = $stat[Muscle];
+			}
+			if((my_basestat($stat[Mysticality]) < my_basestat(myStat)) && (my_basestat($stat[Mysticality]) < 70))
+			{
+				myStat = $stat[Mysticality];
+			}
+			if((my_basestat($stat[Moxie]) < my_basestat(myStat)) && (my_basestat($stat[Moxie]) < 70))
+			{
+				myStat = $stat[Moxie];
+			}
+		}
+		//Else, default to mainstat.
+
+		//Determine where to go for clover stats, do not worry about clover failures
+		location whereTo = $location[none];
+		switch(myStat)
+		{
+			case $stat[Muscle]:			whereTo = $location[The Haunted Gallery];				break;
+			case $stat[Mysticality]:	whereTo = $location[The Haunted Bathroom];				break;
+			case $stat[Moxie]:			whereTo = $location[The Haunted Ballroom];				break;
+		}
+		
+		if (whereTo == $location[The Haunted Ballroom] && internalQuestStatus("questM21Dance") > 3)
+		{
+			use(item_amount($item[ten-leaf clover]), $item[ten-leaf clover]);
+			LX_spookyBedroomCombat();
+			return true;
+		}
+		if(cloversAvailable() > 0)
+		{
+			cloverUsageInit();
+		}
+		autoAdv(1, whereTo);
+		cloverUsageFinish();
+		return true;
+	}
+	//Banish mahogant, elegant after gown only. (Harold\'s Bell?)
+	return LX_spookyBedroomCombat();
+}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -19,55 +19,138 @@ item[int] drops_available();
 item[int] hugpocket_available();
 boolean is_ghost_in_zone(location loc);
 
-boolean zone_unlock(location loc){
-	boolean unlock_thinknerd(){
-		auto_log_debug("Attempting to open " + loc + " by acquiring/equipping a shirt.");
-
-		if(!auto_have_skill($skill[Torso Awaregness])){
+boolean LX_unlockThinknerdWarehouse(boolean spend_resources)
+{
+	//unlocks [The Thinknerd Warehouse], returns true if successful or adv is spent
+	//much easier to do if you already have torso awaregness
+	
+	if(internalQuestStatus("questM22Shirt") > -1)
+	{
+		return false;
+	}
+	
+	auto_log_debug("Trying to unlock [The Thinknerd Warehouse] with spend_resources set to " + spend_resources);
+	
+	//unlocking is a multi step process. We want to try things in reverse to conserve resources and in case some steps were already complete.
+	
+	boolean useLetter()
+	{
+		if(item_amount($item[Letter for Melvign the Gnome]) > 0)
+		{
+			if(use(1, $item[Letter for Melvign the Gnome]))
+			{
+				auto_log_debug("Successfully unlocked the [The Thinknerd Warehouse]");
+				return true;
+			}
+			else
+			{
+				abort("Somehow failed to use [Letter for Melvign the Gnome]... aborting to prevent infinite loops");
+			}
+		}
+		return false;
+	}
+	
+	item target_shirt = $item[none];
+	boolean hasShirt = false;
+	
+	//one time initial scan of inventory
+	foreach it in get_inventory()
+	{
+		if(to_slot(it) == $slot[shirt])
+		{
+			target_shirt = it;
+			hasShirt = true;
+			break;
+		}
+	}
+		
+	boolean useShirtThenLetter()
+	{
+		if(!hasShirt)
+		{
 			return false;
 		}
-
-		item shirt = $item[none];
-		foreach i in get_inventory(){
-			if(to_slot(i) == $slot[shirt]){
-				shirt = i;
-				break;
-			}
-		}
-
-		if(shirt == $item[none] && isjanuaryToteAvailable() && januaryToteAcquire($item[Makeshift Garbage Shirt])){
-			shirt = $item[Makeshift Garbage Shirt];
-		}
-
-		if(shirt == $item[none] && shouldUseWishes() && wishesAvailable() > 0){
-			shirt = to_item("blessed rustproof +2 gray dragon scale mail");
-			makeGenieWish("for a " + shirt);
-			if(item_amount(shirt) == 0){
-				shirt = $item[none];
-			}
-		}
-
-		if(shirt == $item[none] && auto_have_skill($skill[Armorcraftiness])){
-			static boolean[item] craftable_shirts = $items[barskin cloak, bat-ass leather jacket, clownskin harness, demonskin jacket, gnauga hide vest, hipposkin poncho, lynyrdskin tunic, tuxedo shirt, white snakeskin duster, yak anorak];
-
-			foreach craftable in craftable_shirts{
-				if(creatable_amount(craftable) > 0 && create(1, craftable)){
-					shirt = craftable;
-					break;
-				}
-			}
-		}
-
-		if(shirt == $item[none] && neverendingPartyAvailable()){
-			auto_log_warning("Couldnt find a shirt to unlock Thinknerd. You may want to run NEP with +item to get a shirt");
-		}
-
-		return shirt != $item[none] && autoEquip($slot[shirt], shirt);
+		string temp = visit_url("inv_equip.php?pwd&which=2&action=equip&whichitem=" + target_shirt.to_int());
+		if(useLetter()) return true;
+		auto_log_error("For some reason LX_unlockThinknerdWarehouse failed when trying to use the shirt [" + target_shirt + "] to get [Letter for Melvign the Gnome] to start the quest", "red");
+		return false;
 	}
+	void getShirtWhenHaveNone(item it)
+	{
+		if(hasShirt) return;
+		if(canPull(it))
+		{
+			if(pullXWhenHaveY(it, 1, 0))
+			{
+				target_shirt = it;
+				hasShirt = true;
+			}
+		}
+		else if(creatable_amount(it) > 0 && (spend_resources || knoll_available()))
+		{
+			if(create(1, it))
+			{
+				target_shirt = it;
+				hasShirt = true;
+			}
+		}
+	}
+	
+	//if you already had a shirt or a letter, then just unlock the quest now
+	if(useLetter()) return true;
+	if(useShirtThenLetter()) return true;
+	
+	//Try to acquire a shirt.
+	
+	//IOTM that does not require a pull
+	januaryToteAcquire($item[Letter For Melvign The Gnome]);	//no stats and no pull required
+	if(useLetter()) return true;
+	
+	//TODO, make the following IOTM foldables actually work
+	//getShirtWhenHaveNone($item[flaming pink shirt])		//foldable IOTM that requires torso awaregness.
+	//getShirtWhenHaveNone($item[origami pasties])			//foldable IOTM that requires torso awaregness.
+	//getShirtWhenHaveNone($item[sugar shirt])				//libram summons sugar sheet, multiuse 1 with torso awaregness to get sugar shirt
+	
+	//Shirts to pull
+	getShirtWhenHaveNone($item[Sneaky Pete\'s leather jacket]);		//useful IOTM shirt with no state requirements to wear
+	getShirtWhenHaveNone($item[Sneaky Pete\'s leather jacket (collar popped)]);
+	getShirtWhenHaveNone($item[Professor What T-Shirt]);			//you likely have it, no requirements to wear, very cheap in mall
+	
+	//Shirts to smith. Will likely cost 1 adv unless in knoll sign.
+	getShirtWhenHaveNone($item[white snakeskin duster]);		//7 mus req
+	getShirtWhenHaveNone($item[clownskin harness]);				//15 mus req
+	getShirtWhenHaveNone($item[demonskin jacket]);				//25 mus req
+	getShirtWhenHaveNone($item[gnauga hide vest]);				//25 mus req
+	getShirtWhenHaveNone($item[tuxedo shirt]);					//35 mus req
+	getShirtWhenHaveNone($item[yak anorak]);					//42 mus req
+	getShirtWhenHaveNone($item[hipposkin poncho]);				//45 mus req
+	getShirtWhenHaveNone($item[lynyrdskin tunic]);				//70 mus req
+	getShirtWhenHaveNone($item[bat-ass leather jacket]);		//77 mus req
+
+	//wish for a shirt
+	if(spend_resources && wishesAvailable() > 0 && shouldUseWishes() && item_amount($item[blessed rustproof +2 gray dragon scale mail]) == 0)
+	{
+		makeGenieWish("for a blessed rustproof +2 gray dragon scale mail");
+		target_shirt = $item[blessed rustproof +2 gray dragon scale mail];
+		hasShirt = true;
+	}
+	
+	//TODO adventure somewhere to acquire shirt
+	//if(spend_resources && hasTorso())
+	
+	//did we succeeded in getting a shirt? use it and then the letter.
+	if(useShirtThenLetter()) return true;
+	
+	//sadness, we couldn't unlock this zone.
+	auto_log_debug("Failed to unlock [The Thinknerd Warehouse]");
+	return false;
+}
+
+boolean zone_unlock(location loc){
 
 	boolean unlocked = false;
 	if(loc == $location[The Thinknerd Warehouse]){
-		unlocked = unlock_thinknerd();
+		unlocked = LX_unlockThinknerdWarehouse(false);
 	} else{
 		auto_log_debug("Dont know how to unlock " + loc);
 		return false;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -172,7 +172,7 @@ boolean L12_finalizeWar();									//Defined in autoscend/auto_quest_level_12.as
 //Defined in autoscend/auto_quest_level_13.ash
 boolean LX_getDigitalKey();
 boolean LX_getStarKey();
-boolean L13_powerLevel();
+boolean L13_startQuest();
 boolean L13_sorceressDoor();
 boolean L13_towerNSContests();
 boolean L13_towerNSHedge();
@@ -983,6 +983,7 @@ int stomach_left();											//Defined in autoscend/auto_util.ash
 boolean theSource_buySkills();								//Defined in autoscend/auto_theSource.ash
 boolean theSource_initializeSettings();						//Defined in autoscend/auto_theSource.ash
 boolean theSource_oracle();									//Defined in autoscend/auto_theSource.ash
+boolean LX_attemptPowerLevelTheSource();					//Defined in autoscend/auto_theSource.ash
 boolean timeSpinnerAdventure();								//Defined in autoscend/auto_mr2016.ash
 boolean timeSpinnerAdventure(string option);				//Defined in autoscend/auto_mr2016.ash
 boolean timeSpinnerCombat(monster goal);					//Defined in autoscend/auto_mr2016.ash
@@ -1238,6 +1239,7 @@ generic_t zone_needItem(location loc);						//Defined in autoscend/auto_zone.ash
 generic_t zone_difficulty(location loc);					//Defined in autoscend/auto_zone.ash
 generic_t zone_combatMod(location loc);						//Defined in autoscend/auto_zone.ash
 generic_t zone_delay(location loc);							//Defined in autoscend/auto_zone.ash
+boolean LX_unlockThinknerdWarehouse(boolean spend_resources);		//Defined in autoscend/auto_zone.ash
 generic_t zone_available(location loc);						//Defined in autoscend/auto_zone.ash
 boolean zone_unlock(location loc);
 location[int] zone_list();									//Defined in autoscend/auto_zone.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -172,7 +172,6 @@ boolean L12_finalizeWar();									//Defined in autoscend/auto_quest_level_12.as
 //Defined in autoscend/auto_quest_level_13.ash
 boolean LX_getDigitalKey();
 boolean LX_getStarKey();
-boolean L13_startQuest();
 boolean L13_sorceressDoor();
 boolean L13_towerNSContests();
 boolean L13_towerNSHedge();


### PR DESCRIPTION
L13_powerLevel() reworked:
*Power leveling code was split between L13_powerLevel() and LX_attemptPowerLevel() in a messy fashion. Consolidated it into LX_attemptPowerLevel()
*moved The Source path specific powerleveling code to boolean LX_attemptPowerLevelTheSource()
*releasing the softblock on quests awaiting optimal conditions was done far too late in L13_powerLevel(). moved it to be done right before L13_powerLevel() is called, and inserted a mcall to getDigitalKey and getStarKey between those two.
*removed L13_powerLevel() entirely as the only thing it still does is serve as a wrapper for LX_attemptPowerLevel(). replaced it with calling on LX_attemptPowerLevel() if under level 13.
*boolean LX_unlockThinknerdWarehouse(boolean spend_resources) added and used in melvin quest and in zone_unlock(location loc)
*adventuring in thinknerd warehouse, either as part of melvign quest or by itself, removed from powerleveling function. While it is a scaling zone, it has a very low cap on max stats of enemies which means much lower XP than the haunted gallery. As such the side quest code is not called anywhere. But will likely be added later as a UI toggle to instruct us to do it despite being not optimal.

# How it has been tested

Been running it on multiple accounts for several days. but only some of them needed to level.
Seems to work as expected though.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
