### PR TITLE
fixed steel organ quest

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3122,9 +3122,9 @@ boolean LX_steelOrgan()
 	}
 	if(get_property("questM10Azazel") == "started")
 	{
-		if(((item_amount($item[Observational Glasses]) == 0) || (item_amount($item[Imp Air]) < 5)) && (item_amount($item[Azazel\'s Tutu]) == 0))
+		if((!possessEquipment($item[Observational Glasses]) || item_amount($item[Imp Air]) < 5) && item_amount($item[Azazel\'s Tutu]) == 0)
 		{
-			if(item_amount($item[Observational Glasses]) == 0)
+			if(!possessEquipment($item[Observational Glasses]))
 			{
 				uneffect($effect[The Sonata of Sneakiness]);
 				buffMaintain($effect[Hippy Stench], 0, 1, 1);
@@ -3231,8 +3231,9 @@ boolean LX_steelOrgan()
 		{
 			foreach it in $items[Hilarious Comedy Prop, Victor\, the Insult Comic Hellhound Puppet, Observational Glasses]
 			{
-				if(item_amount(it) > 0)
+				if(possessEquipment(it))
 				{
+					equip(it);
 					string temp = visit_url("pandamonium.php?action=mourn&whichitem=" + to_int(it) + "&pwd=");
 				}
 				else

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3233,7 +3233,7 @@ boolean LX_steelOrgan()
 			{
 				if(possessEquipment(it))
 				{
-					equip(it);
+					autoForceEquip(it);
 					string temp = visit_url("pandamonium.php?action=mourn&whichitem=" + to_int(it) + "&pwd=");
 				}
 				else


### PR DESCRIPTION
fixed steel organ quest:
*make sure to equip items before trying to turn them in to mourn
*don't continue adventuring in laugh floor hoping to get observational glasses to dropped if the glasses are currently equipped already (such as if they are the best gear you have)

## How Has This Been Tested?

My test account got stuck doing the laugh floor, even after getting the glasses, because it was wearing the glasses, because maximizer decided they were the best item to wear.
With this fix it went on to do the rest of the quest properly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
