### PR TITLE
oil peak bypass wait for better conditions if powerleveling.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_9.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_9.ash
@@ -764,7 +764,7 @@ boolean L9_oilPeak()
 
 	auto_MaxMLToCap(auto_convertDesiredML(100), false);
 
-	if((monster_level_adjustment() < 50) && (my_level() < 12))
+	if(monster_level_adjustment() < 50 && my_level() < 12 && my_level() != get_property("auto_powerLevelLastLevel").to_int())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Make oil peak's wait for better conditions be a soft-block instead of a hard one. that gets unblocked if you start powerleveling.

## How Has This Been Tested?

On an account which had nothing to do except oil peak or power level, and was power leveling, it started doing oil with the change until it leveled up halfway through doing oil. At which point it stopped to go do other quests

also played with it for several days on all my accounts with no issue.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
