### PR TITLE
mafia's run_combat gives us the monster name as a $monster

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -437,22 +437,22 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			if(enemy == $monster[Your Shadow])
 			{
-				auto_log_debug("plumber confirmed to be identifying $monster[Your Shadow] without need for workaround");
+				auto_log_debug("plumber confirmed to be identifying $monster[Your Shadow] without need for workaround. please report this");
 			}
 			else
 			{
-				auto_log_debug("plumber confirmed still need a workaround for identifying $monster[Your Shadow]");
+				auto_log_debug("plumber confirmed still need a workaround for identifying $monster[Your Shadow]. please report this");
 			}
 		}
 		if($classes[Snake Oiler, Cow Puncher, Beanslinger, Gelatinous Noob] contains my_class())
 		{
 			if(enemy == $monster[Your Shadow])
 			{
-				auto_log_debug(my_class() +" confirmed to be identifying $monster[Your Shadow] without need for workaround");
+				auto_log_debug(my_class() +" confirmed to be identifying $monster[Your Shadow] without need for workaround. please report this");
 			}
 			else
 			{
-				auto_log_debug(my_class() +" confirmed still need a workaround for identifying $monster[Your Shadow]");
+				auto_log_debug(my_class() +" confirmed still need a workaround for identifying $monster[Your Shadow]. please report this");
 			}
 		}
 		

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -432,6 +432,30 @@ string auto_combatHandler(int round, monster enemy, string text)
 	//TODO test plumber, geleatinous noob, and west of loathing paths to see if these workarounds are still needed.
 	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger, shadow gelatinous noob, Shadow Plumber] contains enemy.to_string())
 	{
+		//debug as you go
+		if(in_zelda())
+		{
+			if(enemy == $monster[Your Shadow])
+			{
+				auto_log_debug("plumber confirmed to be identifying $monster[Your Shadow] without need for workaround");
+			}
+			else
+			{
+				auto_log_debug("plumber confirmed still need a workaround for identifying $monster[Your Shadow]");
+			}
+		}
+		if($classes[Snake Oiler, Cow Puncher, Beanslinger, Gelatinous Noob] contains my_class())
+		{
+			if(enemy == $monster[Your Shadow])
+			{
+				auto_log_debug(my_class() +" confirmed to be identifying $monster[Your Shadow] without need for workaround");
+			}
+			else
+			{
+				auto_log_debug(my_class() +" confirmed still need a workaround for identifying $monster[Your Shadow]");
+			}
+		}
+		
 		if(in_zelda())
 		{
 			if(item_amount($item[super deluxe mushroom]) > 0)

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2,8 +2,6 @@ script "auto_combat.ash"
 
 monster ocrs_helper(string page);
 void awol_helper(string page);
-string auto_edCombatHandler(int round, string opp, string text);
-string auto_combatHandler(int round, string opp, string text);
 
 boolean registerCombat(string action);
 boolean registerCombat(skill sk);
@@ -232,10 +230,9 @@ string getStallString(monster enemy)
 }
 
 
-string auto_combatHandler(int round, string opp, string text)
+string auto_combatHandler(int round, monster enemy, string text)
 {
 	#Yes, round 0, really.
-	monster enemy = to_monster(opp);
 	boolean blocked = contains_text(text, "(STUN RESISTED)");
 	int damageReceived = 0;
 	if(round == 0)
@@ -432,7 +429,8 @@ string auto_combatHandler(int round, string opp, string text)
 		return "runaway";
 	}
 
-	if((enemy == $monster[Your Shadow]) || (opp == "shadow cow puncher") || (opp == "shadow snake oiler") || (opp == "shadow beanslinger") || (opp == "shadow gelatinous noob") || (opp == "Shadow Plumber"))
+	//TODO test plumber, geleatinous noob, and west of loathing paths to see if these workarounds are still needed.
+	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger, shadow gelatinous noob, Shadow Plumber] contains enemy.to_string())
 	{
 		if(in_zelda())
 		{
@@ -2368,10 +2366,8 @@ string auto_combatHandler(int round, string opp, string text)
 	return attackMinor;
 }
 
-string findBanisher(int round, string opp, string text)
+string findBanisher(int round, monster enemy, string text)
 {
-	monster enemy = to_monster(opp);
-
 	string banishAction = banisherCombatString(enemy, my_location(), true);
 	if(banishAction != "")
 	{
@@ -2394,20 +2390,18 @@ string findBanisher(int round, string opp, string text)
 	{
 		return useSkill($skill[Storm of the Scarab], false);
 	}
-	return auto_combatHandler(round, opp, text);
+	return auto_combatHandler(round, enemy, text);
 }
 
-string auto_JunkyardCombatHandler(int round, string opp, string text)
+string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 {
-	monster enemy = to_monster(opp);
-
 	if(!($monsters[A.M.C. gremlin, batwinged gremlin, erudite gremlin, spider gremlin, vegetable gremlin] contains enemy))
 	{
 		if (isActuallyEd())
 		{
-			return auto_edCombatHandler(round, opp, text);
+			return auto_edCombatHandler(round, enemy, text);
 		}
-		return auto_combatHandler(round, opp, text);
+		return auto_combatHandler(round, enemy, text);
 	}
 
 	auto_log_info("auto_JunkyardCombatHandler: " + round, "brown");
@@ -2557,7 +2551,7 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 		{
 			if (get_property("_edDefeats").to_int() >= 2)
 			{
-				return findBanisher(round, opp, text);
+				return findBanisher(round, enemy, text);
 			}
 			else if (canUse($item[Seal Tooth], false) && get_property("auto_edStatus") == "UNDYING!")
 			{
@@ -2566,7 +2560,7 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 		}
 		else
 		{
-			return findBanisher(round, opp, text);
+			return findBanisher(round, enemy, text);
 		}
 	}
 
@@ -2585,7 +2579,7 @@ string auto_JunkyardCombatHandler(int round, string opp, string text)
 	return "attack with weapon";
 }
 
-string auto_edCombatHandler(int round, string opp, string text)
+string auto_edCombatHandler(int round, monster enemy, string text)
 {
 	boolean blocked = contains_text(text, "(STUN RESISTED)");
 	int damageReceived = 0;
@@ -2644,7 +2638,6 @@ string auto_edCombatHandler(int round, string opp, string text)
 		abort("Somehow got to 60 rounds.... aborting");
 	}
 
-	monster enemy = to_monster(opp);
 	phylum type = monster_phylum(enemy);
 	string combatState = get_property("auto_combatHandler");
 	string edCombatState = get_property("auto_edCombatHandler");
@@ -2871,7 +2864,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 		}
 	}
 
