### PR TITLE
exclude text scramblers from maximizer by default

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -222,8 +222,9 @@ void resetMaximize()
 	}
 	
 	// don't want to equip these items automatically
-	// spoon breaks mafia, snow suit bonus drops every 5 combats so is best saved for important things.
-	foreach it in $items[hewn moon-rune spoon, snow suit]
+	// snow suit bonus drops every 5 combats so is best saved for important things
+	// spoon, sword, and staph are text scramblers which cause errors in mafia tracking
+	foreach it in $items[hewn moon-rune spoon, sword behind inappropriate prepositions, staph of homophones, snow suit]
 	{
 		if (possessEquipment(it))
 		{


### PR DESCRIPTION
exclude the text scramblers [staph of homophones] and [sword behind inappropriate prepositions] from default maximizer string if you happen to have them on hand.
Likely because you pulled them for their rollover bonus

## How Has This Been Tested?

It validated

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
