### PR TITLE
familiars revamped

### DIFF
--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -1,0 +1,90 @@
+# "drop" type is used when we want to grab a familiar that drops items themselves rather than boosting the odds of the enemy dropping items.
+#
+# First we grab up to small amount of various specific drops.
+#
+# 5 turkey booze drops a day. each is size 1 and density of either 5, 5.5, or 6
+Fist Turkey	prop:_turkeyBooze<5
+# every 10 yellow pixels make a size 2 density 5 food or drink. unlimited drops per day. prioritize having enough to craft 2.
+# drops 1 per combat with chance of 2nd if wearing familiar specific equip
+Puck Man	item:Yellow Pixel<20
+Ms. Puck Man	item:Yellow Pixel<20
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
+Optimistic Candle	prop:optimisticCandleProgress>=25
+# 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
+Rockin' Robin	prop:rockinRobinProgress>=25
+# 1st burning newspaper per run only takes 5 combats, afterwards 30. can be used for +5 adv on dayroll back equip
+Garbage Fire	prop:garbageFireProgress>=25
+# Hot ashes can make a potion that gives +15 ML for 15 adv. keep 1 of them in stock
+Galloping Grill	prop:_hotAshesDrops<5;item:hot ashes<1
+#
+# get substats from fist turkey in The Source path
+Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
+Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
+Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
+#
+# Cat Burgler can charge up heists. 30 combats give it 2 charges.
+Cat Burglar	prop:_catBurglarCharge<30
+#
+# Drops many items. make sure we got 1 in stock of the banisher, as well as size 1 density 5 food/drink
+# Because it drops so many different items the odds of getting what we want are reduced. so lowered its priority
+Elf Operative	item:tryptophan dart<1
+Elf Operative	item:elf army field rations<1
+Elf Operative	item:martiny<1
+# drops size 1 density 4.5 food and drink. odds of drop are relatively low so it down here
+Garbage Fire	item:extra-toasted half sandwich<1
+Garbage Fire	item:mulled hobo wine<1
+#
+# Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
+Intergnat	item:BACON<150
+#
+# Below this lines drops are not needed more of for the run and are just grabbing for profit.
+# Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
+#
+# density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
+# Here they are only used to grab extras.
+Grim Brother	prop:_grimFairyTaleDrops<5;!prop_boolean:_auto_thisLoopPlusNoncombat
+Pair of Stomping Boots	prop:_bootStomps<7
+Baby Sandworm	prop:_aguaDrops<5
+Bloovian Groose	prop:_grooseDrops<5
+Golden Monkey	prop:_powderedGoldDrops<5
+Unconscious Collective	prop:_dreamJarDrops<5
+# psychoanalytic jar 1 per day.
+Angry Jung Man	prop:_jungDrops<1
+# grimstone mask 1 per day
+Grimstone Golem	prop:_grimstoneMaskDrops<1
+# tales of spelunking 1 per day
+Adventurous Spelunker	prop:_spelunkingTalesDrops<1
+# can drop 5 devilish folio a day
+Blavious Kloop	prop:_kloopDrops<5
+# can drop 5 absinthe a day
+Green Pixie	prop:_absintheDrops<5
+# Drops robin's egg every 30 combats. +3 all res potion
+Rockin' Robin	item:robin\'s egg<1
+# Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
+Galloping Grill	prop:_hotAshesDrops<5
+#
+# Below this line are familiars with no properties. meaning if you have it then it will be kept selected permanently.
+# Most of those also appear higher up in the file with properties. Meaning we use them until a select amount is grabbed first.
+#
+# Drops many items. among them: banish, restore, stun, damage, size 1 density 5 food/drink, -combat equip, all res +2 equip, +3XP equip, +15% meat equip
+Elf Operative
+# Drops more burning newspapers. one per 30 combats. also drops size 1 density 4.5 food and drink
+Garbage Fire
+# Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
+XO Skeleton
+# Drops BACON every combat
+Intergnat
+# Generates adventures after combat
+Reagnimated Gnome
+# Every 30 combats drops wax which makes a single size 2 density 4.25 food or drink 
+Optimistic Candle
+# Drops robin's egg every 30 combats. +3 all res potion
+Rockin' Robin
+# cheap IOTM derivative that drops many different things. many are junk, but it does have size 3 density 3.83 food which is better than nothing.
+Lil' Barrel Mimic
+# Once the hot ashes all dropped. remaining drops are not that useful.
+Galloping Grill
+# Can use to track phyllum, every 11 encounters from tracked phyllum results in a drop. Needs more code before it goes higher on the list
+Red-Nosed Snapper
+# 2% and 4% chance respectively to drop time's arrow and arrowgram.
+Obtuse Angel

--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -1,66 +1,38 @@
-# Undead familiars only when a zombie
-XO Skeleton	path:Zombie Master;prop:_xoHugsUsed<11
-Reagnimated Gnome	path:Zombie Master
-# Do we wanna grab cubeling drops? Usually yes.
-Gelatinous Cubeling	prop:auto_useCubeling=true;prop:auto_cubeItems=true
-# Cheerleader isn't subject to weight restrictions in KOLHS, so let's just use it before almost anything to be safee
+# "Item" is used when we want a familiar that boosts the chance of a monster dropping an item
+# We expect that familiars that drop items directly a limited amount of times per day will be used first elsewhere. So do not account for those.
+#
+# exempt from 10 lbs restriction in KOHLS path
 Steam-Powered Cheerleader	path:KOLHS
-# Wanna get that jar
-Angry Jung Man	prop:_jungDrops<1;day:1
-# Wanna get that mask
-Grimstone Golem	prop:_grimstoneMaskDrops<1;day:1
-# That's some nice booze
-Fist Turkey	prop:_turkeyBooze<5
-# Might as well grab an egg
-Rockin' Robin	prop:rockinRobinProgress>=25
-# And some wax
-Optimistic Candle	prop:optimisticCandleProgress>=25
-# And some garbage
-Garbage Fire	prop:garbageFireProgress>=25
-# And devilish folios
-Blavious Kloop	prop:_kloopDrops<3
-# And some absinthe
-Green Pixie	prop:_absintheDrops<3
-# And a tales of spelunking
-Adventurous Spelunker	prop:_spelunkingTalesDrops<1
-# And some substats, if in The Source
-Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
-Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
-Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
-# And some BACON
-Intergnat	item:BACON<350
-# And some heist charges
-Cat Burglar	prop:_catBurglarCharge<30
-# And some hugpockets
-XO Skeleton	prop:_xoHugsUsed<5
-# And some pastes
-Pair of Stomping Boots	prop:_bootStomps<7
-# And some more hugpockets
-XO Skeleton	prop:_xoHugsUsed<11
-# And some adventures
-Reagnimated Gnome
 # Fairies with a multiplier
