### PR TITLE
Handful of small changes/fixes

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -19,3 +19,4 @@ War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>28
+Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -112,6 +112,7 @@ sniff	17	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 sniff	18	Possessed Wine Rack
 sniff	19	Blue Oyster cultist
 sniff	20	Dirty Old Lihc	prop:cyrptNicheEvilness>28
+sniff	21	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4759,17 +4759,7 @@ boolean doTasks()
 
 	basicAdjustML();
 	powerLevelAdjustment();
-	if (!canChangeFamiliar() && my_familiar() == $familiar[none])
-	{
-		// re-equip a familiar if it's a 100% run just in case something unequipped it
-		// looking at you auto_maximizedConsumeStuff()...
-		handleFamiliar(to_familiar(get_property("auto_100familiar")));
-		auto_log_debug("Re-equipped your " + get_property("auto_100familiar") + " as something had unequipped it. This is bad and should be investigated.");
-	}
-	else
-	{
-		handleFamiliar("item");
-	}
+	handleFamiliar("item");
 	basicFamiliarOverrides();
 
 	councilMaintenance();
@@ -5152,7 +5142,6 @@ void auto_begin()
 	backupSetting("promptAboutCrafting", 0);
 	backupSetting("requireBoxServants", false);
 	backupSetting("breakableHandling", 4);
-	backupSetting("recoveryScript", "");
 	backupSetting("trackLightsOut", false);
 	backupSetting("autoSatisfyWithCloset", false);
 	backupSetting("autoSatisfyWithCoinmasters", true);
@@ -5165,13 +5154,15 @@ void auto_begin()
 	backupSetting("afterAdventureScript", "scripts/autoscend/auto_post_adv.ash");
 	backupSetting("choiceAdventureScript", "scripts/autoscend/auto_choice_adv.ash");
 	backupSetting("betweenBattleScript", "scripts/autoscend/auto_pre_adv.ash");
+	backupSetting("recoveryScript", "");
 
