### PR TITLE
boolean L9_leafletQuest() refactoring

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1340,7 +1340,7 @@ void initializeDay(int day)
 		if(get_property("auto_day_init").to_int() < 1)
 		{
 			//big rock is what mafia returns when you have no dwelling.
-			if (item_amount($item[Newbiesport&trade; tent]) > 0 && get_dwelling() == $item[big rock])
+			if(item_amount($item[Newbiesport&trade; tent]) > 0 && auto_is_valid($item[Newbiesport&trade; tent]) && get_dwelling() == $item[big rock])
 			{
 				use(1, $item[Newbiesport&trade; tent]);
 			}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1339,7 +1339,8 @@ void initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 1)
 		{
-			if (item_amount($item[Newbiesport&trade; tent]) > 0)
+			//big rock is what mafia returns when you have no dwelling.
+			if (item_amount($item[Newbiesport&trade; tent]) > 0 && get_dwelling() == $item[big rock])
 			{
 				use(1, $item[Newbiesport&trade; tent]);
 			}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20114; // Lock Picking can be cast once per ascension. track in "lockPicked" property
+since r20127; // Leaflet use is now tracked via "leafletCompleted" setting
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -2471,8 +2471,18 @@ boolean LX_attemptPowerLevel()
 
 boolean disregardInstantKarma()
 {
-	//under level 13 we wan to get max XP. level 14+ we already missed the insta karma, no need to hold back anymore.
-	return my_level() != 13 || get_property("auto_disregardInstantKarma").to_boolean();
+	//do we want to ignore the instant karma you get for defeating the naughty sorceress at exactly level 13. Used to tweak our XP gains.
+	if(inAftercore())
+	{
+		return true;
+	}
+	if(my_level() != 13)
+	{
+		//under level 13 we wan to get max XP gains. level 14+ we already missed the insta karma, no need to hold back anymore.
+		return true;
+	}
+	//auto_disregardInstantKarma is a user configured setting
+	return get_property("auto_disregardInstantKarma").to_boolean();
 }
 
 int auto_freeCombatsRemaining()
@@ -3505,6 +3515,7 @@ boolean doTasks()
 	if(chateauPainting())			return true;
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;
+	if(L9_leafletQuest())				return true;
 	if(L5_findKnob())					return true;
 	if(LM_edTheUndying())				return true;
 	if(L12_sonofaPrefix())				return true;
@@ -3570,7 +3581,6 @@ boolean doTasks()
 		return true;
 	}
 
-	if(L9_leafletQuest())				return true;
 	if(L7_crypt())						return true;
 	if(fancyOilPainting())				return true;
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -66,7 +66,8 @@ boolean L9_leafletQuest()
 		cli_execute("leaflet nomagic");		//no substat gains
 	}
 	
-	if(auto_get_campground() contains $item[Newbiesport&trade; tent])
+	//upgrade dwelling. big rock is what mafia returns when you have no dwelling.
+	if(get_dwelling() == $item[big rock] || get_dwelling() == $item[Newbiesport&trade; tent])
 	{
 		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -26,26 +26,50 @@ boolean LX_loggingHatchet()
 
 boolean L9_leafletQuest()
 {
-	if((my_level() < 9) || possessEquipment($item[Giant Pinky Ring]))
+	if(my_level() < 9)
 	{
 		return false;
 	}
-	if (isActuallyEd() || in_koe())
+	if(isActuallyEd() || in_koe())
 	{
 		return false;
 	}
-	if(auto_get_campground() contains $item[Frobozz Real-Estate Company Instant House (TM)])
+	if(get_property("leafletCompleted").to_boolean())
 	{
 		return false;
 	}
-	if(item_amount($item[Frobozz Real-Estate Company Instant House (TM)]) > 0)
+	
+	//get a [strange leaflet]
+	item leaflet = $item[strange leaflet];
+	if(closet_amount($item[strange leaflet]) > 0)
 	{
-		return false;
+		take_closet(1, $item[strange leaflet]);
 	}
+	if(available_amount($item[strange leaflet]) == 0)
+	{
+		council();
+		if(item_amount($item[strange leaflet]) == 0)
+		{
+			auto_log_debug("Tried to grab a [strange leaflet] from the council and it did not work... This needs fixing. skipping for now.");
+			return false;
+		}
+	}
+	
 	auto_log_info("Got a leaflet to do", "blue");
-	council();
-	cli_execute("leaflet");
-	use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
+	if(disregardInstantKarma())		//checks a user setting as well as current level
+	{
+		cli_execute("leaflet");		//also gain +200 substats for each stat
+	}
+	else
+	{
+		//in plumber you eat manually and can jump from level 8 to 13 via food.
+		cli_execute("leaflet nomagic");		//no substat gains
+	}
+	
+	if(auto_get_campground() contains $item[Newbiesport&trade; tent])
+	{
+		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
+	}
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -40,7 +40,6 @@ boolean L9_leafletQuest()
 	}
 	
 	//get a [strange leaflet]
-	item leaflet = $item[strange leaflet];
 	if(closet_amount($item[strange leaflet]) > 0)
 	{
 		take_closet(1, $item[strange leaflet]);
@@ -71,7 +70,8 @@ boolean L9_leafletQuest()
 	{
 		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
 	}
-	return true;
+	
+	return get_property("leafletCompleted").to_boolean();
 }
 
 void L9_chasmMaximizeForNoncombat()


### PR DESCRIPTION
*track internally quest progress. (for now. talking to mafia devs about adding mafia tracking)
**checking for items it drops is unreliable. frobozz house can be lost. giant pinky ring can be sold or pulled from previous ascension.
**fix not doing leaflet in casual.

## How Has This Been Tested?

tested in a low key run. it worked

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
