### PR TITLE
january tote fix folding items, and verify success before returning true. also maximizer fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1823,6 +1823,7 @@ boolean doBedtime()
 	getSpaceJelly();
 	while(acquireHermitItem($item[Ten-leaf Clover]));
 
+	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel
 	loveTunnelAcquire(true, $stat[none], true, 3, true, 1);
 
 	if(item_amount($item[Genie Bottle]) > 0)
@@ -3605,28 +3606,6 @@ boolean LX_craftAcquireItems()
 		mummifyFamiliar($familiar[Intergnat], my_primestat());
 		mummifyFamiliar($familiar[Hobo Monkey], "meat");
 		mummifyFamiliar($familiar[XO Skeleton], "mpregen");
-		if((my_primestat() == $stat[Muscle]) && get_property("loveTunnelAvailable").to_boolean() && is_unrestricted($item[Heart-Shaped Crate]) && possessEquipment($item[LOV Eardigan]))
-		{
-			if((januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) > 0) && (my_session_adv() > 75) && ((januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) + 15) > my_adventures()))
-			{
-				januaryToteAcquire($item[Makeshift Garbage Shirt]);
-			}
-			else
-			{
-				januaryToteAcquire($item[Wad Of Used Tape]);
-			}
-		}
-		else
-		{
-			if((januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) > 0) && hasTorso() && (my_session_adv() > 75))
-			{
-				januaryToteAcquire($item[Makeshift Garbage Shirt]);
-			}
-			else
-			{
-				januaryToteAcquire($item[Wad Of Used Tape]);
-			}
-		}
 		#set_property("_dailyCreates", true);
 	}
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1823,7 +1823,7 @@ boolean doBedtime()
 	getSpaceJelly();
 	while(acquireHermitItem($item[Ten-leaf Clover]));
 
-	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel
+	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel. also keep leftover charges for tomorrow.
 	loveTunnelAcquire(true, $stat[none], true, 3, true, 1);
 
 	if(item_amount($item[Genie Bottle]) > 0)

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -53,6 +53,10 @@ boolean januaryToteAcquire(item it)
 		return false;
 	}
 	
+	//in pre_adventure we routinely switch to wad of used tape. This allows us to avoid switching away from a desired item.
+	//can't use adventure count in case of free fights.
+	set_property("auto_januaryToteAcquireCalledThisTurn", true);
+	
 	//Special handling for if we already have the item on hand. We might want to replace it with tiself.
 	//do not use possessEquipment nor equipmentAmount here, they have special handling for tote foldables that always counts number of january's garbage totes instead of the target item. Resulting in this if always being true.
 	if(available_amount(it) > 0)

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -57,6 +57,13 @@ boolean januaryToteAcquire(item it)
 	//can't use adventure count in case of free fights.
 	set_property("auto_januaryToteAcquireCalledThisTurn", true);
 	
+	//by default resetMaximize() will add a block for not equipping garbage tote items with charges to preserve the charges.
+	//If we call januaryToteAcquire for an item we want to remove that block for that item.
+	if($items[Deceased Crimbo Tree, Broken Champagne Bottle, Makeshift Garbage Shirt] contains it)
+	{
+		removeFromMaximize("-equip " + it);
+	}
+	
 	//Special handling for if we already have the item on hand. We might want to replace it with itself
 	//do not use possessEquipment nor equipmentAmount here, they have special handling for tote foldables that always counts number of january's garbage totes instead of the target item. Resulting in this if always being true.
 	if(available_amount(it) > 0)

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -57,7 +57,7 @@ boolean januaryToteAcquire(item it)
 	//can't use adventure count in case of free fights.
 	set_property("auto_januaryToteAcquireCalledThisTurn", true);
 	
-	//Special handling for if we already have the item on hand. We might want to replace it with tiself.
+	//Special handling for if we already have the item on hand. We might want to replace it with itself
 	//do not use possessEquipment nor equipmentAmount here, they have special handling for tote foldables that always counts number of january's garbage totes instead of the target item. Resulting in this if always being true.
 	if(available_amount(it) > 0)
 	{

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -46,7 +46,7 @@ int januaryToteTurnsLeft(item it)
 
 boolean januaryToteAcquire(item it)
 {
-	//a function acquire january's garbage tote equipment. like basic acquire command, this also returns true if you already have the item on hand.
+	//a function to acquire january's garbage tote equipment. like basic acquire command, this also returns true if you already have the item on hand.
 	
 	if(!isjanuaryToteAvailable())
 	{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1042,6 +1042,8 @@ void main()
 	{
 		set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 	}
+	
+	set_property("auto_januaryToteAcquireCalledThisTurn", false);
 
 	auto_log_info("Post Adventure done, beep.", "purple");
 }

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -457,6 +457,12 @@ void main()
 
 	// Here we enforce our ML restrictions if +/-ML is not specifically called in the current maximizer string
 	enforceMLInPreAdv();
+	
+	// Last minute switching for garbage tote. But only if nothing called on januaryToteAcquire this turn.
+	if(!get_property("auto_januaryToteAcquireCalledThisTurn").to_boolean())
+	{
+		januaryToteAcquire($item[Wad Of Used Tape]);
+	}
 
 // EQUIP MAXIMIZED GEAR
 	equipMaximizedGear();


### PR DESCRIPTION
# Description

january tote fixed:
*verify crafting actually succeeded before returning true.
*fix a block that only allowed crafting one item per day.
*fixed special handling for letter to melvin the gnome
*fixed leftover charge saving logic to actually protect leftover charges
*since this is an acquire function, return true if you already had the item even if no crafting occurs.
*instead of preemptively switching to garbage shirt during doTasks in preparation for love tunnel during doBedtime when love on adventures. Actually call on the garbage shirt crafting during doBedtime right before adventuring in the tunnel of love.
*instead of calling to acquire wad of used tape every loop early in doTasks, call on it in pre adventure right before equipping maximizer gear, only if nothing called on januaryToteAcquire this turn. This prevents flip flopping on the item being used
*when we call januaryToteAcquire(item it) for an item with charges, remove the default maximizer ban on equipping said it (which is used to preserve charges on tote items)


## How Has This Been Tested?

tt_test.ash script to call all the individual crafting options and print their result too.
and every time i made a small change i tested it.

Also used it on my account while playing.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
