### PR TITLE
Don't burn delay in The Oasis unless ultrahydrated

### DIFF
--- a/RELEASE/scripts/autoscend/auto_mr2019.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2019.ash
@@ -227,14 +227,6 @@ boolean auto_sausageGoblin(location loc, string option)
 		return true;
 	}
 
-	if (loc == $location[The Oasis] && have_effect($effect[Ultrahydrated]) == 0)
-	{
-		// The Ultrahydrated superlikely has a higher priority than Sausage Goblins
-		// see Lyft's encounter hierarchy chart in ASS Discord for details.
-		auto_log_info("Can't burn delay using Sausage Goblins in the Oasis without Ultrahydrated!");
-		return false;
-	}
-
 	autoEquip($item[Kramco Sausage-o-Matic&trade;]);
 	return autoAdv(1, loc, option);
 }

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -630,7 +630,7 @@ generic_t zone_delay(location loc)
 	switch(loc)
 	{
 	case $location[The Oasis]:
-		if(get_property("desertExploration").to_int() < 100)
+		if(get_property("desertExploration").to_int() < 100 && have_effect($effect[Ultrahydrated]) > 0)
 		{
 			value = 5 - loc.turns_spent;
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -630,6 +630,7 @@ generic_t zone_delay(location loc)
 	switch(loc)
 	{
 	case $location[The Oasis]:
+		// Superlikely adventures take priority over all wanderers now.
 		if(get_property("desertExploration").to_int() < 100 && have_effect($effect[Ultrahydrated]) > 0)
 		{
 			value = 5 - loc.turns_spent;


### PR DESCRIPTION
# Description

Superlikelies beat all wanderers now, not just goblins

Fixes trying to burn delay in The Oasis and getting Ultrahydrated instead and wasting a turn

## How Has This Been Tested?

trivial change, check effect

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
