### PR TITLE
Critical: Consume fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -1105,15 +1105,34 @@ void auto_autoDrinkNightcap(boolean simulate)
 
 boolean auto_autoConsumeOne(string type, boolean simulate)
 {
-	if (inebriety_left() == 0) return false;
+	int organLeft()
+	{
+		if (type == "eat") return fullness_left();
+		if (type == "drink") return inebriety_left();
+		abort("Unrecognized organ type: should be 'eat' or 'drink', was " + type);
+		return 0;
+	}
+	if (organLeft() == 0) return false;
 
 	ConsumeAction[int] actions;
 	loadConsumables(type, actions);
 
+	int remaining_space = organLeft();
+
+	float[int] desirability;
+	int[int] space;
+	for (int i=0; i<count(actions); i++)
+	{
+		desirability[i] = actions[i].desirability;
+		space[i] = actions[i].size;
+	}
+
+	boolean[int] result = knapsack(remaining_space, count(space), space, desirability);
+
 	float best_desirability_per_fill = 0.0;
 	float best_adv_per_fill = 0.0;
 	int best = -1;
-	for (int i=0; i < count(actions); i++)
+	foreach i in result
 	{
 		float tentative_desirability_per_fill = actions[i].desirability/actions[i].size;
 		if (tentative_desirability_per_fill > best_desirability_per_fill)

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -1143,6 +1143,12 @@ boolean auto_autoConsumeOne(string type, boolean simulate)
 		}
 	}
 
+	if (best == -1)
+	{
+		auto_log_info("auto_autoConsumeOne: Nothing found to consume", "blue");
+		return false;
+	}
+
 	auto_log_info("auto_autoConsumeOne: Planning to execute " + type + " " + to_pretty_string(actions[best]), "blue");
 	if (best_adv_per_fill < get_property("auto_consumeMinAdvPerFill").to_float())
 	{


### PR DESCRIPTION
# Description

I was accidentally only checking inebreity == 0 in consume one, and wasn't otherwise considering remaining space.

## How Has This Been Tested?

Ensured the 0 remaining case worked, but I'm not in a run so I can't test this right now. Should work though, the knapsack call was copied from the old consumption function.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