-	if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+	if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster").to_monster() != enemy && get_property("_edDefeats").to_int() < 3)
 	{
 		if(auto_wantToSniff(enemy, my_location()))
 		{
@@ -2883,7 +2876,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if(my_location() == $location[The Secret Council Warehouse])
 	{
-		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster").to_monster() != enemy && get_property("_edDefeats").to_int() < 3)
 		{
 			boolean doStench = false;
 			#	Rememeber, we are looking to see if we have enough of the opposite item here.
@@ -2917,7 +2910,7 @@ string auto_edCombatHandler(int round, string opp, string text)
 
 	if(my_location() == $location[The Smut Orc Logging Camp])
 	{
-		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster") != opp && get_property("_edDefeats").to_int() < 3)
+		if (!contains_text(edCombatState, "curseofstench") && canUse($skill[Curse Of Stench]) && get_property("stenchCursedMonster").to_monster() != enemy && get_property("_edDefeats").to_int() < 3)
 		{
 			boolean doStench = false;
 			string stenched = to_lower_case(get_property("stenchCursedMonster"));
@@ -3339,7 +3332,8 @@ string auto_edCombatHandler(int round, string opp, string text)
 	return useSkill($skill[Mild Curse], false);
 }
 
-string auto_saberTrickMeteorShowerCombatHandler(int round, string opp, string text){
+string auto_saberTrickMeteorShowerCombatHandler(int round, monster enemy, string text)
+{
 	if(canUse($skill[Use the Force]) && auto_saberChargesAvailable() > 0 && auto_have_skill($skill[Meteor Lore])){
 		if(canUse($skill[Meteor Shower])){
 			return useSkill($skill[Meteor Shower]);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -479,9 +479,9 @@ void auto_begin();											//Defined in autoscend.ash
 item auto_bestBadge();										//Defined in autoscend/auto_mr2016.ash
 boolean auto_change_mcd(int mcd);								//Defined in autoscend/auto_util.ash
 boolean auto_change_mcd(int mcd, boolean immediately);			//Defined in autoscend/auto_util.ash
-string auto_combatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash
+string auto_combatHandler(int round, monster enemy, string text);	//Defined in autoscend/auto_combat.ash
 boolean auto_doPrecinct();									//Defined in autoscend/auto_mr2016.ash
-string auto_edCombatHandler(int round, string opp, string text);//Defined in autoscend/auto_combat.ash
+string auto_edCombatHandler(int round, monster enemy, string text);	//Defined in autoscend/auto_combat.ash
 string auto_saberTrickMeteorShowerCombatHandler(int round, string opp, string text); //Defined in autoscend/auto_combat.ash
 boolean auto_floundryAction();								//Defined in autoscend/auto_clan.ash
 boolean auto_floundryUse();									//Defined in autoscend/auto_clan.ash


### PR DESCRIPTION
mafia's run_combat() gives us the monster name as a $monster
don't force convert it into a string and then immediately convert said string into a $monster
this introduces bugs where it fails to recognize various monsters and thinks we are fighting $monster[none]

## How Has This Been Tested?

currently testing it, so far it is working.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
