### PR TITLE
Track additional interesting data for relay

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -75,7 +75,7 @@ void handleSetting(string type, int x)
 	writeln("<input type='hidden' name='"+set.name+"_didchange' value='"+get_property(set.name)+"' />");
 }
 
-void generateTrackingData(string tracked, boolean hasSkill)
+void generateTrackingData(string tracked)
 {
 	int day = 0;
 	string[int] tracking = split_string(get_property(tracked), ",");
@@ -97,20 +97,6 @@ void generateTrackingData(string tracked, boolean hasSkill)
 		tracking[x] = replace_all(cheat, "CHEAT CODE -");
 		string[int] current = split_string(tracking[x], ":");
 		int curDay = to_int(current[0]);
-		string enemy = current[1];
-
-		string skillUsed = "";
-		int turns = 0;
-
-		if(hasSkill)
-		{
-			skillUsed = current[2];
-			turns = to_int(current[3]);
-		}
-		else
-		{
-			turns = to_int(current[2]);
-		}
 		if(curDay > day)
 		{
 			day = curDay;
@@ -120,14 +106,17 @@ void generateTrackingData(string tracked, boolean hasSkill)
 			}
 			writeln("Day " + day + ": ");
 		}
-		if(hasSkill)
+		string toWrite = "(";
+		for i from i to count(current) 
 		{
-			writeln("(" + enemy + ":" + skillUsed + ":" + turns + "), ");
+			toWrite = toWrite + current[i];
+			if (i != count(current) - 1)
+			{
+				toWrite = toWrite + ":";
+			}
 		}
-		else
-		{
-			writeln("(" + enemy + ":" + turns + "), ");
-		}
+		toWrite = toWrite + "),";
+		writeln(toWrite);
 	}
 }
 
@@ -254,68 +243,68 @@ void main()
 	writeln("<br>Handle <a href=\"autoscend_quests.php\">Quest Tracker</a><br>");
 
 	writeln("<h2>Banishes</h2>");
-	generateTrackingData("auto_banishes", true);
+	generateTrackingData("auto_banishes");
 
 	writeln("<h2>Yellow Rays <img src=\"images/itemimages/eyes.gif\"></h2>");
-	generateTrackingData("auto_yellowRays", true);
+	generateTrackingData("auto_yellowRays");
 
 	writeln("<h2>Sniffing</h2>");
-	generateTrackingData("auto_sniffs", true);
+	generateTrackingData("auto_sniffs");
 
 	writeln("<h2>Copies</h2>");
-	generateTrackingData("auto_copies", true);
+	generateTrackingData("auto_copies");
 
 	writeln("<h2>Replaces</h2>");
-	generateTrackingData("auto_replaces", true);
+	generateTrackingData("auto_replaces");
 
 	writeln("<h2>Instakills</h2>");
-	generateTrackingData("auto_instakill", true);
+	generateTrackingData("auto_instakill");
 
 	writeln("<h2>Eated</h2>");
-	generateTrackingData("auto_eaten", false);
+	generateTrackingData("auto_eaten");
 
 	writeln("<h2>Drinkenated</h2>");
-	generateTrackingData("auto_drunken", false);
+	generateTrackingData("auto_drunken");
 
 	writeln("<h2>Chewed</h2>");
-	generateTrackingData("auto_chewed", false);
+	generateTrackingData("auto_chewed");
 
 	// Don't want to show if they can't make wishes, but maybe they can with pocket wishes
 	if(get_property("auto_wishes") != "" || item_amount($item[genie bottle]) > 0)
 	{
 		writeln("<h2>Wishes</h2>");
-		generateTrackingData("auto_wishes", true);
+		generateTrackingData("auto_wishes");
 	}
 
 	if(my_class() == $class[Ed])
 	{
 		writeln("<h2>Lash of the Cobra <img src=\"images/itemimages/cobrahead.gif\"></h2>");
-		generateTrackingData("auto_lashes", false);
+		generateTrackingData("auto_lashes");
 
 		writeln("<h2>Talisman of Renenutet <img src=\"images/itemimages/tal_r.gif\"></h2>");
-		generateTrackingData("auto_renenutet", false);
+		generateTrackingData("auto_renenutet");
 	}
 
 	if(my_path() == "One Crazy Random Summer")
 	{
 		writeln("<h2>One Crazy Random Summer Fun-o-meter!</h2>");
-		generateTrackingData("auto_funTracker", true);
+		generateTrackingData("auto_funTracker");
 	}
 
 	if(!in_hardcore())
 	{
 		writeln("<h2>Pulls</h2>");
-		generateTrackingData("auto_pulls", false);
+		generateTrackingData("auto_pulls");
 	}
 
 	if (auto_hasPowerfulGlove())
 	{
 		writeln("<h2>Powerful Glove</h2>");
-		generateTrackingData("auto_powerfulglove", true);
+		generateTrackingData("auto_powerfulglove");
 	}
 
 	writeln("<h2>Other Stuff</h2>");
