### PR TITLE
refactoring LX_unlockHauntedLibrary()

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3146,7 +3146,7 @@ int speculative_pool_skill()
 	{
 		expectPool += my_inebriety();
 	}
-	if(auto_my_path() != "G-Lover" && (have_effect($effect[Chalky Hand]) > 0 || item_amount($item[Handful of Hand Chalk]) > 0))
+	if(auto_is_valid($item[Handful of Hand Chalk]) && (have_effect($effect[Chalky Hand]) > 0 || item_amount($item[Handful of Hand Chalk]) > 0))
 	{
 		expectPool += 3;
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3146,7 +3146,7 @@ int speculative_pool_skill()
 	{
 		expectPool += my_inebriety();
 	}
-	if((have_effect($effect[Chalky Hand]) > 0) || (item_amount($item[Handful of Hand Chalk]) > 0))
+	if(auto_my_path() != "G-Lover" && (have_effect($effect[Chalky Hand]) > 0 || item_amount($item[Handful of Hand Chalk]) > 0))
 	{
 		expectPool += 3;
 	}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -245,11 +245,14 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(2); // skip
 			}
 			break;
-		case 875: // Welcome To Our ool Table (The Haunted Billiards Room)
-			if (currentPoolSkill() >= 18) {
-				run_choice(1);
-			} else {
-				run_choice(2);
+		case 875: // Welcome To Our ool Table (The Haunted Billiards Room).
+			if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
+			{
+				run_choice(1);		//try to win the key. on failure still gain 1 pool skill
+			}
+			else
+			{
+				run_choice(2);		//practice pool skill
 			}
 			break;
 		case 876: // One Simple Nightstand (The Haunted Bedroom)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7346,3 +7346,12 @@ int currentPoolSkill() {
 	string [int] poolskill_command = split_string(cli_execute_output("poolskill"));
 	return substring(poolskill_command[0], poolskill_command[0].last_index_of(":") + 2,  poolskill_command[0].length() - 1).to_int();
 }
+
+int poolSkillPracticeGains()
+{
+	//predict gains from choosing to practice your pool skill (choice 2) in noncombat adv 875 "Welcome To Our ool Table"
+	int count = 1;
+	if(have_effect($effect[chalky hand]) > 0) count += 1;
+	if(equipped_amount($item[[2268]Staff of Fats]) > 0) count += 2;		//note that $item[[7964]Staff of Fats] does not help here.
+	return count;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1223,6 +1223,7 @@ boolean is_superlikely(string encounterName); // Defined in autoscend/auto_util.
 boolean hasTTBlessing();									 // Defined in autoscend/auto_util.ash
 void effectAblativeArmor(boolean passive_dmg_allowed);		 // Defined in autoscend/auto_util.ash
 int currentPoolSkill(); 		 // Defined in autoscend/auto_util.ash
+int poolSkillPracticeGains();								// Defined in autoscend/auto_util.ash
 
 //Record from autoscend/auto_zone.ash
 record generic_t

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -225,9 +225,19 @@ boolean LX_unlockHauntedLibrary()
 			resetMaximize();	//cancel equipping pool cue
 			return false;
 		}
-		//handling paths with max inebrity over 10
-		//TODO change consumption code to actually drink one at a time and then add rules here.
-		//do not forget to reset maximize if you want to return false.
+		if(my_inebriety() < 8)
+		{
+			auto_log_info("I will come back when I had more to drink.", "green");
+			resetMaximize();	//cancel equipping pool cue
+			return false;
+		}
+		if(my_inebriety() > 11)
+		{
+			int penalty = 2 * (10 - my_inebriety());
+			auto_log_info("I overshot my inebrity goal for the [Haunted Billiards Room] which gives me a penalty of " + penalty + "pool skill. I will come back tomorrow or if I run out of things to do.", "green");
+			resetMaximize();	//cancel equipping pool cue
+			return false;
+		}
 	}
 	
 	//+3 pool skill & +1 training gains. speculative_pool_skill() already assumed we would use it if we can.


### PR DESCRIPTION
refactoring LX_unlockHauntedLibrary()
*use auto_is_valid to check chalky hands. for example in g-lover it is not valid.
*chalky hands logic was faulty. it was only used when equipping a cue while calculations were assuming we always use it (as we should because it boosts training speed)
*boris cannot equip pool cues. do not add it to maximizer.
*don't add ALL cues available to maximizer, only add the best cue
*do not skip all calculations / equipment logic / inebrity rules when you have not yet encountered "That's your cue" (NC that drops a basic pool cue). It no longer blocks other NCs in that zone.
*reworked the cue equipping logic.
*adjusted drunkness rules to account for the current way consumption code works. (it drinks to full. so only wait for drinking in paths whose max is under 11. if we change way drinking works we can readd some rules for this)
*added comments
*added poolSkillPracticeGains() and used it.
**predict the amount of pool skill you would gain for taking choice 2 (training) in choiceAdv875 (welcome to our ool table)
**if you only gain 1 pool skill from training, then always take choice 1 (try to win).
**if you gain more than 1 pool skill then start using choice 1 when poolskill is over 15.

## How Has This Been Tested?

ash calls
HC sneaky pete runs.
HC actually ed runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.