+# 1.4x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
-#Mutant Fire Ant	grimdark:0
+# 1.3x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>100
-# Jumpsuited Hound Dog DELIBERATELY not included because it provides usually unwanted +combat
+# Jumpsuited Hound Dog is a 1.25x multiplier fairy that provides +combat. only use it if we did not provide noncombat this loop.
+Jumpsuited Hound Dog	!prop_boolean:_auto_thisLoopPlusNoncombat
+# 1.2x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
-#Mutant Fire Ant	grimdark:1
+# 1.1x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
+# fairy that generates extra adventures
+Reagnimated Gnome
+# Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
+XO Skeleton
+# Fairy that drops bacon with no limit. 1 per combat
+Intergnat
 # Fairyballs
 Elf Operative
 Optimistic Candle
 Rockin' Robin
-# More BACON, why not
-Intergnat
 # Fairywhelps
 Pocket Professor
-XO Skeleton
 Garbage Fire
 Dandy Lion
 # Fairychauns
+Fist Turkey
 Cat Burglar
 Angry Jung Man
+Grimstone Golem
 Adventurous Spelunker
 Blavious Kloop
 Hippo Ballerina
@@ -78,20 +50,24 @@ Gelatinous Cubeling
 Steam-Powered Cheerleader
 Obtuse Angel
 Green Pixie
-#Mutant Fire Ant	grimdark:2
-# Let's bowl 300!
-Bowlet
 # Elemental fairies
 Sleazy Gravy Fairy
 Stinky Gravy Fairy
 Flaming Gravy Fairy
 Frozen Gravy Fairy
 Spooky Gravy Fairy
+# Physical damage fairy
+Bowlet
 # Barely special fairies
 Mechanical Songbird
 Grouper Groupie
 Peppermint Rhino
+# Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
+Slimeling
 # Turtles are cute
 Syncopated Turtle
 # The original
 Baby Gravy Fairy
+# Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
+# If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
+Mutant Fire Ant

--- a/BUILD/familiars/regen.dat
+++ b/BUILD/familiars/regen.dat
@@ -4,14 +4,14 @@
 # But starfish restore roughly 0.25*weight PER TURN
 # and average combat length looks to be ~6 rounds in autoscend, so that's 1.5*weight on average
 # Not even bothering with cocoabos
-# Ash is nice
+# starfish. drops 5 ash/day which makes +15 ML potion for 15 adv
 Galloping Grill	prop:_hotAshesDrops<5
-# Tokens are nice
+# starfish that drops 5 tokens a day that can be exchanged for a spleen consumable that gives adv
 Rogue Program	prop:_tokenDrops<5
-# Hugpockets are good, Xs and Os are good, even if whelps aren't as good as starfish
-XO Skeleton	prop:_xoHugsUsed<11
-# Free stuff!
-Lil' Barrel Mimic
+# whelp. Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
+XO Skeleton
+# Drops assorted stuff, mostly junk. has some awesome food. requires familiar equip brass bung spigot to regen HP/MP
+Lil' Barrel Mimic	item:brass bung spigot>0
 # It's a starfish with reduced activation rate, except it ALWAYS attacks on turn one, so that's probably more hits per battle on average in short battles? oh, and it's a sombrero too
 Galloping Grill
 # A super starfish (50% activation instead of 33%)

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -17,6 +17,96 @@ boss	2	Mu
 boss	3	Warbear Drone
 boss	4	Mosquito
 
+# "drop" type is used when we want to grab a familiar that drops items themselves rather than boosting the odds of the enemy dropping items.
+#
+# First we grab up to small amount of various specific drops.
+#
+# 5 turkey booze drops a day. each is size 1 and density of either 5, 5.5, or 6
+drop	0	Fist Turkey	prop:_turkeyBooze<5
+# every 10 yellow pixels make a size 2 density 5 food or drink. unlimited drops per day. prioritize having enough to craft 2.
+# drops 1 per combat with chance of 2nd if wearing familiar specific equip
+drop	1	Puck Man	item:Yellow Pixel<20
+drop	2	Ms. Puck Man	item:Yellow Pixel<20
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
+drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
+# 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
+drop	4	Rockin' Robin	prop:rockinRobinProgress>=25
+# 1st burning newspaper per run only takes 5 combats, afterwards 30. can be used for +5 adv on dayroll back equip
+drop	5	Garbage Fire	prop:garbageFireProgress>=25
+# Hot ashes can make a potion that gives +15 ML for 15 adv. keep 1 of them in stock
+drop	6	Galloping Grill	prop:_hotAshesDrops<5;item:hot ashes<1
+#
+# get substats from fist turkey in The Source path
+drop	7	Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
+drop	8	Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
+drop	9	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
+#
+# Cat Burgler can charge up heists. 30 combats give it 2 charges.
+drop	10	Cat Burglar	prop:_catBurglarCharge<30
+#
+# Drops many items. make sure we got 1 in stock of the banisher, as well as size 1 density 5 food/drink
+# Because it drops so many different items the odds of getting what we want are reduced. so lowered its priority
+drop	11	Elf Operative	item:tryptophan dart<1
+drop	12	Elf Operative	item:elf army field rations<1
+drop	13	Elf Operative	item:martiny<1
+# drops size 1 density 4.5 food and drink. odds of drop are relatively low so it down here
+drop	14	Garbage Fire	item:extra-toasted half sandwich<1
+drop	15	Garbage Fire	item:mulled hobo wine<1
+#
+# Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
+drop	16	Intergnat	item:BACON<150
+#
+# Below this lines drops are not needed more of for the run and are just grabbing for profit.
+# Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
+#
+# density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
+# Here they are only used to grab extras.
+drop	17	Grim Brother	prop:_grimFairyTaleDrops<5;!prop_boolean:_auto_thisLoopPlusNoncombat
+drop	18	Pair of Stomping Boots	prop:_bootStomps<7
+drop	19	Baby Sandworm	prop:_aguaDrops<5
+drop	20	Bloovian Groose	prop:_grooseDrops<5
+drop	21	Golden Monkey	prop:_powderedGoldDrops<5
+drop	22	Unconscious Collective	prop:_dreamJarDrops<5
+# psychoanalytic jar 1 per day.
+drop	23	Angry Jung Man	prop:_jungDrops<1
+# grimstone mask 1 per day
+drop	24	Grimstone Golem	prop:_grimstoneMaskDrops<1
+# tales of spelunking 1 per day
+drop	25	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
+# can drop 5 devilish folio a day
+drop	26	Blavious Kloop	prop:_kloopDrops<5
+# can drop 5 absinthe a day
+drop	27	Green Pixie	prop:_absintheDrops<5
+# Drops robin's egg every 30 combats. +3 all res potion
+drop	28	Rockin' Robin	item:robin's egg<1
+# Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
+drop	29	Galloping Grill	prop:_hotAshesDrops<5
+#
+# Below this line are familiars with no properties. meaning if you have it then it will be kept selected permanently.
+# Most of those also appear higher up in the file with properties. Meaning we use them until a select amount is grabbed first.
+#
+# Drops many items. among them: banish, restore, stun, damage, size 1 density 5 food/drink, -combat equip, all res +2 equip, +3XP equip, +15% meat equip
+drop	30	Elf Operative
+# Drops more burning newspapers. one per 30 combats. also drops size 1 density 4.5 food and drink
+drop	31	Garbage Fire
+# Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
+drop	32	XO Skeleton
+# Drops BACON every combat
+drop	33	Intergnat
+# Generates adventures after combat
+drop	34	Reagnimated Gnome
+# Every 30 combats drops wax which makes a single size 2 density 4.25 food or drink
+drop	35	Optimistic Candle
+# Drops robin's egg every 30 combats. +3 all res potion
+drop	36	Rockin' Robin
+# cheap IOTM derivative that drops many different things. many are junk, but it does have size 3 density 3.83 food which is better than nothing.
+drop	37	Lil' Barrel Mimic
+# Once the hot ashes all dropped. remaining drops are not that useful.
+drop	38	Galloping Grill
+# Can use to track phyllum, every 11 encounters from tracked phyllum results in a drop. Needs more code before it goes higher on the list
+drop	39	Red-Nosed Snapper
+# 2% and 4% chance respectively to drop time's arrow and arrowgram.
+
 # We want to delevel, but don't want to deal damage
 gremlins	0	Nosy Nose
 gremlins	1	Plastic Pirate Skull
