### PR TITLE
fix broken adventuring

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3776,7 +3776,8 @@ void auto_begin()
 	backupSetting("autoAbortThreshold", -0.05);
 
 	backupSetting("currentMood", "apathetic");
-
+	backupSetting("battleAction", "custom combat script");
+	
 	backupSetting("choiceAdventure1107", 1);
 	backupSetting("choiceAdventure330", 1);		//haunted billiards room NC shark chum
 


### PR DESCRIPTION
reinstate ccs setting to fix broken adventuring. mafia is dumb.