### PR TITLE
fix trying to initialize ed run after a plumber run. or any run whose…

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3546,6 +3546,7 @@ void auto_begin()
 	auto_spoonTuneConfirm();
 
 	settingFixer();
+	resetMaximize();
 
 	uneffect($effect[Ode To Booze]);
 	handlePulls(my_daycount());


### PR DESCRIPTION
fix trying to initialize ed run after a plumber run. or any run whose last adv left a maximizer string that is invalid for ed the undying. and potentially any other path that equips baseline gear as part of their day initialization

## How Has This Been Tested?

After a plumber run I had ascended into ed. equipBaseline caused autoscend to crash because it was trying to maximize for `plumber` as ed
Tried to run it several times and it did not work. But adding the reset maximize before the `initializeDay` call fixed this and allowed ed to finish initializing. Should also resolve similar issues for other paths which do something similar

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
