### PR TITLE
LKS: Fix for pulling white pixels too early

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -79,7 +79,9 @@ boolean LX_getDigitalKey()
 	}
 	
 	//if you are at the tower door and still don't have it, pull some pixels to save adv. keeping 5 pulls for later.
-	if(whitePixelCount() < 30 && internalQuestStatus("questL13Final") == 5 && canPull($item[white pixel]))
+	boolean needLowKeyPixels = (in_lowkeysummer() ? (lowkey_needKey($item[Digital Key]) && lowkey_keysRemaining() == 1) : true);
+	// in low-key summer, only pull pixels if we have no other keys left to get. Otherwise this wastes pulls as it starts at the door.
+	if(whitePixelCount() < 30 && (internalQuestStatus("questL13Final") == 5 && needLowKeyPixels) && canPull($item[white pixel]))
 	{
 		int pulls_needed = min((pulls_remaining()-5), 30 - whitePixelCount());
 		pullXWhenHaveY($item[white pixel], pulls_needed, item_amount($item[white pixel]));	//do not use whitePixelCount() in this line.


### PR DESCRIPTION
# Description

- don't pull white pixels in low key summer unless we only need the digital key to open the door.

## How Has This Been Tested?

Ran `validate autoscend` with no errors. Need to wait until rollover to properly test but the logic should be correct as far as I can see.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