@@ -30,103 +120,78 @@ init	2	Oily Woim
 # That and it's booze isn't terribly relevant nowadays, so it's been demoted
 init	3	Happy Medium
 
-# Undead familiars only when a zombie
-item	0	XO Skeleton	path:Zombie Master;prop:_xoHugsUsed<11
-item	1	Reagnimated Gnome	path:Zombie Master
-# Do we wanna grab cubeling drops? Usually yes.
-item	2	Gelatinous Cubeling	prop:auto_useCubeling=true;prop:auto_cubeItems=true
-# Cheerleader isn't subject to weight restrictions in KOLHS, so let's just use it before almost anything to be safee
-item	3	Steam-Powered Cheerleader	path:KOLHS
-# Wanna get that jar
-item	4	Angry Jung Man	prop:_jungDrops<1;day:1
-# Wanna get that mask
-item	5	Grimstone Golem	prop:_grimstoneMaskDrops<1;day:1
-# That's some nice booze
-item	6	Fist Turkey	prop:_turkeyBooze<5
-# Might as well grab an egg
-item	7	Rockin' Robin	prop:rockinRobinProgress>=25
-# And some wax
-item	8	Optimistic Candle	prop:optimisticCandleProgress>=25
-# And some garbage
-item	9	Garbage Fire	prop:garbageFireProgress>=25
-# And devilish folios
-item	10	Blavious Kloop	prop:_kloopDrops<3
-# And some absinthe
-item	11	Green Pixie	prop:_absintheDrops<3
-# And a tales of spelunking
-item	12	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
-# And some substats, if in The Source
-item	13	Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
-item	14	Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
-item	15	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
-# And some BACON
-item	16	Intergnat	item:BACON<350
-# And some heist charges
-item	17	Cat Burglar	prop:_catBurglarCharge<30
-# And some hugpockets
-item	18	XO Skeleton	prop:_xoHugsUsed<5
-# And some pastes
-item	19	Pair of Stomping Boots	prop:_bootStomps<7
-# And some more hugpockets
-item	20	XO Skeleton	prop:_xoHugsUsed<11
-# And some adventures
-item	21	Reagnimated Gnome
+# "Item" is used when we want a familiar that boosts the chance of a monster dropping an item
+# We expect that familiars that drop items directly a limited amount of times per day will be used first elsewhere. So do not account for those.
+#
+# exempt from 10 lbs restriction in KOHLS path
+item	0	Steam-Powered Cheerleader	path:KOLHS
 # Fairies with a multiplier
-item	22	Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
-#Mutant Fire Ant	grimdark:0
-item	23	Steam-Powered Cheerleader	prop:_cheerleaderSteam>100
-# Jumpsuited Hound Dog DELIBERATELY not included because it provides usually unwanted +combat
-item	24	Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
-#Mutant Fire Ant	grimdark:1
-item	25	Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
+# 1.4x multiplier fairy
+item	1	Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
+# 1.3x multiplier fairy
+item	2	Steam-Powered Cheerleader	prop:_cheerleaderSteam>100
+# Jumpsuited Hound Dog is a 1.25x multiplier fairy that provides +combat. only use it if we did not provide noncombat this loop.
+item	3	Jumpsuited Hound Dog	!prop_boolean:_auto_thisLoopPlusNoncombat
+# 1.2x multiplier fairy
+item	4	Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
+# 1.1x multiplier fairy
+item	5	Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
+# fairy that generates extra adventures
+item	6	Reagnimated Gnome
+# Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
+item	7	XO Skeleton
+# Fairy that drops bacon with no limit. 1 per combat
+item	8	Intergnat
 # Fairyballs
-item	26	Elf Operative
-item	27	Optimistic Candle
-item	28	Rockin' Robin
-# More BACON, why not
-item	29	Intergnat
+item	9	Elf Operative
+item	10	Optimistic Candle
+item	11	Rockin' Robin
 # Fairywhelps
