### PR TITLE
free combat fixes. do free combats in doTasks() when 1 unreserved adv remains + god lobster fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -141,6 +141,7 @@ void initializeSettings()
 	set_property("auto_day1_dna", "");
 	set_property("auto_debuffAsdonDelay", 0);
 	set_property("auto_disableAdventureHandling", false);
+	set_property("auto_disableFamiliarChanging", false);
 	set_property("auto_doCombatCopy", "no");
 	set_property("auto_drunken", "");
 	set_property("auto_eaten", "");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -141,7 +141,6 @@ void initializeSettings()
 	set_property("auto_day1_dna", "");
 	set_property("auto_debuffAsdonDelay", 0);
 	set_property("auto_disableAdventureHandling", false);
-	set_property("auto_disableFamiliarChanging", false);
 	set_property("auto_doCombatCopy", "no");
 	set_property("auto_drunken", "");
 	set_property("auto_eaten", "");
@@ -4682,10 +4681,10 @@ boolean doTasks()
 		auto_log_warning("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");	
 		return false;	
 	}
-	if(get_property("auto_doCombatCopy") == "yes")
-	{	# This should never persist into another turn, ever.
-		set_property("auto_doCombatCopy", "no");
-	}
+	
+	//These settings should never persist into another turn, ever.
+	set_property("auto_doCombatCopy", "no");
+	set_property("auto_disableFamiliarChanging", false);
 
 	print_header();
 
@@ -5129,6 +5128,7 @@ void auto_begin()
 	auto_log_info("Current Ascension: " + auto_my_path());
 
 	set_property("auto_disableAdventureHandling", false);
+	set_property("auto_disableFamiliarChanging", false);
 
 	auto_spoonTuneConfirm();
 

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -314,6 +314,11 @@ boolean autoAdvBypass(string url, string option)
 
 void preAdvUpdateFamiliar(location place)
 {
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
+	{
+		return;
+	}
+	
 	familiar famChoice = to_familiar(get_property("auto_familiarChoice"));
 	if(auto_my_path() == "Pocket Familiars")
 	{

--- a/RELEASE/scripts/autoscend/auto_aftercore.ash
+++ b/RELEASE/scripts/autoscend/auto_aftercore.ash
@@ -1151,7 +1151,7 @@ boolean auto_cheesePostCS(int leave)
 	{
 		put_closet(item_amount($item[PARTY HARD T-Shirt]), $item[PARTY HARD T-Shirt]);
 	}
-	while(lx_freecombats());
+	while(LX_freeCombats(true));
 
 	if(!get_property("_pottedTeaTreeUsed").to_boolean() && (get_campground() contains $item[Potted Tea Tree]))
 	{

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -187,12 +187,6 @@ boolean godLobsterCombat(item it, int goal, string option)
 		return false;
 	}
 
-	// Avoid fighting the lobster when we are in our pajamas.
-	if (in_zelda() && !zelda_equippedHammer() && !zelda_equippedFlower() && !zelda_equippedBoots())
-	{
-		return false;
-	}
-
 	handleFamiliar($familiar[God Lobster]);
 	use_familiar($familiar[God Lobster]);
 
@@ -201,12 +195,11 @@ boolean godLobsterCombat(item it, int goal, string option)
 		equip($slot[familiar], it);
 	}
 
-	// TODO: Disabling adventure handling means we do not swap out equipment,
-	// which means sometimes we fight the god lobster in our pajamas and die.
-	set_property("auto_disableAdventureHandling", true);
+	//when pre_adventure.ash is run by mafia before fighting god lobster, we do not want it to switch to another familiar.
+	set_property("auto_disableFamiliarChanging", true);
 
-	string temp = visit_url("main.php?fightgodlobster=1");
-	if(contains_text(temp, "You can't challenge your God Lobster anymore"))
+	string page_text = visit_url("main.php?fightgodlobster=1");
+	if(contains_text(page_text, "You can't challenge your God Lobster anymore"))
 	{
 		set_property("_godLobsterFights", 3);
 	}
@@ -216,16 +209,8 @@ boolean godLobsterCombat(item it, int goal, string option)
 		autoAdv(1, $location[Noob Cave], option);
 	}
 
-	set_property("auto_disableAdventureHandling", false);
+	set_property("auto_disableFamiliarChanging", false);
 
