### PR TITLE
Moving stuff to the choiceAdventureScript

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2447,27 +2447,20 @@ boolean LX_attemptPowerLevel()
 		switch (my_primestat())
 		{
 			case $stat[Muscle]:
-				set_property("louvreDesiredGoal", "4"); // get Muscle stats
+				backupSetting("louvreDesiredGoal", "4"); // get Muscle stats
 				break;
 			case $stat[Mysticality]:
-				set_property("louvreDesiredGoal", "5"); // get Myst stats
+				backupSetting("louvreDesiredGoal", "5"); // get Myst stats
 				break;
 			case $stat[Moxie]:
-				set_property("louvreDesiredGoal", "6"); // get Moxie stats
+				backupSetting("louvreDesiredGoal", "6"); // get Moxie stats
 				break;
 		}
-		if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield])))
-		{
-			set_property("choiceAdventure89", "2"); // fight the snake knight (as Ed)
+		providePlusNonCombat(25, true);
+		if(autoAdv($location[The Haunted Gallery])) {
+			return true;
 		}
-		else
-		{
-			set_property("choiceAdventure89", "6"); // ignore the NC & banish it for 10 adv
-		}
-		providePlusNonCombat(25);
-		if(autoAdv($location[The Haunted Gallery])) return true;
 	}
-	
 	return false;
 }
 
@@ -3532,11 +3525,10 @@ boolean doTasks()
 	}
 	if(LX_bitchinMeatcar())				return true;
 	if(L5_getEncryptionKey())			return true;
-	if(LX_handleSpookyravenNecklace())	return true;
 	if(LX_unlockPirateRealm())			return true;
 	if(handleRainDoh())				return true;
 	if(routineRainManHandler())			return true;
-	if(LX_handleSpookyravenFirstFloor())return true;
+	if(LX_spookyravenManorFirstFloor())	return true;
 
 	if(!get_property("auto_slowSteelOrgan").to_boolean() && get_property("auto_getSteelOrgan").to_boolean())
 	{
@@ -3546,10 +3538,7 @@ boolean doTasks()
 
 	if(L4_batCave())					return true;
 	if(L2_mosquito())					return true;
-	if(L2_treeCoin())					return true;
-	if(L2_spookyMap())					return true;
-	if(L2_spookyFertilizer())			return true;
-	if(L2_spookySapling())				return true;
+	if(LX_unlockHiddenTemple())	return true;
 	if(L6_dakotaFanning())				return true;
 	if(L5_haremOutfit())				return true;
 	if(LX_phatLootToken())				return true;
@@ -3564,7 +3553,7 @@ boolean doTasks()
 		}
 	}
 
-	if(LX_spookyravenSecond())			return true;
+	if(LX_spookyravenManorSecondFloor())			return true;
 	if(L3_tavern())						return true;
 	if(L6_friarsGetParts())				return true;
 	if(LX_hardcoreFoodFarm())			return true;
@@ -3772,6 +3761,7 @@ void auto_begin()
 	backupSetting("choiceAdventureScript", "scripts/autoscend/auto_choice_adv.ash");
 	backupSetting("betweenBattleScript", "scripts/autoscend/auto_pre_adv.ash");
 	backupSetting("recoveryScript", "");
+	backupSetting("counterScript", "");
 
 	backupSetting("hpAutoRecovery", -0.05);
 	backupSetting("hpAutoRecoveryTarget", -0.05);
@@ -3782,16 +3772,9 @@ void auto_begin()
 	backupSetting("autoAbortThreshold", -0.05);
 
 	backupSetting("currentMood", "apathetic");
-	backupSetting("customCombatScript", "autoscend_null");
-	backupSetting("battleAction", "custom combat script");
 
 	backupSetting("choiceAdventure1107", 1);
 	backupSetting("choiceAdventure330", 1);		//haunted billiards room NC shark chum
-
-	if(get_property("counterScript") != "")
-	{
-		backupSetting("counterScript", "scripts/autoscend/auto_counter.ash");
-	}
 
 	string charpane = visit_url("charpane.php");
 	if(contains_text(charpane, "<hr width=50%><table"))

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -72,6 +72,87 @@ void main(int choice, string page)
 				run_choice(1); // get miner's helmet
 			}
 			break;
