### PR TITLE
fix faulty while loop in L11_hiddenCity()

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1296,17 +1296,14 @@ boolean L11_hiddenCity()
 			if(have_effect($effect[Thrice-Cursed]) == 0)
 			{
 				L11_hiddenTavernUnlock(true);
-				while(have_effect($effect[Thrice-Cursed]) == 0)
+				while(have_effect($effect[Thrice-Cursed]) == 0 && inebriety_left() >= $item[Cursed Punch].inebriety && canDrink($item[Cursed Punch]) && my_ascensions() == get_property("hiddenTavernUnlock").to_int() && !in_tcrs())
 				{
-					if((inebriety_left() >= $item[Cursed Punch].inebriety) && canDrink($item[Cursed Punch]) && (my_ascensions() == get_property("hiddenTavernUnlock").to_int()) && !in_tcrs())
+					buyUpTo(1, $item[Cursed Punch]);
+					if(item_amount($item[Cursed Punch]) == 0)
 					{
-						buyUpTo(1, $item[Cursed Punch]);
-						if(item_amount($item[Cursed Punch]) == 0)
-						{
-							abort("Could not acquire Cursed Punch, unable to deal with Hidden Apartment Properly");
-						}
-						autoDrink(1, $item[Cursed Punch]);
+						abort("Could not acquire Cursed Punch, unable to deal with Hidden Apartment Properly");
 					}
+					autoDrink(1, $item[Cursed Punch]);
 				}
 			}
 			auto_log_info("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");


### PR DESCRIPTION
fix faulty while loop in L11_hiddenCity()
It was doing
```
while (not thrice cursed)
 if (various checks for if you can drink cursed punch)
  drink cursed punch
```
which should have been
```
while (not thrice cursed && various checks for if you can drink cursed punch)
 drink cursed punch
```
If you couldn't drink cursed punch it meant you get stuck in this infinite loop

## How Has This Been Tested?

I was getting stuck in an infinite loop every time i ran autoscend on one of my accounts. until i tracked it down to this and once I applied the code it stopped getting stuck in said loop and continued to adventure

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
