### PR TITLE
account for user set delay being less than 0

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3288,7 +3288,7 @@ void print_header()
 
 boolean doTasks()
 {
-	if(get_property("_casualAscension").to_int() >= my_ascensions())
+	if(inCasual())
 	{	
 		auto_log_warning("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");	
 		return false;	
@@ -3303,7 +3303,7 @@ boolean doTasks()
 	auto_interruptCheck();
 
 	int delay = get_property("auto_delayTimer").to_int();
-	if(delay != 0)
+	if(delay > 0)
 	{
 		auto_log_info("Delay between adventures... beep boop... ", "blue");
 		wait(delay);


### PR DESCRIPTION
*account for user set delay being less than 0
*replace casual check with in_casual() at start of doTasks()

## How Has This Been Tested?

2 days of ed run
which should be sufficient considering the contents

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
