### PR TITLE
inAftercore() created and used

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -430,7 +430,7 @@ boolean handleFamiliar(familiar fam)
 		#use_familiar(toEquip);
 		set_property("auto_familiarChoice", toEquip);
 	}
-	if(get_property("kingLiberated").to_boolean() && (toEquip != $familiar[none]) && (toEquip != my_familiar()) && (my_bjorned_familiar() != toEquip))
+	if(inAftercore() && (toEquip != $familiar[none]) && (toEquip != my_familiar()) && (my_bjorned_familiar() != toEquip))
 	{
 		use_familiar(toEquip);
 	}
@@ -608,7 +608,7 @@ boolean LX_faxing()
 
 int pullsNeeded(string data)
 {
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return 0;
 	}
@@ -1167,7 +1167,7 @@ boolean fortuneCookieEvent()
 
 void initializeDay(int day)
 {
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return;
 	}
@@ -1236,7 +1236,7 @@ void initializeDay(int day)
 		}
 	}
 
-	if(!get_property("_pottedTeaTreeUsed").to_boolean() && (auto_get_campground() contains $item[Potted Tea Tree]) && !get_property("kingLiberated").to_boolean())
+	if(!get_property("_pottedTeaTreeUsed").to_boolean() && (auto_get_campground() contains $item[Potted Tea Tree]) && !inAftercore())
 	{
 		if(get_property("auto_teaChoice") != "")
 		{
@@ -1707,7 +1707,7 @@ boolean doBedtime()
 	{
 		handleFamiliar("stat");
 		int oldSeals = get_property("_sealsSummoned").to_int();
-		while((get_property("_sealsSummoned").to_int() < 5) && (!get_property("kingLiberated").to_boolean()) && (my_meat() > 4500))
+		while((get_property("_sealsSummoned").to_int() < 5) && (!inAftercore()) && (my_meat() > 4500))
 		{
 			boolean summoned = false;
 			if((my_daycount() == 1) && (my_level() >= 6) && isHermitAvailable())
@@ -1899,7 +1899,7 @@ boolean doBedtime()
 		}
 	}
 
-	if((my_daycount() == 1) && (possessEquipment($item[Thor\'s Pliers]) || (freeCrafts() > 0)) && !possessEquipment($item[Chrome Sword]) && !get_property("kingLiberated").to_boolean() && !in_tcrs())
+	if((my_daycount() == 1) && (possessEquipment($item[Thor\'s Pliers]) || (freeCrafts() > 0)) && !possessEquipment($item[Chrome Sword]) && !inAftercore() && !in_tcrs())
 	{
 		item oreGoal = to_item(get_property("trapperOre"));
 		int need = 1;
@@ -1977,7 +1977,7 @@ boolean doBedtime()
 		}
 		if(!get_property("_aprilShower").to_boolean())
 		{
-			if(get_property("kingLiberated").to_boolean())
+			if(inAftercore())
 			{
 				cli_execute("shower ice");
 			}
@@ -2002,7 +2002,7 @@ boolean doBedtime()
 	{
 		cli_execute("concert 2");
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		if((item_amount($item[The Legendary Beat]) > 0) && !get_property("_legendaryBeat").to_boolean())
 		{
@@ -2064,7 +2064,7 @@ boolean doBedtime()
 
 	if(is_unrestricted($item[Source Terminal]) && (get_campground() contains $item[Source Terminal]))
 	{
-		if(!get_property("_kingLiberated").to_boolean() && (get_property("auto_extrudeChoice") != "none"))
+		if(!inAftercore() && (get_property("auto_extrudeChoice") != "none"))
 		{
 			int count = 3 - get_property("_sourceTerminalExtrudes").to_int();
 
@@ -2257,7 +2257,7 @@ boolean doBedtime()
 	}
 	else
 	{
-		if(!get_property("kingLiberated").to_boolean())
+		if(!inAftercore())
 		{
 			auto_log_info(get_property("auto_banishes_day" + my_daycount()));
 			auto_log_info(get_property("auto_yellowRay_day" + my_daycount()));
@@ -3633,7 +3633,7 @@ boolean doTasks()
 	if(LX_getStarKey())					return true;
 	if(L12_lastDitchFlyer())			return true;
 
-	if(!get_property("kingLiberated").to_boolean() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
+	if(!inAftercore() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
 	{
 		int[item] camp = auto_get_campground();
 		if((camp contains $item[Packet of Thanksgarden Seeds]) && (camp contains $item[Cornucopia]) && (camp[$item[Cornucopia]] > 0) && (internalQuestStatus("questL12War") >= 1))
@@ -3823,7 +3823,7 @@ void auto_begin()
 	}
 	
 	// the main loop of autoscend is doTasks() which is actually called as part of the while.
-	while(auto_unreservedAdvRemaining() && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !get_property("kingLiberated").to_boolean() && doTasks())
+	while(auto_unreservedAdvRemaining() && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !inAftercore() && doTasks())
 	{
 		if((my_fullness() >= fullness_limit()) && (my_inebriety() >= inebriety_limit()) && (my_spleen_use() == spleen_limit()) && (my_adventures() < 4) && (my_rain() >= 50) && (get_counters("Fortune Cookie", 0, 4) == "Fortune Cookie"))
 		{
@@ -3833,7 +3833,7 @@ void auto_begin()
 		consumeStuff();
 	}
 
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		equipBaseline();
 		handleFamiliar("item");

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -313,7 +313,7 @@ void preAdvUpdateFamiliar(location place)
 
 	if((famChoice != $familiar[none]) && canChangeFamiliar() && (internalQuestStatus("questL13Final") < 13))
 	{
-		if((famChoice != my_familiar()) && !get_property("kingLiberated").to_boolean())
+		if((famChoice != my_familiar()) && !inAftercore())
 		{
 #			auto_log_error("FAMILIAR DIRECTIVE ERROR: Selected " + famChoice + " but have " + my_familiar(), "red");
 			use_familiar(famChoice);

--- a/RELEASE/scripts/autoscend/auto_casual.ash
+++ b/RELEASE/scripts/autoscend/auto_casual.ash
@@ -9,10 +9,15 @@ boolean inCasual()
 	return false;
 }
 
+boolean inAftercore()
+{
+	return get_property("kingLiberated").to_boolean();
+}
+
 boolean inPostRonin()
 {
-	//can interact means you are not in ronin and not in hardcore, but it does not mean you are not in casual.
-	if(can_interact() && !inCasual())
+	//can interact means you are not in ronin and not in hardcore. It returns true in casual, aftercore, and postronin
+	if(can_interact() && !inCasual() && !inAftercore())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -309,7 +309,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 	#Handle different path is monster_level_adjustment() > 150 (immune to staggers?)
 	int mcd = monster_level_adjustment();
 
-	boolean doBanisher = !get_property("kingLiberated").to_boolean();
+	boolean doBanisher = !inAftercore();
 
 	if(my_path() == "Disguises Delimit")
 	{
@@ -1036,7 +1036,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(canUse($skill[Extract]) && get_property("kingLiberated").to_boolean())
+	if(canUse($skill[Extract]) && inAftercore())
 	{
 		return useSkill($skill[Extract]);
 	}
@@ -1229,7 +1229,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(!get_property("kingLiberated").to_boolean())
+	if(!inAftercore())
 	{
 		if(item_amount($item[short writ of habeas corpus]) > 0)
 		{
@@ -1405,7 +1405,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 		if(canUse($skill[Chest X-Ray]) && equipped_amount($item[Lil\' Doctor&trade; bag]) > 0 && (get_property("_chestXRayUsed").to_int() < 3))
 		{
-			if((my_adventures() < 20) || get_property("kingLiberated").to_boolean() || (my_daycount() >= 3))
+			if((my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))
 			{
 				handleTracker(enemy, $skill[Chest X-Ray], "auto_instakill");
 				loopHandlerDelayAll();
@@ -1414,7 +1414,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 		if(canUse($skill[shattering punch]) && (get_property("_shatteringPunchUsed").to_int() < 3))
 		{
-			if((my_adventures() < 20) || get_property("kingLiberated").to_boolean() || (my_daycount() >= 3))
+			if((my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))
 			{
 				handleTracker(enemy, $skill[shattering punch], "auto_instakill");
 				loopHandlerDelayAll();
@@ -1423,7 +1423,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 		if(canUse($skill[Gingerbread Mob Hit]) && !get_property("_gingerbreadMobHitUsed").to_boolean())
 		{
-			if((my_adventures() < 20) || get_property("kingLiberated").to_boolean() || (my_daycount() >= 3))
+			if((my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))
 			{
 				handleTracker(enemy, $skill[Gingerbread Mob Hit], "auto_instakill");
 				loopHandlerDelayAll();
@@ -1517,7 +1517,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 		if($item[Daily Affirmation: Keep Free Hate In Your Heart].combat)
 		{
-			if(canUse($item[Daily Affirmation: Keep Free Hate In Your Heart]) && get_property("kingLiberated").to_boolean() && hippy_stone_broken() && !get_property("_affirmationHateUsed").to_boolean())
+			if(canUse($item[Daily Affirmation: Keep Free Hate In Your Heart]) && inAftercore() && hippy_stone_broken() && !get_property("_affirmationHateUsed").to_boolean())
 			{
 				return useItem($item[Daily Affirmation: Keep Free Hate In Your Heart]);
 			}
@@ -1738,7 +1738,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(canUse($skill[Candyblast]) && (my_mp() > 60) && get_property("kingLiberated").to_boolean())
+	if(canUse($skill[Candyblast]) && (my_mp() > 60) && inAftercore())
 	{
 		# We can get only one candy and we can detect it, if so desired:
 		# "Hey, some of it is even intact afterwards!"
@@ -1760,7 +1760,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Stuffed Mortar Shell]);
 	}
 
-	if(canUse($skill[Duplicate]) && (get_property("_sourceTerminalDuplicateUses").to_int() == 0) && !get_property("kingLiberated").to_boolean() && (auto_my_path() != "Nuclear Autumn"))
+	if(canUse($skill[Duplicate]) && (get_property("_sourceTerminalDuplicateUses").to_int() == 0) && !inAftercore() && (auto_my_path() != "Nuclear Autumn"))
 	{
 		if($monsters[Dairy Goat] contains enemy)
 		{
@@ -1786,7 +1786,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Curse Of Weaksauce]);
 	}
 
-	if(canUse($skill[Digitize]) && (get_property("_sourceTerminalDigitizeUses").to_int() == 0) && !get_property("kingLiberated").to_boolean())
+	if(canUse($skill[Digitize]) && (get_property("_sourceTerminalDigitizeUses").to_int() == 0) && !inAftercore())
 	{
 		if($monsters[Ninja Snowman Assassin, Lobsterfrogman] contains enemy)
 		{
@@ -1798,7 +1798,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(canUse($skill[Digitize]) && (get_property("_sourceTerminalDigitizeUses").to_int() < 3) && !get_property("kingLiberated").to_boolean())
+	if(canUse($skill[Digitize]) && (get_property("_sourceTerminalDigitizeUses").to_int() < 3) && !inAftercore())
 	{
 		if(get_property("auto_digitizeDirective") == enemy)
 		{

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -542,7 +542,7 @@ void consumeStuff()
 	{
 		return;
 	}
-	if (get_property("kingLiberated").to_boolean())
+	if (inAftercore())
 	{
 		return;
 	}

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -4,7 +4,7 @@ import <autoscend.ash>
 void handleKingLiberation()
 {
 	restoreAllSettings();
-	if(get_property("kingLiberated").to_boolean() && (get_property("auto_snapshot") == ""))
+	if(inAftercore() && (get_property("auto_snapshot") == ""))
 	{
 		auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
 		if(!get_property("auto_kingLiberation").to_boolean())
@@ -113,7 +113,7 @@ void handleKingLiberation()
 		}
 	}
 
-	if((get_property("kingLiberated") == "true") && !get_property("auto_aftercore").to_boolean())
+	if(inAftercore() && !get_property("auto_aftercore").to_boolean())
 	{
 //		buy_item($item[4-d camera], 1, 10000);
 //		buy_item($item[mojo filter], 2, 3500);

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -293,7 +293,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Eau de Tortue], 0, 1, 1);
 	}
 
-	if((monster_level_adjustment() > 140) && !get_property("kingLiberated").to_boolean())
+	if((monster_level_adjustment() > 140) && !inAftercore())
 	{
 		buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
 		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
@@ -415,7 +415,7 @@ boolean auto_post_adventure()
 	effect awolDesired = awol_walkBuff();
 	if(awolDesired != $effect[none])
 	{
-		if(!get_property("kingLiberated").to_boolean())
+		if(!inAftercore())
 		{
 			int awolMP = 85;
 			if(my_class() == $class[Beanslinger])
@@ -645,7 +645,7 @@ boolean auto_post_adventure()
 	else
 	{
 		boolean didOutfit = false;
-		if((my_basestat($stat[mysticality]) >= 200) && (my_buffedstat($stat[mysticality]) >= 200) && (get_property("kingLiberated") != "false") && (item_amount($item[Wand of Oscus]) > 0) && (item_amount($item[Oscus\'s Dumpster Waders]) > 0) && (item_amount($item[Oscus\'s Pelt]) > 0))
+		if((my_basestat($stat[mysticality]) >= 200) && (my_buffedstat($stat[mysticality]) >= 200) && inAftercore() && (item_amount($item[Wand of Oscus]) > 0) && (item_amount($item[Oscus\'s Dumpster Waders]) > 0) && (item_amount($item[Oscus\'s Pelt]) > 0))
 		{
 			cli_execute("outfit save Backup");
 			#Using the cli command may not upgrade our stats if our max mp drops
@@ -792,7 +792,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Mathematically Precise], 150, 1, 5);
 #		buffMaintain($effect[Rotten Memories], 150, 1, 10);
 
-		if(get_property("kingLiberated").to_boolean())
+		if(inAftercore())
 		{
 			if((auto_have_skill($skill[Summon Rad Libs])) && (my_mp() > 6))
 			{
@@ -917,7 +917,7 @@ boolean auto_post_adventure()
 		set_property("auto_cubeItems", false);
 	}
 
-	if(!get_property("kingLiberated").to_boolean())
+	if(!inAftercore())
 	{
 		if((my_daycount() == 1) && (my_bjorned_familiar() != $familiar[grim brother]) && (get_property("_grimFairyTaleDropsCrown").to_int() == 0) && (have_familiar($familiar[grim brother])) && (equipped_item($slot[back]) == $item[Buddy Bjorn]) && (my_familiar() != $familiar[Grim Brother]))
 		{
@@ -950,7 +950,7 @@ boolean auto_post_adventure()
 		auto_log_info("Have " + item_amount($item[Hellseal Sinew]) + " sinew(s).", "green");
 	}
 
-	if((my_location() == $location[The Hidden Bowling Alley]) && get_property("kingLiberated").to_boolean())
+	if((my_location() == $location[The Hidden Bowling Alley]) && inAftercore())
 	{
 		if(item_amount($item[Bowling Ball]) > 0)
 		{
@@ -958,7 +958,7 @@ boolean auto_post_adventure()
 		}
 	}
 
-	if((my_level() < 13) && !get_property("kingLiberated").to_boolean() && (my_meat() > 7500))
+	if((my_level() < 13) && !inAftercore() && (my_meat() > 7500))
 	{
 		if(item_amount($item[pulled red taffy]) >= 6)
 		{
@@ -1001,7 +1001,7 @@ boolean auto_post_adventure()
 
 
 	# We only do this in aftercore because we don't want a spiralling death loop in-run.
-	if(get_property("kingLiberated").to_boolean() && (have_effect($effect[Beaten Up]) > 0) && (my_mp() >= mp_cost($skill[Tongue of the Walrus])) && auto_have_skill($skill[Tongue of the Walrus]))
+	if(inAftercore() && (have_effect($effect[Beaten Up]) > 0) && (my_mp() >= mp_cost($skill[Tongue of the Walrus])) && auto_have_skill($skill[Tongue of the Walrus]))
 	{
 		auto_log_warning("Owwie, was beaten up but trying to recover", "red");
 		use_skill(1, $skill[Tongue of the Walrus]);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -125,7 +125,7 @@ boolean auto_pre_adventure()
 		}
 	}
 
-	if(!get_property("kingLiberated").to_boolean())
+	if(!inAftercore())
 	{
 		if(($locations[Barrrney\'s Barrr, The Black Forest, The F\'c\'le, Monorail Work Site] contains place))
 		{
@@ -363,7 +363,7 @@ boolean auto_pre_adventure()
 	boolean[location] lowMLZones = $locations[The Smut Orc Logging Camp];
 
 	// Generic Conditions
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		doML = false;
 		removeML = false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1464,7 +1464,7 @@ boolean auto_wantToBanish(monster enemy, location loc)
 
 string banisherCombatString(monster enemy, location loc, boolean inCombat)
 {
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return "";
 	}
@@ -4064,7 +4064,7 @@ boolean use_barrels()
 	{
 		return false;
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return false;
 	}
@@ -4508,7 +4508,7 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 	{
 		return false;
 	}
-	if(!is_unrestricted(it) && !get_property("kingLiberated").to_boolean())
+	if(!is_unrestricted(it) && !inAftercore())
 	{
 		return false;
 	}
@@ -4653,7 +4653,7 @@ boolean pulverizeThing(item it)
 boolean buy_item(item it, int quantity, int maxprice)
 {
 	take_closet(closet_amount(it), it);
-	if(get_property("kingLiberated") != "false")
+	if(inAftercore())
 	{
 		take_storage(storage_amount(it), it);
 	}
@@ -5951,7 +5951,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}
 		if($effects[Drunk and Avuncular, Record Hunger] contains buff)
 		{
-			if(get_property("kingLiberated").to_boolean())
+			if(inAftercore())
 			{
 				return false;
 			}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -515,6 +515,7 @@ boolean containsCombat(skill sk);							//Defined in autoscend/auto_combat.ash
 boolean containsCombat(string action);						//Defined in autoscend/auto_combat.ash
 
 boolean inCasual();											//Defined in autoscend/auto_casual.ash
+boolean inAftercore();										//Defined in autoscend/auto_casual.ash
 boolean inPostRonin();										//Defined in autoscend/auto_casual.ash
 
 string cs_combatKing(int round, string opp, string text);	//Defined in autoscend/auto_community_service.ash

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -173,7 +173,7 @@ boolean [location] get_floundry_locations()
 	static boolean [location] floundryLocations;
 
 	int currentLiberation = 1;
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		currentLiberation = 2;
 	}
@@ -691,7 +691,7 @@ boolean auto_floundryAction()
 	{
 		return false;
 	}
-	if(!get_property("_floundryItemGot").to_boolean() && (auto_get_clan_lounge() contains $item[Clan Floundry]) && !get_property("kingLiberated").to_boolean())
+	if(!get_property("_floundryItemGot").to_boolean() && (auto_get_clan_lounge() contains $item[Clan Floundry]) && !inAftercore())
 	{
 		if(get_property("auto_floundryChoice") != "")
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -58,7 +58,7 @@ boolean auto_barrelPrayers()
 			return false;
 		}
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return false;
 	}
@@ -216,7 +216,7 @@ boolean auto_mayoItems()
 	{
 		return false;
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return false;
 	}
@@ -532,7 +532,7 @@ boolean chateaumantegna_nightstandSet()
 	{
 		return false;
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -60,7 +60,7 @@ boolean snojoFightAvailable()
 		return false;
 	}
 
-	if(!get_property("kingLiberated").to_boolean())
+	if(!inAftercore())
 	{
 		int[string] controls;
 		controls["MUSCLE"] = 1;

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1109,7 +1109,7 @@ boolean getSpaceJelly()
 	}
 	if(my_path() != "Standard")
 	{
-		if(!get_property("kingLiberated").to_boolean())
+		if(!inAftercore())
 		{
 			return false;
 		}
@@ -1273,7 +1273,7 @@ boolean asdonAutoFeed(int goal)
 	{
 		return false;
 	}
-	if(get_property("kingLiberated").to_boolean())
+	if(inAftercore())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -1336,7 +1336,7 @@ boolean LA_cs_communityService()
 			{
 				auto_log_warning("Waiting a few seconds, please hold.", "red");
 				wait(5);
-				if(get_property("kingLiberated").to_boolean())
+				if(inAftercore())
 				{
 					cli_execute("call auto_king");
 					return true;

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -769,7 +769,7 @@ boolean L13_towerFinalHeavyRains()
 	else
 	{
 		visit_url("place.php?whichplace=nstower&action=ns_11_prism");
-		if(get_property("kingLiberated") == "true")
+		if(inAftercore())
 		{
 			abort("All done. King Ralph has been freed");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1224,7 +1224,7 @@ boolean L13_towerNSFinal()
 	}
 
 	visit_url("place.php?whichplace=nstower&action=ns_11_prism");
-	if(get_property("kingLiberated") == "false")
+	if(!inAftercore())
 	{
 		abort("Yeah, so, I'm done. You might be stuck at the shadow, or at the final boss, or just with a king in a prism. I don't know and quite frankly, after the last " + my_daycount() + " days, I don't give a damn. That's right, I said it. Bitches.");
 	}


### PR DESCRIPTION
*inAftercore() created and used
**replaced the various permutations of checking property kingLiberated
**fixed function boolean inPostRonin(). It needed to verify we are !inAftercore()

## How Has This Been Tested?

ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
