### PR TITLE
Basic low key summer support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20103; // Low Key Summer Keys
+since r20111; // nsTowerDoorKeysUsed should be correct now
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -61,6 +61,7 @@ import <autoscend/paths/pocket_familiars.ash>
 import <autoscend/paths/standard.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
+import <autoscend/paths/low_key_summer.ash>
 
 import <autoscend/quests/level_2.ash>
 import <autoscend/quests/level_3.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -233,6 +233,7 @@ void initializeSettings()
 	bat_initializeSettings();
 	koe_initializeSettings();
 	zelda_initializeSettings();
+	lowkey_initializeSettings();
 
 	set_property("auto_doneInitialize", my_ascensions());
 }

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r19979; // If you can recover HP or MP with a restorative, it is not banned in your path
+since r20103; // Low Key Summer Keys
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3532,6 +3532,7 @@ boolean doTasks()
 	{
 		if(LX_bitchinMeatcar())			return true;
 	}
+	if(LX_findHelpfulLowKey())			return true;
 	if(LX_bitchinMeatcar())				return true;
 	if(L5_getEncryptionKey())			return true;
 	if(LX_handleSpookyravenNecklace())	return true;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -107,6 +107,13 @@ void main(int choice, string page)
 				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 			}
 			break;
+		case 1061: // Heart of Madness(Madness Bakery Quest)
+			if(internalQuestStatus("questM25Armorer") <= 1) {
+				run_choice(1);
+			} else {
+				run_choice(5);
+			}
+			break;
 		case 1082: // The "Rescue" (post-Cake Lord in Madness Bakery)
 			run_choice(1);
 			break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -713,6 +713,19 @@ boolean startGalaktikSubQuest()
 	return false;
 }
 
+boolean startHippyBoatmanSubQuest()
+{
+	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted")
+	{
+		string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
+		temp = visit_url("choice.php?pwd=&whichchoice=798&option=1");
+		temp = visit_url("choice.php?pwd=&whichchoice=798&option=2");
+		temp = visit_url("woods.php");
+		return true;
+	}
+	return false;
+}
+
 location provideAdvPHPZone()
 {
 	if(elementalPlanes_access($element[stench]))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -6040,6 +6040,11 @@ location solveDelayZone()
 		burnZone = $location[The Exploaded Battlefield];
 	}
 
+	if(in_lowkeysummer())
+	{
+		burnZone = lowkey_nextAvailableKeyDelayLocation();
+	}
+
 	return burnZone;
 }
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1206,7 +1206,6 @@ boolean in_lowkeysummer(); // Defined in autoscend/paths/low_key_summer.ash
 boolean lowkey_initializeSettings(); // Defined in autoscend/paths/low_key_summer.ash
 int lowkey_keyDelayRemaining(location loc); // Defined in autoscend/paths/low_key_summer.ash
 int lowkey_keysRemaining(); // Defined in autoscend/paths/low_key_summer.ash
-int lowkey_keyLocationsAvailable(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextKeyLocation(boolean checkAvailable); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextAvailableKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -978,6 +978,7 @@ int spleen_left();											//Defined in autoscend/auto_util.ash
 boolean startArmorySubQuest();								//Defined in autoscend/auto_util.ash
 boolean startGalaktikSubQuest();							//Defined in autoscend/auto_util.ash
 boolean startMeatsmithSubQuest();							//Defined in autoscend/auto_util.ash
+boolean startHippyBoatmanSubQuest();						//Defined in autoscend/auto_util.ash
 string statCard();											//Defined in autoscend/auto_util.ash
 int stomach_left();											//Defined in autoscend/auto_util.ash
 boolean theSource_buySkills();								//Defined in autoscend/auto_theSource.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1201,6 +1201,14 @@ boolean zelda_canDealScalingDamage(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_skillValid(skill sk); // Defined in autoscend/auto_zelda.ash
 boolean zelda_equipTool(stat st); // Defined in autoscend/auto_zelda.ash
 
+boolean lowkey_initializeSettings(); // Defined in autoscend/paths/low_key_summer.ash
+int lowkey_keyDelayRemaining(location loc); // Defined in autoscend/paths/low_key_summer.ash
+int lowkey_keysRemaining(); // Defined in autoscend/paths/low_key_summer.ash
+int lowkey_keyLocationsAvailable(); // Defined in autoscend/paths/low_key_summer.ash
+location lowkey_nextKeyLocation(boolean checkAvailable); // Defined in autoscend/paths/low_key_summer.ash
+location lowkey_nextKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
+location lowkey_nextAvailableKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
+
 element currentFlavour(); // Defined in autoscend/auto_util.ash
 void resetFlavour(); // Defined in autoscend/auto_util.ash
 boolean setFlavour(element ele); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1208,6 +1208,7 @@ int lowkey_keyLocationsAvailable(); // Defined in autoscend/paths/low_key_summer
 location lowkey_nextKeyLocation(boolean checkAvailable); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextAvailableKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
+boolean L13_sorceressDoorLowKey(); // Defined in autoscend/paths/low_key_summer.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash
 void resetFlavour(); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1201,6 +1201,7 @@ boolean zelda_canDealScalingDamage(); // Defined in autoscend/auto_zelda.ash
 boolean zelda_skillValid(skill sk); // Defined in autoscend/auto_zelda.ash
 boolean zelda_equipTool(stat st); // Defined in autoscend/auto_zelda.ash
 
+boolean in_lowkeysummer(); // Defined in autoscend/paths/low_key_summer.ash
 boolean lowkey_initializeSettings(); // Defined in autoscend/paths/low_key_summer.ash
 int lowkey_keyDelayRemaining(location loc); // Defined in autoscend/paths/low_key_summer.ash
 int lowkey_keysRemaining(); // Defined in autoscend/paths/low_key_summer.ash
@@ -1208,6 +1209,7 @@ int lowkey_keyLocationsAvailable(); // Defined in autoscend/paths/low_key_summer
 location lowkey_nextKeyLocation(boolean checkAvailable); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextAvailableKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
+location lowkey_nextAvailableKeyDelayLocation(); // Defined in autoscend/paths/low_key_summer.ash
 boolean L13_sorceressDoorLowKey(); // Defined in autoscend/paths/low_key_summer.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1210,6 +1210,8 @@ location lowkey_nextKeyLocation(boolean checkAvailable); // Defined in autoscend
 location lowkey_nextKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextAvailableKeyLocation(); // Defined in autoscend/paths/low_key_summer.ash
 location lowkey_nextAvailableKeyDelayLocation(); // Defined in autoscend/paths/low_key_summer.ash
+boolean lowkey_keyAdv(item key); // Defined in autoscend/paths/low_key_summer.ash
+boolean LX_findHelpfulLowKey();  // Defined in autoscend/paths/low_key_summer.ash
 boolean L13_sorceressDoorLowKey(); // Defined in autoscend/paths/low_key_summer.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -190,7 +190,7 @@ boolean L13_sorceressDoorLowKey()
 			abort("Please unlock zones manually and try again.");
 		}
 		// TODO: Unlock doors