-	generateTrackingData("auto_otherstuff", true);
+	generateTrackingData("auto_otherstuff");
 
 
 	writeln("<h2>Info</h2>");

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -107,7 +107,7 @@ void generateTrackingData(string tracked)
 			writeln("Day " + day + ": ");
 		}
 		string toWrite = "(";
-		for i from i to count(current) 
+		for i from 1 to count(current) 
 		{
 			toWrite = toWrite + current[i];
 			if (i != count(current) - 1)

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -107,7 +107,7 @@ void generateTrackingData(string tracked)
 			writeln("Day " + day + ": ");
 		}
 		string toWrite = "(";
-		for i from 1 to count(current) 
+		for i from 1 to count(current) - 1
 		{
 			toWrite = toWrite + current[i];
 			if (i != count(current) - 1)

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -308,6 +308,12 @@ void main()
 		generateTrackingData("auto_pulls", false);
 	}
 
+	if (auto_hasPowerfulGlove())
+	{
+		writeln("<h2>Powerful Glove</h2>");
+		generateTrackingData("auto_powerfulglove", true);
+	}
+
 	writeln("<h2>Other Stuff</h2>");
 	generateTrackingData("auto_otherstuff", true);
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -167,6 +167,7 @@ void initializeSettings()
 	set_property("auto_ignoreFlyer", false);
 	set_property("auto_instakill", "");
 	set_property("auto_modernzmobiecount", "");
+	set_property("auto_powerfulglove", "");
 	set_property("auto_otherstuff", "");
 	set_property("auto_paranoia", -1);
 	set_property("auto_paranoia_counter", 0);

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1281,7 +1281,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			{
 				if (to_skill(substring(combatAction, 6)) == $skill[CHEAT CODE: Replace Enemy])
 				{
-					handleTracker($item[Powerful Glove], $skill[CHEAT CODE: Replace Enemy], "auto_powerfulglove");
+					handleTracker($skill[CHEAT CODE: Replace Enemy], "auto_powerfulglove");
 				}
 				handleTracker(enemy, to_skill(substring(combatAction, 6)), "auto_replaces");
 			}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1279,6 +1279,10 @@ string auto_combatHandler(int round, monster enemy, string text)
 			set_property("auto_combatHandler", combatState + "(replacer)");
 			if(index_of(combatAction, "skill") == 0)
 			{
+				if (to_skill(substring(combatAction, 6)) == $skill[CHEAT CODE: Replace Enemy])
+				{
+					handleTracker($item[Powerful Glove], $skill[CHEAT CODE: Replace Enemy], "auto_powerfulglove");
+				}
 				handleTracker(enemy, to_skill(substring(combatAction, 6)), "auto_replaces");
 			}
 			else if(index_of(combatAction, "item") == 0)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -459,6 +459,8 @@ string safeString(string input)
 {
 	matcher comma = create_matcher("[,]", input);
 	input = replace_all(comma, ".");
+	matcher colon = create_matcher("[:]", input);
+	input = replace_all(colon, ".");
 	return input;
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -542,6 +542,39 @@ void handleTracker(item used, string detail, string tracker)
 	set_property(tracker, cur);
 }
 
