### PR TITLE
Support Lock Picking

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3544,6 +3544,7 @@ boolean doTasks()
 	if(LX_unlockHiddenTemple())	return true;
 	if(L6_dakotaFanning())				return true;
 	if(L5_haremOutfit())				return true;
+	if(LX_lockPicking())					return true;
 	if(LX_phatLootToken())				return true;
 	if(L5_goblinKing())					return true;
 	if(LX_islandAccess())				return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20111; // nsTowerDoorKeysUsed should be correct now
+since r20114; // Lock Picking can be cast once per ascension. track in "lockPicked" property
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -402,6 +402,19 @@ void main(int choice, string page)
 		case 1387: // Using the Force (Fourth of May Cosplay Saber)
 			run_choice(get_property("_auto_saberChoice").to_int());
 			break;
+		case 1414: // Lock Picking
+			if(item_amount($item[Boris\'s Key]) == 0)
+			{
+				run_choice(1);
+			}
+			else if(item_amount($item[Jarlsberg\'s Key]) == 0)
+			{
+				run_choice(2);
+			}
+			else if(item_amount($item[Sneaky Pete\'s Key]) == 0)
+			{
+				run_choice(3);
+			}
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -402,19 +402,6 @@ void main(int choice, string page)
 		case 1387: // Using the Force (Fourth of May Cosplay Saber)
 			run_choice(get_property("_auto_saberChoice").to_int());
 			break;
-		case 1414: // Lock Picking
-			if(item_amount($item[Boris\'s Key]) == 0)
-			{
-				run_choice(1);
-			}
-			else if(item_amount($item[Jarlsberg\'s Key]) == 0)
-			{
-				run_choice(2);
-			}
-			else if(item_amount($item[Sneaky Pete\'s Key]) == 0)
-			{
-				run_choice(3);
-			}
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -21,6 +21,7 @@ boolean LA_cs_communityService();				//Defined in autoscend/auto_community_servi
 boolean LM_edTheUndying();						//Defined in autoscend/auto_edTheUndying.ash
 
 boolean LX_desertAlternate();
+boolean LX_lockPicking();
 boolean LX_phatLootToken();
 boolean LX_islandAccess();
 boolean fancyOilPainting();

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -252,12 +252,12 @@ boolean LX_islandAccess()
 
 boolean LX_lockPicking()
 {
-	if (!auto_have_skill($skill[Lock Picking]))
+	if(!auto_have_skill($skill[Lock Picking]))
 	{
 		return false;
 	}
 
-	if (get_property("lockPicked").to_boolean() == true)
+	if(get_property("lockPicked").to_boolean() == true)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -286,6 +286,7 @@ boolean LX_lockPicking()
 	}
 
 	use_skill(1, $skill[Lock Picking]);
+	run_turn();
 	return get_property("lockPicked").to_boolean();
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -250,6 +250,33 @@ boolean LX_islandAccess()
 	return false;
 }
 
+boolean LX_lockPicking()
+{
+	if (!auto_have_skill($skill[Lock Picking]))
+	{
+		return false;
+	}
+
+	if (get_property("lockPicked").to_boolean() == true)
+	{
+		return false;
+	}
+
+	if(towerKeyCount(false) >= 3)
+	{
+		return false;
+	}
+
+	if(my_mp() < mp_cost($skill[Lock Picking]))
+	{
+		return false;
+	}
+
+	use_skill(1, $skill[Lock Picking]);
+	run_turn();
+	return get_property("lockPicked").to_boolean();
+}
+
 boolean LX_phatLootToken()
 {
 	if(towerKeyCount(false) >= 3)

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -272,8 +272,20 @@ boolean LX_lockPicking()
 		return false;
 	}
 
+	if(item_amount($item[Boris\'s Key]) == 0)
+	{
+		set_property("choiceAdventure1414", 1);
+	}
+	else if(item_amount($item[Jarlsberg\'s Key]) == 0)
+	{
+		set_property("choiceAdventure1414", 2);
+	}
+	else if(item_amount($item[Sneaky Pete\'s Key]) == 0)
+	{
+		set_property("choiceAdventure1414", 3);
+	}
+
 	use_skill(1, $skill[Lock Picking]);
-	run_turn();
 	return get_property("lockPicked").to_boolean();
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -257,7 +257,7 @@ boolean LX_lockPicking()
 		return false;
 	}
 
-	if(get_property("lockPicked").to_boolean() == true)
+	if(get_property("lockPicked").to_boolean())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -272,7 +272,9 @@ boolean LX_lockPicking()
 		return false;
 	}
 
+	// As of r20114, this choice does not work in choice adventure script
 	if(item_amount($item[Boris\'s Key]) == 0)
+
 	{
 		set_property("choiceAdventure1414", 1);
 	}


### PR DESCRIPTION
# Description

Support casting Lock Picking before acquiring any loot tokens.

## How Has This Been Tested?

Ran LX_lockPicking() to test, seemed to work.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
