### PR TITLE
speakeasy drinks are not mall tradeable.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -884,7 +884,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				craftables[it] = min(howmany, max(0, creatable_amount(it) - auto_reserveCraftAmount(it)));
 			}
-			if (is_tradeable(it))
+			// speakeasy drinks are not available as items and will cause a crash here if not excluded.
+			if (is_tradeable(it) && !isSpeakeasyDrink(it))
 			{
 				pullables[it] = min(howmany, pulls_remaining());
 			}


### PR DESCRIPTION
speakeasy drinks are not mall tradeable.
fixes a crash when it tries to mallbuy them

## How Has This Been Tested?

played a day in out of standard path with VIP key

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