-	backupSetting("hpAutoRecovery", -1);
-	backupSetting("hpAutoRecoveryTarget", -1);
-	backupSetting("mpAutoRecovery", -1);
-	backupSetting("mpAutoRecoveryTarget", -1);
-	backupSetting("manaBurningTrigger", -1);
-	backupSetting("manaBurningThreshold", -1);
+	backupSetting("hpAutoRecovery", -0.05);
+	backupSetting("hpAutoRecoveryTarget", -0.05);
+	backupSetting("mpAutoRecovery", -0.05);
+	backupSetting("mpAutoRecoveryTarget", -0.05);
+	backupSetting("manaBurningTrigger", -0.05);
+	backupSetting("manaBurningThreshold", -0.05);
+	backupSetting("autoAbortThreshold", -0.05);
 
 	backupSetting("currentMood", "apathetic");
 	backupSetting("customCombatScript", "autoscend_null");

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -3,6 +3,8 @@ import<autoscend.ash>
 
 void main(int choice, string page)
 {
+	auto_log_debug("Running auto_choice_adv.ash");
+	
 	switch (choice) {
 		case 15: // Yeti Nother Hippy (The eXtreme Slope)
 			if (possessEquipment($item[eXtreme mittens])) {

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -579,7 +579,9 @@ void consumeStuff()
 		}
 	}
 
-	if (my_adventures() < 10)
+	boolean edSpleenCheck = (isActuallyEd() && spleen_left() > 0); // Ed should fill spleen first
+
+	if (my_adventures() < 10 && !edSpleenCheck)
 	{
 		if (inebriety_left() > 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_edTheUndying.ash
+++ b/RELEASE/scripts/autoscend/auto_edTheUndying.ash
@@ -1475,6 +1475,17 @@ boolean LM_edTheUndying()
 	{
 		return true;
 	}
+
+	if (!have_skill($skill[Even More Elemental Wards])) { 
+		// if we don't have the last Elemental Resistance Upgrade, we still need Ka
+		// Thus we shouldn't block quests that Shen might request as almost all of them are Ka zones.
+		if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished") {
+			auto_log_warning("I was trying to avoid zones that Shen might need, but I still need Ka for upgrades.", "red");
+			set_property("auto_shenSkipLastLevel", my_level());
+			return true;
+		}
+	}
+
 	// Crush the jackass adventurer!
 	if (L13_ed_towerHandler())
 	{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -3,6 +3,8 @@ import<autoscend.ash>
 
 void main()
 {
+	auto_log_debug("Running auto_post_adv.ash");
+
 	if(limit_mode() == "spelunky")
 	{
 		return;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -3,6 +3,7 @@ import<autoscend.ash>
 
 void main()
 {
+	auto_log_debug("Running auto_pre_adv.ash");
 
 	location place = my_location();
 	if((equipped_item($slot[familiar]) == $item[none]) && (my_familiar() != $familiar[none]) && (auto_my_path() == "Heavy Rains"))
@@ -254,6 +255,14 @@ void main()
 	}
 
 	equipOverrides();
+
+	if (!canChangeFamiliar() && my_familiar() == $familiar[none])
+	{
+		// re-equip a familiar if it's a 100% run just in case something unequipped it
+		// looking at you auto_maximizedConsumeStuff()...
+		handleFamiliar(get_property("auto_100familiar").to_familiar());
+		auto_log_debug("Re-equipped your " + get_property("auto_100familiar") + " as something had unequipped it. This is bad and should be investigated.");
+	}
 
 	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))
 	{

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -1990,6 +1990,7 @@ boolean L12_finalizeWar()
 	if(possessOutfit("War Hippy Fatigues"))
 	{
 		auto_log_info("Getting dimes.", "blue");
+		outfit("War Hippy Fatigues");
 		foreach it in $items[padl phone, red class ring, blue class ring, white class ring]
 		{
 			sell(it.buyer, item_amount(it), it);
@@ -2009,6 +2010,7 @@ boolean L12_finalizeWar()
 	if(possessOutfit("Frat Warrior Fatigues"))
 	{
 		auto_log_info("Getting quarters.", "blue");
+		outfit("Frat Warrior Fatigues");
 		foreach it in $items[pink clay bead, purple clay bead, green clay bead, communications windchimes]
 		{
 			sell(it.buyer, item_amount(it), it);

--- a/RELEASE/scripts/autoscend/auto_quest_level_6.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_6.ash
@@ -16,7 +16,14 @@ boolean L6_friarsGetParts()
 
 	if($location[The Dark Heart of the Woods].turns_spent == 0)
 	{
-		visit_url("friars.php?action=friars&pwd=");
+		visit_url("friars.php?action=friars&pwd");
+		if (isActuallyEd()) {
+			// mafia bug doesn't update the quest property when visiting the Friars as Ed
+			// See https://kolmafia.us/showthread.php?24912-minor-questL06Friar-isn-t-changed-to-step1-when-talking-to-the-Friars-as-Ed
+			// not that it matters at all, the items we need and locations they're in are the same regardless.
+			// but we can force it to update from the quest log
+			cli_execute("refresh quests");
+		}
 	}
 
 	handleFamiliar("item");


### PR DESCRIPTION
# Description

- Add Possibility Giant to Sniffed monsters
- Move checking we're not breaking a 100% familiar run to auto_pre_adv (I should have put it there in the first place).
- Set autorecovery options to the same values that mafia uses to disable. This fixes the abort that can happen if you end up on 0 HP after an adventure.
- make sure Ed fills his spleen first before trying to eat or drink (we have failover code to farm Ka if needed which doesn't trigger otherwise)
- Add code to set `auto_shenSkipLastLevel` in Ed if we run out of quests that we can get Ka from and don't have the 3rd Elemental Resistance Upgrade (as that is when we consider Ed "done" with Ka farming for upgrades).
- Equip war outfits before turning in war loot to the coinmasters to avoid mafia repeatedly unequipping and requipping unnecessarily.
- Add a workaround for the friars quest property not being updated appropriately in Ed runs.
- Add a debug log message for all the scripts that mafia runs for us (pre_adv, post_adv, choice_adv). Might help track down issues like #313 

Fixes #318, #330

## How Has This Been Tested?

Ran at least 2 HC Ed runs thus far, 3rd in progress. Most of this stuff has had more testing than that as I had it pending while testing/working on #315 as it's all pretty minor single line changes mostly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
