### PR TITLE
Some random fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2138,22 +2138,28 @@ boolean doBedtime()
 	return false;
 }
 
-boolean powerLevelAdjustment()
-{
-	if(get_property("auto_powerLevelLastLevel").to_int() != my_level() && get_property("auto_powerLevelAdvCount").to_int() > 0)
-	{
-		set_property("auto_powerLevelLastLevel", my_level());
-		set_property("auto_powerLevelAdvCount", 0);
-		return true;
-	}
-	return false;
+boolean isAboutToPowerlevel() {
+	return get_property("auto_powerLevelLastLevel").to_int() == my_level();
 }
 
 boolean LX_attemptPowerLevel()
 {
+	if (my_level() > 12) {
+		return false;
+	}
+
+	if (!isAboutToPowerlevel()) {
+		//release the softblock on various quests that await optimal conditions.
+		auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
+		set_property("auto_powerLevelLastLevel", my_level());
+		set_property("auto_powerLevelAdvCount", 0);
+		return true;
+	}
+
+	auto_log_warning("I've run out of stuff to do. Time to powerlevel, I suppose.", "red");
+
 	set_property("auto_powerLevelAdvCount", get_property("auto_powerLevelAdvCount").to_int() + 1);
 	set_property("auto_powerLevelLastAttempted", my_turncount());
-	set_property("auto_powerLevelLastLevel", my_level());
 	
 	handleFamiliar("stat");
 	addToMaximize("100 exp");
@@ -3148,7 +3154,6 @@ boolean doTasks()
 	resetFlavour();
 
 	basicAdjustML();
-	powerLevelAdjustment();
 	handleFamiliar("item");
 	basicFamiliarOverrides();
 
@@ -3438,21 +3443,8 @@ boolean doTasks()
 		return true;
 	}
 	
-	//release the softblock on various quests that await optimal conditions.
-	if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
-	{
-		auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
-		set_property("auto_powerLevelLastLevel", my_level());
-		return true;
-	}
-	
 	if(LX_getDigitalKey()) 				return true;
 	if(LX_getStarKey()) 				return true;
-	
-	if (my_level() < 13)
-	{
-		if(LX_attemptPowerLevel()) return true;
-	}
 	
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
@@ -3461,12 +3453,7 @@ boolean doTasks()
 	if(L13_towerNSNagamar())			return true;
 	if(L13_towerNSFinal())				return true;
 
-	if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
-	{
-		auto_log_warning("I've run out of stuff to do. Time to powerlevel, I suppose.", "red");
-		set_property("auto_powerLevelLastLevel", my_level());
-		return true;
-	}
+	if (LX_attemptPowerLevel()) return true;	
 
 	auto_log_info("I should not get here more than once because I pretty much just finished all my in-run stuff. Beep", "blue");
 	return false;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -499,6 +499,10 @@ boolean auto_pre_adventure()
 		acquireHP();
 	}
 
+	if (my_hp() <= (my_maxhp() * 0.75)) {
+		acquireHP();
+	}
+
 	int wasted_mp = my_mp() + mp_regen() - my_maxmp();
 	if(wasted_mp > 0 && my_mp() > 400)
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -817,7 +817,7 @@ int auto_meteoriteAdesUsed();								//Defined in autoscend/iotms/auto_mr2017.as
 boolean handleBarrelFullOfBarrels(boolean daily);			//Defined in autoscend/auto_util.ash
 boolean handleCopiedMonster(item itm);						//Defined in autoscend/auto_util.ash
 boolean handleCopiedMonster(item itm, string option);		//Defined in autoscend/auto_util.ash