+void handleTracker(item used, skill detail, string tracker)
+{
+	string cur = get_property(tracker);
+	if(cur != "")
+	{
+		cur = cur + ", ";
+	}
+	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
+	set_property(tracker, cur);
+}
+
+void handleTracker(familiar used, string tracker)
+{
+	string cur = get_property(tracker);
+	if(cur != "")
+	{
+		cur = cur + ", ";
+	}
+	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
+	set_property(tracker, cur);
+}
+
+void handleTracker(familiar used, item detail, string tracker)
+{
+	string cur = get_property(tracker);
+	if(cur != "")
+	{
+		cur = cur + ", ";
+	}
+	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
+	set_property(tracker, cur);
+}
+
 void handleTracker(string used, string tracker)
 {
 	string cur = get_property(tracker);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -55,12 +55,7 @@ boolean handleSealAncient(string option);
 boolean handleSealElement(element flavor);
 boolean handleSealElement(element flavor, string option);
 void handleTracker(string used, string tracker);
-void handleTracker(item used, string tracker);
-void handleTracker(item used, string detail, string tracker);
-void handleTracker(monster enemy, string tracker);
-void handleTracker(monster enemy, skill toTrack, string tracker);
-void handleTracker(monster enemy, string toTrack, string tracker);
-void handleTracker(monster enemy, item toTrack, string tracker);
+void handleTracker(string used, string detail, string tracker);
 int internalQuestStatus(string prop);
 string runChoice(string page_text);
 int turkeyBooze();
@@ -478,105 +473,6 @@ string safeString(monster input)
 	return safeString("" + input);
 }
 
