### PR TITLE
Disguise Delimit welding & tiki mask combat handling

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1868,7 +1868,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 	//disguise delimit path specific killing
 	if(majora == 13)	//welding mask
 	{
-		//reflect damage from spells back to player. changing masks does not stop this.
+		//reflect damage from spells back to player. kept if mask is changed
 		//some spells actually damage the monster too.
 		//saucegeyser confirmed to not damage the monster. saucestorm confirmed to damage the monster.
 		if(enemy.physical_resistance >= 80)
@@ -1885,6 +1885,26 @@ string auto_combatHandler(int round, monster enemy, string text)
 			return "attack with weapon";
 		}
 		abort("Not sure how to handle welding mask.");
+	}
+	if(majora == 25)	//tiki mask
+	{
+		//triples HP and hard caps damage at 10 per source. kept if mask is changed
+		//seal clubbers have ways to increase this damage but its overly complicated to calculate. simplified calculation is used.
+		int hot_dmg = min(10,numeric_modifier("hot damage"));
+		int cold_dmg = min(10,numeric_modifier("cold damage"));
+		int stench_dmg = min(10,numeric_modifier("stench damage"));
+		int sleaze_dmg = min(10,numeric_modifier("sleaze damage"));
+		int spooky_dmg = min(10,numeric_modifier("spooky damage"));
+		int attack_dmg = 10 + hot_dmg + cold_dmg + stench_dmg + sleaze_dmg + spooky_dmg;
+		
+		if(attack_dmg > 20)
+		{
+			return "attack with weapon";
+		}
+		if(canUse($skill[Saucestorm], false))
+		{
+			return useSkill($skill[Saucestorm], false);
+		}
 	}
 
 	string attackMinor = "attack with weapon";

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -311,9 +311,9 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	boolean doBanisher = !inAftercore();
 
+	int majora = -1;
 	if(my_path() == "Disguises Delimit")
 	{
-		int majora = -1;
 		matcher maskMatch = create_matcher("mask(\\d+).png", text);
 		if(maskMatch.find())
 		{
@@ -1863,6 +1863,28 @@ string auto_combatHandler(int round, monster enemy, string text)
 			return useSkill($skill[[7333]Fireball Barrage]);
 		}
 		return useSkill($skill[Fireball Toss], false);
+	}
+
+	//disguise delimit path specific killing
+	if(majora == 13)	//welding mask
+	{
+		//reflect damage from spells back to player. changing masks does not stop this.
+		//some spells actually damage the monster too.
+		//saucegeyser confirmed to not damage the monster. saucestorm confirmed to damage the monster.
+		if(enemy.physical_resistance >= 80)
+		{
+			if(my_hp() > monster_hp() + 150 && canUse($skill[Saucestorm], false))
+			{
+				return useSkill($skill[Saucestorm], false);
+			}
+			//TODO check if our physical attack can deal elemental damage.
+			else abort("Not sure how to handle a physically resistent enemy wearing a welding mask.");
+		}
+		if(canSurvive(1.5) && round < 10)
+		{
+			return "attack with weapon";
+		}
+		abort("Not sure how to handle welding mask.");
 	}
 
 	string attackMinor = "attack with weapon";


### PR DESCRIPTION
Disguise Delimit combat handling for:
*welding mask. It reflects spell damage but also lets the monster suffer said damage too... from some spells. Wiki was wrong about this, saying the monster still takes damage from all spells.
Saucegeyser (our preferred attack method) does not deal damage to the monster with welding mask while saucestorm does.
I changed it to prefer to just use attack with weapon on the monster unless the monster the has over 80% physical resistance in which case it prefers to use saucestorm if we we have enough HP to tank it.
Fixes #406

*tiki mask. triples monster HP and hard caps damage at 10 per source. we were tossing saucegeysers at it dealing 10 dmg per round at very high MP cost. Now checks prismatic weapon damage. if weapon deals more than 20 damage to tiki mask we will attack, if not we will use saucestorm which is vastly cheaper than geyser and deals 20 damage per round instead of 10.

## How Has This Been Tested?

2 days in disguise delimit run. went from dying often to not dying anymore.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
