### PR TITLE
Low Key Summer changes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3403,16 +3403,6 @@ boolean doTasks()
 	if(L11_hiddenCityZones())			return true;
 	if(ornateDowsingRod())				return true;
 	if(L11_aridDesert())				return true;
-
-	if (get_property("sidequestNunsCompleted") != "none" && item_amount($item[Half A Purse]) == 1)
-	{
-		pulverizeThing($item[Half A Purse]);
-		if(item_amount($item[Handful of Smithereens]) > 0)
-		{
-			cli_execute("make " + $item[Louder Than Bomb]);
-		}
-	}
-
 	if(L11_hiddenCity())				return true;
 	if(L11_talismanOfNam())				return true;
 	if(L11_palindome())					return true;
@@ -3443,6 +3433,7 @@ boolean doTasks()
 
 	if (L12_clearBattlefield())			return true;
 	if(LX_koeInvaderHandler())			return true;
+	if (LX_lowkeySummer())					return true;
 	
 	//release the softblock on quests that are waiting for shen quest
 	if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished")

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3418,8 +3418,6 @@ boolean doTasks()
 	if(L12_farm())						return true;
 	if(L11_getBeehive())				return true;
 	if(L12_finalizeWar())				return true;
-	if(LX_getDigitalKey())				return true;
-	if(LX_getStarKey())					return true;
 	if(L12_lastDitchFlyer())			return true;
 
 	if(!inAftercore() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -72,6 +72,11 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(1); // get miner's helmet
 			}
 			break;