-void handleTracker(monster enemy, skill toTrack, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(enemy) + ":" + safeString(toTrack) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(monster enemy, string toTrack, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(enemy) + ":" + safeString(toTrack) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(monster enemy, item toTrack, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(enemy) + ":" + safeString(toTrack) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(monster enemy, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(enemy) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(item used, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(item used, string detail, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(item used, skill detail, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(familiar used, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
-void handleTracker(familiar used, item detail, string tracker)
-{
-	string cur = get_property(tracker);
-	if(cur != "")
-	{
-		cur = cur + ", ";
-	}
-	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
-	set_property(tracker, cur);
-}
-
 void handleTracker(string used, string tracker)
 {
 	string cur = get_property(tracker);
@@ -585,6 +481,17 @@ void handleTracker(string used, string tracker)
 		cur = cur + ", ";
 	}
 	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
+	set_property(tracker, cur);
+}
+
+void handleTracker(string used, string detail, string tracker)
+{
+	string cur = get_property(tracker);
+	if(cur != "")
+	{
+		cur = cur + ", ";
+	}
+	cur = cur + "(" + my_daycount() + ":" + safeString(used) + ":" + safeString(detail) + ":" + my_turncount() + ")";
 	set_property(tracker, cur);
 }
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -836,16 +836,8 @@ item handleSolveThing(boolean[item] poss);					//Defined in autoscend/auto_equip
 item handleSolveThing(boolean[item] poss, slot loc);		//Defined in autoscend/auto_equipment.ash
 item handleSolveThing(item[int] poss);						//Defined in autoscend/auto_equipment.ash
 item handleSolveThing(item[int] poss, slot loc);			//Defined in autoscend/auto_equipment.ash
-void handleTracker(item used, string tracker);				//Defined in autoscend/auto_util.ash
-void handleTracker(monster enemy, item toTrack, string tracker);//Defined in autoscend/auto_util.ash
-void handleTracker(monster enemy, skill toTrack, string tracker);//Defined in autoscend/auto_util.ash
-void handleTracker(monster enemy, string toTrack, string tracker);//Defined in autoscend/auto_util.ash
-void handleTracker(monster enemy, string tracker);			//Defined in autoscend/auto_util.ash
-void handleTracker(string used, string tracker); //Defined in autoscend/auto_util.ash
-void handleTracker(item used, string detail, string tracker); //Defined in autoscend/auto_util.ash
-void handleTracker(item used, skill detail, string tracker); //Defined in autoscend/auto_util.ash
-void handleTracker(familiar used, string tracker);			//Defined in autoscend/auto_util.ash
-void handleTracker(familiar used, item detail, string tracker); //Defined in autoscend/auto_util.ash
+void handleTracker(string used, string tracker);			//Defined in autoscend/auto_util.ash
+void handleTracker(string used, string detail, string tracker);	//Defined in autoscend/auto_util.ash
 boolean hasArm(monster enemy);								//Defined in autoscend/auto_monsterparts.ash
 boolean hasHead(monster enemy);								//Defined in autoscend/auto_monsterparts.ash
 boolean hasLeg(monster enemy);								//Defined in autoscend/auto_monsterparts.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -843,6 +843,9 @@ void handleTracker(monster enemy, string toTrack, string tracker);//Defined in a
 void handleTracker(monster enemy, string tracker);			//Defined in autoscend/auto_util.ash
 void handleTracker(string used, string tracker); //Defined in autoscend/auto_util.ash
 void handleTracker(item used, string detail, string tracker); //Defined in autoscend/auto_util.ash
+void handleTracker(item used, skill detail, string tracker); //Defined in autoscend/auto_util.ash
+void handleTracker(familiar used, string tracker);			//Defined in autoscend/auto_util.ash
+void handleTracker(familiar used, item detail, string tracker); //Defined in autoscend/auto_util.ash
 boolean hasArm(monster enemy);								//Defined in autoscend/auto_monsterparts.ash
 boolean hasHead(monster enemy);								//Defined in autoscend/auto_monsterparts.ash
 boolean hasLeg(monster enemy);								//Defined in autoscend/auto_monsterparts.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -101,6 +101,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
+	handleTracker($item[Mumming Trunk], fam, "auto_otherstuff");
 	
 	return true;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -101,6 +101,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
+	
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -488,6 +488,7 @@ boolean catBurglarHeist(item it)
 			string choice_name = button.group(1);
 			string url = "choice.php?whichchoice=1320&option=1&"+choice_name+"="+to_string(it)+"&pwd=" + my_hash();
 			page = visit_url(url);
+			handleTracker($familiar[Cat Burglar], it, "auto_otherstuff");
 			return true;
 		}
 		auto_log_warning("We don't seem to be able to heist a " + it + ". Maybe we didn't fight it with the Cat Burglar?", "red");

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -753,7 +753,39 @@ boolean auto_pillKeeper(int pill)
 	auto_log_info("Using pill keeper: consuming pill #" + pill, "blue");
 	string page = visit_url("main.php?eowkeeper=1", false);
 	page = visit_url("choice.php?pwd=&whichchoice=1395&pwd&option=" + pill, true);
-	return true;
+	// Succeeded in consuming a pill
+	if (contains_text(page, "You grab the day"))
+	{
+		string type = "unknown";
+		switch(pill)
+		{
+			case 1: type = "yellow ray"; break;
+			case 2: type = "potion"; break;
+			case 3: type = "noncombat"; break;
+			case 4: type = "resistance"; break;
+			case 5: type = "stat"; break;
+			case 6: type = "fam weight"; break;
+			case 7: type = "semirare"; break;
+			case 8: type = "random"; break;
+		}
+		handleTracker($item[Eight Days a Week Pill Keeper], type, "auto_chewed");
+		return true;
+	}
+
+	// yellow ray, noncombat, or semirare already queued
+	if (contains_text(page, "You can't take any more of that right now."))
+	{
+		auto_log_warning("Pill keeper pill #" + pill + " already in effect", "yellow");
+		return true;
+	}
+
+	if (contains_text("Your spleen can't handle any more days worth of medicine!"))
+	{
+		auto_log_warning("Not enough spleen remaining to use pill keeper", "red");
+	}
+
+	// Failed to consume a pill
+	return false;
 }
 
 boolean auto_pillKeeper(string pill)

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -156,6 +156,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 			auto_log_warning("Somehow failed to eat a sausage! What??", "red");
 			return false;
 		}
+		handleTracker($item[magical sausage], "auto_eaten");
 		maxToEat--;
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -763,19 +763,19 @@ boolean auto_pillKeeper(int pill)
 	// Succeeded in consuming a pill
 	if (contains_text(page, "You grab the day"))
 	{
-		string type = "unknown";
+		string detail = "unknown";
 		switch(pill)
 		{
-			case 1: type = "yellow ray"; break;
-			case 2: type = "potion"; break;
-			case 3: type = "noncombat"; break;
-			case 4: type = "resistance"; break;
-			case 5: type = "stat"; break;
-			case 6: type = "fam weight"; break;
-			case 7: type = "semirare"; break;
-			case 8: type = "random"; break;
+			case 1: detail = "yellow ray"; break;
+			case 2: detail = "potion"; break;
+			case 3: detail = "noncombat"; break;
+			case 4: detail = "resistance"; break;
+			case 5: detail = "stat"; break;
+			case 6: detail = "fam weight"; break;
+			case 7: detail = "semirare"; break;
+			case 8: detail = "random"; break;
 		}
-		handleTracker($item[Eight Days a Week Pill Keeper], type, "auto_chewed");
+		handleTracker($item[Eight Days a Week Pill Keeper], detail, "auto_chewed");
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -782,7 +782,7 @@ boolean auto_pillKeeper(int pill)
 	// yellow ray, noncombat, or semirare already queued
 	if (contains_text(page, "You can't take any more of that right now."))
 	{
-		auto_log_warning("Pill keeper pill #" + pill + " already in effect", "yellow");
+		auto_log_warning("Pill keeper pill #" + pill + " already in effect", "red");
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -677,7 +677,13 @@ boolean auto_beachCombHead(string name)
 	if(!auto_beachCombAvailable())   return false;
 	if(!auto_canBeachCombHead(name)) return false;
 
-	return cli_execute("beach head " + auto_beachCombHeadNumFrom(name));
+	boolean ret = cli_execute("beach head " + auto_beachCombHeadNumFrom(name));
+	
+	if (ret)
+	{
+		handleTracker($item[Beach Comb], name, "auto_otherstuff");
+	}
+	return ret;
 }
 
 int auto_beachCombFreeUsesLeft(){

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -786,7 +786,7 @@ boolean auto_pillKeeper(int pill)
 		return true;
 	}
 
-	if (contains_text("Your spleen can't handle any more days worth of medicine!"))
+	if (contains_text(page, "Your spleen can't handle any more days worth of medicine!"))
 	{
 		auto_log_warning("Not enough spleen remaining to use pill keeper", "red");
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -114,7 +114,7 @@ boolean auto_powerfulGloveNoncombatSkill(skill sk)
 
 	if (ret)
 	{
-		handleTracker($item[Powerful Glove], sk, "auto_powerfulglove");
+		handleTracker(sk, "auto_powerfulglove");
 	}
 
 	return ret;

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -112,6 +112,11 @@ boolean auto_powerfulGloveNoncombatSkill(skill sk)
 		equip($slot[Acc3], old);
 	}
 
+	if (ret)
+	{
+		handleTracker($item[Powerful Glove], sk, "auto_powerfulglove");
+	}
+
 	return ret;
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -344,14 +344,15 @@ boolean getLadySpookyravensDancingShoes() {
 	}
 
 	// Louvre It or Leave It choice adventure has a delay of 5 adventures.
-	// TODO: add a check for delay burning?
 	backupSetting("louvreDesiredGoal", "7"); // lets just let mafia automate this for us.
 	auto_log_info("Spookyraven: Gallery", "blue");
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
-	if (!auto_forceNextNoncombat()) {
-		providePlusNonCombat(25, true);
+	if ($location[The Haunted Gallery].turns_spent >= 5) {
+		if (!auto_forceNextNoncombat()) {
+			providePlusNonCombat(25, true);
+		}
 	}
 	if (autoAdv($location[The Haunted Gallery])) {
 		return true;
@@ -368,13 +369,14 @@ boolean getLadySpookyravensPowderPuff() {
 		return false;
 	}
 	// Never Gonna Make You Up choice adventure has a delay of 5 adventures.
-	// TODO: add a check for delay burning?
 	auto_log_info("Spookyraven: Bathroom", "blue");
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
-	if (!auto_forceNextNoncombat()) {
-		providePlusNonCombat(25, true);
+	if ($location[The Haunted Bathroom].turns_spent >= 5) {
+		if (!auto_forceNextNoncombat()) {
+			providePlusNonCombat(25, true);
+		}
 	}
 	if (autoAdv($location[The Haunted Bathroom])) {
 		return true;


### PR DESCRIPTION
# Description

- Check for success when using pill keeper pills
- Track pill keeper usage in auto_chewed
- Track Powerful Glove usage in auto_powerfulglove
- Track beach comb Beach Head in auto_otherstuff
- Track eating magical sausage
- Track Cat Burglar heists in auto_otherstuff
- Track Mumming Trunk in auto_otherstuff
- Simplify handleTracker & generateTrackingData functions

- Minor fix: Defer forcing a non-combat in gallery or bathroom if delay hasn't been burned (fixes possibly wasting a forced non-combat on out in the garden for example)

## How Has This Been Tested?

Ran day 1 of hardcore standard:

![image](https://user-images.githubusercontent.com/1320480/83820962-ce943480-a682-11ea-9b32-44fc7379d16e.png)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