+		case 89: // Out in the Garden (The Haunted Gallery)
+			if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield]))) {
+				run_choice(2); // fight the snake knight (should non-Ed classes/paths do this too?)
+			} else {
+				run_choice(4); // ignore the NC & banish it for 10 adv
+			}
+			break;
+		case 90: // Curtains (The Haunted Ballroom)
+			run_choice(3); // skip;
+			break;
+		case 105: // Having a Medicine Ball (The Haunted Bathroom)
+			if (my_primestat() == $stat[Mysticality]) {
+				run_choice(1); // get mysticality substats
+			} else {
+				run_choice(2); // go to Bad Medicine is What You Need (#107)
+			}
+			break;
+		case 106: // Strung-Up Quartet (The Haunted Ballroom)
+			run_choice(3); // +5% item drops everywhere
+			break;
+		case 107: // Bad Medicine is What You Need (The Haunted Bathroom)
+			run_choice(4); // skip
+			break;
+		case 163: // Melvil Dewey Would Be Ashamed (The Haunted Library)
+			run_choice(4); // skip
+			break;
+		case 502: // Arboreal Respite (The Spooky Forest)
+			if (internalQuestStatus("questL02Larva") == 0 && item_amount($item[mosquito larva]) == 0) {
+				// need the mosquito larva
+				run_choice(2); // go to Consciousness of a Stream (#505)
+			} else if (!hidden_temple_unlocked()) {
+				if (item_amount($item[Tree-Holed Coin]) == 0 && item_amount($item[Spooky Temple map]) == 0) {
+					// need the tree-holed coin
+					run_choice(2); // go to Consciousness of a Stream (#505)
+				} else if (item_amount($item[Spooky Temple map]) == 0 || item_amount($item[Spooky-Gro Fertilizer]) == 0) {
+					// have the coin, need the spooky temple map and spooky-gro fertilizer
+					run_choice(3); // go to Through Thicket and Thinnet (#506)
+				} else {
+					// need the spooky sapling
+					run_choice(1); // go to The Road Less Traveled (#503)
+				}
+			} else {
+				auto_log_warning("In Arboreal Respite for some reason but we don't need a mosquito larva or to unlock the hidden temple!");
+				run_choice(2); // go to Consciousness of a Stream (#505)
+			}
+			break;
+		case 503: // The Road Less Traveled (The Spooky Forest)
+			run_choice(3); // go to Tree's Last Stand (#504)
+			break;
+		case 504: // Tree's Last Stand (The Spooky Forest)
+			if (item_amount($item[bar skin]) > 1) {
+				run_choice(2); // sell all bar skins (doesn't leave choice)
+			} else if (item_amount($item[bar skin]) == 1) {
+				run_choice(1); // sell all bar skins (doesn't leave choice)
+			}
+			if (!hidden_temple_unlocked() && item_amount($item[Spooky Sapling]) == 0 && my_meat() > 100) {
+				run_choice(3); // get the spooky sapling (doesn't leave choice)
+			}
+			run_choice(4); // leave the choice (skip).
+			break;
+		case 505: // Consciousness of a Stream (The Spooky Forest)
+			if (internalQuestStatus("questL02Larva") == 0 && item_amount($item[mosquito larva]) == 0) {
+				run_choice(1); // Get the mosquito larva
+			} else {
+				run_choice(2); // Get the tree-holed coin or skip
+			}
+			break;
+		case 506: // Through Thicket and Thinnet (The Spooky Forest)
+			if (!hidden_temple_unlocked() && item_amount($item[Spooky-Gro Fertilizer]) == 0) {
+				run_choice(2); // get the spooky-gro fertilizer
+			} else {
+				run_choice(3); // go to O Lith, Mon (#507)
+			}
+			break;
+		case 507: // O Lith, Mon (The Spooky Forest)
+			if (!hidden_temple_unlocked() && item_amount($item[Tree-Holed Coin]) > 0 && item_amount($item[Spooky Temple map]) == 0) {
+				run_choice(1); // get the spooky temple map
+			} else {
+				run_choice(3); // skip
+			}
+			break;
 		case 556: // More Locker Than Morlock (Itznotyerzitz Mine)
 			if (!possessOutfit("Mining Gear")) {
 				run_choice(1); // get an outfit piece
@@ -88,6 +169,175 @@ void main(int choice, string page)
 				} else {
 					run_choice(4); // Lucky Pill. (Clover for 1 spleen, worth?)
 				}
