### PR TITLE
have plumber in default string in plumber

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -192,7 +192,7 @@ string defaultMaximizeStatement()
 		}
 		if (in_zelda())
 		{
-			res += ",-ml";
+			res += ",plumber,-ml";
 		}
 	}
 


### PR DESCRIPTION
# Description

in default maximizer string include `plumber` when in_zelda()

Fixes #325 subissue 1

## How Has This Been Tested?

part of a softcore plumber run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.