+		case 22: // The Arrrbitrator (The Obligatory Pirate's Cove)
+		case 23: // Barrie Me at Sea (The Obligatory Pirate's Cove)
+		case 24: // Amatearrr Night (The Obligatory Pirate's Cove)
+			piratesCoveChoiceHandler(choice);
+			break;
 		case 89: // Out in the Garden (The Haunted Gallery)
 			if (isActuallyEd() && (!possessEquipment($item[serpentine sword]) || !possessEquipment($item[snake shield]))) {
 				run_choice(2); // fight the snake knight (should non-Ed classes/paths do this too?)
@@ -97,6 +102,27 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 163: // Melvil Dewey Would Be Ashamed (The Haunted Library)
 			run_choice(4); // skip
+			break;
+		case 184: // That Explains All The Eyepatches (Barrrney's Barrr)
+		case 185: // Yes, You're a Rock Starrr (Barrrney's Barrr)
+		case 186: // A Test of Testarrrsterone (Barrrney's Barrr)
+			barrrneysBarrrChoiceHandler(choice);
+			break;
+			// Note: 187 is the Beer Pong NC and is currently handled differently.
+		case 188: // The Infiltrationist (Orcish Frat House blueprints)
+			if (is_wearing_outfit("Frat Boy Ensemble")) {
+				run_choice(1);
+			} else if (equipped_amount($item[mullet wig]) == 1 && item_amount($item[briefcase]) > 0) {
+				run_choice(2);
+			} else {
+				run_choice(3);
+			}
+			break;
+		case 189: // O Cap'm, My Cap'm (The Poop Deck)
+			run_choice(2); // skip
+			break;
+		case 191: // Chatterboxing (The F'c'le)
+			fcleChoiceHandler(choice);
 			break;
 		case 502: // Arboreal Respite (The Spooky Forest)
 			if (internalQuestStatus("questL02Larva") == 0 && item_amount($item[mosquito larva]) == 0) {
@@ -245,6 +271,12 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(2); // skip
 			}
 			break;
+		case 794: // Once More Unto the Junk (The Old Landfill)
+		case 795: // The Bathroom of Ten Men (The Old Landfill)
+		case 796: // The Den of Iquity (The Old Landfill)
+		case 797: // Let's Workshop This a Little (The Old Landfill)
+			oldLandfillChoiceHandler(choice);
+			break;
 		case 875: // Welcome To Our ool Table (The Haunted Billiards Room).
 			if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
 			{
@@ -289,6 +321,9 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 882: // Off the Rack (The Haunted Bathroom)
 			run_choice(1); // take the towel
+			break;
+		case 885: // Chasin' Babies (Nursery) (The Haunted Nursery)
+			run_choice(6); // skip
 			break;
 		case 888: // Take a Look, it's in a Book! (Rise) (The Haunted Library)
 			run_choice(4); // skip
@@ -360,7 +395,16 @@ boolean auto_run_choice(int choice, string page)
 				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 			}
 			break;
-		case 1061: // Heart of Madness(Madness Bakery Quest)
+		case 1060: // Temporarily Out of Skeletons (The Skeleton Store)
+			if (item_amount($item[Skeleton Store office key]) == 0) {
+				run_choice(1); // Skeleton Store office key
+			} else if (internalQuestStatus("questM23Meatsmith") < 1) {
+				run_choice(4); // fight The former owner of the Skeleton Store
+			} else {
+				run_choice(2); // get ring of telling skeletons what to do or 300 meat
+			}
+			break;
+		case 1061: // Heart of Madness (Madness Bakery Quest)
 			if(internalQuestStatus("questM25Armorer") <= 1) {
 				run_choice(1);
 			} else {

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1055,7 +1055,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(canUse($item[The Big Book of Pirate Insults]) && (numPirateInsults() < 8) && (internalQuestStatus("questM12Pirate") < 5))
 	{
-		if(($locations[Barrrney\'s Barrr, The Obligatory Pirate\'s Cove] contains my_location()) || ((enemy == $monster[Gaudy Pirate]) && (my_location() != $location[Belowdecks])))
+		if ($locations[Barrrney\'s Barrr, The Obligatory Pirate\'s Cove] contains my_location())
 		{
 			return useItem($item[The Big Book Of Pirate Insults]);
 		}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -311,6 +311,16 @@ boolean auto_pre_adventure()
 		autoEquip($slot[acc3], $item[Blackberry Galoshes]);
 	}
 
+	if ($locations[Barrrney\'s Barrr, The F\'c\'le, The Poop Deck, Belowdecks] contains place) {
+		if (possessEquipment($item[pirate fledges])) {
+			autoEquip($slot[acc3], $item[pirate fledges]);
+		} else if (possessOutfit("Swashbuckling Getup")) {
+			autoOutfit("Swashbuckling Getup");
+		} else {
+			abort("Trying to be a pirate without being able to dress like a pirate.");
+		}
+	}
+
 	bat_formPreAdventure();
 	horsePreAdventure();
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -65,7 +65,6 @@ int internalQuestStatus(string prop);
 string runChoice(string page_text);
 int turkeyBooze();
 int amountTurkeyBooze();
-int numPirateInsults();
 int fastenerCount();
 int lumberCount();
 skill preferredLibram();
@@ -88,7 +87,6 @@ item bangPotionNeeded(effect need);
 boolean solveBangPotion(effect need);
 boolean pulverizeThing(item it);
 boolean buy_item(item it, int quantity, int maxprice);
-string tryBeerPong();
 boolean hasShieldEquipped();
 boolean[skill] ATSongList();
 void shrugAT();
@@ -174,7 +172,6 @@ int auto_predictAccordionTurns();
 // Private Prototypes
 boolean buffMaintain(item source, effect buff, int uses, int turns);
 boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns);
-string beerPong(string page);
 boolean beehiveConsider();
 string safeString(string input);
 string safeString(skill input);
@@ -3255,8 +3252,8 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		if(resfam != $familiar[none])
 		{
 			// need to use now so maximizer will see it
+			familiar currentFamiliar = my_familiar();
 			use_familiar(resfam);
-			handleFamiliar(resfam);
 			if(resfam == $familiar[Trick-or-Treating Tot])
 			{
 				cli_execute("acquire 1 li'l candy corn costume");
@@ -3267,6 +3264,7 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			{
 				delta[ele] = simValue(ele + " Resistance") - numeric_modifier(ele + " Resistance");
 			}
+			use_familiar(currentFamiliar);
 		}
 		if(pass())
 			return result();
@@ -4085,22 +4083,6 @@ int amountTurkeyBooze()
 	return 0;
 }
 
-int numPirateInsults()
-{
-	int retval = 0;
-	int i = 1;
-	while(i <= 8)
-	{
-		if(get_property("lastPirateInsult"+i) == "true")
-		{
-			retval = retval + 1;
-		}
-		i = i + 1;
-	}
-	return retval;
-}
-
-
 int fastenerCount()
 {
 	int base = get_property("chasmBridgeProgress").to_int();
@@ -4564,82 +4546,6 @@ boolean buy_item(item it, int quantity, int maxprice)
 	return true;
 }
 
-//Thanks, Rinn!
-string beerPong(string page)
-{
-	record r {
-		string insult;
-		string retort;
-	};
-
-	r [int] insults;
-	insults[1].insult="Arrr, the power of me serve'll flay the skin from yer bones!";
-	insults[1].retort="Obviously neither your tongue nor your wit is sharp enough for the job.";
-	insults[2].insult="Do ye hear that, ye craven blackguard?  It be the sound of yer doom!";
-	insults[2].retort="It can't be any worse than the smell of your breath!";
-	insults[3].insult="Suck on <i>this</i>, ye miserable, pestilent wretch!";
-	insults[3].retort="That reminds me, tell your wife and sister I had a lovely time last night.";
-	insults[4].insult="The streets will run red with yer blood when I'm through with ye!";
-	insults[4].retort="I'd've thought yellow would be more your color.";
-	insults[5].insult="Yer face is as foul as that of a drowned goat!";
-	insults[5].retort="I'm not really comfortable being compared to your girlfriend that way.";
-	insults[6].insult="When I'm through with ye, ye'll be crying like a little girl!";
-	insults[6].retort="It's an honor to learn from such an expert in the field.";
-	insults[7].insult="In all my years I've not seen a more loathsome worm than yerself!";
-	insults[7].retort="Amazing!  How do you manage to shave without using a mirror?";
-	insults[8].insult="Not a single man has faced me and lived to tell the tale!";
-	insults[8].retort="It only seems that way because you haven't learned to count to one.";
-
-	while(!page.contains_text("victory laps"))
-	{
-		string old_page = page;
-
-		if(!page.contains_text("Insult Beer Pong"))
-		{
-			abort("You don't seem to be playing Insult Beer Pong.");
-		}
-
-		if(page.contains_text("Phooey"))
-		{
-			auto_log_info("Looks like something went wrong and you lost.", "lime");
-			return page;
-		}
-
-		foreach i in insults
-		{
-			if(page.contains_text(insults[i].insult))
-			{
-				if(page.contains_text(insults[i].retort))
-				{
-					auto_log_info("Found appropriate retort for insult.", "lime");
-					auto_log_debug("Insult: " + insults[i].insult, "lime");
-					auto_log_debug("Retort: " + insults[i].retort, "lime");
-					page = visit_url("beerpong.php?value=Retort!&response=" + i);
-					break;
-				}
-				else
-				{
-					auto_log_info("Looks like you needed a retort you haven't learned.", "red");
-					auto_log_debug("Insult: " + insults[i].insult, "lime");
-					auto_log_debug("Retort: " + insults[i].retort, "lime");
-
-					// Give a bad retort
-					page = visit_url("beerpong.php?value=Retort!&response=9");
-					return page;
-				}
-			}
-		}
-
-		if(page == old_page)
-		{
-			abort("String not found. There may be an error with one of the insult or retort strings.");
-		}
-	}
-
-	auto_log_info("You won a thrilling game of Insult Beer Pong!", "lime");
-	return page;
-}
-
 int howLongBeforeHoloWristDrop()
 {
 	int drops = get_property("_holoWristDrops").to_int() + 1;
@@ -4989,17 +4895,6 @@ int [item] auto_get_campground()
 	}
 
 	return campItems;
-}
-
-//Thanks, Rinn!
-string tryBeerPong()
-{
-	string page = visit_url("adventure.php?snarfblat=157");
-	if(contains_text(page, "Arrr You Man Enough?"))
-	{
-		page = beerPong(visit_url("choice.php?pwd&whichchoice=187&option=1"));
-	}
-	return page;
 }
 
 boolean buyUpTo(int num, item it)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -21,6 +21,8 @@ boolean LA_cs_communityService();				//Defined in autoscend/auto_community_servi
 boolean LM_edTheUndying();						//Defined in autoscend/auto_edTheUndying.ash
 
 boolean LX_desertAlternate();
+boolean LX_hippyBoatman();
+void oldLandfillChoiceHandler(int choice);
 boolean LX_lockPicking();
 boolean LX_phatLootToken();
 boolean LX_islandAccess();
@@ -29,6 +31,15 @@ boolean LX_fcle();
 boolean ornateDowsingRod();
 boolean LX_nastyBooty();
 boolean LX_guildUnlock();
+boolean LX_pirateOutfit();
+void piratesCoveChoiceHandler(int choice);
+boolean LX_joinPirateCrew();
+void barrrneysBarrrChoiceHandler(int choice, string page);
+boolean LX_fledglingPirateIsYou();
+void fcleChoiceHandler(int choice);
+boolean LX_unlockBelowdecks();
+boolean LX_pirateQuest();
+boolean LX_acquireLegendaryEpicWeapon();
 boolean LX_hardcoreFoodFarm();
 boolean LX_melvignShirt();
 boolean LX_attemptPowerLevel();
@@ -1205,6 +1216,7 @@ location lowkey_nextAvailableKeyDelayLocation(); // Defined in autoscend/paths/l
 boolean lowkey_keyAdv(item key); // Defined in autoscend/paths/low_key_summer.ash
 boolean LX_findHelpfulLowKey();  // Defined in autoscend/paths/low_key_summer.ash
 boolean L13_sorceressDoorLowKey(); // Defined in autoscend/paths/low_key_summer.ash
+boolean LX_lowkeySummer(); // Defined in autoscend/paths/low_key_summer.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash
 void resetFlavour(); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -172,16 +172,24 @@ boolean lowkey_zoneUnlocks()
 {
 	if(startHippyBoatmanSubQuest())
 	{
+		// opens The Old Landfill for scrap metal key (+20% to all Moxie Gains)
 		return true;
 	}
 
 	if (startArmorySubQuest())
 	{
+		// opens Madness Bakery for deep-fried key (+3 sleaze res, +15 sleaze dmg, +30 sleaze spell dmg)
 		return true;
 	}
 
 	if (startGalaktikSubQuest())
 	{
+		// opens The Overgrown Lot for discarded bike lock key (+10 MP,  4-5 MP regen)
+		return true;
+	}
+
+	if (startMeatsmithSubQuest()) {
+		// opens The Skeleton Store for actual skeleton key (100 DA, 10 DR)
 		return true;
 	}
 
@@ -211,65 +219,74 @@ boolean LX_findHelpfulLowKey()
 		// needs knob lab access
 		if (my_primestat() == $stat[Muscle] && lowkey_keyAdv($item[Knob labinet key])) { return true; }
 		// needs accept landfil quest
-		if (my_primestat() == $stat[Moxie] && lowkey_keyAdv($item[scrap metal key])) { return true; }
+		if (my_primestat() == $stat[Moxie] && (LX_hippyBoatman() || lowkey_keyAdv($item[scrap metal key]))) { return true; }
 		// Needs Pandamonium access
 		if (my_primestat() == $stat[Mysticality] && lowkey_keyAdv($item[Demonic key])) { return true; }
 	}
 
-	// -combat
+	// Attributes. This is a nowander zone so burning delay here is unlikely.
+	if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
+
+	// familiar weight
+	if (lowkey_keyAdv($item[Black rose key])) { return true; }
+
+	// -combat. Key sausage needs Cobb's Knob Access
 	if (lowkey_keyAdv($item[Key sausage])) { return true; }
 
 	// +item
-	// needs pirate quest ugh
+	// Treasure chest key needs Belowdecks access
 	if (lowkey_keyAdv($item[Treasure chest key])) { return true; }
 
-	// +meat
+	// +meat. Knob treasury key needs Cobb's Knob Access. Kekekey needs The Valley of Rof L'm Fao access.
 	if (lowkey_keyAdv($item[Knob treasury key])) { return true; }
 	if (lowkey_keyAdv($item[Kekekey])) { return true; }
 
-	// Knob key to unlock shaft for +adv
-	if (lowkey_keyAdv($item[Knob labinet key])) { return true; }
+	// Knob key to unlock shaft for +adv. needs Cobb's Knob Access
+	if (item_amount($item[Cobb\'s Knob lab key]) < 1 && lowkey_keyAdv($item[Knob labinet key])) { return true; }
 
-	// +adv
+	// +adv. Knob shaft skate key needs Cobb's Knob lab key for access to Knob Shaft
 	if (lowkey_keyAdv($item[Knob shaft skate key])) { return true; }
 
-	if (internalQuestStatus("questL09Topping") == 3)
-	{
+	if (internalQuestStatus("questM20Necklace") < 1) {
+		// hot res for the Haunted Kitchen. aquí needs Desert Beach Access
+		if (lowkey_keyAdv($item[aqu&iacute;])) { return true; }
+		// stench res for the Haunted Kitchen
+		if (lowkey_keyAdv($item[batting cage key])) { return true; }
+	}
+
+	if (internalQuestStatus("questL09Topping") > 0 && internalQuestStatus("questL09Topping") < 3) {
 		// +ml (before oil peak)
-		// needs pirate quest ugh
+		// F'c'le sh'c'le k'y needs F'c'le access
 		if (lowkey_keyAdv($item[F\'c\'le sh\'c\'le k\'y])) { return true; }
-		// needs accept nemesis quest
+		// Clown car key needs "Fun" house access
 		if (lowkey_keyAdv($item[Clown car key])) { return true; }
-		// cold res before aboo
+		// cold res before aboo. Needs Icy Peak Access
 		if (lowkey_keyAdv($item[Ice Key])) { return true; }
-		// spooky res before aboo
+		// spooky res before aboo. Needs Menagerie access.
 		if (lowkey_keyAdv($item[Weremoose key])) { return true; }
 	}
 
 	// sleaze damage before red zeppelin
-	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
-	{
+	if (internalQuestStatus("questL11Ron") > -1 && internalQuestStatus("questL11Ron") < 2) {
 		if (lowkey_keyAdv($item[Deep-fried key])) { return true; }
+		// Clown car key needs "Fun" house access
 		if (lowkey_keyAdv($item[Clown car key])) { return true; }
 	}
 
-	// cold spell damage before orcs
+	// cold spell damage before orcs. Ice Key needs The Icy Peak access
 	if (internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < 30)
 	{
 		if (lowkey_keyAdv($item[Ice Key])) { return true; }
 	}
 
-	// +combat before sonofa
+	// +combat before sonofa. Music Box Key needs Spookyraven Manor third floor access
 	if (internalQuestStatus("questL12War") == 1 && get_property("sidequestLighthouseCompleted") == "none")
 	{
 		if (lowkey_keyAdv($item[Music Box Key])) { return true; }
 	}
 
-	// Attributes?
-	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
-
-	// familiar weight?
-	//if (lowkey_keyAdv($item[Black rose key])) { return true; }
+	// stats. Needs Island access. May as well finish this off since we'll be farming the Pirate Outfit
+	if (lowkey_keyAdv($item[peg key])) { return true; }
 
 	// food drops?
 	//if (lowkey_keyAdv($item[Anchovy can key])) { return true; }
@@ -308,10 +325,27 @@ boolean L13_sorceressDoorLowKey()
 			}
 			abort("Please unlock zones manually and try again.");
 		}
-		// TODO: Unlock doors
-		abort("All low keys found, please unlock door manually.");
+		// Unlock door
+		if (tower_door()) {
+			return true;
+		}
 		return false;
 	}
 
 	return autoAdv(1, loc);
+}
+
+boolean LX_lowkeySummer() {
+	if (!in_lowkeysummer()) {
+		return false;
+	}
+
+	// Stuff we need to do in this path to unlock key zones.
+	if (LX_pirateQuest()) {
+		return true;
+	}
+	if (LX_acquireLegendaryEpicWeapon()) {
+		return true;
+	}
+	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -224,9 +224,6 @@ boolean LX_findHelpfulLowKey()
 		if (my_primestat() == $stat[Mysticality] && lowkey_keyAdv($item[Demonic key])) { return true; }
 	}
 
-	// Attributes. This is a nowander zone so burning delay here is unlikely.
-	if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
-
 	// familiar weight
 	if (lowkey_keyAdv($item[Black rose key])) { return true; }
 
@@ -286,7 +283,10 @@ boolean LX_findHelpfulLowKey()
 	}
 
 	// stats. Needs Island access. May as well finish this off since we'll be farming the Pirate Outfit
-	if (lowkey_keyAdv($item[peg key])) { return true; }
+	//if (LX_pirateOutfit() || lowkey_keyAdv($item[peg key])) { return true; }
+
+	// Attributes. This is a nowander zone so burning delay here is unlikely.
+	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
 
 	// food drops?
 	//if (lowkey_keyAdv($item[Anchovy can key])) { return true; }

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -282,9 +282,6 @@ boolean LX_findHelpfulLowKey()
 		if (lowkey_keyAdv($item[Music Box Key])) { return true; }
 	}
 
-	// stats. Needs Island access. May as well finish this off since we'll be farming the Pirate Outfit
-	//if (LX_pirateOutfit() || lowkey_keyAdv($item[peg key])) { return true; }
-
 	// Attributes. This is a nowander zone so burning delay here is unlikely.
 	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -287,7 +287,7 @@ boolean LX_spookyravenManorFirstFloor() {
 }
 
 boolean LX_danceWithLadySpookyraven() {
-	if (internalQuestStatus("questM21Dance") > 2) {
+	if (internalQuestStatus("questM21Dance") != 2) {
 		return false;
 	}
 
@@ -297,6 +297,10 @@ boolean LX_danceWithLadySpookyraven() {
 	auto_log_info("Finished Spookyraven, just dancing with the lady.", "blue");
 	visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 	if (autoAdv($location[The Haunted Ballroom])) {
+		if (in_lowkeysummer()) {
+			// need to open the Haunted Nursery for the music box key.
+			visit_url("place.php?whichplace=manor3&action=manor3_ladys");
+		}
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1406,7 +1406,10 @@ boolean L12_lastDitchFlyer()
 				return true;
 			}
 		}
-		return true;
+	} else if (needDigitalKey()) {
+		if (LX_getDigitalKey()) {
+			return true;
+		}
 	}
 	else
 	{
@@ -1418,6 +1421,7 @@ boolean L12_lastDitchFlyer()
 		}
 		return true;
 	}
+	return false;
 }
 
 boolean LX_attemptFlyering()

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -101,52 +101,11 @@ boolean LX_desertAlternate()
 {
 	if(auto_my_path() == "Nuclear Autumn")
 	{
-		if(my_basestat(my_primestat()) < 25)
-		{
-			return false;
-		}
-		if(get_property("questM19Hippy") == "unstarted")
-		{
-			startHippyBoatmanSubQuest();
-
-			if(get_property("questM19Hippy") == "unstarted")
-			{
-				abort("Failed to unlock The Old Landfill. Not sure what to do now...");
-			}
-			return true;
-		}
-		if((item_amount($item[Old Claw-Foot Bathtub]) > 0) && (item_amount($item[Old Clothesline Pole]) > 0) && (item_amount($item[Antique Cigar Sign]) > 0) && (item_amount($item[Worse Homes and Gardens]) > 0))
-		{
-			cli_execute("make 1 junk junk");
-			string temp = visit_url("place.php?whichplace=woods&action=woods_hippy");
-			return true;
-		}
-
-		if(item_amount($item[Funky Junk Key]) > 0)
-		{
-			//We will hit a Once More Unto the Junk adventure now
-			if(item_amount($item[Old Claw-Foot Bathtub]) == 0)
-			{
-				set_property("choiceAdventure794", 1);
-				set_property("choiceAdventure795", 1);
-			}
-			else if(item_amount($item[Old Clothesline Pole]) == 0)
-			{
-				set_property("choiceAdventure794", 2);
-				set_property("choiceAdventure796", 2);
-			}
-			else if(item_amount($item[Antique Cigar Sign]) == 0)
-			{
-				set_property("choiceAdventure794", 3);
-				set_property("choiceAdventure797", 3);
-			}
-			return autoAdv($location[The Old Landfill]);
-		}
-		else
-		{
-			return autoAdv($location[The Old Landfill]);
-		}
-
+		return LX_hippyBoatman();
+	}
+	if(get_property("lastDesertUnlock").to_int() == my_ascensions())
+	{
+		return false;
 	}
 	if(knoll_available())
 	{
@@ -168,6 +127,10 @@ boolean LX_islandAccess()
 	if(in_koe())
 	{
 		return false;
+	}
+
+	if (in_lowkeysummer()) {
+		return LX_hippyBoatman();
 	}
 
 	boolean canDesert = (get_property("lastDesertUnlock").to_int() == my_ascensions());
@@ -248,6 +211,76 @@ boolean LX_islandAccess()
 		return true;
 	}
 	return false;
+}
+
+boolean LX_hippyBoatman() {
+	if (get_property("lastIslandUnlock").to_int() >= my_ascensions()) {
+		return false;
+	}
+
+	if (item_amount($item[junk junk]) > 0 ) {
+		return false;
+	}
+
+	if (get_property("questM19Hippy") == "finished") {  // TODO: replace this with internalQuestStatus when you have the steps
+		return false;
+	}
+
+	if (my_basestat(my_primestat()) < 25) {
+		return false;
+	}
+
+	if (internalQuestStatus("questM19Hippy") < 0) {
+		startHippyBoatmanSubQuest();
+
+		if (internalQuestStatus("questM19Hippy") < 0) {
+			abort("Failed to unlock The Old Landfill. Not sure what to do now...");
+		}
+		return true;
+	}
+
+	if (autoAdv($location[The Old Landfill])) {
+		if (item_amount($item[Old Claw-Foot Bathtub]) > 0 && item_amount($item[Old Clothesline Pole]) > 0 && item_amount($item[Antique Cigar Sign]) > 0 && item_amount($item[Worse Homes and Gardens]) > 0) {
+			create(1, $item[junk junk]);
+			visit_url("place.php?whichplace=woods&action=woods_hippy");
+		}
+		return true;
+	}
+	return false;
+}
+
+void oldLandfillChoiceHandler(int choice) {
+	if (choice == 794) { // Once More Unto the Junk
+		if (item_amount($item[Old Claw-Foot Bathtub]) == 0) {
+			run_choice(1); // go to The Bathroom of Ten Men (#795)
+		} else if(item_amount($item[Old Clothesline Pole]) == 0) {
+			run_choice(2); // go to The Den of Iquity (#796)
+		} else if(item_amount($item[Antique Cigar Sign]) == 0) {
+			run_choice(3); // go to Let's Workshop This a Little (#797)
+		} else {
+			run_choice(1); // go to The Bathroom of Ten Men (#795)
+		}
+	} else if (choice == 795) { // The Bathroom of Ten Men
+		if (item_amount($item[Old Claw-Foot Bathtub]) == 0) {
+			run_choice(1); // get old claw-foot bathtub
+		} else {
+			run_choice(2); // fight a random enemy from the zone
+		}
+	} else if (choice == 796) { // The Den of Iquity
+		if(item_amount($item[Old Clothesline Pole]) == 0) {
+			run_choice(2); // get old clothesline pole
+		} else {
+			run_choice(3); // get tangle of copper wire
+		}
+	} else if (choice == 797) { // Let's Workshop This a Little
+		if(item_amount($item[Antique Cigar Sign]) == 0) {
+			run_choice(3); // get antique cigar sign
+		} else {
+			run_choice(1); // get Junk-Bond
+		}
+	} else {
+		abort("unhandled choice in oldLandfillChoiceHandler");
+	}
 }
 
 boolean LX_lockPicking()

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -367,3 +367,362 @@ boolean LX_guildUnlock()
 	}
 	return false;
 }
+
+boolean LX_pirateOutfit() {
+	if (get_property("lastIslandUnlock").to_int() < my_ascensions()) {
+		return LX_islandAccess();
+	}
+	if (possessOutfit("Swashbuckling Getup")) {
+		if (item_amount($item[The Big Book Of Pirate Insults]) == 0 && my_meat() > npc_price($item[The Big Book Of Pirate Insults])) {
+			buyUpTo(1, $item[The Big Book Of Pirate Insults]);
+		}
+		return false;
+	}
+	auto_log_info("Searching for a pirate outfit.", "blue");
+	providePlusNonCombat(25, true);
+	if (autoAdv($location[The Obligatory Pirate\'s Cove])) {
+		return true;
+	}
+	return false;
+}
+
+void piratesCoveChoiceHandler(int choice) {
+	if (choice == 22) { // The Arrrbitrator
+		if (possessEquipment($item[eyepatch])) {
+			if (possessEquipment($item[swashbuckling pants])) {
+				run_choice(3); // get 100 Meat.
+			} else {
+				run_choice(2); // get swashbuckling pants
+			}
+		} else {
+			run_choice(1); // get eyepatch
+		}
+	} else if (choice == 23) { // Barrie Me at Sea
+		if (possessEquipment($item[stuffed shoulder parrot])) {
+			if (possessEquipment($item[swashbuckling pants])) {
+				run_choice(3); // get 100 Meat.
+			} else {
+				run_choice(2); // get swashbuckling pants
+			}
+		} else {
+			run_choice(1); // get stuffed shoulder parrot
+		}
+	} else if (choice == 24) { // Amatearrr Night
+		if (possessEquipment($item[stuffed shoulder parrot])) {
+			if (possessEquipment($item[eyepatch])) {
+				run_choice(2); // get 100 Meat.
+			} else {
+				run_choice(3); // get eyepatch
+			}
+		} else {
+			run_choice(1); // get stuffed shoulder parrot
+		}
+	} else {
+		abort("unhandled choice in piratesCoveChoiceHandler");
+	}
+}
+
+string beerPong(string page)
+{
+	record r {
+		string insult;
+		string retort;
+	};
+
+	r [int] insults;
+	insults[1].insult="Arrr, the power of me serve'll flay the skin from yer bones!";
+	insults[1].retort="Obviously neither your tongue nor your wit is sharp enough for the job.";
+	insults[2].insult="Do ye hear that, ye craven blackguard?  It be the sound of yer doom!";
+	insults[2].retort="It can't be any worse than the smell of your breath!";
+	insults[3].insult="Suck on <i>this</i>, ye miserable, pestilent wretch!";
+	insults[3].retort="That reminds me, tell your wife and sister I had a lovely time last night.";
+	insults[4].insult="The streets will run red with yer blood when I'm through with ye!";
+	insults[4].retort="I'd've thought yellow would be more your color.";
+	insults[5].insult="Yer face is as foul as that of a drowned goat!";
+	insults[5].retort="I'm not really comfortable being compared to your girlfriend that way.";
+	insults[6].insult="When I'm through with ye, ye'll be crying like a little girl!";
+	insults[6].retort="It's an honor to learn from such an expert in the field.";
+	insults[7].insult="In all my years I've not seen a more loathsome worm than yerself!";
+	insults[7].retort="Amazing!  How do you manage to shave without using a mirror?";
+	insults[8].insult="Not a single man has faced me and lived to tell the tale!";
+	insults[8].retort="It only seems that way because you haven't learned to count to one.";
+
+	while(!page.contains_text("victory laps"))
+	{
+		string old_page = page;
+
+		if(!page.contains_text("Insult Beer Pong"))
+		{
+			abort("You don't seem to be playing Insult Beer Pong.");
+		}
+
+		if(page.contains_text("Phooey"))
+		{
+			auto_log_info("Looks like something went wrong and you lost.", "lime");
+			return page;
+		}
+
+		foreach i in insults
+		{
+			if(page.contains_text(insults[i].insult))
+			{
+				if(page.contains_text(insults[i].retort))
+				{
+					auto_log_info("Found appropriate retort for insult.", "lime");
+					auto_log_debug("Insult: " + insults[i].insult, "lime");
+					auto_log_debug("Retort: " + insults[i].retort, "lime");
+					page = visit_url("beerpong.php?value=Retort!&response=" + i);
+					break;
+				}
+				else
+				{
+					auto_log_info("Looks like you needed a retort you haven't learned.", "red");
+					auto_log_debug("Insult: " + insults[i].insult, "lime");
+					auto_log_debug("Retort: " + insults[i].retort, "lime");
+
+					// Give a bad retort
+					page = visit_url("beerpong.php?value=Retort!&response=9");
+					return page;
+				}
+			}
+		}
+
+		if(page == old_page)
+		{
+			abort("String not found. There may be an error with one of the insult or retort strings.");
+		}
+	}
+
+	auto_log_info("You won a thrilling game of Insult Beer Pong!", "lime");
+	return page;
+}
+
+string tryBeerPong()
+{
+	string page = visit_url("adventure.php?snarfblat=157"); //http://127.0.0.1:60081/adventure.php?snarfblat=157
+	if(contains_text(page, "Arrr You Man Enough?"))
+	{
+		page = beerPong(visit_url("choice.php?pwd&whichchoice=187&option=1"));
+	}
+	return page;
+}
+
+int numPirateInsults() {
+	int retval = 0;
+	int i = 1;
+	while (i <= 8) {
+		if (get_property("lastPirateInsult" + i) == "true") {
+			retval = retval + 1;
+		}
+		i = i + 1;
+	}
+	return retval;
+}
+
+boolean LX_joinPirateCrew() {
+	if (get_property("lastIslandUnlock").to_int() < my_ascensions()) {
+		return LX_islandAccess();
+	}
+	if (internalQuestStatus("questM12Pirate") > 4) {
+		return false;
+	}
+	if (!possessOutfit("Swashbuckling Getup", true)) {
+		auto_log_info("Can not equip, or do not have the Swashbuckling Getup. Delaying.", "red");
+		return false;
+	}
+	if (item_amount($item[The Big Book Of Pirate Insults]) == 0 && my_meat() > npc_price($item[The Big Book Of Pirate Insults])) {
+		buyUpTo(1, $item[The Big Book Of Pirate Insults]);
+	}
+	if (internalQuestStatus("questM12Pirate") == -1 || internalQuestStatus("questM12Pirate") == 1 || internalQuestStatus("questM12Pirate") == 3) {
+		auto_log_info("Findin' the Cap'n", "blue");
+		autoOutfit("Swashbuckling Getup");
+		if (numPirateInsults() >= 6) {
+			providePlusNonCombat(25, true);
+		}
+		autoAdv($location[Barrrney\'s Barrr]); // this returns false on the Cap'n Caronch adventures for some reason.
+		return true;
+	} else if (internalQuestStatus("questM12Pirate") == 0) {
+		auto_log_info("Nasty Booty time!", "red");
+		if (autoAdvBypass("inv_use.php?pwd=&which=3&whichitem=2950", $location[Noob Cave])) {
+			return true;
+		}
+	} else if (internalQuestStatus("questM12Pirate") == 2) {
+		auto_log_info("Attempting to infiltrate the frat house", "blue");
+		boolean infiltrationReady = false;
+		if (possessOutfit("Frat Boy Ensemble", true))  {
+			outfit("Frat Boy Ensemble");
+			infiltrationReady = true;
+		} else if (possessEquipment($item[mullet wig]) && item_amount($item[briefcase]) > 0) {
+			autoForceEquip($item[mullet wig]);
+			infiltrationReady = true;
+		} else if (possessEquipment($item[frilly skirt]) && item_amount($item[hot wing]) > 2) {
+			autoForceEquip($item[frilly skirt]);
+			infiltrationReady = true;
+		}
+
+		if (!infiltrationReady) {
+			if (item_amount($item[hot wing]) > 2) {
+				if (knoll_available() && my_meat() > npc_price($item[frilly skirt])) {
+					buyUpTo(1, $item[frilly skirt]);
+					autoForceEquip($item[frilly skirt]);
+					infiltrationReady = true;
+				} else {
+					if (internalQuestStatus("questM01Untinker") == -1) {
+						visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
+					}
+					if (autoAdv($location[The Degrassi Knoll Gym])) {
+						return true;
+					}
+				}
+			}
+			// TODO: add handling for the other methods here? Do we care about anything other than Catburgling?
+		}
+
+		if (infiltrationReady) {
+			if (use(1, $item[Orcish Frat House blueprints])) {
+				return true;
+			}
+		}
+	} else if (internalQuestStatus("questM12Pirate") == 4) {
+		if (numPirateInsults() >= 6) {
+			// this is held together with duct tape and hopes and dreams.
+			// it can and will fail but it will have to do for now.
+			auto_log_info("Beer Pong time.", "blue");
+			outfit("Swashbuckling Getup");
+			backupSetting("choiceAdventure187", "0");
+			tryBeerPong();
+			return true;
+		} else {
+			auto_log_info("Insult gathering party.", "blue");
+			addToMaximize("-outfit Swashbuckling Getup");
+			providePlusCombat(25, true);
+			if (autoAdv($location[The Obligatory Pirate\'s Cove])) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+void barrrneysBarrrChoiceHandler(int choice) {
+	auto_log_info("barrrneysBarrrChoiceHandler Running choice " + choice, "blue");
+	if (choice == 184) { // That Explains All The Eyepatches
+		if (my_primestat() == $stat[mysticality]) {
+			run_choice(3); // get shot of rotgut
+		} else {
+			run_choice(1); // combat with tipsy pirate
+		}
+	} else if (choice == 185) { // Yes, You're a Rock Starrr
+		run_choice(3); // combat with tetchy pirate at 0 drunkenness or stats otherwise
+	} else if (choice == 186) { // A Test of Testarrrsterone
+		if (my_primestat() == $stat[moxie]) {
+			run_choice(3); // moxie stats
+		} else {
+			run_choice(1); // stats
+		}
+	} else {
+		abort("unhandled choice in barrrneysBarrrChoiceHandler");
+	}
+}
+
+boolean LX_fledglingPirateIsYou() {
+	if (internalQuestStatus("questM12Pirate") != 5) {
+		return false;
+	}
+
+	if (possessEquipment($item[pirate fledges])) {
+		return false;
+	}
+
+	auto_log_info("F'c'le t'me!", "blue");
+	autoOutfit("Swashbuckling Getup");
+	providePlusCombat(25, true);
+	if (autoAdv($location[The F\'c\'le])) {
+		return true;
+	}
+	return false;
+}
+
+void fcleChoiceHandler(int choice) {
+	if (choice == 191) {
+		if(item_amount($item[Valuable Trinket]) > 0) {
+			run_choice(2);
+		} else {
+			switch(my_primestat()) {
+				case $stat[Muscle]:
+					run_choice(3);
+					break;
+				case $stat[Mysticality]:
+					run_choice(4);
+					break;
+				case $stat[Moxie]:
+					run_choice(1);
+					break;
+			}
+		}
+	} else {
+		abort("unhandled choice in fcleChoiceHandler");
+	}
+}
+
+boolean LX_unlockBelowdecks() {
+	if (internalQuestStatus("questM12Pirate") != 6 || internalQuestStatus("questL11MacGuffin") < 2) {
+		return false;
+	}
+
+	if (!possessEquipment($item[pirate fledges])) {
+		return false;
+	}
+
+	auto_log_info("Swordfish? Every password was swordfish!", "blue");
+	autoEquip($item[pirate fledges]);
+	providePlusNonCombat(25, true);
+	if (autoAdv($location[The Poop Deck])) {
+		return true;
+	}
+	return false;
+}
+
+boolean LX_pirateQuest() {
+	if (LX_pirateOutfit() || LX_joinPirateCrew() || LX_fledglingPirateIsYou() || LX_unlockBelowdecks()) {
+		return true;
+	}
+	return false;
+}
+
+string[class] legendaryEpicWeapons;
+legendaryEpicWeapons[$class[Seal Clubber]] = "Hammer of Smiting";
+legendaryEpicWeapons[$class[Turtle Tamer]] = "Chelonian Morningstar";
+legendaryEpicWeapons[$class[Pastamancer]] = "Greek Pasta Spoon of Peril";
+legendaryEpicWeapons[$class[Sauceror]] = "17-alarm Saucepan";
+legendaryEpicWeapons[$class[Disco Bandit]] = "Shagadelic Disco Banjo";
+legendaryEpicWeapons[$class[Accordion Thief]] = "Squeezebox of the Ages";
+// usage: item legendaryEpicWeapon = legendaryEpicWeapons[my_class()].to_item();
+
+boolean LX_acquireLegendaryEpicWeapon() {
+	if (internalQuestStatus("questG04Nemesis") < 0 || internalQuestStatus("questG04Nemesis") > 4) {
+		return false;
+	}
+
+	if (item_amount(legendaryEpicWeapons[my_class()].to_item()) > 0) {
+		return false;
+	}
+
+	if (internalQuestStatus("questG04Nemesis") == 4) {
+		visit_url("guild.php?place=scg");
+		return true;
+	}
+
+	if (autoAdv($location[The Unquiet Garves])) {
+		return true;
+	}
+	return false;
+}
+
+// TODO: Add the rest of the Nemesis quest with a flag to enable doing it in-run?
+boolean LX_NemesisQuest() {
+	if (LX_acquireLegendaryEpicWeapon()) {
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
# Description

- add Pirates Quest handling to unlock all zones. Also move functions from auto_util.ash which relate to pirates quest.
- add first stage of Nemesis quest handling to unlock "Fun" House.
- get Junk Junk for island access in Low Key Summer since we need to farm the scrap metal key in the zone anyway. add choice handling for the zone.
- start 3rd part of Lady Spookyraven's quest to open access to the Haunted Nursery for the music box key and add choice handling for the zone.
- add starting the Meatsmith quest to open the Skeleton Store for the actual skeleton key and add choice handling for the Skeleton Store.
- some fixes & tweaks to acquiring useful keys (few bugs with conditions but mostly ensuring we do the quest in the appropriate zone first if required.
- use tower_door() function to unlock the door (should update non-path code to do similarly).

## How Has This Been Tested?

All of the keys and quests (including the NS) completed using automation in my first run but I was writing these changes as I went. Will start a second run using these momentarily.
Acquiring the Junk Junk is untested at present as my run was past the point where it acquired a dingy dinghy when I made those changes (I let it run as far as it could before needing intervention to see what needed fixed/changed).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
