### PR TITLE
Boris demand sandwich and ongoing MP to HP conversion

### DIFF
--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -275,13 +275,45 @@ void boris_buySkills()
 	set_property("auto_borisSkills", my_level());
 }
 
+void borisDemandSandwich()
+{
+	//Boris can summon a sandwich 3 times per day at cost of 5 MP.
+	if(!in_boris())
+	{
+		return;
+	}
+	if(get_property("_demandSandwich").to_int() > 2) 		//max 3 casts a day
+	{
+		return;
+	}
+	
+	//use ongoing MP recovery to summon sandwiches as boris if you can get the best sandwich.
+	if(my_level() > 8)
+	{
+		while(my_mp() > 4 && get_property("_demandSandwich").to_int() < 3)
+		{
+			use_skill(1, $skill[Demand Sandwich]);
+		}
+	}
+	//if your level is too low for the best sandwich, summon a single inferior sandwich to tide you over when low on adventures and if you don't already have one in inventory.
+	//this part semi relies on a future update to consumption code to make it eat one item at a time.
+	else if(my_adventures() < 8 && item_amount($item[club sandwich]) == 0 && item_amount($item[PB&BP]) == 0)
+	{
+		if(my_mp() > 4 && get_property("_demandSandwich").to_int() < 3)
+		{
+			use_skill(1, $skill[Demand Sandwich]);
+		}
+	}
+}
+
 boolean LM_boris()
 {
 	if(!in_boris())
 	{
 		return false;
 	}
-
+	
+	borisDemandSandwich();
 	boris_buySkills();
 
 	return false;

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -306,8 +306,47 @@ void borisDemandSandwich()
 	}
 }
 
+void borisWastedMP()
+{
+	//Check for wasted MP regeneration and use it up. primarily called towards the end of auto_pre_adv.ash
+	//Mostly the MP regen would come from clancy
+	if(!in_boris())
+	{
+		return;
+	}
+	
+	float max_potential_mp_regen = numeric_modifier("MP Regen Max");
+	float missing_mp = my_maxmp() - my_mp();
+	float potential_mp_wasted = 0;
+	if(max_potential_mp_regen > missing_mp)
+	{
+		potential_mp_wasted = max_potential_mp_regen - missing_mp;
+	}
+	
+	//Laugh it off costs 1 MP to cast and gives either 1 or 2 HP randomly.
+	while(my_hp() < my_maxhp() && potential_mp_wasted > 0)
+	{
+		//multi use without risking wastage. Need to loop a few times because we can't predict what we actually roll for healing.
+		int missingHP = my_maxhp() - my_hp();
+		int castAmount = min(potential_mp_wasted, missingHP / 2);
+		
+		//at exactly 1 HP missing there is a 50% chance of wasting 1 point of HP healed. Better than 100% chance of wasting MP though, so do it.
+		//also this prevents an infinite loop at 1HP missing. Keep that in mind if you remove this
+		if(missingHP == 1)	
+		{
+			castAmount = 1;
+		}
+		
+		potential_mp_wasted = potential_mp_wasted - castAmount;		
+		use_skill(castAmount, $skill[Laugh it Off]);
+	}
+}
+
 boolean LM_boris()
 {
+	//this function is called early once every loop of doTasks() in autoscend.ash
+	//if something in this function returns true then it will restart the loop and get called again.
+	
 	if(!in_boris())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -580,6 +580,11 @@ void consumeStuff()
 	}
 
 	boolean edSpleenCheck = (isActuallyEd() && spleen_left() > 0); // Ed should fill spleen first
+	
+	if (fullness_left() > 0 && in_boris())
+	{
+		borisDemandSandwich(true);
+	}
 
 	if (my_adventures() < 10 && !edSpleenCheck)
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -498,6 +498,7 @@ void main()
 		auto_log_info("Burning " + wasted_mp + " MP...");
 		cli_execute("burn " + wasted_mp);
 	}
+	borisWastedMP();
 
 	acquireMP(32, 1000);
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -430,6 +430,7 @@ boolean in_boris();											//Defined in autoscend/auto_boris.ash
 boolean borisAdjustML();									//Defined in autoscend/auto_boris.ash
 void boris_buySkills();										//Defined in autoscend/auto_boris.ash
 void borisDemandSandwich();									//Defined in autoscend/auto_boris.ash
+void borisWastedMP();										//Defined in autoscend/auto_boris.ash
 void boris_initializeDay(int day);							//Defined in autoscend/auto_boris.ash
 void boris_initializeSettings();							//Defined in autoscend/auto_boris.ash
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -429,7 +429,7 @@ boolean in_zelda();											//Defined in autoscend/auto_zelda.ash
 boolean in_boris();											//Defined in autoscend/auto_boris.ash
 boolean borisAdjustML();									//Defined in autoscend/auto_boris.ash
 void boris_buySkills();										//Defined in autoscend/auto_boris.ash
-void borisDemandSandwich();									//Defined in autoscend/auto_boris.ash
+boolean borisDemandSandwich(boolean immediately);			//Defined in autoscend/auto_boris.ash
 void borisWastedMP();										//Defined in autoscend/auto_boris.ash
 void boris_initializeDay(int day);							//Defined in autoscend/auto_boris.ash
 void boris_initializeSettings();							//Defined in autoscend/auto_boris.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -429,6 +429,7 @@ boolean in_zelda();											//Defined in autoscend/auto_zelda.ash
 boolean in_boris();											//Defined in autoscend/auto_boris.ash
 boolean borisAdjustML();									//Defined in autoscend/auto_boris.ash
 void boris_buySkills();										//Defined in autoscend/auto_boris.ash
+void borisDemandSandwich();									//Defined in autoscend/auto_boris.ash
 void boris_initializeDay(int day);							//Defined in autoscend/auto_boris.ash
 void boris_initializeSettings();							//Defined in autoscend/auto_boris.ash
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
boolean borisDemandSandwich(boolean immediately) and void void borisWastedMP() created and used

1. boolean borisDemandSandwich(boolean immediately) automatically uses the skill demand sandwich to summon 3 sandwiches a day of the best type between adventures. Or if the eating code was engaged then summoning whatever sandwiches you can get just before eating.
This significantly helps turngen for anyone who doesn't have so many IOTMs they can generate 30 stomach worth of IOTM foods.
TODO: auto unlock a bakery so you could bake some pies.

2. void borisWastedMP() will check if you are about to waste MP regen and if so waste the excess MP regen on laugh it off. It gets called during pre_adv

## How Has This Been Tested?

Played with it for 4 days. So far it works.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
