### PR TITLE
reduce unnecessary equipment flipping.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -4706,7 +4706,6 @@ boolean doTasks()
 	if(LM_glover())						return true;
 
 	tophatMaker();
-	equipBaseline();
 	xiblaxian_makeStuff();
 	deck_useScheme("");
 	autosellCrap();


### PR DESCRIPTION
currently every loop we:
1. reset maximizer string
2. call equipBaseline very early in doTasks, which maximizes with our current freshly reset maximizer string. replacing parts of our outfit. In plumber this means removing boots every single adventure
3. determine where we want to go and modify our maximizer string to match
4. run pre_adventure where we call on equipMaximize, which is identical to equipBaseline and performs a maximize with our current maximizer gear.

This is probably a legacy from when equipbaseline actually did stuff (addressing certain bugs) but a the moment all it does is a wrapper for equipMaximize.
Doing 2 maximizing between each adventure is a waste of server hits and an unnecessary slowdown. simply removing number 2 gives a much better streamlined path of
1. reset maximizer string
2. determine where we want to go and adjust string
3. maximize with the string.

## How Has This Been Tested?

Used it for 1 day on 5 accounts, 3 of which ascended that day so its actually 2 days for them.
Thus far no issues and it is very drastically quicker due to significant cutting down on server hits.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