+			}
+			break;
+		case 780: // Action Elevator (The Hidden Apartment Building)
+			if (auto_my_path() == "Pocket Familiars" && get_property("relocatePygmyLawyer").to_int() != my_ascensions()) {
+				run_choice(3); // relocate lawyers to park
+			} else if (have_effect($effect[Thrice-Cursed]) > 0) {
+				run_choice(1); // fight the spirit
+			} else {
+				run_choice(2); // get cursed
+			}
+			break;
+		case 781: // Earthbound and Down (An Overgrown Shrine (Northwest))
+			if (get_property("hiddenApartmentProgress").to_int() == 0) {
+				run_choice(1); // unlock the Hidden Apartment Building
+			} else if (item_amount($item[moss-covered stone sphere]) > 0) {
+				run_choice(2); // get the stone triangle
+			} else {
+				run_choice(6); // skip
+			}
+			break;
+		case 783: // Water You Dune (An Overgrown Shrine (Southwest))
+			if (get_property("hiddenHospitalProgress").to_int() == 0) {
+				run_choice(1); // unlock the Hidden Hospital
+			} else if (item_amount($item[dripping stone sphere]) > 0) {
+				run_choice(2); // get the stone triangle
+			} else {
+				run_choice(6); // skip
+			}
+			break;
+		case 784: // You, M. D. (The Hidden Hospital)
+			run_choice(1); // fight the spirit
+			break;
+		case 785: // Air Apparent (An Overgrown Shrine (Northeast))
+			if (get_property("hiddenOfficeProgress").to_int() == 0) {
+				run_choice(1); // unlock the Hidden Office Building
+			} else if (item_amount($item[crackling stone sphere]) > 0) {
+				run_choice(2); // get the stone triangle
+			} else {
+				run_choice(6); // skip
+			}
+			break;
+		case 786: // Working Holiday (The Hidden Office Building)
+			if (item_amount($item[McClusky File (Complete)]) > 0) {
+				run_choice(1); // fight the spirit
+			} else if (item_amount($item[Boring Binder Clip]) == 0) {
+				run_choice(2); // get boring binder clip
+			} else {
+				run_choice(3); // fight an accountant
+			}
+			break;
+		case 787: // Fire When Ready (An Overgrown Shrine (Southeast))
+			if (get_property("hiddenBowlingAlleyProgress").to_int() == 0) {
+				run_choice(1); // unlock the Hidden Bowling Alley
+			} else if (item_amount($item[scorched stone sphere]) > 0) {
+				run_choice(2); // get the stone triangle
+			} else {
+				run_choice(6); // skip
+			}
+			break;
+		case 788: // Life is Like a Cherry of Bowls (The Hidden Bowling Alley)
+			run_choice(1); // bowl for stats 4 times then fight the spirit on 5th occurrence
+			break;
+		case 789: // Where Does The Lone Ranger Take His Garbagester? (The Hidden Park)
+			if (get_property("relocatePygmyJanitor").to_int() != my_ascensions()) {
+				run_choice(2); // Relocate the Pygmy Janitor to the park
+			} else {
+				run_choice(1); // Get Hidden City zone items
+			}
+			break;
+		case 791: // Legend of the Temple in the Hidden City (A Massive Ziggurat)
+			if (item_amount($item[stone triangle]) == 4) {
+				run_choice(1); // fight the Protector Spirit (or replacement)
+			} else {
+				run_choice(2); // skip
+			}
+			break;
+		case 875: // Welcome To Our ool Table (The Haunted Billiards Room)
+			if (currentPoolSkill() >= 18) {
+				run_choice(1);
+			} else {
+				run_choice(2);
+			}
+			break;
+		case 876: // One Simple Nightstand (The Haunted Bedroom)
+			run_choice(2); // get muscle substats
+			break;
+		case 877: // One Mahogany Nightstand (The Haunted Bedroom)
+			run_choice(1); // get half of a memo or old coin purse
+			break;
+		case 878: // One Ornate Nightstand (The Haunted Bedroom)
+			boolean needSpectacles = (item_amount($item[Lord Spookyraven\'s Spectacles]) == 0 && internalQuestStatus("questL11Manor") < 2);
+			if (in_boris() || auto_my_path() == "Way of the Surprising Fist" || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
+				needSpectacles = false;
+			}
+			if (needSpectacles) {
+				run_choice(3); // get Lord Spookyraven's spectacles
+			} else if (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1) {
+				run_choice(4); // get disposable instant camera
+			} else {
+				run_choice(2); // get mysticality substats
+			}
+			break;
+		case 879: // One Rustic Nightstand (The Haunted Bedroom)
+			run_choice(1); // get moxie substats
+			break;
+		case 880: // One Elegant Nightstand (The Haunted Bedroom)
+			if (internalQuestStatus("questM21Dance") < 2 && item_amount($item[Lady Spookyraven\'s Finest Gown]) == 0) {
+				run_choice(1); // get Lady Spookyraven's Gown
+			} else {
+				run_choice(2); // get elegant nightstick
+			}
+			break;
+		case 881: // Never Gonna Make You Up (The Haunted Bathroom)
+			run_choice(1); // fight the cosmetics wraith
+			break;
+		case 882: // Off the Rack (The Haunted Bathroom)
+			run_choice(1); // take the towel
+			break;
+		case 888: // Take a Look, it's in a Book! (Rise) (The Haunted Library)
+			run_choice(4); // skip
+			break;
+		case 889: // Take a Look, it's in a Book! (Fall) (The Haunted Library)
+			if (item_amount($item[dictionary]) == 0 && get_property("auto_getDictionary").to_boolean()) {
+				run_choice(4); // get the dictionary
+			} else {
+				run_choice(5); // skip
+			}
+			break;
+		case 921: // We'll All Be Flat (The Haunted Ballroom)
+			run_choice(1); // unlock Spookyraven Manor Cellar 
+			break;
+		case 923: // All Over the Map (The Black Forest)
+			run_choice(1); // go to You Found Your Thrill (#924)
+			break;
+		case 924: // You Found Your Thrill (The Black Forest)
+			if(get_property("auto_getBeehive").to_boolean() && my_adventures() > 3) {
+				run_choice(3); // go to Bee Persistent (#1018)
+			} else if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && my_class() != $class[Vampyre]) {
+				run_choice(2); // go to The Blackberry Cobbler (#928)
+			} else {
+				run_choice(1); // Attack the bushes (fight blackberry bush)
+			}
+			break;
+		case 928: // You Found Your Thrill (The Black Forest)
+			if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && my_class() != $class[Vampyre]) {
+				run_choice(4); // get Blackberry Galoshes
+			} else {
+				run_choice(5); // skip
+			}
+			break;
+		case 1002: // Temple of the Legend in the Hidden City (A Massive Ziggurat/Actually Ed the Undying)
+			if (item_amount($item[stone triangle]) == 4) {
+				run_choice(1); // Put the Ancient Amulet back
+			} else {
+				run_choice(2); // skip
+			}
+			break;
+		case 1018: // Bee Persistent (The Black Forest)
+			if (get_property("auto_getBeehive").to_boolean() && my_adventures() > 2) {
+				run_choice(1); // go to Bee Rewarded (#1019)
+			} else {
+				run_choice(2); // skip
+			}
+			break;
+		case 1019: // Bee Rewarded (The Black Forest)
+			if (get_property("auto_getBeehive").to_boolean()) {
+				run_choice(1); // get the beehive
+			} else {
+				run_choice(2); // skip
 			}
 			break;
 		case 1023: // Like a Bat Into Hell (Actually Ed the Undying)

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -11,11 +11,6 @@ void main()
 		abort("Familiar has no equipment, WTF");
 	}
 
-	if(get_property("customCombatScript") != "autoscend_null")
-	{
-		abort("customCombatScript is set to unrecognized '" + get_property("customCombatScript") + "', should be 'autoscend_null'");
-	}
-
 	if(get_property("auto_disableAdventureHandling").to_boolean())
 	{
 		auto_log_info("Preadventure skipped by standard adventure handler.", "green");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7322,6 +7322,9 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 }
 
 int currentPoolSkill() {
+	// format of the cli 'poolskill' command return value is:
+	// Pool Skill is estimated at : 12.
+	// 0 from equipment, 0 from having 15 inebriety, 2 hustling training and 10 learning from 25 sharks.
 	string [int] poolskill_command = split_string(cli_execute_output("poolskill"));
 	return substring(poolskill_command[0], poolskill_command[0].last_index_of(":") + 2,  poolskill_command[0].length() - 1).to_int();
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7294,7 +7294,7 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	buffMaintain($effect[Reptilian Fortitude], 0, 1, 1);				//8 MP
 	buffMaintain($effect[Astral Shell], 0, 1, 1);						//10 MP
 	buffMaintain($effect[Jingle Jangle Jingle], 0, 1, 1);				//5 MP
-	buffMaintain($effect[Curiosity of Br'er Tarrypin], 0, 1, 1);		//5 MP
+	buffMaintain($effect[Curiosity of Br\'er Tarrypin], 0, 1, 1);		//5 MP
 	
 	//Sauceror Buffs
 	buffMaintain($effect[Elemental Saucesphere], 0, 1, 1);				//10 MP
@@ -7303,7 +7303,7 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//Accordion Thief Buffs. We are not shrugging so it will only apply new ones if we have space for them
 	buffMaintain($effect[The Moxious Madrigal], 0, 1, 1);				//2 MP
 	buffMaintain($effect[The Magical Mojomuscular Melody], 0, 1, 1);	//3 MP
-	buffMaintain($effect[Cletus's Canticle of Celerity], 0, 1, 1);		//4 MP
+	buffMaintain($effect[Cletus\'s Canticle of Celerity], 0, 1, 1);		//4 MP
 	buffMaintain($effect[Power Ballad of the Arrowsmith], 0, 1, 1);		//5 MP
 	buffMaintain($effect[Polka of Plenty], 0, 1, 1);					//7 MP
 	
@@ -7319,4 +7319,9 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	
 	//TODO facial expressions, need to check you are not wearing one first and which ones you have
 	//Maybe just not do facial expressions? too much complexity for a singular effect.
+}
+
+int currentPoolSkill() {
+	string [int] poolskill_command = split_string(cli_execute_output("poolskill"));
+	return substring(poolskill_command[0], poolskill_command[0].last_index_of(":") + 2,  poolskill_command[0].length() - 1).to_int();
 }

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1458,7 +1458,7 @@ generic_t zone_available(location loc)
 	// compare our result with canadv(https://svn.code.sf.net/p/therazekolmafia/canadv/code/), log a warning if theres a difference. Ideally we can see if there are any differences between our code and Bales, and if not remove all of ours in favor of the dependency
 	boolean canAdvRetval = can_adv(loc);
 	if(canAdvRetval != retval._boolean){
-		auto_log_warning("Uh oh, autoscend and canadv dont agree on whether we can adventure at " + loc + " (autoscend: "+retval._boolean+", canadv: "+canAdvRetval+"). Will assume locaiton available if either is true.");
+		auto_log_debug("Uh oh, autoscend and canadv dont agree on whether we can adventure at " + loc + " (autoscend: "+retval._boolean+", canadv: "+canAdvRetval+"). Will assume locaiton available if either is true.");
 		retval._boolean = retval._boolean || canAdvRetval;
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -21,16 +21,12 @@ boolean LA_cs_communityService();				//Defined in autoscend/auto_community_servi
 boolean LM_edTheUndying();						//Defined in autoscend/auto_edTheUndying.ash
 
 boolean LX_desertAlternate();
-boolean LX_handleSpookyravenNecklace();
-boolean LX_handleSpookyravenFirstFloor();
 boolean LX_phatLootToken();
 boolean LX_islandAccess();
 boolean fancyOilPainting();
 boolean LX_fcle();
 boolean ornateDowsingRod();
 boolean LX_nastyBooty();
-boolean LX_spookyravenSecond();
-boolean LX_spookyBedroomCombat();
 boolean LX_guildUnlock();
 boolean LX_hardcoreFoodFarm();
 boolean LX_melvignShirt();
@@ -62,10 +58,6 @@ boolean LX_dinseylandfillFunbucks();		//Defined in autoscend/auto_optionals.ash
 boolean handleRainDoh();					//Defined in autoscend/auto_mr2012.ash
 
 boolean L2_mosquito();
-boolean L2_treeCoin();
-boolean L2_spookyMap();
-boolean L2_spookyFertilizer();
-boolean L2_spookySapling();
 
 boolean L3_tavern();
 
@@ -102,6 +94,9 @@ boolean[location] shenSnakeLocations(int day, int n_items_returned);	//Defined i
 boolean[location] shenZonesToAvoidBecauseMaybeSnake();					//Defined in autoscend/auto_quest_level_11.ash
 boolean shenShouldDelayZone(location loc);								//Defined in autoscend/auto_quest_level_11.ash
 
+boolean LX_unlockHiddenTemple();
+boolean LX_spookyravenManorFirstFloor();
+boolean LX_spookyravenManorSecondFloor();
 boolean L11_palindome();
 boolean L11_hiddenCity();
 boolean L11_hiddenTavernUnlock();
@@ -122,7 +117,6 @@ boolean L11_unlockPyramid();
 boolean L11_unlockEd();
 boolean L11_defeatEd();
 boolean L11_getBeehive();
-boolean L11_fistDocuments();
 
 // Used in autoscend/auto_quest_level_12.ash
 record WarPlan
@@ -1214,6 +1208,7 @@ boolean auto_haveQueuedForcedNonCombat(); // Defined in autoscend/auto_util.ash
 boolean is_superlikely(string encounterName); // Defined in autoscend/auto_util.ash
 boolean hasTTBlessing();									 // Defined in autoscend/auto_util.ash
 void effectAblativeArmor(boolean passive_dmg_allowed);		 // Defined in autoscend/auto_util.ash
+int currentPoolSkill(); 		 // Defined in autoscend/auto_util.ash
 
 //Record from autoscend/auto_zone.ash
 record generic_t

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -44,7 +44,6 @@ void ed_initializeSettings()
 		set_property("auto_edCombatCount", 0);
 		set_property("auto_edCombatRoundCount", 0);
 
-		set_property("choiceAdventure1002", 1);
 		set_property("desertExploration", 100);
 		set_property("nsTowerDoorKeysUsed", "Boris's key,Jarlsberg's key,Sneaky Pete's key,Richard's star key,skeleton key,digital key");
 		set_property("auto_delayHauntedKitchen", true);
@@ -1058,8 +1057,8 @@ void ed_handleAdventureServant(location loc)
 		}
 	}
 
-	// Locations where meat drop is required for quest furthering purposes
-	if (loc == $location[The Themthar Hills] && have_servant($servant[Maid]))
+	// Locations where meat drop is required for quest furthering purposes (or just nice to have)
+	if ($locations[The Themthar Hills, The Filthworm Queen\'s Chamber] contains loc && have_servant($servant[Maid]))
 	{
 		myServant = $servant[Maid];
 	}
@@ -1461,7 +1460,7 @@ boolean LM_edTheUndying()
 		return true;
 	}
 	// need to do L2 quest to unlock the L3. 0.83 Ka zone or 1/1.25/1.67 with 1/2/3 banishes
-	if (L2_mosquito() || L2_treeCoin() || L2_spookyMap() || L2_spookyFertilizer() || L2_spookySapling())
+	if (L2_mosquito() || LX_unlockHiddenTemple())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/the_source.ash
+++ b/RELEASE/scripts/autoscend/paths/the_source.ash
@@ -303,7 +303,7 @@ boolean LX_attemptPowerLevelTheSource()
 		if (whereTo == $location[The Haunted Ballroom] && internalQuestStatus("questM21Dance") > 3)
 		{
 			use(item_amount($item[ten-leaf clover]), $item[ten-leaf clover]);
-			LX_spookyBedroomCombat();
+			autoAdv($location[The Haunted Bedroom]);
 			return true;
 		}
 		if(cloversAvailable() > 0)
@@ -315,5 +315,5 @@ boolean LX_attemptPowerLevelTheSource()
 		return true;
 	}
 	//Banish mahogant, elegant after gown only. (Harold\'s Bell?)
-	return LX_spookyBedroomCombat();
+	return autoAdv($location[The Haunted Bedroom]);
 }

--- a/RELEASE/scripts/autoscend/quests/level_2.ash
+++ b/RELEASE/scripts/autoscend/quests/level_2.ash
@@ -1,132 +1,25 @@
 script "level_2.ash"
 
-boolean L2_treeCoin()
-{
-	if (hidden_temple_unlocked())
-	{
-		return false;
-	}
-	if (item_amount($item[Tree-Holed Coin]) > 0 || item_amount($item[spooky temple map]) > 0)
-	{
-		return false;
-	}
-
-	auto_log_info("Time for a tree-holed coin", "blue");
-	set_property("choiceAdventure502", "2");
-	set_property("choiceAdventure505", "2");
-	autoAdv(1, $location[The Spooky Forest]);
-	return true;
-}
-
-boolean L2_spookyMap()
-{
-	if (hidden_temple_unlocked())
-	{
-		return false;
-	}
-	if (item_amount($item[spooky temple map]) > 0)
-	{
-		return false;
-	}
-
-	auto_log_info("Need a spooky map now", "blue");
-	set_property("choiceAdventure502", "3");
-	set_property("choiceAdventure506", "3");
-	set_property("choiceAdventure507", "1");
-	autoAdv(1, $location[The Spooky Forest]);
-	return true;
-}
-
-boolean L2_spookyFertilizer()
-{
-	if (hidden_temple_unlocked())
-	{
-		return false;
-	}
-	pullXWhenHaveY($item[Spooky-Gro Fertilizer], 1, 0);
-	if(item_amount($item[Spooky-Gro Fertilizer]) > 0)
-	{
-		return false;
-	}
-	auto_log_info("Need some poop, I mean fertilizer now", "blue");
-	set_property("choiceAdventure502", "3");
-	set_property("choiceAdventure506", "2");
-	autoAdv(1, $location[The Spooky Forest]);
-	return true;
-}
-
-boolean L2_spookySapling()
-{
-	if (hidden_temple_unlocked())
-	{
-		return false;
-	}
-	if(my_meat() < 100)
-	{
-		return false;
-	}
-	auto_log_info("And a spooky sapling!", "blue");
-	set_property("choiceAdventure502", "1");
-	set_property("choiceAdventure503", "3");
-	set_property("choiceAdventure504", "3");
-
-	if(!autoAdvBypass("adventure.php?snarfblat=15", $location[The Spooky Forest]))
-	{
-		if(contains_text(get_property("lastEncounter"), "Hoom Hah"))
-		{
-			return true;
-		}
-		if(contains_text(get_property("lastEncounter"), "Blaaargh! Blaaargh!"))
-		{
-			auto_log_warning("Ewww, fake blood semirare. Worst. Day. Ever.", "red");
-			return true;
-		}
-		if(lastAdventureSpecialNC())
-		{
-			auto_log_info("Special Non-combat interrupted us, no worries...", "green");
-			return true;
-		}
-		visit_url("choice.php?whichchoice=502&option=1&pwd");
-		visit_url("choice.php?whichchoice=503&option=3&pwd");
-		if(item_amount($item[bar skin]) > 0)
-		{
-			visit_url("choice.php?whichchoice=504&option=2&pwd");
-		}
-		visit_url("choice.php?whichchoice=504&option=3&pwd");
-		visit_url("choice.php?whichchoice=504&option=4&pwd");
-		if(item_amount($item[Spooky Sapling]) > 0)
-		{
-			use(1, $item[Spooky Temple Map]);
-		}
-		else
-		{
-			abort("Supposedly bought a spooky sapling, but failed :( (Did the semi-rare window just expire, just run me again, sorry)");
-		}
-	}
-	return true;
-}
-
 boolean L2_mosquito()
 {
 	if (internalQuestStatus("questL02Larva") < 0 || internalQuestStatus("questL02Larva") > 1)
 	{
 		return false;
 	}
-
-	buffMaintain($effect[Snow Shoes], 0, 1, 1);
-	providePlusNonCombat(25);
-
+	// Arboreal Respite choice adventure has a delay of 5 adventures.
+	// TODO: add a check for delay burning?
+	providePlusNonCombat(25, true);
 	auto_log_info("Trying to find a mosquito.", "blue");
-	set_property("choiceAdventure502", "2"); // Arboreal Respite: go to Consciousness of a Stream
-	set_property("choiceAdventure505", "1"); // Consciousness of a Stream: Acquire Mosquito Larva
-	autoAdv(1, $location[The Spooky Forest]);
-	if (internalQuestStatus("questL02Larva") > 0 || item_amount($item[mosquito larva]) > 0)
-	{
-		council();
-		if (in_koe())
+	if (autoAdv($location[The Spooky Forest])) {
+		if (internalQuestStatus("questL02Larva") > 0 || item_amount($item[mosquito larva]) > 0)
 		{
-			cli_execute("refresh quests");
+			council();
+			if (in_koe())
+			{
+				cli_execute("refresh quests");
+			}
 		}
+		return true;
 	}
-	return true;
+	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_7.ash
+++ b/RELEASE/scripts/autoscend/quests/level_7.ash
@@ -24,7 +24,7 @@ boolean L7_crypt()
 	boolean edAlcove = true;
 	if (isActuallyEd())
 	{
-		edAlcove = have_skill($skill[More Legs]);
+		edAlcove = (have_skill($skill[More Legs]) && (expected_damage($monster[modern zmobie]) + 1) < my_maxhp());
 	}
 
 	if((get_property("romanticTarget") != $monster[modern zmobie]) && (get_property("auto_waitingArrowAlcove").to_int() < 50))
@@ -54,31 +54,6 @@ boolean L7_crypt()
 		}
 
 		provideInitiative(850, true);
-
-		if (isActuallyEd() && expected_damage($monster[modern zmobie]) >= my_maxhp())
-		{
-			// Need to be able to tank a hit from the modern zmobies as Ed
-			// as we'll never get the jump because their initiative is ridiculous.
-			// Otherwise we'll just die repeatedly.
-			if (get_property("telescopeUpgrades").to_int() > 0 && !get_property("telescopeLookedHigh").to_boolean())
-			{
-				cli_execute("telescope high");
-			}
-			if (!get_property("_lyleFavored").to_boolean())
-			{
-				cli_execute("monorail");
-			}
-			if (have_effect($effect[Butt-Rock Hair]) == 0)
-			{
-				buyUpTo(1, $item[Hair Spray]);
-				buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
-			}
-			if (have_effect($effect[Go Get \'Em, Tiger!]) == 0)
-			{
-				buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-				buffMaintain($effect[Go Get \'Em, Tiger!], 0, 1, 1);
-			}
-		}
 
 		autoEquip($item[Gravy Boat]);
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -124,51 +124,55 @@ boolean L9_chasmBuild()
 	asdonBuff($effect[Driving Intimidatingly]);
 
 	// Check our Load out to see if spells are the best option for Orc-Thumping
-	boolean useSpellsInOrcCamp = false;
-	if(setFlavour($element[cold]) && canUse($skill[Stuffed Mortar Shell]))
-	{
-		useSpellsInOrcCamp = true;
+	if (isGuildClass()) {
+		// This only applies to classes which can use perm'd skills,
+		// so let's not waste time and console spam when we're a class or path that can't do any of this.
+		boolean useSpellsInOrcCamp = false;
+		if(setFlavour($element[cold]) && canUse($skill[Stuffed Mortar Shell]))
+		{
+			useSpellsInOrcCamp = true;
+		}
+
+		if(setFlavour($element[cold]) && canUse($skill[Cannelloni Cannon], false))
+		{
+			useSpellsInOrcCamp = true;
+		}
+
+		if(canUse($skill[Saucegeyser], false))
+		{
+			useSpellsInOrcCamp = true;
+		}
+
+		if(canUse($skill[Saucecicle], false))
+		{
+			useSpellsInOrcCamp = true;
+		}
+
+		// Always Maximize and choose our default Non-Com First, in case we are wrong about the non-com we MAY have some gear still equipped to help us.
+		if(useSpellsInOrcCamp == true)
+		{
+			auto_log_info("Preparing to Blast Orcs with Cold Spells!", "blue");
+			addToMaximize("myst,40spell damage,80spell damage percent,40cold spell damage,-1000 ml");
+			buffMaintain($effect[Carol of the Hells], 50, 1, 1);
+			buffMaintain($effect[Song of Sauce], 150, 1, 1);
+
+			auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
+			auto_log_info("Currently setup for Myst/Spell Damage, option 2: Blast it down with a spell", "blue");
+			set_property("choiceAdventure1345", 0);
+		}
+		else
+		{
+			auto_log_info("Preparing to Ice-Punch Orcs!", "blue");
+			addToMaximize("muscle,40weapon damage,60weapon damage percent,40cold damage,-1000 ml");
+			buffMaintain($effect[Carol of the Bulls], 50, 1, 1);
+			buffMaintain($effect[Song of The North], 150, 1, 1);
+
+			auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
+			auto_log_info("Currently setup for Muscle/Weapon Damage, option 1: Kick it down", "blue");
+			set_property("choiceAdventure1345", 0);
+		}
 	}
-
-	if(setFlavour($element[cold]) && canUse($skill[Cannelloni Cannon], false))
-	{
-		useSpellsInOrcCamp = true;
-	}
-
-	if(canUse($skill[Saucegeyser], false))
-	{
-		useSpellsInOrcCamp = true;
-	}
-
-	if(canUse($skill[Saucecicle], false))
-	{
-		useSpellsInOrcCamp = true;
-	}
-
-	// Always Maximize and choose our default Non-Com First, in case we are wrong about the non-com we MAY have some gear still equipped to help us.
-	if(useSpellsInOrcCamp == true)
-	{
-		auto_log_info("Preparing to Blast Orcs with Cold Spells!", "blue");
-		addToMaximize("myst,40spell damage,80spell damage percent,40cold spell damage,-1000 ml");
-		buffMaintain($effect[Carol of the Hells], 50, 1, 1);
-		buffMaintain($effect[Song of Sauce], 150, 1, 1);
-
-		auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
-		auto_log_info("Currently setup for Myst/Spell Damage, option 2: Blast it down with a spell", "blue");
-		set_property("choiceAdventure1345", 0);
-	}
-	else
-	{
-		auto_log_info("Preparing to Ice-Punch Orcs!", "blue");
-		addToMaximize("muscle,40weapon damage,60weapon damage percent,40cold damage,-1000 ml");
-		buffMaintain($effect[Carol of the Bulls], 50, 1, 1);
-		buffMaintain($effect[Song of The North], 150, 1, 1);
-
-		auto_log_info("If we encounter Blech House when we are not expecting it we will stop.", "blue");
-		auto_log_info("Currently setup for Muscle/Weapon Damage, option 1: Kick it down", "blue");
-		set_property("choiceAdventure1345", 0);
-	}
-
+	
 	if(get_property("smutOrcNoncombatProgress").to_int() == 15)
 	{
 		// If we think the non-com will hit NOW we clear maximizer to keep previous settings from carrying forward


### PR DESCRIPTION
Description

- move choice handling for Spooky Forest, Spookyraven first and second floors, and Hidden City zones to choiceAdventureScript
- refactor quest handling functions for unlocking Hidden Temple, L2 quest, unlocking Spookyraven first and second floor and some of the Hidden City (lots more to do).
- handful of other minor fixes/tweaks.

This started off as an attempt to fix our handling of the Haunted Bedroom encounters and the Hidden City zone unlocking and kind of grew arms and legs.

I was hoping to get to work on the hidden city unlocking quest handling (so we can handle not having Stone Wool) and more of the macguffin quest but I need to put this up now as it's growing large, I have a mining fix to look into and the new path needs to be worked on.

## How Has This Been Tested?

Ran 3 HC Eds so far.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