-		abort("All low keys found, please unlock door.")
+		abort("All low keys found, please unlock door.");
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -159,8 +159,32 @@ boolean lowkey_keyAdv(item key)
 	return autoAdv(1, loc);
 }
 
+boolean lowkey_zoneUnlocks()
+{
+	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted")
+	{
+		string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
+		temp = visit_url("choice.php?pwd=&whichchoice=798&option=1");
+		temp = visit_url("choice.php?pwd=&whichchoice=798&option=2");
+		temp = visit_url("woods.php");
+
+		if(get_property("questM19Hippy") == "unstarted")
+		{
+			abort("Failed to unlock The Old Landfill. Not sure what to do now...");
+		}
+		return true;
+	}
+
+	return false;
+}
+
 boolean LX_findHelpfulLowKey()
 {
+	if (lowkey_zoneUnlocks())
+	{
+		return true;
+	}
+
 	// mainstat
 	if (my_level() < 13)
 	{

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -25,8 +25,6 @@ lowKeys[$item[aqu&iacute;]] = $location[South of the Border];
 lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
 
-// TODO: Check available_amount + nsTowerDoorKeysUsed
-
 boolean in_lowkeysummer()
 {
 	return auto_my_path() == "Low Key Summer";
@@ -63,7 +61,7 @@ int lowkey_keysRemaining()
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (key.available_amount() > 0)
+		if (!lowkey_needKey(key))
 		{
 			found++;
 		}
@@ -72,24 +70,14 @@ int lowkey_keysRemaining()
 	return 23 - found;
 }
 
-int lowkey_keyLocationsAvailable()
+boolean lowkey_needKey(item key)
 {
-	if (!in_lowkeysummer())
+	if (internalQuestStatus("questL13Final") != 5)
 	{
-		return 0;
+		return false;
 	}
 
-	int available = 0;
-	foreach key in lowKeys
-	{
-		location loc = lowKeys[key];
-		if (key.available_amount() == 0 && zone_isAvailable(loc))
-		{
-			available++;
-		}
-	}
-
-	return available;
+	return key.available_amount() == 0 && !contains_text(get_property("nsTowerDoorKeysUsed"), key);
 }
 
 // TODO: Unaware if a key has been used and lost
@@ -104,7 +92,7 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (key.available_amount() == 0)
+		if (lowkey_needKey(key))
 		{
 			if (!checkAvailable || zone_isAvailable(loc))
 			{
@@ -136,7 +124,7 @@ location lowkey_nextAvailableKeyDelayLocation()
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (key.available_amount() == 0 && zone_isAvailable(loc) && lowkey_keyDelayRemaining(loc) > 0)
+		if (lowkey_needKey(key) && zone_isAvailable(loc) && lowkey_keyDelayRemaining(loc) > 0)
 		{
 			return lowKeys[key];
 		}
@@ -147,7 +135,7 @@ location lowkey_nextAvailableKeyDelayLocation()
 
 boolean lowkey_keyAdv(item key)
 {
-	if (key.available_amount() > 0)
+	if (!lowkey_needKey(key))
 	{
 		return false;
 	}
@@ -314,15 +302,14 @@ boolean L13_sorceressDoorLowKey()
 	if (loc == $location[none])
 	{
 		int remaining = lowkey_keysRemaining();
-		// TODO: Unlock required zones
 		if (remaining > 0)
 		{
 			auto_log_warning("Unable to adventure for remaining low keys");
 			foreach key in lowKeys
 			{
-				if (key.available_amount() == 0)
+				if (lowkey_needKey(key))
 				{
-					auto_log_warning(lowKeys[key] + " " + key);
+					auto_log_warning(lowKeys[key] + ": " + key);
 				}
 			}
 			abort("Please unlock zones manually and try again.");

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -175,6 +175,11 @@ boolean lowkey_zoneUnlocks()
 		return true;
 	}
 
+	if (startArmorySubQuest())
+	{
+		return true;
+	}
+
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -26,17 +26,17 @@ lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
 
 item[stat] lowKeyStats;
-lowKeyStats[$stat[muscle]] = $item[Knob labinet key];
-lowKeyStats[$stat[moxie]] = $item[scrap metal key];
-lowKeyStats[$stat[muscle]] = $item[Demonic key];
+lowKeyStats[$stat[Muscle]] = $item[Knob labinet key];
+lowKeyStats[$stat[Moxie]] = $item[scrap metal key];
+lowKeyStats[$stat[Mysticality]] = $item[Demonic key];
 
 // TODO Order
 // Treasure chest key,			// +30 item, +30 meat
 // F\'c\'le sh\'c\'le k\'y,	// +20 ml
 // knob shaft skate key,		// +adv
 boolean[item] lowKeyPriority = $items[
-	Knob treasury key,			// +50 meat, +20 pickpocket
 	Key sausage,				// -10 combat?
+	Knob treasury key,			// +50 meat, +20 pickpocket
 	Music Box Key,				// +10 combat?
 	Clown car key,				// +10 ml, +10 prismatic damage
 	Peg key,					// +5 stats
@@ -89,7 +89,7 @@ int lowkey_keyLocationsAvailable()
 // order is subjective
 location lowkey_nextKeyLocation(boolean checkAvailable)
 {
-	if (auto_my_path() == "Low Key Summer")
+	if (auto_my_path() != "Low Key Summer")
 	{
 		return $location[none];
 	}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -165,7 +165,7 @@ boolean LX_findHelpfulLowKey()
 	if (my_level() < 13)
 	{
 		// needs knob lab access
-		if (my_primestat() == $stat[Muscle]) && lowkey_keyAdv($item[Knob labinet key])) { return true; }
+		if (my_primestat() == $stat[Muscle] && lowkey_keyAdv($item[Knob labinet key])) { return true; }
 		// needs accept landfil quest
 		if (my_primestat() == $stat[Moxie] && lowkey_keyAdv($item[scrap metal key])) { return true; }
 		// Needs Pandamonium access

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -159,12 +159,12 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 
 location lowkey_nextKeyLocation()
 {
-	return lowkey_nextKeyLocation(false, false);
+	return lowkey_nextKeyLocation(false);
 }
 
 location lowkey_nextAvailableKeyLocation()
 {
-	return lowkey_nextKeyLocation(true, false);
+	return lowkey_nextKeyLocation(true);
 }
 
 location lowkey_nextAvailableKeyDelayLocation()

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -161,6 +161,7 @@ boolean lowkey_keyAdv(item key)
 
 boolean lowkey_zoneUnlocks()
 {
+	// TODO: Put this in a function, share with LX_desertAlternate()
 	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted")
 	{
 		string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
@@ -176,6 +177,11 @@ boolean lowkey_zoneUnlocks()
 	}
 
 	if (startArmorySubQuest())
+	{
+		return true;
+	}
+
+	if (startGalaktikSubQuest())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -4,7 +4,7 @@ location[item] lowKeys;
 lowKeys[$item[Clown car key]] = $location[The \"Fun\" House];
 lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
 lowKeys[$item[Ice Key]] = $location[The Icy Peak];
-lowKeys[$item[Demonic key]] = $location[Pandemonium Slums];
+lowKeys[$item[Demonic key]] = $location[Pandamonium Slums];
 lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
 lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
 lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -44,19 +44,31 @@ boolean[item] lowKeyPriority = $items[
 
 void lowkey_initializeSettings()
 {
-	if (auto_my_path() == "Low Key Summer")
+	if (auto_my_path() != "Low Key Summer")
 	{
-		// TODO?
+		return;
 	}
+
+	// TODO?
 }
 
 int lowkey_keyDelayRemaining(location loc)
 {
+	if (auto_my_path() != "Low Key Summer")
+	{
+		return 0;
+	}
+
 	return max(11 - loc.turns_spent, 0);
 }
 
 int lowkey_keysRemaining()
 {
+	if (auto_my_path() != "Low Key Summer")
+	{
+		return 0;
+	}
+
 	int found = 0;
 	foreach key in lowKeys
 	{
@@ -72,6 +84,11 @@ int lowkey_keysRemaining()
 
 int lowkey_keyLocationsAvailable()
 {
+	if (auto_my_path() != "Low Key Summer")
+	{
+		return 0;
+	}
+
 	int available = 0;
 	foreach key in lowKeys
 	{

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -156,23 +156,34 @@ boolean lowkey_keyAdv(item key)
 		return false;
 	}
 
+	// Pirate equipment
+	if ($locations[The F\'c\'le, Belowdecks] contains loc)
+	{
+		// Ca
+		if (possessEquipment($item[pirate fledges]) > 0)
+		{
+			autoEquip($item[pirate fledges]);
+		}
+		else if (have_outfit("swashbuckling getup"))
+		{
+			autoEquip($item[eyepatch]);
+			autoEquip($item[swashbuckling pants]);
+			autoEquip($item[stuffed shoulder parrot]);
+		}
+		else
+		{
+			// Shouldn't get here due to zone_isAvailable check
+			return false;
+		}
+	}
+
 	return autoAdv(1, loc);
 }
 
 boolean lowkey_zoneUnlocks()
 {
-	// TODO: Put this in a function, share with LX_desertAlternate()
-	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted")
+	if(startHippyBoatmanSubQuest())
 	{
-		string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
-		temp = visit_url("choice.php?pwd=&whichchoice=798&option=1");
-		temp = visit_url("choice.php?pwd=&whichchoice=798&option=2");
-		temp = visit_url("woods.php");
-
-		if(get_property("questM19Hippy") == "unstarted")
-		{
-			abort("Failed to unlock The Old Landfill. Not sure what to do now...");
-		}
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -3,25 +3,25 @@ script "low_key_summer.ash"
 location[item] lowKeys;
 lowKeys[$item[Clown car key]] = $location[The \"Fun\" House];
 lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
-lowKeys[$item[Ice Key]] = $location[The Icy Peak];
+//lowKeys[$item[Ice Key]] = $location[The Icy Peak];
 lowKeys[$item[Demonic key]] = $location[Pandamonium Slums];
 lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
 lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
 lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];
 //The Valley of Rof L'm Fao(?) OR The Enormous Greater-Than Sign(?);
-lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
+//lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
 lowKeys[$item[Music Box Key]] = $location[The Haunted Nursery];
 lowKeys[$item[Actual skeleton key]] = $location[The Skeleton Store];
 lowKeys[$item[Batting cage key]] = $location[The Bat Hole Entrance];
 lowKeys[$item[Anchovy can key]] = $location[The Haunted Pantry];
-lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
-lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
+//lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
+//lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
 lowKeys[$item[Key sausage]] = $location[Cobb\'s Knob Kitchens];
-lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
+//lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
 lowKeys[$item[Black rose key]] = $location[The Haunted Conservatory];
 lowKeys[$item[scrap metal key]] = $location[The Old Landfill];
 lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
-lowKeys[$item[Aquí]] = $location[South of the Border];
+lowKeys[$item[aqu&iacute;]] = $location[South of the Border];
 lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
 
@@ -31,14 +31,14 @@ lowKeyStats[$stat[moxie]] = $item[scrap metal key];
 lowKeyStats[$stat[muscle]] = $item[Demonic key];
 
 // TODO Order
+// Treasure chest key,			// +30 item, +30 meat
+// F\'c\'le sh\'c\'le k\'y,	// +20 ml
+// knob shaft skate key,		// +adv
 boolean[item] lowKeyPriority = $items[
-	Treasure chest key,			// +30 item, +30 meat
 	Knob treasury key,			// +50 meat, +20 pickpocket
 	Key sausage,				// -10 combat?
 	Music Box Key,				// +10 combat?
-	F\'c\'le sh\'c\'le k\'y,	// +20 ml
 	Clown car key,				// +10 ml, +10 prismatic damage
-	knob shaft skate key,		// +adv
 	Peg key,					// +5 stats
 ];
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -25,24 +25,6 @@ lowKeys[$item[aqu&iacute;]] = $location[South of the Border];
 lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
 
-item[stat] lowKeyStats;
-lowKeyStats[$stat[Muscle]] = $item[Knob labinet key];
-lowKeyStats[$stat[Moxie]] = $item[scrap metal key];
-lowKeyStats[$stat[Mysticality]] = $item[Demonic key];
-
-// TODO Order
-boolean[item] lowKeyPriority = $items[
-	Key sausage,				// -10 combat?
-	Treasure chest key,			// +30 item, +30 meat
-	Knob treasury key,			// +50 meat, +20 pickpocket
-	Kekekey,					// +50 meat,
-	knob shaft skate key,		// +adv
-	Music Box Key,				// +10 combat?
-	F\'c\'le sh\'c\'le k\'y,	// +20 ml
-	Clown car key,				// +10 ml, +10 prismatic damage
-	Peg key,					// +5 stats
-];
-
 boolean in_lowkeysummer()
 {
 	return auto_my_path() == "Low Key Summer";
@@ -117,31 +99,6 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 		return $location[none];
 	}
 
-	// Get primestat gains key first?
-	if (my_level() < 13)
-	{
-		item primestatKey = lowKeyStats[my_primestat()];
-		location primestatLocation = lowKeys[primestatKey];
-		if (primestatKey.available_amount() == 0 && zone_isAvailable(primestatLocation))
-		{
-			return primestatLocation;
-		}
-	}
-
-	// Get high priority keys
-	foreach key in lowKeyPriority
-	{
-		location loc = lowKeys[key];
-		if (key.available_amount() == 0)
-		{
-			if (!checkAvailable || zone_isAvailable(loc))
-			{
-				return lowKeys[key];
-			}
-		}
-	}
-
-	// The rest, I'm not ordering all the keys some are garbage
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
@@ -186,6 +143,96 @@ location lowkey_nextAvailableKeyDelayLocation()
 	return $location[none];
 }
 
+boolean lowkey_keyAdv(item key)
+{
+	if (key.available_amount() > 0)
+	{
+		return false;
+	}
+
+	location loc = lowKeys[key];
+	if (!zone_isAvailable(zone))
+	{
+		return false;
+	}
+
+	return autoAdv(1, loc);
+}
+
+boolean LX_findHelpfulLowKey()
+{
+	// mainstat
+	if (my_level() < 13)
+	{
+		// needs knob lab access
+		if (my_primestat() == $stat[Muscle]) && lowkey_keyAdv($item[Knob labinet key])) { return true };
+		// needs accept landfil quest
+		if (my_primestat() == $stat[Moxie] && lowkey_keyAdv($item[scrap metal key])) { return true };
+		// Needs Pandamonium access
+		if (my_primestat() == $stat[Mysticality] && lowkey_keyAdv($item[Demonic key])) { return true };
+	}
+
+	// -combat
+	if (lowkey_keyAdv($item[Key sausage])) { return true };
+
+	// +item
+	// needs pirate quest ugh
+	if (lowkey_keyAdv($item[Treasure chest key])) { return true };
+
+	// +meat
+	if (lowkey_keyAdv($item[Knob treasury key])) { return true };
+	if (lowkey_keyAdv($item[Kekekey])) { return true };
+
+	// Knob key to unlock shaft for +adv
+	if (lowkey_keyAdv($item[Knob labinet key])) { return true };
+
+	// +adv
+	if (lowkey_keyAdv($item[Knob shaft skate key])) { return true };
+
+	if (internalQuestStatus("questL09Topping") == 3)
+	{
+		// +ml (before oil peak)
+		// needs pirate quest ugh
+		if (lowkey_keyAdv($item[F\'c\'le sh\'c\'le k\'y])) { return true };
+		// needs accept nemesis quest
+		if (lowkey_keyAdv($item[Clown car key])) { return true };
+		// cold res before aboo
+		if (lowkey_keyAdv($item[Ice Key])) { return true };
+		// spooky res before aboo
+		if (lowkey_keyAdv($item[Weremoose key])) { return true };
+	}
+
+	// sleaze damage before red zeppelin
+	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
+	{
+		if (lowkey_keyAdv($item[Deep-fried key])) { return true };
+		if (lowkey_keyAdv($item[Clown car key])) { return true };
+	}
+
+	// cold spell damage before orcs
+	if (internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < 30)
+	{
+		if (lowkey_keyAdv($item[Ice Key])) { return true };
+	}
+
+	// +combat before sonofa
+	if (internalQuestStatus("questL12War") == 1 && get_property("sidequestLighthouseCompleted") == "none"))
+	{
+		if (lowkey_keyAdv($item[Music Box Key])) { return true };
+	}
+
+	// Attributes?
+	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true };
+
+	// familiar weight?
+	//if (lowkey_keyAdv($item[Black rose key])) { return true };
+
+	// food drops?
+	//if (lowkey_keyAdv($item[Anchovy can key])) { return true };
+
+	return false;
+}
+
 boolean L13_sorceressDoorLowKey()
 {
 	if (!in_lowkeysummer())
@@ -217,7 +264,7 @@ boolean L13_sorceressDoorLowKey()
 			abort("Please unlock zones manually and try again.");
 		}
 		// TODO: Unlock doors
-		abort("All low keys found, please unlock door.");
+		abort("All low keys found, please unlock door manually.");
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -25,6 +25,8 @@ lowKeys[$item[aqu&iacute;]] = $location[South of the Border];
 lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
 
+// TODO: Check available_amount + nsTowerDoorKeysUsed
+
 boolean in_lowkeysummer()
 {
 	return auto_my_path() == "Low Key Summer";
@@ -303,6 +305,7 @@ boolean L13_sorceressDoorLowKey()
 
 	// TODO: Check door for unlocked locks to prevent infinite loops
 	// https://kolmafia.us/showthread.php?25001-Low-Key-path&p=157469&viewfull=1#post157469
+	// nsTowerDoorKeysUsed currently isn't always updated
 
 	// TODO: Handle the standard keys
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -202,6 +202,16 @@ boolean lowkey_zoneUnlocks()
 
 boolean LX_findHelpfulLowKey()
 {
+	if (!in_lowkeysummer())
+	{
+		return false;
+	}
+
+	if (internalQuestStatus("questL13Final") != 5)
+	{
+		return false;
+	}
+
 	if (lowkey_zoneUnlocks())
 	{
 		return true;
@@ -282,6 +292,11 @@ boolean LX_findHelpfulLowKey()
 boolean L13_sorceressDoorLowKey()
 {
 	if (!in_lowkeysummer())
+	{
+		return false;
+	}
+
+	if (internalQuestStatus("questL13Final") != 5)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -151,7 +151,7 @@ boolean lowkey_keyAdv(item key)
 	}
 
 	location loc = lowKeys[key];
-	if (!zone_isAvailable(zone))
+	if (!zone_isAvailable(loc))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -1,0 +1,142 @@
+script "low_key_summer.ash"
+
+location[item] lowKeys;
+lowKeys[$item[Clown car key]] = $location[The \"Fun\" House];
+lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
+lowKeys[$item[Ice Key]] = $location[The Icy Peak];
+lowKeys[$item[Demonic key]] = $location[Pandemonium Slums];
+lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
+lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
+lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];
+//The Valley of Rof L'm Fao(?) OR The Enormous Greater-Than Sign(?);
+lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
+lowKeys[$item[Music Box Key]] = $location[The Haunted Nursery];
+lowKeys[$item[Actual skeleton key]] = $location[The Skeleton Store];
+lowKeys[$item[Batting cage key]] = $location[The Bat Hole Entrance];
+lowKeys[$item[Anchovy can key]] = $location[The Haunted Pantry];
+lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
+lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
+lowKeys[$item[Key sausage]] = $location[Cobb\'s Knob Kitchens];
+lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
+lowKeys[$item[Black rose key]] = $location[The Haunted Conservatory];
+lowKeys[$item[scrap metal key]] = $location[The Old Landfill];
+lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
+lowKeys[$item[Aquí]] = $location[South of the Border];
+lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
+lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
+
+item[stat] lowKeyStats;
+lowKeyStats[$stat[muscle]] = $item[Knob labinet key];
+lowKeyStats[$stat[moxie]] = $item[scrap metal key];
+lowKeyStats[$stat[muscle]] = $item[Demonic key];
+
+// TODO Order
+boolean[item] lowKeyPriority = $items[
+	Treasure chest key,			// +30 item, +30 meat
+	Knob treasury key,			// +50 meat, +20 pickpocket
+	Key sausage,				// -10 combat?
+	Music Box Key,				// +10 combat?
+	F\'c\'le sh\'c\'le k\'y,	// +20 ml
+	Clown car key,				// +10 ml, +10 prismatic damage
+	knob shaft skate key,		// +adv
+	Peg key,					// +5 stats
+];
+
+void lowkey_initializeSettings()
+{
+	if (auto_my_path() == "Low Key Summer")
+	{
+		// TODO?
+	}
+}
+
+int lowkey_keyDelayRemaining(location loc)
+{
+	return max(11 - loc.turns_spent, 0);
+}
+
+int lowkey_keysRemaining()
+{
+	int found = 0;
+	foreach key in lowKeys
+	{
+		location loc = lowKeys[key];
+		if (key.available_amount() > 0)
+		{
+			found++;
+		}
+	}
+
+	return 23 - found;
+}
+
+int lowkey_keyLocationsAvailable()
+{
+	int available = 0;
+	foreach key in lowKeys
+	{
+		location loc = lowKeys[key];
+		if (key.available_amount() == 0 && zone_isAvailable(primstatLocation))
+		{
+			available++;
+		}
+	}
+
+	return available;
+}
+
+// TODO: Unaware if a key has been used and lost
+// order is subjective
+location lowkey_nextKeyLocation(boolean checkAvailable)
+{
+	if (auto_my_path() == "Low Key Summer")
+	{
+		return $location[none];
+	}
+
+	// Get primestat gains key first?
+	if (my_level() < 13)
+	{
+		item primestatkey = lowKeyStats[my_primestat()];
+		location primstatLocation = lowKeys[primestatkey];
+		if (primestatkey.available_amount() == 0 && zone_isAvailable(primstatLocation))
+		{
+			return primstatLocation;
+		}
+	}
+
+	// Get high priority keys
+	foreach key in lowKeyPriority
+	{
+		location loc = lowKeys[key];
+		if (key.available_amount() == 0)
+		{
+			if (checkAvailable || zone_isAvailable(loc))
+			{
+				return lowKeys[key];
+			}
+		}
+	}
+
+	// The rest, I'm not ordering all the keys some are garbage
+	foreach key in lowKeys
+	{
+		location loc = lowKeys[key];
+		if (key.available_amount() == 0 && zone_isAvailable(loc))
+		{
+			return lowKeys[key];
+		}
+	}
+
+	return $location[none];
+}
+
+location lowkey_nextKeyLocation()
+{
+	return lowkey_nextKeyLocation(false);
+}
+
+location lowkey_nextAvailableKeyLocation()
+{
+	return lowkey_nextKeyLocation(true);
+}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -43,9 +43,14 @@ boolean[item] lowKeyPriority = $items[
 	Peg key,					// +5 stats
 ];
 
+boolean in_lowkeysummer()
+{
+	return auto_my_path() == "Low Key Summer";
+}
+
 void lowkey_initializeSettings()
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return;
 	}
@@ -55,7 +60,7 @@ void lowkey_initializeSettings()
 
 int lowkey_keyDelayRemaining(location loc)
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return 0;
 	}
@@ -65,7 +70,7 @@ int lowkey_keyDelayRemaining(location loc)
 
 int lowkey_keysRemaining()
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return 0;
 	}
@@ -85,7 +90,7 @@ int lowkey_keysRemaining()
 
 int lowkey_keyLocationsAvailable()
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return 0;
 	}
@@ -107,7 +112,7 @@ int lowkey_keyLocationsAvailable()
 // order is subjective
 location lowkey_nextKeyLocation(boolean checkAvailable)
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return $location[none];
 	}
@@ -129,7 +134,7 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 		location loc = lowKeys[key];
 		if (key.available_amount() == 0)
 		{
-			if (checkAvailable || zone_isAvailable(loc))
+			if (!checkAvailable || zone_isAvailable(loc))
 			{
 				return lowKeys[key];
 			}
@@ -140,9 +145,12 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (key.available_amount() == 0 && zone_isAvailable(loc))
+		if (key.available_amount() == 0)
 		{
-			return lowKeys[key];
+			if (!checkAvailable || zone_isAvailable(loc))
+			{
+				return lowKeys[key];
+			}
 		}
 	}
 
@@ -151,17 +159,36 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 
 location lowkey_nextKeyLocation()
 {
-	return lowkey_nextKeyLocation(false);
+	return lowkey_nextKeyLocation(false, false);
 }
 
 location lowkey_nextAvailableKeyLocation()
 {
-	return lowkey_nextKeyLocation(true);
+	return lowkey_nextKeyLocation(true, false);
+}
+
+location lowkey_nextAvailableKeyDelayLocation()
+{
+	if (!in_lowkeysummer())
+	{
+		return $location[none];
+	}
+
+	foreach key in lowKeys
+	{
+		location loc = lowKeys[key];
+		if (key.available_amount() == 0 && zone_isAvailable(loc) && lowkey_keyDelayRemaining(loc) > 0)
+		{
+			return lowKeys[key];
+		}
+	}
+
+	return $location[none];
 }
 
 boolean L13_sorceressDoorLowKey()
 {
-	if (auto_my_path() != "Low Key Summer")
+	if (!in_lowkeysummer())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -40,6 +40,16 @@ void lowkey_initializeSettings()
 	// TODO?
 }
 
+boolean lowkey_needKey(item key)
+{
+	if (internalQuestStatus("questL13Final") != 5)
+	{
+		return false;
+	}
+
+	return key.available_amount() == 0 && !contains_text(get_property("nsTowerDoorKeysUsed"), key);
+}
+
 int lowkey_keyDelayRemaining(location loc)
 {
 	if (!in_lowkeysummer())
@@ -68,16 +78,6 @@ int lowkey_keysRemaining()
 	}
 
 	return 23 - found;
-}
-
-boolean lowkey_needKey(item key)
-{
-	if (internalQuestStatus("questL13Final") != 5)
-	{
-		return false;
-	}
-
-	return key.available_amount() == 0 && !contains_text(get_property("nsTowerDoorKeysUsed"), key);
 }
 
 // TODO: Unaware if a key has been used and lost

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -3,21 +3,21 @@ script "low_key_summer.ash"
 location[item] lowKeys;
 lowKeys[$item[Clown car key]] = $location[The \"Fun\" House];
 lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
-//lowKeys[$item[Ice Key]] = $location[The Icy Peak];
+lowKeys[$item[Ice Key]] = $location[The Icy Peak];
 lowKeys[$item[Demonic key]] = $location[Pandamonium Slums];
 lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
 lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
 lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];
-//The Valley of Rof L'm Fao(?) OR The Enormous Greater-Than Sign(?);
-//lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
+lowkeys[$item[Kekekey]] = $location[The Valley of Rof L\'m Fao];
+lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
 lowKeys[$item[Music Box Key]] = $location[The Haunted Nursery];
 lowKeys[$item[Actual skeleton key]] = $location[The Skeleton Store];
 lowKeys[$item[Batting cage key]] = $location[The Bat Hole Entrance];
 lowKeys[$item[Anchovy can key]] = $location[The Haunted Pantry];
-//lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
-//lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
+lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
+lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
 lowKeys[$item[Key sausage]] = $location[Cobb\'s Knob Kitchens];
-//lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
+lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
 lowKeys[$item[Black rose key]] = $location[The Haunted Conservatory];
 lowKeys[$item[scrap metal key]] = $location[The Old Landfill];
 lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
@@ -31,13 +31,14 @@ lowKeyStats[$stat[Moxie]] = $item[scrap metal key];
 lowKeyStats[$stat[Mysticality]] = $item[Demonic key];
 
 // TODO Order
-// Treasure chest key,			// +30 item, +30 meat
-// F\'c\'le sh\'c\'le k\'y,	// +20 ml
-// knob shaft skate key,		// +adv
 boolean[item] lowKeyPriority = $items[
 	Key sausage,				// -10 combat?
+	Treasure chest key,			// +30 item, +30 meat
 	Knob treasury key,			// +50 meat, +20 pickpocket
+	Kekekey,					// +50 meat,
+	knob shaft skate key,		// +adv
 	Music Box Key,				// +10 combat?
+	F\'c\'le sh\'c\'le k\'y,	// +20 ml
 	Clown car key,				// +10 ml, +10 prismatic damage
 	Peg key,					// +5 stats
 ];

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -76,7 +76,7 @@ int lowkey_keyLocationsAvailable()
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (key.available_amount() == 0 && zone_isAvailable(primstatLocation))
+		if (key.available_amount() == 0 && zone_isAvailable(loc))
 		{
 			available++;
 		}
@@ -97,11 +97,11 @@ location lowkey_nextKeyLocation(boolean checkAvailable)
 	// Get primestat gains key first?
 	if (my_level() < 13)
 	{
-		item primestatkey = lowKeyStats[my_primestat()];
-		location primstatLocation = lowKeys[primestatkey];
-		if (primestatkey.available_amount() == 0 && zone_isAvailable(primstatLocation))
+		item primestatKey = lowKeyStats[my_primestat()];
+		location primestatLocation = lowKeys[primestatKey];
+		if (primestatKey.available_amount() == 0 && zone_isAvailable(primestatLocation))
 		{
-			return primstatLocation;
+			return primestatLocation;
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -158,3 +158,41 @@ location lowkey_nextAvailableKeyLocation()
 {
 	return lowkey_nextKeyLocation(true);
 }
+
+boolean L13_sorceressDoorLowKey()
+{
+	if (auto_my_path() != "Low Key Summer")
+	{
+		return false;
+	}
+
+	// TODO: Check door for unlocked locks to prevent infinite loops
+	// https://kolmafia.us/showthread.php?25001-Low-Key-path&p=157469&viewfull=1#post157469
+
+	// TODO: Handle the standard keys
+
+	location loc = lowkey_nextAvailableKeyLocation();
+
+	if (loc == $location[none])
+	{
+		int remaining = lowkey_keysRemaining();
+		// TODO: Unlock required zones
+		if (remaining > 0)
+		{
+			auto_log_warning("Unable to adventure for remaining low keys");
+			foreach key in lowKeys
+			{
+				if (key.available_amount() == 0)
+				{
+					auto_log_warning(lowKeys[key] + " " + key);
+				}
+			}
+			abort("Please unlock zones manually and try again.");
+		}
+		// TODO: Unlock doors
+		abort("All low keys found, please unlock door.")
+		return false;
+	}
+
+	return autoAdv(1, loc);
+}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -80,7 +80,6 @@ int lowkey_keysRemaining()
 	return 23 - found;
 }
 
-// TODO: Unaware if a key has been used and lost
 // order is subjective
 location lowkey_nextKeyLocation(boolean checkAvailable)
 {
@@ -149,7 +148,6 @@ boolean lowkey_keyAdv(item key)
 	// Pirate equipment
 	if ($locations[The F\'c\'le, Belowdecks] contains loc)
 	{
-		// Ca
 		if (possessEquipment($item[pirate fledges]))
 		{
 			autoEquip($item[pirate fledges]);
@@ -290,10 +288,6 @@ boolean L13_sorceressDoorLowKey()
 	{
 		return false;
 	}
-
-	// TODO: Check door for unlocked locks to prevent infinite loops
-	// https://kolmafia.us/showthread.php?25001-Low-Key-path&p=157469&viewfull=1#post157469
-	// nsTowerDoorKeysUsed currently isn't always updated
 
 	// TODO: Handle the standard keys
 

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -165,70 +165,70 @@ boolean LX_findHelpfulLowKey()
 	if (my_level() < 13)
 	{
 		// needs knob lab access
-		if (my_primestat() == $stat[Muscle]) && lowkey_keyAdv($item[Knob labinet key])) { return true };
+		if (my_primestat() == $stat[Muscle]) && lowkey_keyAdv($item[Knob labinet key])) { return true; }
 		// needs accept landfil quest
-		if (my_primestat() == $stat[Moxie] && lowkey_keyAdv($item[scrap metal key])) { return true };
+		if (my_primestat() == $stat[Moxie] && lowkey_keyAdv($item[scrap metal key])) { return true; }
 		// Needs Pandamonium access
-		if (my_primestat() == $stat[Mysticality] && lowkey_keyAdv($item[Demonic key])) { return true };
+		if (my_primestat() == $stat[Mysticality] && lowkey_keyAdv($item[Demonic key])) { return true; }
 	}
 
 	// -combat
-	if (lowkey_keyAdv($item[Key sausage])) { return true };
+	if (lowkey_keyAdv($item[Key sausage])) { return true; }
 
 	// +item
 	// needs pirate quest ugh
-	if (lowkey_keyAdv($item[Treasure chest key])) { return true };
+	if (lowkey_keyAdv($item[Treasure chest key])) { return true; }
 
 	// +meat
-	if (lowkey_keyAdv($item[Knob treasury key])) { return true };
-	if (lowkey_keyAdv($item[Kekekey])) { return true };
+	if (lowkey_keyAdv($item[Knob treasury key])) { return true; }
+	if (lowkey_keyAdv($item[Kekekey])) { return true; }
 
 	// Knob key to unlock shaft for +adv
-	if (lowkey_keyAdv($item[Knob labinet key])) { return true };
+	if (lowkey_keyAdv($item[Knob labinet key])) { return true; }
 
 	// +adv
-	if (lowkey_keyAdv($item[Knob shaft skate key])) { return true };
+	if (lowkey_keyAdv($item[Knob shaft skate key])) { return true; }
 
 	if (internalQuestStatus("questL09Topping") == 3)
 	{
 		// +ml (before oil peak)
 		// needs pirate quest ugh
-		if (lowkey_keyAdv($item[F\'c\'le sh\'c\'le k\'y])) { return true };
+		if (lowkey_keyAdv($item[F\'c\'le sh\'c\'le k\'y])) { return true; }
 		// needs accept nemesis quest
-		if (lowkey_keyAdv($item[Clown car key])) { return true };
+		if (lowkey_keyAdv($item[Clown car key])) { return true; }
 		// cold res before aboo
-		if (lowkey_keyAdv($item[Ice Key])) { return true };
+		if (lowkey_keyAdv($item[Ice Key])) { return true; }
 		// spooky res before aboo
-		if (lowkey_keyAdv($item[Weremoose key])) { return true };
+		if (lowkey_keyAdv($item[Weremoose key])) { return true; }
 	}
 
 	// sleaze damage before red zeppelin
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
 	{
-		if (lowkey_keyAdv($item[Deep-fried key])) { return true };
-		if (lowkey_keyAdv($item[Clown car key])) { return true };
+		if (lowkey_keyAdv($item[Deep-fried key])) { return true; }
+		if (lowkey_keyAdv($item[Clown car key])) { return true; }
 	}
 
 	// cold spell damage before orcs
 	if (internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < 30)
 	{
-		if (lowkey_keyAdv($item[Ice Key])) { return true };
+		if (lowkey_keyAdv($item[Ice Key])) { return true; }
 	}
 
 	// +combat before sonofa
 	if (internalQuestStatus("questL12War") == 1 && get_property("sidequestLighthouseCompleted") == "none"))
 	{
-		if (lowkey_keyAdv($item[Music Box Key])) { return true };
+		if (lowkey_keyAdv($item[Music Box Key])) { return true; }
 	}
 
 	// Attributes?
-	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true };
+	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
 
 	// familiar weight?
-	//if (lowkey_keyAdv($item[Black rose key])) { return true };
+	//if (lowkey_keyAdv($item[Black rose key])) { return true; }
 
 	// food drops?
-	//if (lowkey_keyAdv($item[Anchovy can key])) { return true };
+	//if (lowkey_keyAdv($item[Anchovy can key])) { return true; }
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -160,7 +160,7 @@ boolean lowkey_keyAdv(item key)
 	if ($locations[The F\'c\'le, Belowdecks] contains loc)
 	{
 		// Ca
-		if (possessEquipment($item[pirate fledges]) > 0)
+		if (possessEquipment($item[pirate fledges]))
 		{
 			autoEquip($item[pirate fledges]);
 		}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -216,7 +216,7 @@ boolean LX_findHelpfulLowKey()
 	}
 
 	// +combat before sonofa
-	if (internalQuestStatus("questL12War") == 1 && get_property("sidequestLighthouseCompleted") == "none"))
+	if (internalQuestStatus("questL12War") == 1 && get_property("sidequestLighthouseCompleted") == "none")
 	{
 		if (lowkey_keyAdv($item[Music Box Key])) { return true; }
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -647,6 +647,13 @@ boolean L13_sorceressDoor()
 		return false;
 	}
 
+	// Low Key Summer has an entirely different door.
+	if (auto_my_path() == "Low Key Summer")
+	{
+		// TODO: call this function earlier?
+		return L13_sorceressDoorLowKey();
+	}
+
 	if(LX_getDigitalKey()) return true;
 
 	string page = visit_url("place.php?whichplace=nstower_door");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -648,7 +648,7 @@ boolean L13_sorceressDoor()
 	}
 
 	// Low Key Summer has an entirely different door.
-	if (auto_my_path() == "Low Key Summer")
+	if (in_lowkeysummer())
 	{
 		// TODO: call this function earlier?
 		return L13_sorceressDoorLowKey();

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -650,7 +650,6 @@ boolean L13_sorceressDoor()
 	// Low Key Summer has an entirely different door.
 	if (in_lowkeysummer())
 	{
-		// TODO: call this function earlier?
 		return L13_sorceressDoorLowKey();
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -107,10 +107,7 @@ boolean LX_desertAlternate()
 		}
 		if(get_property("questM19Hippy") == "unstarted")
 		{
-			string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
-			temp = visit_url("choice.php?pwd=&whichchoice=798&option=1");
-			temp = visit_url("choice.php?pwd=&whichchoice=798&option=2");
-			temp = visit_url("woods.php");
+			startHippyBoatmanSubQuest();
 
 			if(get_property("questM19Hippy") == "unstarted")
 			{
@@ -213,7 +210,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if(!canDesert || !isGeneralStoreAvailable())
+	if(!canDesert || !isGeneralStoreAvailable() || in_lowkeysummer())
 	{
 		return LX_desertAlternate();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -210,7 +210,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if(!canDesert || !isGeneralStoreAvailable() || in_lowkeysummer())
+	if(!canDesert || !isGeneralStoreAvailable())
 	{
 		return LX_desertAlternate();
 	}


### PR DESCRIPTION
# Description

Supports adventuring for low key summer keys. Some keys are acquired early if they would help with quests, otherwise they are all acquired at the end of the run when all other quests are completed.

Currently does not support the following
* Epic weapon quest to unlock fun house
* Pirate quest to unlock F'cl'e or Belowdecks
* Unlock door
* Lock Picking skill

If the script has nothing left to do it will abort and tell you the remaining zones you need to do manually (for now).

## How Has This Been Tested?

Two low key summer runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