-item	30	Pocket Professor
-item	31	XO Skeleton
-item	32	Garbage Fire
-item	33	Dandy Lion
+item	12	Pocket Professor
+item	13	Garbage Fire
+item	14	Dandy Lion
 # Fairychauns
-item	34	Cat Burglar
-item	35	Angry Jung Man
-item	36	Adventurous Spelunker
-item	37	Blavious Kloop
-item	38	Hippo Ballerina
-item	39	Dancing Frog
-item	40	Coffee Pixie
-item	41	Attention-Deficit Demon
-item	42	Jitterbug
-item	43	Casagnova Gnome
-item	44	Psychedelic Bear
-item	45	Piano Cat
+item	15	Fist Turkey
+item	16	Cat Burglar
+item	17	Angry Jung Man
+item	18	Grimstone Golem
+item	19	Adventurous Spelunker
+item	20	Blavious Kloop
+item	21	Hippo Ballerina
+item	22	Dancing Frog
+item	23	Coffee Pixie
+item	24	Attention-Deficit Demon
+item	25	Jitterbug
+item	26	Casagnova Gnome
+item	27	Psychedelic Bear
+item	28	Piano Cat
 # Slightly special fairies
-item	46	Red-Nosed Snapper
-item	47	Pair of Stomping Boots
-item	48	Gelatinous Cubeling
-item	49	Steam-Powered Cheerleader
-item	50	Obtuse Angel
-item	51	Green Pixie
-#Mutant Fire Ant	grimdark:2
-# Let's bowl 300!
-item	52	Bowlet
+item	29	Red-Nosed Snapper
+item	30	Pair of Stomping Boots
+item	31	Gelatinous Cubeling
+item	32	Steam-Powered Cheerleader
+item	33	Obtuse Angel
+item	34	Green Pixie
 # Elemental fairies
-item	53	Sleazy Gravy Fairy
-item	54	Stinky Gravy Fairy
-item	55	Flaming Gravy Fairy
-item	56	Frozen Gravy Fairy
-item	57	Spooky Gravy Fairy
+item	35	Sleazy Gravy Fairy
+item	36	Stinky Gravy Fairy
+item	37	Flaming Gravy Fairy
+item	38	Frozen Gravy Fairy
+item	39	Spooky Gravy Fairy
+# Physical damage fairy
+item	40	Bowlet
 # Barely special fairies
-item	58	Mechanical Songbird
-item	59	Grouper Groupie
-item	60	Peppermint Rhino
+item	41	Mechanical Songbird
+item	42	Grouper Groupie
+item	43	Peppermint Rhino
+# Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
+item	44	Slimeling
 # Turtles are cute
-item	61	Syncopated Turtle
+item	45	Syncopated Turtle
 # The original
-item	62	Baby Gravy Fairy
+item	46	Baby Gravy Fairy
+# Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
+# If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1
@@ -193,14 +258,14 @@ meat	39	Leprechaun
 # But starfish restore roughly 0.25*weight PER TURN
 # and average combat length looks to be ~6 rounds in autoscend, so that's 1.5*weight on average
 # Not even bothering with cocoabos
-# Ash is nice
+# starfish. drops 5 ash/day which makes +15 ML potion for 15 adv
 regen	0	Galloping Grill	prop:_hotAshesDrops<5
-# Tokens are nice
+# starfish that drops 5 tokens a day that can be exchanged for a spleen consumable that gives adv
 regen	1	Rogue Program	prop:_tokenDrops<5
-# Hugpockets are good, Xs and Os are good, even if whelps aren't as good as starfish
-regen	2	XO Skeleton	prop:_xoHugsUsed<11
-# Free stuff!
-regen	3	Lil' Barrel Mimic
+# whelp. Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
+regen	2	XO Skeleton
+# Drops assorted stuff, mostly junk. has some awesome food. requires familiar equip brass bung spigot to regen HP/MP
+regen	3	Lil' Barrel Mimic	item:brass bung spigot>0
 # It's a starfish with reduced activation rate, except it ALWAYS attacks on turn one, so that's probably more hits per battle on average in short battles? oh, and it's a sombrero too
 regen	4	Galloping Grill
 # A super starfish (50% activation instead of 33%)
@@ -241,7 +306,6 @@ regen	26	Pet Cheezling	class:Sauceror
 regen	27	Pottery Barn Owl
 # Regular old whelps
 regen	28	Pet Cheezling
-regen	29	Ghuol Whelp
 
 # Sombrero is desirable with a decent amount of ML
 stat	0	Galloping Grill	ML:>=120

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3085,9 +3085,9 @@ boolean doTasks()
 		return false;	
 	}
 	
-	//These settings should never persist into another turn, ever.
-	set_property("auto_doCombatCopy", "no");
-	set_property("auto_disableFamiliarChanging", false);
+	//These settings should never persist into another turn, ever. They only track something for a single instance of the main loop.
+	//We use boolean instead of adventure count because of free combats.
+	resetThisLoop();
 
 	print_header();
 
@@ -3154,8 +3154,6 @@ boolean doTasks()
 	resetFlavour();
 
 	basicAdjustML();
-	handleFamiliar("item");
-	basicFamiliarOverrides();
 
 	councilMaintenance();
 	# This function buys missing skills in general, not just for Picky.

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -41,17 +41,7 @@ boolean pathAllowsFamiliar()
 
 boolean auto_have_familiar(familiar fam)
 {
-	if(auto_my_path() == "License to Adventure")
-	{
-		return false;
-	}
-	if($classes[
-		Avatar Of Boris,
-		Avatar Of Jarlsberg,
-		Avatar Of Sneaky Pete,
-		Ed,
-		Vampyre,
-		] contains my_class())
+	if(!pathAllowsFamiliar())
 	{
 		return false;
 	}
@@ -59,6 +49,22 @@ boolean auto_have_familiar(familiar fam)
 	{
 		return false;
 	}
+	
+	//handle blacklisting of familiars by users
+	int[familiar] blacklist;
+	if(get_property("auto_blacklistFamiliar") != "")
+	{
+		string[int] noFams = split_string(get_property("auto_blacklistFamiliar"), ";");
+		foreach index, fam in noFams
+		{
+			blacklist[to_familiar(trim(fam))] = 1;
+		}
+	}
+	if(blacklist contains fam)
+	{
+		return false;
+	}
+	
 	return have_familiar(fam);
 }
 