-boolean powerLevelAdjustment();								//Defined in autoscend.ash
+boolean isAboutToPowerlevel();
 boolean handleFaxMonster(monster enemy);					//Defined in autoscend/auto_clan.ash
 boolean handleFaxMonster(monster enemy, boolean fightIt);	//Defined in autoscend/auto_clan.ash
 boolean handleFaxMonster(monster enemy, boolean fightIt, string option);//Defined in autoscend/auto_clan.ash

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -129,7 +129,7 @@ boolean LX_unlockHauntedBilliardsRoom() {
 	}
 	
 	boolean delayKitchen = get_property("auto_delayHauntedKitchen").to_boolean();
-	if(my_level() == get_property("auto_powerLevelLastLevel").to_int())
+	if(isAboutToPowerlevel())
 	{
 		// if we're at the point where we need to level up to get more quests other than this, we might as well just do this instead
 		delayKitchen = false;
@@ -216,7 +216,7 @@ boolean LX_unlockHauntedLibrary()
 	}
 	
 	//inebrity handling. do not care if: auto succeed or can't drink or ran out of things to do.
-	if(expectPool < 18 && can_drink() && my_level() != get_property("auto_powerLevelLastLevel").to_int())
+	if(expectPool < 18 && can_drink() && !isAboutToPowerlevel())
 	{
 		//paths with inebrity limit under 11 should wait until they are at max to do this
 		if(my_inebriety() < inebriety_limit() && inebriety_limit() < 11)
@@ -401,7 +401,7 @@ boolean L11_blackMarket()
 	{
 		return false;
 	}
-	if ((possessEquipment($item[Blackberry Galoshes]) && !auto_can_equip($item[Blackberry Galoshes])) && my_level() != get_property("auto_powerLevelLastLevel").to_int())
+	if ((possessEquipment($item[Blackberry Galoshes]) && !auto_can_equip($item[Blackberry Galoshes])) && !isAboutToPowerlevel())
 	{
 		return false;
 	}
@@ -1690,7 +1690,7 @@ boolean L11_mauriceSpookyraven()
 
 boolean L11_redZeppelin()
 {
-	if (internalQuestStatus("questL11Shen") < 8 && my_level() != get_property("auto_powerLevelLastLevel").to_int())
+	if (internalQuestStatus("questL11Shen") < 8 && !isAboutToPowerlevel())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_3.ash
+++ b/RELEASE/scripts/autoscend/quests/level_3.ash
@@ -224,7 +224,7 @@ boolean L3_tavern()
 		}
 	}
 
