### PR TITLE
Various fixes

### DIFF
--- a/BUILD/monsters/replace.dat
+++ b/BUILD/monsters/replace.dat
@@ -1,5 +1,5 @@
 Banshee Librarian	item:Killing Jar>0
-Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4
+Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber
 Knob Goblin Madam	item:Knob Goblin Perfume>0
 Bookbat
 Craven Carven Raven

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -53,7 +53,7 @@ banish	47	Warehouse Janitor
 banish	48	Upgraded Ram
 
 replace	0	Banshee Librarian	item:Killing Jar>0
-replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4
+replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber
 replace	2	Knob Goblin Madam	item:Knob Goblin Perfume>0
 replace	3	Bookbat
 replace	4	Craven Carven Raven

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -456,7 +456,10 @@ boolean basicFamiliarOverrides()
 	int spleen_hold = 8 * item_amount($item[Astral Energy Drink]);
 	foreach it in $items[Agua De Vida, Grim Fairy Tale, Groose Grease, Powdered Gold, Unconscious Collective Dream Jar]
 	{
-		spleen_hold += 4 * item_amount(it);
+		if (auto_is_valid(it))
+		{
+			spleen_hold += 4 * item_amount(it);
+		}
 	}
 	if((spleen_left() >= (4 + spleen_hold)) && haveSpleenFamiliar())
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -436,7 +436,7 @@ boolean handleFamiliar(familiar fam)
 	}
 #	set_property("auto_familiarChoice", my_familiar());
 
-	if(hr_handleFamiliar(fam))
+	if(hr_handleFamiliar(toEquip))
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3812,6 +3812,12 @@ void auto_begin()
 		use_familiar($familiar[none]);
 	}
 	dailyEvents();
+
+	// Try to consume something if not enough adventures to get going
+	if (!auto_unreservedAdvRemaining())
+	{
+		consumeStuff();
+	}
 	
 	// the main loop of autoscend is doTasks() which is actually called as part of the while.
 	while(auto_unreservedAdvRemaining() && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !get_property("kingLiberated").to_boolean() && doTasks())

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -858,7 +858,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
-			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean() || get_property("_distentionPillUsed").to_boolean())) continue;
+			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);
 			// Only one Spaghetti Breakfast can be eaten

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -858,7 +858,6 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
-			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
 			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -866,7 +866,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
 			}
 			// Only one Spaghetti Breakfast can be eaten, and it must be first
-			if(t == $item[Spaghetti Breakfast])
+			if(it == $item[Spaghetti Breakfast])
 			{
 				if (my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean()) continue;
 				howmany = 1;

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -858,7 +858,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
-			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
+			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean() || get_property("_distentionPillUsed").to_boolean())) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);
 			// Only one Spaghetti Breakfast can be eaten

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -859,7 +859,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
 			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
-			if((it == $item[Spaghetti Breakfast])) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
+			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);
 			// Only one Spaghetti Breakfast can be eaten

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -857,19 +857,16 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			is_unrestricted(it) &&
 			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
 		{
-			if((it == $item[astral pilsner] || it == $item[Cold One]) && my_level() < 11) continue;
+			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
 			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
+			if((it == $item[Spaghetti Breakfast])) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);
+			// Only one Spaghetti Breakfast can be eaten
+			if(it == $item[Spaghetti Breakfast]) howmany = 1;
 			if (item_amount(it) > 0 && organCost(it) <= 5)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
-			}
-			// Only one Spaghetti Breakfast can be eaten, and it must be first
-			if(it == $item[Spaghetti Breakfast])
-			{
-				if (my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean()) continue;
-				howmany = 1;
 			}
 			// don't add speakeasy drinks, because they can't actually be bought as items
 			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -801,9 +801,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	int[item] large_owned;
 	int[item] craftables;
 
-	// Spaghetti breakfast is awkward since it has to be the first food consumed
-	// and we can only consume one. We don't handle this yet, so... blacklist!
-	boolean[item] blacklist = $items[spaghetti breakfast];
+	boolean[item] blacklist = $items[Cursed Punch];
 	boolean[item] craftable_blacklist;
 
 	// If we have 2 sticks of firewood, the current knapsack-solver
@@ -861,12 +859,17 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One]) && my_level() < 11) continue;
 			if((it == $item[astral hot dog] || it == $item[Spaghetti Breakfast]) && my_level() < 11) continue;
-			if (it == $item[Cursed Punch]) continue;
 
 			int howmany = 1 + organLeft()/organCost(it);
 			if (item_amount(it) > 0 && organCost(it) <= 5)
 			{
 				small_owned[it] = min(max(item_amount(it) - auto_reserveAmount(it), 0), howmany);
+			}
+			// Only one Spaghetti Breakfast can be eaten, and it must be first
+			if(t == $item[Spaghetti Breakfast])
+			{
+				if (my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean()) continue;
+				howmany = 1;
 			}
 			// don't add speakeasy drinks, because they can't actually be bought as items
 			if (npc_price(it) > 0 && !isSpeakeasyDrink(it))
@@ -933,6 +936,18 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				auto_log_info("If we pulled and ate a " + it + " we could skip getting a fat loot token...");
 				actions[n].desirability += 25;
+			}
+			if ((obtain_mode == SL_OBTAIN_NULL) && (it == $item[Spaghetti Breakfast]))
+			{
+				if (get_property("_spaghettiBreakfastEaten").to_boolean() || my_fullness() > 0)
+				{
+					actions[n].desirability -= 50;
+				}
+				else
+				{
+					auto_log_info("Spaghetti Breakfast available, we should eat that first.");
+					actions[n].desirability += 50;
+				}
 			}
 			if (obtain_mode == SL_OBTAIN_CRAFT)
 			{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4516,6 +4516,10 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 	{
 		return false;
 	}
+	if (!auto_is_valid(it))
+	{
+		return false;
+	}
 	if((item_amount(it) + equipped_amount(it)) == whenHave)
 	{
 		int lastStorage = storage_amount(it);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1720,6 +1720,7 @@ boolean L11_redZeppelin()
 	buffMaintain($effect[Greasy Peasy], 0, 1, 1);
 	buffMaintain($effect[Musky], 0, 1, 1);
 	buffMaintain($effect[Blood-Gorged], 0, 1, 1);
+	pullXWhenHaveY($item[deck of lewd playing cards], 1, 0);
 
 	providePlusNonCombat(25);
 


### PR DESCRIPTION
# Description

- Don't replace beefy bodyguard bats for paths with an alternate boss bat
- Allow eating spaghetti breakfast only as the first thing
- Check auto_is_valid before pulling anything, to prevent pulling harmful \ unusable items
- Pull deck of lewd playing cards for protesters
- Fix not consuming anything if script is started below adventure threshold
- Fix heavy rains familiar handling equipping to wrong familiar
- Fix considering switching to familiars when dropped spleen item is unusable

Fixes #65
Fixes #85
Fixes #346 

## How Has This Been Tested?

Validates
Manually ran auto_autoConsumeOne to consume spaghetti breakfas

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
