### PR TITLE
boris wait until <10 adv left before disregard level for demand sandwich

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -581,7 +581,7 @@ void consumeStuff()
 
 	boolean edSpleenCheck = (isActuallyEd() && spleen_left() > 0); // Ed should fill spleen first
 	
-	if (fullness_left() > 0 && in_boris())
+	if (my_adventures() < 10 && fullness_left() > 0 && in_boris())
 	{
 		borisDemandSandwich(true);
 	}


### PR DESCRIPTION
# Description

correcting a mistake I made on previous boris related PR.
Boris should wait until less than 10 adventures remain (which is the prerequisite for knapsack to consume until full) before disregarding level for demand sandwich.

## How Has This Been Tested?

Used it in boris run and observed results.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