-	if(my_level() == get_property("auto_powerLevelLastLevel").to_int())
+	if(isAboutToPowerlevel())
 	{
 		delayTavern = false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_5.ash
+++ b/RELEASE/scripts/autoscend/quests/level_5.ash
@@ -63,7 +63,7 @@ boolean L5_haremOutfit()
 
 	if(!adjustForYellowRayIfPossible($monster[Knob Goblin Harem Girl]))
 	{
-		if(my_level() != get_property("auto_powerLevelLastLevel").to_int())
+		if(!isAboutToPowerlevel())
 		{
 			return false;
 		}
@@ -76,7 +76,10 @@ boolean L5_haremOutfit()
 	bat_formBats();
 
 	auto_log_info("Looking for some sexy lingerie!", "blue");
-	return autoAdv($location[Cobb\'s Knob Harem]);
+	if (autoAdv($location[Cobb\'s Knob Harem])) {
+		return true;
+	}
+	return false;
 }
 
 boolean L5_goblinKing()
@@ -85,7 +88,7 @@ boolean L5_goblinKing()
 	{
 		return false;
 	}
-	if (my_level() < 8 && get_property("auto_powerLevelAdvCount").to_int() < 9)
+	if (my_level() < 8 && !isAboutToPowerlevel()) // needs to be changed to check if we'll survive
 	{
 		return false;
 	}
@@ -110,12 +113,12 @@ boolean L5_goblinKing()
 	buffMaintain($effect[Knob Goblin Perfume], 0, 1, 1);
 	if(have_effect($effect[Knob Goblin Perfume]) == 0)
 	{
-		autoAdv($location[Cobb\'s Knob Harem]);
-		if(contains_text(get_property("lastEncounter"), "Cobb's Knob lab key"))
+		boolean advSpent = autoAdv($location[Cobb\'s Knob Harem]);
+		if (have_effect($effect[Knob Goblin Perfume]) == 0)
 		{
-			autoAdv($location[Cobb\'s Knob Harem]);
+			advSpent = autoAdv($location[Cobb\'s Knob Harem]);
 		}
-		return true;
+		return advSpent;
 	}
 
 	if(my_primestat() == $stat[Muscle])
@@ -132,21 +135,16 @@ boolean L5_goblinKing()
 		buffMaintain($effect[Temporary Lycanthropy], 0, 1, 1);
 	}
 
-	if(monster_level_adjustment() > 150)
-	{
-		autoEquip($slot[acc2], $item[none]);
-	}
-
 	// TODO: I died here, maybe we should heal a bit?
 	if (!in_zelda())
 	{
 		auto_change_mcd(10); // get the Crown from the Goblin King.
 	}
-	autoAdv($location[Throne Room]);
+	boolean advSpent = autoAdv($location[Throne Room]);
 
 	if((item_amount($item[Crown of the Goblin King]) > 0) || (item_amount($item[Glass Balls of the Goblin King]) > 0) || (item_amount($item[Codpiece of the Goblin King]) > 0) || (get_property("questL05Goblin") == "finished") || in_zelda())
 	{
 		council();
 	}
-	return true;
+	return advSpent;
 }

--- a/RELEASE/scripts/autoscend/quests/level_8.ash
+++ b/RELEASE/scripts/autoscend/quests/level_8.ash
@@ -324,7 +324,7 @@ boolean L8_getMineOres()
 		if(get_property("auto_wandOfNagamar").to_boolean())
 		{
 			numCloversKeep = 1;
-			if(get_property("auto_powerLevelLastLevel").to_int() == my_level())
+			if(isAboutToPowerlevel())
 			{
 				numCloversKeep = 0;
 			}
@@ -537,7 +537,7 @@ boolean L8_trapperGroar()
 			return true;
 		}
 	}
-	if(get_property("auto_powerLevelAdvCount").to_int() > 8)
+	if(isAboutToPowerlevel())
 	{
 		if(L8_trapperExtreme())
 		{

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -746,7 +746,7 @@ boolean L9_oilPeak()
 
 	auto_MaxMLToCap(auto_convertDesiredML(100), false);
 
-	if(monster_level_adjustment() < 50 && my_level() < 12 && my_level() != get_property("auto_powerLevelLastLevel").to_int())
+	if(monster_level_adjustment() < 50 && my_level() < 12 && !isAboutToPowerlevel())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -737,6 +737,11 @@ boolean LX_acquireLegendaryEpicWeapon()
 		return true;
 	}
 
+	if (shenShouldDelayZone($location[The Unquiet Garves])) {
+		auto_log_debug("Delaying The Unquiet Garves in case of Shen.");
+		return false;
+	}
+
 	addToMaximize("-equip " + starterWeapons[my_class()].to_string());
 
 	if (autoAdv($location[The Unquiet Garves])) {


### PR DESCRIPTION
# Description
- heal if we're at less than 75% hp in pre-adv as otherwise we die a lot unnecessarily at low levels by entering combat on tiny amounts of hp
- add shen delay check to LX_acquireLegendaryEpicWeapon() since it adventures in The Unquiet Garves
- remove powerlevelAdjustment, move functionality in to LX_attemptPowerLevel along with the soft block unlock.
- create isAboutToPowerlevel() and replace calls to checking the auto_powerlevelLastLevel property with it.

## How Has This Been Tested?

Ran some LKS runs with these changes. No issues thus far. The healing before adventuring is helping with not dying for dumb reasons (like starting combats on 1 or 2 hp) so adventures are being saved.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