-	cli_execute("auto_post_adv");
-
-	# r18906 seems to lose track of the astral pet sweater. Ugh.
-	cli_execute("refresh all");
-	if(equipped_item($slot[familiar]) != lastGear)
-	{
-		abort("Mafia lost track of our familiar equipment. Ugh...");
-	}
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -166,14 +166,6 @@ boolean godLobsterCombat(item it, int goal)
 
 boolean godLobsterCombat(item it, int goal, string option)
 {
-	if(!have_familiar($familiar[God Lobster]))
-	{
-		return false;
-	}
-	if(!is_unrestricted($familiar[God Lobster]))
-	{
-		return false;
-	}
 	if(!canChangeToFamiliar($familiar[God Lobster]))
 	{
 		return false;
@@ -201,9 +193,6 @@ boolean godLobsterCombat(item it, int goal, string option)
 		return false;
 	}
 
-	familiar last = my_familiar();
-	item lastGear = equipped_item($slot[familiar]);
-
 	handleFamiliar($familiar[God Lobster]);
 	use_familiar($familiar[God Lobster]);
 
@@ -228,14 +217,6 @@ boolean godLobsterCombat(item it, int goal, string option)
 	}
 
 	set_property("auto_disableAdventureHandling", false);
-	if(my_familiar() != last)
-	{
-		use_familiar(last);
-	}
-	if(equipped_item($slot[familiar]) != lastGear)
-	{
-		equip($slot[familiar], lastGear);
-	}
 
 	cli_execute("auto_post_adv");
 

--- a/RELEASE/scripts/autoscend/auto_mr2018.ash
+++ b/RELEASE/scripts/autoscend/auto_mr2018.ash
@@ -197,6 +197,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 
 	//when pre_adventure.ash is run by mafia before fighting god lobster, we do not want it to switch to another familiar.
 	set_property("auto_disableFamiliarChanging", true);
+	cli_execute("auto_pre_adv.ash");
 
 	string page_text = visit_url("main.php?fightgodlobster=1");
 	if(contains_text(page_text, "You can't challenge your God Lobster anymore"))

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -256,7 +256,7 @@ void main()
 
 	equipOverrides();
 
-	if (!canChangeFamiliar() && my_familiar() == $familiar[none])
+	if (is100FamRun() && my_familiar() == $familiar[none])
 	{
 		// re-equip a familiar if it's a 100% run just in case something unequipped it
 		// looking at you auto_maximizedConsumeStuff()...

--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -1355,7 +1355,7 @@ boolean L12_flyerBackup()
 		return false;
 	}
 
-	return LX_freeCombats();
+	return LX_freeCombats(true);
 }
 
 boolean L12_lastDitchFlyer()

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -919,12 +919,22 @@ boolean canChangeFamiliar()
 		return false;
 	}
 	
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
+	{
+		return false;
+	}
+	
 	return true;
 }
 
 boolean canChangeToFamiliar(familiar target)
 {
 	// answers the question of "am I allowed to change familiar to a familiar named target"
+	
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
+	{
+		return false;
+	}
 
 	// if you don't have a familiar, you can't change to it.
 	if(!auto_have_familiar(target))

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -316,6 +316,7 @@ boolean useCocoon();
 
 
 //Large pile dump.
+boolean disregardInstantKarma();							//Defined in autoscend.ash
 int auto_freeCombatsRemaining();							//Defined in autoscend.ash
 int auto_freeCombatsRemaining(boolean print_remaining_fights);		//Defined in autoscend.ash
 int auto_advToReserve();									//Defined in autoscend.ash


### PR DESCRIPTION
free combat fixes:
*additional debug logging messages related to free combats, also improved comments and better worded error messages.
*boolean disregardInstantKarma() created and used.
*more places now specifically state if they want to powerlevel when calling LX_freeCombats rather than letting it be determined automatically
*do your free combats as part of doTasks() loop when only 1 non-reserved adv remains. Before it was left exclusively for doBedtime().
** resolves aborting during bedtime free combats if used override to reserve 1 adv
** resolves aborting during bedtime free combats if some bug (like god lobster one below) prevented you from doing one of the free fights.
** resolves automatic adventure reserving ending the day with 2 adv and 0 free fights left instead of 1 adv and 0 free fights, when you don't have any reason other than free fights to reserve 2 adv.
*moved switching to a +stats granting familiar from doBedtime() right before LX_freeCombats is called into LX_freeCombats itself. now it will use stats familiar no matter where it is called from. also made it conditional on disregardInstantKarma()
*god lobster fixes
** don't backup and restore the previously equipped familiar and their equipment, we already got general code to equip the best familiar before we go adventuring. and this just causes it to flip flop on familiar when fighting god lobster.
** remove some redundant old checks and obsolete fixes for old mafia issues.
** instead of disabling pre_adventure (which according to the TODO note causes a known bug of fighting god lobster in pajamas and losing), only disable familiar changing temporarily. Then manually call on pre_adventure to maximize our equipment, buffs, etc in preparation for general combat.
***fixes the bug of fighting it in pajamas and losing
***fixes a bug where plumber will fight it without boots and be unable to attack it

## How Has This Been Tested?

ash calls.
day 2 and 3 of a 3 day softcore plumber run with all standard IOTMs
day 1 of a 3 day softcore plumber run with all standard IOTMs
sent it to a user on discord who has been having some of the specific issues and above and they confirmed that this fixes those issues for them

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
