### PR TITLE
equipment maximizer bugs squashed.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -5197,6 +5197,7 @@ void auto_begin()
 
 	if(my_daycount() > 1)
 	{
+		resetMaximize();
 		equipBaseline();
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -311,6 +311,7 @@ void removeFromMaximize(string rem)
 	string res = get_property("auto_maximize_current");
 	res = res.replace_string(rem, "");
 	// let's be safe here
+	res = res.replace_string(" ,", ",");
 	res = res.replace_string(",,", ",");
 	if(res.ends_with(","))
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -211,19 +211,46 @@ void resetMaximize()
 	{
 		res = defaultMaximizeStatement();
 	}
-	foreach it in $items[hewn moon-rune spoon, makeshift garbage shirt, broken champagne bottle, snow suit]
+	
+	void exclude(item it)
+	{
+		if(res != "")
+		{
+			res += ",";
+		}
+		res += "-equip " + it;
+	}
+	
+	// don't want to equip these items automatically
+	// spoon breaks mafia, snow suit maximizer handling is problematic
+	foreach it in $items[hewn moon-rune spoon, snow suit]
 	{
 		if (possessEquipment(it))
 		{
-			if(res != "")
-			{
-				res += ",";
-			}
-			// don't want to equip these items automatically
-			// spoon breaks mafia, and the others have limited charges
-			res += "-equip " + it;
+			exclude(it);
 		}
 	}
+	//IOTM [january's garbage tote] specific handling.
+	if(isjanuaryToteAvailable())
+	{
+		//preserve leftover charges, prevent mafia halting automation for confirmation.
+		if(!get_property("_garbageItemChanged").to_boolean())	//did not change tote item today
+		{
+			foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Tinsel Tights, Wad Of Used Tape, Makeshift Garbage Shirt]
+			{
+				exclude(it);
+			}
+		}
+		//preserve current charges
+		else foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Makeshift Garbage Shirt]
+		{
+			if(januaryToteTurnsLeft(it) > 0)
+			{
+				exclude(it);
+			}
+		}
+	}
+	
 	set_property("auto_maximize_current", res);
 	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");
 
@@ -257,6 +284,11 @@ void finalizeMaximize()
 
 void addToMaximize(string add)
 {
+	if(maximizeContains(add))	//skip if trying to add duplicate
+	{
+		auto_log_debug('Tried to add a duplicate of "' + add + '" to current maximizer statement... skipping', "gold");
+		return;
+	}
 	auto_log_debug('Adding "' + add + '" to current maximizer statement', "gold");
 	string res = get_property("auto_maximize_current");
 	boolean addHasComma = add.starts_with(",");

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -312,6 +312,7 @@ void removeFromMaximize(string rem)
 	res = res.replace_string(rem, "");
 	// let's be safe here
 	res = res.replace_string(" ,", ",");
+	res = res.replace_string(", ", ",");
 	res = res.replace_string(",,", ",");
 	if(res.ends_with(","))
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -222,7 +222,7 @@ void resetMaximize()
 	}
 	
 	// don't want to equip these items automatically
-	// spoon breaks mafia, snow suit maximizer handling is problematic
+	// spoon breaks mafia, snow suit bonus drops every 5 combats so is best saved for important things.
 	foreach it in $items[hewn moon-rune spoon, snow suit]
 	{
 		if (possessEquipment(it))

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -2,7 +2,8 @@ script "auto_mr2018.ash"
 
 #	This is meant for items that have a date of 2018.
 
-boolean isjanuaryToteAvailable(){
+boolean isjanuaryToteAvailable()
+{
 	return item_amount($item[January\'s Garbage Tote]) > 0 && auto_is_valid($item[January\'s Garbage Tote]);
 }
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -649,6 +649,7 @@ item[element] getCharterIndexable();						//Defined in autoscend/auto_elementalP
 boolean getDiscoStyle();									//Defined in autoscend/auto_elementalPlanes.ash
 boolean getDiscoStyle(int choice);							//Defined in autoscend/auto_elementalPlanes.ash
 boolean mummifyFamiliar(familiar fam, string bonus);		//Defined in autoscend/auto_mr2017.ash
+boolean isjanuaryToteAvailable();							//Defined in autoscend/auto_mr2018.ash
 int januaryToteTurnsLeft(item it);							//Defined in autoscend/auto_mr2018.ash
 boolean januaryToteAcquire(item it);						//Defined in autoscend/auto_mr2018.ash
 boolean godLobsterCombat();									//Defined in autoscend/auto_mr2018.ash


### PR DESCRIPTION
# Description

equipment maximizer bugs squashed:
*resetMaximize() special handling of jtote items fixed.
**Above required adding `boolean isjanuaryToteAvailable();` to header file
*addToMaximize won't add duplicates anymore
*removeFromMaximize also protect against `comma space comma` or ending in `comma space` or starting in `space comma`. should probably do a loop on those but I think it is good enough as is.
*when initializing settings (before doTasks() is reached). Have  `resetMaximize();` be done before doing `equipBaseline();`

Fixes #348

## How Has This Been Tested?

Ash calls. Also had an instance where I was stuck on trying to run it due to an outdated state call during the early equipBaseline() that was able to go through once I used this.

Also played with it for a day

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
