### PR TITLE
Auto consume improvements

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -21,6 +21,7 @@ auto_blacklistFamiliar	string	A semi-colon separated string of familiar names th
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+auto_consumeMinAdvPerFull	float	The minimum adventures per full to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
 auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -21,7 +21,7 @@ auto_blacklistFamiliar	string	A semi-colon separated string of familiar names th
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-auto_consumeMinAdvPerFull	float	The minimum adventures per full to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
 auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -29,32 +29,34 @@ any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar n
 any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	46	auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
-any	47	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	48	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	23	auto_consumeMinAdvPerFull	float	The minimum adventures per full to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	24	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	25	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	26	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	27	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	28	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	29	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	30	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	31	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	32	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	33	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	34	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	35	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	36	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	37	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	38	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	39	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	40	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	41	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	42	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	43	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	44	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	45	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	46	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	47	auto_mineForOres	boolean	BETA: If true, will attempt to acquire the Mining Gear and then mine in Itznotyerzitzmine for Ore during level 8 quest
+any	48	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	49	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	50	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -29,7 +29,7 @@ any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar n
 any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	23	auto_consumeMinAdvPerFull	float	The minimum adventures per full to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	23	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 any	24	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
 any	25	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 any	26	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -592,7 +592,7 @@ void consumeStuff()
 				shouldDrink = false;
 				if (fullness_left() == 0)
 				{
-					auto_log_warning("Nede to drink as no fullness is available, pool skill will suffer.");
+					auto_log_warning("Need to drink as no fullness is available, pool skill will suffer.");
 					shouldDrink = true;
 				}
 			}

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -883,7 +883,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			}
 			if (is_tradeable(it))
 			{
-				pullables[it] = min(howmany, pulls_remaining()));
+				pullables[it] = min(howmany, pulls_remaining());
 			}
 			if ((KEY_LIME_PIES contains it) && !(pullables contains it) && !in_hardcore())
 			{

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -44,17 +44,6 @@ boolean saucemavenApplies(item it)
 
 float expectedAdventuresFrom(item it)
 {
-	if(it == $item[magical sausage]) return 1;
-
-	if ($items[campfire baked potato, campfire beans, campfire coffee] contains it)
-	{
-		return 4.5; // I guess?
-	}
-	if ($items[campfire hot dog, campfire s\'more, campfire stew] contains it)
-	{
-		return 3.5; // I guess?
-	}
-
 	float parse()
 	{
 		if (!it.adventures.contains_text("-")) return it.adventures.to_int();

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -674,10 +674,6 @@ boolean autoPrepConsume(ConsumeAction action)
 	{
 		auto_log_info("autoPrepConsume: Pulling a " + action.it, "blue");
 		action.howToGet = SL_OBTAIN_NULL;
-		if (storage_amount(action.it) == 0)
-		{
-			buy_using_storage(1, action.it);
-		}
 		return pullXWhenHaveY(action.it, 1, item_amount(action.it));
 	}
 	else if(action.howToGet == SL_OBTAIN_CRAFT)

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -1099,14 +1099,16 @@ boolean auto_autoConsumeOne(string type, boolean simulate)
 	ConsumeAction[int] actions;
 	loadConsumables(type, actions);
 
+	float best_desirability_per_fill = 0.0;
 	float best_adv_per_fill = 0.0;
 	int best = -1;
 	for (int i=0; i < count(actions); i++)
 	{
-		float tentative_adv_per_fill = actions[i].desirability/actions[i].size;
-		if (tentative_adv_per_fill > best_adv_per_fill)
+		float tentative_desirability_per_fill = actions[i].desirability/actions[i].size;
+		if (tentative_desirability_per_fill > best_desirability_per_fill)
 		{
-			best_adv_per_fill = tentative_adv_per_fill;
+			best_desirability_per_fill = tentative_desirability_per_fill;
+			best_adv_per_fill = actions[i].adventures/actions[i].size;
 			best = i;
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -685,6 +685,10 @@ boolean autoPrepConsume(ConsumeAction action)
 	{
 		auto_log_info("autoPrepConsume: Pulling a " + action.it, "blue");
 		action.howToGet = SL_OBTAIN_NULL;
+		if (storage_amount(action.it) == 0)
+		{
+			buy_using_storage(1, action.it);
+		}
 		return pullXWhenHaveY(action.it, 1, item_amount(action.it));
 	}
 	else if(action.howToGet == SL_OBTAIN_CRAFT)
@@ -877,9 +881,9 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				craftables[it] = min(howmany, max(0, creatable_amount(it) - auto_reserveCraftAmount(it)));
 			}
-			if (storage_amount(it) > 0 && is_tradeable(it))
+			if (is_tradeable(it))
 			{
-				pullables[it] = min(howmany, min(pulls_remaining(), storage_amount(it)));
+				pullables[it] = min(howmany, pulls_remaining()));
 			}
 			if ((KEY_LIME_PIES contains it) && !(pullables contains it) && !in_hardcore())
 			{

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -585,7 +585,7 @@ void consumeStuff()
 			{
 				use_familiar($familiar[none]);
 			}
-			boolean shouldDrink = false;
+			boolean shouldDrink = true;
 			if (!hasSpookyravenLibraryKey() && my_inebriety() >= 10)
 			{
 				auto_log_info("Will not drink to maintain pool skill for Haunted Billiards room.");

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -565,6 +565,7 @@ void consumeStuff()
 		{
 			buyUpTo(1, $item[Fortune Cookie], npc_price($item[Fortune Cookie]));
 			autoEat(1, $item[Fortune Cookie]);
+			return;
 		}
 	}
 
@@ -583,11 +584,11 @@ void consumeStuff()
 			{
 				use_familiar($familiar[none]);
 			}
-			auto_knapsackAutoConsume("drink", false);
+			auto_autoConsumeOne("drink", false);
 		}
 		if (fullness_left() > 0)
 		{
-			auto_knapsackAutoConsume("eat", false);
+			auto_autoConsumeOne("eat", false);
 		}
 	}
 }
@@ -1073,26 +1074,31 @@ void auto_autoDrinkNightcap(boolean simulate)
 	autoConsume(actions[best]);
 }
 
-boolean auto_autoDrinkOne(boolean simulate)
+boolean auto_autoConsumeOne(string type, boolean simulate)
 {
 	if (inebriety_left() == 0) return false;
 
 	ConsumeAction[int] actions;
-	loadConsumables("drink", actions);
+	loadConsumables(type, actions);
 
-	float best_adv_per_drunk = 0.0;
+	float best_adv_per_fill = 0.0;
 	int best = -1;
 	for (int i=0; i < count(actions); i++)
 	{
-		float tentative_adv_per_drunk = actions[i].desirability/actions[i].size;
-		if (tentative_adv_per_drunk > best_adv_per_drunk)
+		float tentative_adv_per_fill = actions[i].desirability/actions[i].size;
+		if (tentative_adv_per_fill > best_adv_per_fill)
 		{
-			best_adv_per_drunk = tentative_adv_per_drunk;
+			best_adv_per_fill = tentative_adv_per_fill;
 			best = i;
 		}
 	}
 
-	auto_log_info("auto_autoDrinkOne: Planning to execute " + to_pretty_string(actions[best]), "blue");
+	auto_log_info("auto_autoConsumeOne: Planning to execute " + type + " " + to_pretty_string(actions[best]), "blue");
+	if (best_adv_per_fill < get_property("auto_consumeMinAdvPerFull").to_float())
+	{
+		auto_log_warning("auto_autoConsumeOne: Will not consume, min adventures per full " + best_adv_per_fill + " is less than auto_consumeMinAdvPerFull " + get_property("auto_consumeMinAdvPerFull"));
+		return false;
+	}
 
 	if(!simulate)
 	{

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -1114,9 +1114,9 @@ boolean auto_autoConsumeOne(string type, boolean simulate)
 	}
 
 	auto_log_info("auto_autoConsumeOne: Planning to execute " + type + " " + to_pretty_string(actions[best]), "blue");
-	if (best_adv_per_fill < get_property("auto_consumeMinAdvPerFull").to_float())
+	if (best_adv_per_fill < get_property("auto_consumeMinAdvPerFill").to_float())
 	{
-		auto_log_warning("auto_autoConsumeOne: Will not consume, min adventures per full " + best_adv_per_fill + " is less than auto_consumeMinAdvPerFull " + get_property("auto_consumeMinAdvPerFull"));
+		auto_log_warning("auto_autoConsumeOne: Will not consume, min adventures per full " + best_adv_per_fill + " is less than auto_consumeMinAdvPerFill " + get_property("auto_consumeMinAdvPerFill"));
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -578,17 +578,35 @@ void consumeStuff()
 
 	if (my_adventures() < 10 && !edSpleenCheck)
 	{
+		// Stop drinking at 10 drunk if spookyraven billiards room isn't completed, unless no fullness is available
 		if (inebriety_left() > 0)
 		{
 			if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper])
 			{
 				use_familiar($familiar[none]);
 			}
-			auto_autoConsumeOne("drink", false);
+			boolean shouldDrink = false;
+			if (!hasSpookyravenLibraryKey() && my_inebriety() >= 10)
+			{
+				auto_log_info("Will not drink to maintain pool skill for Haunted Billiards room.");
+				shouldDrink = false;
+				if (fullness_left() == 0)
+				{
+					auto_log_warning("Nede to drink as no fullness is available, pool skill will suffer.");
+					shouldDrink = true;
+				}
+			}
+			if (shouldDrink && auto_autoConsumeOne("drink", false))
+			{
+				return;
+			}
 		}
 		if (fullness_left() > 0)
 		{
-			auto_autoConsumeOne("eat", false);
+			if (auto_autoConsumeOne("eat", false))
+			{
+				return;
+			}
 		}
 	}
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -455,7 +455,7 @@ boolean autoEat(int howMany, item toEat, boolean silent);		//Defined in autoscen
 boolean auto_knapsackAutoConsume(string type, boolean simulate);	//Defined in autoscend/auto_cooking.ash
 boolean loadConsumables(item[int] item_backmap, int[int] cafe_backmap, float[int] adv, int[int] inebriety);	 //Defined in autoscend/auto_cooking.ash
 void auto_autoDrinkNightcap(boolean simulate);				//Defined in autoscend/auto_cooking.ash
-boolean auto_autoDrinkOne(boolean simulate);					//Defined in autoscend/auto_cooking.ash
+boolean auto_autoConsumeOne(string type, boolean simulate);					//Defined in autoscend/auto_cooking.ash
 boolean saucemavenApplies(item it);							//Defined in autoscend/auto_cooking.ash
 boolean autoMaximize(string req, boolean simulate);			//Defined in autoscend/auto_util.ash
 boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate);//Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -274,7 +274,6 @@ boolean LX_lockPicking()
 
 	// As of r20114, this choice does not work in choice adventure script
 	if(item_amount($item[Boris\'s Key]) == 0)
-
 	{
 		set_property("choiceAdventure1414", 1);
 	}


### PR DESCRIPTION
# Description

Improve consumption code:
* Only consume a single item at once
* Don't prevent pulled consumables on if they are in storage already
* Stop drinking at 10 inebriety if billiards room isn't completed, unless there is no fullness remaining
* Add auto_consumeMinAdvPerFill to prevent eating garbage
* fill isn't checked in auto_knapsackAutoConsume, this function is now not called.

Fixes # (issue)

## How Has This Been Tested?

Ran auto_autoConsumeOne with simulate, ran manually to test consumption

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