@@ -92,7 +98,7 @@ boolean canChangeToFamiliar(familiar target)
 	{
 		return false;
 	}
-
+	
 	// if you don't have a familiar, you can't change to it.
 	if(!auto_have_familiar(target))
 	{
@@ -110,81 +116,101 @@ boolean canChangeToFamiliar(familiar target)
 		return false;
 	}
 	
+	//handle a target of none. after we verified we are not breaking a 100% run to do so.
+	if(target == $familiar[none])
+	{
+		//on paths that do not allow familiars at all, trying to switch to $familiar[none] causes an exception.
+		return pathAllowsFamiliar();
+	}
+	
 	// if you reached this point, then auto_100familiar must not be set to anything, you are allowed to change familiar.
 	return true;
 }
 
-boolean handleFamiliar(string type)
+familiar lookupFamiliarDatafile(string type)
 {
-	//Can this take zoneInfo into account?
-
-	//	Put all familiars in reverse priority order here.
-	int[familiar] blacklist;
-
-	int ascensionThreshold = get_property("auto_ascensionThreshold").to_int();
-	if(ascensionThreshold == 0)
-	{
-		ascensionThreshold = 100;
-	}
-
-	if(get_property("auto_blacklistFamiliar") != "")
-	{
-		string[int] noFams = split_string(get_property("auto_blacklistFamiliar"), ";");
-		foreach index, fam in noFams
-		{
-			blacklist[to_familiar(trim(fam))] = 1;
-		}
-	}
-
-	boolean suggest = type.ends_with("Suggest");
-	if(suggest)
-	{
-		type = type.substring(0, type.length() - length("Suggest"));
-		if(familiar_weight(my_familiar()) < 20)
-		{
-			return false;
-		}
-	}
-
+	//This function looks through /data/autoscend_familiars.txt for the matching "type" in order and selects the first match whose conditions are met. Said conditions typically include path exclusions and a check to see if that familiar dropped something today.
+	//we do not want a fallback here. if no matching familiar is found then do nothing here, a familiar will be automatically set in pre adventure
+	
+	auto_log_debug("lookupFamiliarDatafile is checking for type [" + type + "]");
 	string [string,int,string] familiars_text;
 	if(!file_to_map("autoscend_familiars.txt", familiars_text))
-		auto_log_critical("Could not load autoscend_familiars.txt. This is bad!", "red");
+	{
+		abort("Could not load /data/autoscend_familiars.txt");
+	}
 	foreach i,name,conds in familiars_text[type]
 	{
 		familiar thisFamiliar = name.to_familiar();
-		if(thisFamiliar == $familiar[none] && name != "none")
+		if(thisFamiliar == $familiar[none])
 		{
-			auto_log_error('"' + name + '" does not convert to a familiar properly!', "red");
-			auto_log_error(type + "; " + i + "; " + conds, "red");
+			if(name != "none")
+			{
+				auto_log_error("lookupFamiliarDatafile failed to convert string [" + name + "] to familiar", "red");
+				auto_log_error(type + "; " + i + "; " + conds, "red");
+			}
 			continue;
 		}
-		if(!auto_check_conditions(conds))
+		if(!auto_check_conditions(conds))		//checks for the conditions specified in the data file
 			continue;
-		if(!auto_have_familiar(thisFamiliar))
+		if(!canChangeToFamiliar(thisFamiliar))	//check various things that could prevent us from changing to it
 			continue;
-		if(blacklist contains thisFamiliar)
-			continue;
-		return handleFamiliar(thisFamiliar);
+		return thisFamiliar;
+	}
+	
+	//no suitable familiars found in datafile
+	return $familiar[none];
+}
+
+boolean handleFamiliar(string type)
+{
+	//This function calls familiar lookupFamiliarDatafile(string type) and if a result is found will send it over to handleFamiliar(familiar fam) so it can be set as our target familiar to be used during pre adventure.
+	//we do not want a fallback here. if no matching familiar is found then do nothing here, a familiar will be automatically set in pre adventure
+	
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
+	{
+		return false;	//familiar changing temporarily disabled.
+	}
+	if(!pathAllowsFamiliar())
+	{
+		return false;
+	}
+	
+	familiar target = lookupFamiliarDatafile(type);
+	
+	if(target != $familiar[none])
+	{
+		return handleFamiliar(target);
 	}
 	return false;
 }
 
 boolean handleFamiliar(familiar fam)
 {
-	if(!canChangeFamiliar())
-	{
-		return true;
-	}
+	//This function takes a specific named familiar and sets it as our target familiar. To be changed during pre_adventure.
 
-	if(fam == $familiar[none])
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
 	{
-		return true;
+		return false;	//familiar changing temporarily disabled.
 	}
-	if(!is_unrestricted(fam))
+	if(!pathAllowsFamiliar())
 	{
 		return false;
 	}
-
+	if(is100FamRun() && get_property("auto_100familiar").to_familiar() != fam)
+	{
+		return false;	//do not break a 100% familiar run
+	}
+	if(fam == $familiar[none])
+	{
+		set_property("auto_familiarChoice", "REALLY_NONE");		//special handling for switching to familiar none.
+		return true;
+	}
+	if(get_property("auto_familiarChoice").to_familiar() == fam)	//this should go after $familiar[none] check
+	{
+		return true;	//desired target is already set as the familiar I will be switching to.
+	}
+	
+	//[Ms. Puck Man] and [Puck Man] are interchangeable. so interchange them if needed.
 	if((fam == $familiar[Ms. Puck Man]) && !auto_have_familiar($familiar[Ms. Puck Man]) && auto_have_familiar($familiar[Puck Man]))
 	{
 		fam = $familiar[Puck Man];
@@ -193,156 +219,167 @@ boolean handleFamiliar(familiar fam)
 	{
 		fam = $familiar[Ms. Puck Man];
 	}
-
-	familiar toEquip = $familiar[none];
-	if(auto_have_familiar(fam))
+	
+	//bjorning has priority
+	if(my_bjorned_familiar() == fam)
 	{
-		toEquip = fam;
-	}
-	else
-	{
-		boolean[familiar] poss = $familiars[Mosquito, Leprechaun, Baby Gravy Fairy, Slimeling, Golden Monkey, Hobo Monkey, Crimbo Shrub, Galloping Grill, Fist Turkey, Rockin\' Robin, Piano Cat, Angry Jung Man, Grimstone Golem, Adventurous Spelunker, Rockin\' Robin];
-
-		int spleen_hold = 4;
-		if(item_amount($item[Astral Energy Drink]) > 0)
-		{
-			spleen_hold = spleen_hold + 8;
-		}
-		if(in_hardcore() && ((my_spleen_use() + spleen_hold) <= spleen_limit()))
-		{
-			foreach fam in $familiars[Golden Monkey, Grim Brother, Unconscious Collective]
-			{
-				if((fam.drops_today < 1) && auto_have_familiar(fam))
-				{
-					toEquip = fam;
-				}
-			}
-		}
-		else if(in_hardcore() && (item_amount($item[Yellow Pixel]) < 30) && auto_have_familiar($familiar[Ms. Puck Man]))
-		{
-			toEquip = $familiar[Ms. Puck Man];
-		}
-		else if(in_hardcore() && (item_amount($item[Yellow Pixel]) < 30) && auto_have_familiar($familiar[Puck Man]))
-		{
-			toEquip = $familiar[Puck Man];
-		}
-
-		foreach thing in poss
-		{
-			if((auto_have_familiar(thing)) && (my_bjorned_familiar() != thing))
-			{
-				toEquip = thing;
-			}
-		}
+		return false;
 	}
 
-	if((toEquip != $familiar[none]) && (my_bjorned_familiar() != toEquip))
-	{
-		#use_familiar(toEquip);
-		set_property("auto_familiarChoice", toEquip);
-	}
-	if(inAftercore() && (toEquip != $familiar[none]) && (toEquip != my_familiar()) && (my_bjorned_familiar() != toEquip))
-	{
-		use_familiar(toEquip);
-	}
-#	set_property("auto_familiarChoice", my_familiar());
-
-	if(hr_handleFamiliar(toEquip))
-	{
-		return true;
-	}
-	return false;
+	set_property("auto_familiarChoice", fam);
+	set_property("_auto_thisLoopHandleFamiliar", true);
+	return true;
 }
 
-boolean basicFamiliarOverrides()
+boolean autoChooseFamiliar(location place)
 {
-	if(($familiars[Adventurous Spelunker, Rockin\' Robin] contains my_familiar()) && auto_have_familiar($familiar[Grimstone Golem]) && (in_hardcore() || !possessEquipment($item[Buddy Bjorn])))
+	//if no familiar target was set this loop. then automatically determine which familiar to use
+	
+	if(get_property("auto_disableFamiliarChanging").to_boolean())
 	{
-		if(!possessEquipment($item[Ornate Dowsing Rod]) && (item_amount($item[Odd Silver Coin]) < 5) && (item_amount($item[Grimstone Mask]) == 0) && considerGrimstoneGolem(false))
-		{
-			handleFamiliar($familiar[Grimstone Golem]);
-		}
+		return false;
 	}
-
-	int spleen_hold = 8 * item_amount($item[Astral Energy Drink]);
-	foreach it in $items[Agua De Vida, Grim Fairy Tale, Groose Grease, Powdered Gold, Unconscious Collective Dream Jar]
+	if(!pathAllowsFamiliar())
 	{
-		if (auto_is_valid(it))
-		{
-			spleen_hold += 4 * item_amount(it);
-		}
+		return false;		//will just error in those paths
 	}
-	if((spleen_left() >= (4 + spleen_hold)) && haveSpleenFamiliar())
+	familiar familiar_target_100 = get_property("auto_100familiar").to_familiar();
+	if(familiar_target_100 != $familiar[none])
 	{
-		int spleenHave = 0;
-		foreach fam in $familiars[Baby Sandworm, Bloovian Groose, Golden Monkey, Grim Brother, Unconscious Collective]
+		return handleFamiliar(familiar_target_100);		//do not break 100 familiar runs
+	}
+	set_property("auto_familiarChoice", $familiar[none]);	//reset familiar choice
+	
+	//familiar required to adventure in that zone.
+	if(place == $location[The Deep Machine Tunnels])
+	{
+		return handleFamiliar($familiar[Machine Elf]);
+	}
+	
+	//High priority checks that are too complicated for the datafile
+	familiar famChoice = $familiar[none];
+	
+	//Gelatinous Cubeling drops items that save turns in the daily dungeon
+	if(famChoice == $familiar[none] &&
+	canChangeToFamiliar($familiar[Gelatinous Cubeling]) &&
+	get_property("auto_useCubeling").to_boolean() &&
+	get_property("auto_cubeItems").to_boolean())
+	{
+		famChoice = $familiar[Gelatinous Cubeling];
+	}
+		
+	//grab spleen consumables early if you do not have enough such items to fill up your spleen. Extras will be handled by "drop" datafile
+	//Should take around 10 combats to grab enough on day 1 and on subsequent days you should already have them from previous days.
+	if(famChoice == $familiar[none])
+	{
+		int available_spleen_items_size = 0;
+		foreach it in $items[Agua De Vida, Grim Fairy Tale, Groose Grease, Powdered Gold, Unconscious Collective Dream Jar]
 		{
-			if(auto_have_familiar(fam))
+			if (auto_is_valid(it))
 			{
-				spleenHave++;
+				available_spleen_items_size += 4 * item_amount(it);
 			}
 		}
-
-		if(spleenHave > 0)
+		foreach it in $items[beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste]
 		{
-			int need = (spleen_left() + 3)/4;
-			int bound = (need + spleenHave - 1) / spleenHave;
-			foreach fam in $familiars[Baby Sandworm, Bloovian Groose, Golden Monkey, Grim Brother, Unconscious Collective]
+			//count pastes from fairy-worn boots. excepting excessively expensive pastes.
+			if (auto_is_valid(it) && auto_mall_price(it) < 10000 + auto_mall_price($item[gooey paste]))
 			{
-				if((fam.drops_today < bound) && auto_have_familiar(fam))
+				available_spleen_items_size += 4 * item_amount(it);
+			}
+		}
+		
+		if(spleen_left() >= (4 + available_spleen_items_size) && haveSpleenFamiliar())
+		{
+			int spleenFamiliarsAvailable = 0;
+			foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
+			{
+				if(canChangeToFamiliar(fam))
 				{
-					handleFamiliar(fam);
+					spleenFamiliarsAvailable++;
+				}
+			}
+
+			int spleen_drops_need = (spleen_left() + 3)/4;
+			int bound = (spleen_drops_need + spleenFamiliarsAvailable - 1) / spleenFamiliarsAvailable;
+			
+			if(spleenFamiliarsAvailable > 0) foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
+			{
+				if(get_property("_auto_thisLoopPlusNoncombat").to_boolean() && fam == $familiar[Grim Brother])
+				{
+					continue;	//skip +combat familiars if we want -combat
+				}
+				if((fam.drops_today < bound) && canChangeToFamiliar(fam))
+				{
+					famChoice = fam;
 					break;
 				}
 			}
 		}
 	}
-	else if((item_amount($item[Yellow Pixel]) < 20) && (auto_have_familiar($familiar[Ms. Puck Man]) || auto_have_familiar($familiar[Puck Man])))
+
+	//[grimstone mask] for an [ornate dowsing rod] for the desert. if still needed
+	if(famChoice == $familiar[none] &&
+	canChangeToFamiliar($familiar[Grimstone Golem]) &&
+	!possessEquipment($item[Ornate Dowsing Rod]) &&
+	item_amount($item[Odd Silver Coin]) < 5 &&
+	item_amount($item[Grimstone Mask]) == 0 &&
+	$familiar[Grimstone Golem].drops_today < 1 &&
+	considerGrimstoneGolem(false))
 	{
-		handleFamiliar($familiar[Ms. Puck Man]);
+		famChoice = $familiar[Grimstone Golem];
+	}
+	
+	//[Angry Jung Man] drops [psychoanalytic jar]. we want 1 to save adventures on getting [digital key]
+	if(famChoice == $familiar[none] &&
+	canChangeToFamiliar($familiar[Angry Jung Man]) &&
+	!possessEquipment($item[Powerful Glove]) &&		//powerful glove is a better way to get digital key
+	$familiar[Angry Jung Man].drops_today < 1)
+	{
+		famChoice = $familiar[Angry Jung Man];
+	}
+	
+	//if critically low on MP and meat. use restore familiar to avoid going bankrupt
+	boolean poor = my_meat() < 1000;
+	if(internalQuestStatus("questL11MacGuffin") < 2)
+	{
+		poor = my_meat() < 7000;
+	}
+	if(famChoice == $familiar[none] && 	my_maxmp() > 50 && 	my_mp()*5 < my_maxmp() && poor)
+	{
+		famChoice = lookupFamiliarDatafile("regen");
+	}
+	
+	//select the best familiar that drops items directly. Will prioritize useful items and awesome+ food and drink and then other drops.
+	if(famChoice == $familiar[none])
+	{
+		famChoice = lookupFamiliarDatafile("drop");
+	}
+	
+	//select the best familiar that improves the odds of the enemy dropping an item
+	if(famChoice == $familiar[none])
+	{
+		famChoice = lookupFamiliarDatafile("item");
+	}
+	
+	//fallback choices
+	if(famChoice == $familiar[none])
+	{
+		famChoice = lookupFamiliarDatafile("meat");
+	}
+	if(famChoice == $familiar[none] && canChangeToFamiliar($familiar[Mosquito]))
+	{
+		famChoice = $familiar[Mosquito];
 	}
 
-	foreach fam in $familiars[Golden Monkey, Grim Brother, Unconscious Collective]
-	{
-		if((my_familiar() == fam) && (fam.drops_today >= 1))
-		{
-			handleFamiliar("item");
-		}
-	}
-	if((my_familiar() == $familiar[Puck Man]) && (item_amount($item[Yellow Pixel]) > 20))
-	{
-		handleFamiliar("item");
-	}
-	if((my_familiar() == $familiar[Ms. Puck Man]) && (item_amount($item[Yellow Pixel]) > 20))
-	{
-		handleFamiliar("item");
-	}
-
-	if(in_hardcore() && (my_mp() < 50) && ((my_maxmp() - my_mp()) > 20))
-	{
-		handleFamiliar("regen");
-	}
-
-	return false;
+	return handleFamiliar(famChoice);
 }
 
 boolean haveSpleenFamiliar()
 {
-	boolean [familiar] spleenies = $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey];
-
-	int[familiar] blacklist;
-	if(get_property("auto_blacklistFamiliar") != "")
+	foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
 	{
-		string[int] noFams = split_string(get_property("auto_blacklistFamiliar"), ";");
-		foreach index, fam in noFams
-		{
-			blacklist[to_familiar(trim(fam))] = 1;
-		}
-	}
-
-	foreach fam in spleenies
-	{
-		if(have_familiar(fam) && !(blacklist contains fam))
+		if(auto_have_familiar(fam))
 		{
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -130,10 +130,6 @@ boolean fightScienceTentacle();
 boolean evokeEldritchHorror(string option);
 boolean evokeEldritchHorror();
 boolean auto_change_mcd(int mcd);
-boolean providePlusCombat(int amt);
-boolean providePlusNonCombat(int amt);
-boolean providePlusCombat(int amt, boolean doEquips);
-boolean providePlusNonCombat(int amt, boolean doEquips);
 boolean basicAdjustML();
 boolean auto_is_valid(item it);
 boolean auto_is_valid(familiar fam);
@@ -2675,6 +2671,7 @@ boolean providePlusNonCombat(int amt)
 
 boolean providePlusCombat(int amt, boolean doEquips)
 {
+	set_property("_auto_thisLoopPlusCombat", true);		//track if this was called this loop. can't check adv because of free fights.
 	if(amt == 0)
 	{
 		return true;
@@ -2756,6 +2753,7 @@ boolean providePlusCombat(int amt, boolean doEquips)
 
 boolean providePlusNonCombat(int amt, boolean doEquips)
 {
+	set_property("_auto_thisLoopPlusNoncombat", true);		//track if this was called this loop. can't check adv because of free fights.
 	if(amt == 0)
 	{
 		return true;
@@ -6031,6 +6029,10 @@ boolean auto_check_conditions(string conds)
 				if(!($strings[=,==] contains m2.group(2)))
 					return compare_numbers(prop.to_int(), m2.group(3).to_int(), m2.group(2));
 				return prop == m2.group(3);
+			// data: <propname>
+			// gets propname and converts to a boolean
+			case "prop_boolean":
+				return get_property(condition_data).to_boolean();
 			// data: <questpropname><comparison operator><value>
 			// like prop, but with > and < and >= and <= and uses internalQuestStatus
 			// the value to compare to should always be an integer
@@ -7030,4 +7032,17 @@ int poolSkillPracticeGains()
 	if(have_effect($effect[chalky hand]) > 0) count += 1;
 	if(equipped_amount($item[[2268]Staff of Fats]) > 0) count += 2;		//note that $item[[7964]Staff of Fats] does not help here.
 	return count;
+}
+
+void resetThisLoop()
+{
+	//These settings should never persist into another turn, ever. They only track something for a single instance of the main loop.
+	//We use boolean instead of adventure count because of free combats.
+	
+	set_property("auto_doCombatCopy", "no");
+	set_property("_auto_thisLoopPlusCombat", false);		//have we called providePlusCombat this loop
+	set_property("_auto_thisLoopPlusNoncombat", false);		//have we called providePlusNonCombat this loop
+	set_property("_auto_thisLoopHandleFamiliar", false);	//have we called handleFamiliar this loop
+	set_property("auto_disableFamiliarChanging", false);	//disable autoscend making changes to familiar
+	set_property("auto_familiarChoice", "");				//which familiar do we want to switch to during pre_adventure
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -246,9 +246,10 @@ boolean pathAllowsFamiliar();								//Defined in autoscend/auto_familiar.ash
 boolean auto_have_familiar(familiar fam);					//Defined in autoscend/auto_familiar.ash
 boolean canChangeFamiliar();								//Defined in autoscend/auto_familiar.ash
 boolean canChangeToFamiliar(familiar target);				//Defined in autoscend/auto_familiar.ash
+familiar lookupFamiliarDatafile(string type);				//Defined in autoscend/auto_familiar.ash
 boolean handleFamiliar(string type);						//Defined in autoscend/auto_familiar.ash
 boolean handleFamiliar(familiar fam);						//Defined in autoscend/auto_familiar.ash
-boolean basicFamiliarOverrides();							//Defined in autoscend/auto_familiar.ash
+boolean autoChooseFamiliar(location place);					//Defined in autoscend/auto_familiar.ash
 boolean haveSpleenFamiliar();								//Defined in autoscend/auto_familiar.ash
 
 
@@ -398,6 +399,7 @@ location[int] ListInsertInorder(location[int] list, location what);//Defined in 
 int ListFind(location[int] list, location what);			//Defined in autoscend/auto_list.ash
 int ListFind(location[int] list, location what, int idx);	//Defined in autoscend/auto_list.ash
 location ListOutput(location[int] list);					//Defined in autoscend/auto_list.ash
+void resetThisLoop();										//Defined in autoscend/auto_util.ash
 int [item] auto_get_campground();								//Defined in autoscend/auto_util.ash
 boolean basicAdjustML();									//Defined in autoscend/auto_util.ash
 boolean beatenUpResolution();								//Defined in autoscend.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -285,8 +285,7 @@ boolean fantasyRealmToken()
 	{
 		return false;
 	}
-	set_property("auto_familiarChoice", "none");
-	use_familiar($familiar[none]);
+	handleFamiliar($familiar[none]);
 
 	if(possessEquipment($item[FantasyRealm G. E. M.]))
 	{

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -24,16 +24,6 @@ void hr_initializeSettings()
 	}
 }
 
-boolean hr_handleFamiliar(familiar fam)
-{
-	if((my_path() == "Heavy Rains") && (equipped_item($slot[familiar]) != $item[miniature life preserver]) && (my_familiar() != $familiar[none]))
-	{
-		autoEquip($slot[familiar], $item[miniature life preserver]);
-		return true;
-	}
-	return false;
-}
-
 boolean routineRainManHandler()
 {
 	if(!have_skill($skill[Rain Man]) || (auto_my_path() != "Heavy Rains"))


### PR DESCRIPTION
*handling for intentionally trying to set familiar to $familiar[none]
**fixes wall of bones tower killing without electric bone knife failing to set familiar to none when it was trying to.
**fixes fantasy realm error in pokefam when trying to set familiar to none
*removed familiar consideration of astral energy drinks. it no longer exists
*handleFamiliar now consistently returns false if it cannot set a familiar as a target. before it was inconsistent
*hr_handleFamiliar deleted. it was only wearing life preserver on familiar, but doing it in the wrong place such that you only wore it if you used the same familiar 2 turns in a row. relevant logic was added to preAdvUpdateFamiliar instead
*instead of autoscend calling `handleFamiliar("item"); basicFamiliarOverrides();` it will now just call the latter, which will do both
*refactored the logic on basicFamiliarOverrides() then renamed it to autoChooseFamiliar() to be clearer on what it does
*autoChooseFamiliar will now be called during pre adventure to select a familiar, but only if we did not call handleFamiliar(familiar) this loop
*autoChooseFamiliar() changed to autoChooseFamiliar(location place). since it is called during pre adventure we know where we are adventuring and can take this into account when choosing familiar.
*The following functions now track if they have been called this loop. handleFamiliar(familiar), providePlusNonCombat, providePlusCombat
*auto_have_familiar now respects blacklist
*modifications to familiar datafile for item familiars.
**removed mini list for zombie master. It was just forcing two specific undead familiars intially. but is not needed since we already do a validity check when handling the item list which would catch any invalid non undead familiars (and if not then I will fix that seperately that it does recognize them as invalid).
**added size 4 spleen consumable dropping familiars to familiar dat file.
**add the prop_boolean property to data file conditionals. prop conditional is only designed for comparing a property to integers. which means `prop:name=true` would fail
**split drop.dat from item.dat to seperate familiars that drop items directly from familiars who give a bonus to a monster dropping stuff. For example if we really need a monster to drop an item to proceed, then we would not want it to choose a familiar that drops items directly but provides zero monster drop bonus.
**extensively reworked logic on both of the above.
**minor rework on logic in restore.dat
*Removed Suggest option from handlefamiliar as it was a leftover of pre NS13
*consolidated various redundant fallback and overrides on familiar choice that were sprinkled in too many disparate places.
*added lots of comments and documentation on what is being done
*spunoff familiar lookupFamiliarDatafile(string type) from boolean handleFamiliar(string type) to allow looking up a datafile without changing the property auto_familiarChoice

## How Has This Been Tested?

2 disguise delimit runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
