### PR TITLE
boris use intimidating shout logic changes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -448,20 +448,9 @@ string auto_combatHandler(int round, monster enemy, string text)
 	}
 
 	//TODO test plumber, geleatinous noob, and west of loathing paths to see if these workarounds are still needed.
-	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger, shadow gelatinous noob, Shadow Plumber] contains enemy.to_string())
+	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger, shadow gelatinous noob] contains enemy.to_string())
 	{
 		//debug as you go
-		if(in_zelda())
-		{
-			if(enemy == $monster[Your Shadow])
-			{
-				auto_log_debug("plumber confirmed to be identifying $monster[Your Shadow] without need for workaround. please report this");
-			}
-			else
-			{
-				auto_log_debug("plumber confirmed still need a workaround for identifying $monster[Your Shadow]. please report this");
-			}
-		}
 		if($classes[Snake Oiler, Cow Puncher, Beanslinger, Gelatinous Noob] contains my_class())
 		{
 			if(enemy == $monster[Your Shadow])

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1,14 +1,15 @@
 script "auto_combat.ash"
 
+//since combat functions will never be used outside of combat file, they get declared here instead of the general header file.
 monster ocrs_helper(string page);
 void awol_helper(string page);
-
 boolean registerCombat(string action);
 boolean registerCombat(skill sk);
 boolean registerCombat(item it);
 boolean containsCombat(string action);
 boolean containsCombat(skill sk);
 boolean containsCombat(item it);
+boolean enemyCanBlocksSkills();
 
 /*
 *	Advance combat round, nothing happens.
@@ -229,6 +230,24 @@ string getStallString(monster enemy)
 	return "";
 }
 
+boolean enemyCanBlocksSkills()
+{
+	//we want to know if enemy can sometimes block a skill. For such enemies skills should be used only if absolutely necessary
+	//for enemies that always block a skill a seperate function should be made... if we ever fight any in run.
+	
+	monster enemy = last_monster();
+	
+	if($monsters[
+	Bonerdagon,
+	Naughty Sorceress,
+	Naughty Sorceress (2)
+	] contains enemy)
+	{
+		return true;
+	}
+	
+	return false;
+}
 
 string auto_combatHandler(int round, monster enemy, string text)
 {
@@ -1477,7 +1496,9 @@ string auto_combatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Curse of Weaksauce]);
 	}
 
-	if(canUse($skill[Intimidating Bellow]) && (my_mp() >= 25) && auto_have_skill($skill[Louder Bellows]))
+	//boris specific 3MP skill that delevels by 15%, with an upgrade it delevels 30% and stuns.
+	//even without the upgrade it it is worth it. actually without upgrade you need it more due to low skill.
+	if(canUse($skill[Intimidating Bellow]) && expected_damage() > 0 && !enemyCanBlocksSkills())
 	{
 		return useSkill($skill[Intimidating Bellow]);
 	}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -9,7 +9,6 @@ boolean registerCombat(item it);
 boolean containsCombat(string action);
 boolean containsCombat(skill sk);
 boolean containsCombat(item it);
-boolean enemyCanBlocksSkills();
 
 /*
 *	Advance combat round, nothing happens.


### PR DESCRIPTION
*enemyCanBlocksSkills() created and used (for intimidating shout only at the moment. will be used in more places later)
*boris intimidating bellow logic refactored. Do use it when low on skills. don't require lots of spare MP. don't use it against bosses that interrupt skill use. don't use it if enemy cannot harm us.
*removed obsolete workaround for detecting $monster[your shadow] in plumber path.

## How Has This Been Tested?

still testing

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
