### PR TITLE
boolean L12_filthworms() refactored

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -781,6 +781,7 @@ boolean L12_filthworms()
 	}
 	if(item_amount($item[Heart of the Filthworm Queen]) > 0)
 	{
+		handleFamiliar("meat");
 		return false;
 	}
 
@@ -825,11 +826,17 @@ boolean L12_filthworms()
 	}
 
 	//if we can guarentee stealing the stench gland then no point in buffing item drop
-	if(auto_have_skill($skill[Lash of the Cobra]) && get_property("_edLashCount").to_int() < 31)
+	if(auto_have_skill($skill[Lash of the Cobra]) && get_property("_edLashCount").to_int() < 30)
 	{
 		auto_log_info("Ed will steal stench glands using [Lash of the Cobra]");
 	}
-	else if(get_property("_xoHugsUsed").to_int() < 11 && canChangeToFamiliar($familiar[XO Skeleton]))
+//	else if(auto_have_skill($skill[Smash & Graaagh]))
+//	{
+//		//only 30 per day, can't find mafia tracking for it so it can't be implemented yet.
+//		//Needs to be implemented in auto_combat.ash too before uncommenting this block
+//		auto_log_info("Zombie Master will steal stench glands using [Smash & Graaagh]");
+//	}
+	else if(get_property("_xoHugsUsed").to_int() < 10 && canChangeToFamiliar($familiar[XO Skeleton]))
 	{
 		auto_log_info("Will steal stench glands using [XO Skeleton]");
 		handleFamiliar($familiar[XO Skeleton]);


### PR DESCRIPTION
*fixes #365 prevent maximizer from unintentionally equipping frat warrior fatigues to fight the filthworms prematurely as that causes infinite loop
*don't assume success when adventuring, assuming causes infinite loops
*only try to raise item drop if we can't guarentee stealing (supports Ed and XO skeleton. TODO zombie master and cat burglar)
*removed outded hardcoding of equipping some specific equip that gave +item drop. this outdated code didn't even work anymore (it equipped them then removed them). removed this code instead of fixing it because because we want to maximize and not hardcode equipping specific items.
*item drop code buffing will now use maximize. also use ed item drop servant on the very rare scenario of not having lash.
*don't hardcode switching to item familiar AFTER we are done here.
*equipmaximized before checking if we have enough item drop in live ascend repeat path

## How Has This Been Tested?

Hit issue #365 with a hardcore pete run. applied this fix and it successfully did the quest

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
