### PR TITLE
desert unlocking, get compass, and a few other things

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -177,7 +177,7 @@ void initializeSettings()
 	set_property("auto_powerLevelLastAttempted", "0");
 	set_property("auto_pulls", "");
 
-	 // Day on which the Shen quest was started. Required to predict which zones to avoid until Shen tells us to go there.
+	// Day on which the Shen quest was started. Required to predict which zones to avoid until Shen tells us to go there.
 	set_property("auto_shenStarted", "");
 	// Last level during which we ran out of stuff to do without pre-completing some Shen quests.
 	set_property("auto_shenSkipLastLevel", 0); 
@@ -3329,10 +3329,10 @@ boolean doTasks()
 	if(LX_guildUnlock())				return true;
 	if(knoll_available() && get_property("auto_spoonconfirmed").to_int() == my_ascensions())
 	{
-		if(LX_bitchinMeatcar())			return true;
+		if(LX_bitchinMeatcar())			return true;		//buy the meatcar before switching signs with the rune spoon
 	}
 	if(LX_findHelpfulLowKey())			return true;
-	if(LX_bitchinMeatcar())				return true;
+	if(LX_unlockDesert())				return true;
 	if(L5_getEncryptionKey())			return true;
 	if(LX_unlockPirateRealm())			return true;
 	if(handleRainDoh())				return true;
@@ -3437,16 +3437,15 @@ boolean doTasks()
 	if (LX_lowkeySummer())					return true;
 	
 	//release the softblock on quests that are waiting for shen quest
-	if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished")
+	if(allowSoftblockShen())
 	{
-		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
+		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do. Releasing softblock.", "red");
 		set_property("auto_shenSkipLastLevel", my_level());
 		return true;
 	}
 	
 	if(LX_getDigitalKey()) 				return true;
 	if(LX_getStarKey()) 				return true;
-	
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
 	if(L13_sorceressDoor())				return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -182,7 +182,6 @@ void initializeSettings()
 	// Last level during which we ran out of stuff to do without pre-completing some Shen quests.
 	set_property("auto_shenSkipLastLevel", 0); 
 
-	set_property("auto_skipDesert", 0);
 	set_property("auto_snapshot", "");
 	set_property("auto_sniffs", "");
 	set_property("auto_waitingArrowAlcove", "50");

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -278,11 +278,35 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(2); // skip
 			}
 			break;
+		case 793: // The Shore, Inc. Travel Agency. doing a vacation
+			if(my_primestat() == $stat[Muscle])
+			{
+				run_choice(1);
+			}
+			else if(my_primestat() == $stat[Mysticality])
+			{
+				run_choice(2);
+			}
+			else	//if no prime stat we still want moxie
+			{
+				run_choice(3);
+			}
+			break;
 		case 794: // Once More Unto the Junk (The Old Landfill)
 		case 795: // The Bathroom of Ten Men (The Old Landfill)
 		case 796: // The Den of Iquity (The Old Landfill)
 		case 797: // Let's Workshop This a Little (The Old Landfill)
 			oldLandfillChoiceHandler(choice);
+			break;
+		case 829: // we all wear masks. (grimstone mask)
+			run_choice(1);			//choose step mother. we want [Ornate Dowsing Rod]
+			break;
+		case 822: //The Prince's Ball (In the Restroom)
+		case 823: //The Prince's Ball (On the Dance Floor)
+		case 824: //The Prince's Ball (The Kitchen)
+		case 825: //The Prince's Ball (On the Balcony)
+		case 826: //The Prince's Ball (The Lounge)
+			run_choice(1);			//pickup odd silver coin
 			break;
 		case 875: // Welcome To Our ool Table (The Haunted Billiards Room).
 			if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -323,6 +323,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 				auto_log_info("Found mask: " + majora, "green");
 			}
 		}
+		else
+		{
+			abort("Failed to identify the mask worn by the monster [" + enemy + "]. Finish this combat manually then run me again");
+		}
+		
 		if((majora == 7) && canUse($skill[Swap Mask]))
 		{
 			return useSkill($skill[Swap Mask]);

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -502,5 +502,10 @@ boolean settingFixer()
 		remove_property("auto_hpAutoRecoveryTarget");
 	}
 	
+	if (property_exists("auto_skipDesert"))
+	{
+		remove_property("auto_skipDesert");
+	}
+	
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2276,6 +2276,47 @@ boolean isUnclePAvailable()
 	return !page_text.contains_text("You don't know where a desert beach is");
 }
 
+boolean isDesertAvailable()
+{
+	//Is this workaround still needed or is mafia correctly recognizing desert is available in koe?
+	if(in_koe())
+	{
+		auto_log_info("The desert exploded so no need to build a meatcar...");
+		set_property("lastDesertUnlock", my_ascensions());
+	}
+	
+	return get_property("lastDesertUnlock").to_int() == my_ascensions();
+}
+
+boolean inKnollSign()
+{
+	return $strings[Mongoose, Vole, Wallaby] contains my_sign();
+}
+
+boolean inCanadiaSign()
+{
+	return $strings[Marmot, Opossum, Platypus] contains my_sign();
+}
+
+boolean inGnomeSign()
+{
+	return $strings[Blender, Packrat, Wombat] contains my_sign();
+}
+
+boolean allowSoftblockShen()
+{
+	//Some quests have a softblock on doing them because shen might need them. When we run out of things to do this softblock is released.
+	//Return true means the softblock is active. Return false means the softblock is released.
+	if(get_property("questL11Shen") == "finished")
+	{
+		return false;		//shen quest is over. softblock not needed
+	}
+	
+	//We tell users to disable the shen softblock by setting auto_shenSkipLastLevel to 999.
+	//This is why we want to return < my_level() and not != my_level()
+	return get_property("auto_shenSkipLastLevel").to_int() < my_level();
+}
+
 boolean instakillable(monster mon)
 {
 	if(mon.boss)
@@ -3606,7 +3647,7 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 	if (in_koe()) return false;
 
 	int best = 10;
-	if($strings[Mongoose, Vole, Wallaby] contains my_sign())
+	if(inKnollSign())
 	{
 		if(item_amount($item[Detuned Radio]) == 0)
 		{
@@ -3617,14 +3658,14 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 			return false;
 		}
 	}
-	if($strings[Blender, Packrat, Wombat] contains my_sign())
+	if(inGnomeSign())
 	{
-		if(get_property("lastDesertUnlock").to_int() < my_ascensions())
+		if(gnomads_available())
 		{
 			return false;
 		}
 	}
-	if($strings[Marmot, Opossum, Platypus] contains my_sign())
+	if(inCanadiaSign())
 	{
 		best = 11;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3658,18 +3658,15 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 			return false;
 		}
 	}
-	if(inGnomeSign())
+	if(inGnomeSign() && !gnomads_available())
 	{
-		if(gnomads_available())
-		{
-			return false;
-		}
+		return false;
 	}
 	if(canadia_available())
 	{
 		best = 11;
 	}
-	if(my_sign() == "Bad Moon")
+	if(in_bad_moon())
 	{
 		best = 11;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3665,7 +3665,7 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 			return false;
 		}
 	}
-	if(inCanadiaSign())
+	if(canadia_available())
 	{
 		best = 11;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3647,7 +3647,7 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 	if (in_koe()) return false;
 
 	int best = 10;
-	if(inKnollSign())
+	if(knoll_available())
 	{
 		if(item_amount($item[Detuned Radio]) == 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -834,7 +834,7 @@ generic_t zone_available(location loc)
 		break;
 	case $location[South of The Border]:
 	case $location[The Shore\, Inc. Travel Agency]:
-		if(get_property("lastDesertUnlock").to_int() == my_ascensions())
+		if(isDesertAvailable())
 		{
 			retval._boolean = true;
 		}
@@ -1378,7 +1378,7 @@ generic_t zone_available(location loc)
 		break;
 
 	case $location[Thugnderdome]:
-		if(get_property("lastDesertUnlock").to_int() == my_ascensions())
+		if(isDesertAvailable())
 		{
 			retval._boolean = gnomads_available();
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -879,6 +879,11 @@ boolean isOverdueArrow();									//Defined in autoscend/auto_util.ash
 boolean isOverdueDigitize();								//Defined in autoscend/auto_util.ash
 boolean isProtonGhost(monster mon);							//Defined in autoscend/auto_util.ash
 boolean isUnclePAvailable();								//Defined in autoscend/auto_util.ash
+boolean isDesertAvailable();								//Defined in autoscend/auto_util.ash
+boolean inKnollSign();										//Defined in autoscend/auto_util.ash
+boolean inCanadiaSign();									//Defined in autoscend/auto_util.ash
+boolean inGnomeSign();										//Defined in autoscend/auto_util.ash
+boolean allowSoftblockShen();								//Defined in autoscend/auto_util.ash
 boolean is_avatar_potion(item it);							//Defined in autoscend/auto_util.ash
 int auto_mall_price(item it);									//Defined in autoscend/auto_util.ash
 item[int] itemList();										//Defined in autoscend/auto_list.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -28,7 +28,7 @@ boolean LX_phatLootToken();
 boolean LX_islandAccess();
 boolean fancyOilPainting();
 boolean LX_fcle();
-boolean ornateDowsingRod();
+boolean LX_ornateDowsingRod(boolean doing_desert_now);	//Defined in autoscend/iotms/auto_mr2014.ash
 boolean LX_nastyBooty();
 boolean LX_guildUnlock();
 boolean LX_pirateOutfit();
@@ -115,6 +115,7 @@ boolean L11_hiddenTavernUnlock();
 boolean L11_hiddenTavernUnlock(boolean force);
 boolean L11_blackMarket();
 boolean L11_forgedDocuments();
+boolean L11_getUVCompass();										//Defined in autoscend/auto_quest_level_11.ash
 boolean L11_aridDesert();
 boolean L11_mcmuffinDiary();
 boolean L11_unlockHiddenCity();
@@ -586,7 +587,7 @@ boolean dna_startAcquire();									//Defined in autoscend/iotms/auto_mr2014.ash
 boolean auto_reagnimatedGetPart();							//Defined in autoscend/iotms/auto_mr2012.ash
 boolean doBedtime();										//Defined in autoscend.ash
 boolean doHRSkills();										//Defined in autoscend/auto_heavyrains.ash
-boolean doVacation();										//Defined in autoscend.ash
+boolean LX_doVacation();										//Defined in autoscend.ash
 int doHottub();												//Defined in autoscend/auto_clan.ash
 int hotTubSoaksRemaining();									//Defined in autoscend/auto_clan.ash
 boolean isHotTubAvailable();								//Defined in autoscend/auto_clan.ash
@@ -1152,7 +1153,6 @@ boolean glover_usable(string it);							//Defined in autoscend/auto_glover.ash
 boolean LM_glover();										//Defined in autoscend/auto_glover.ash
 
 boolean groundhogSafeguard();								//Defined in autoscend/auto_groundhog.ash
-void groundhog_initializeSettings();						//Defined in autoscend/auto_groundhog.ash
 boolean canGroundhog(location loc);							//Defined in autoscend/auto_groundhog.ash
 boolean groundhogAbort(location loc);						//Defined in autoscend/auto_groundhog.ash
 boolean LM_groundhog();										//Defined in autoscend/auto_groundhog.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -365,21 +365,20 @@ boolean xiblaxian_makeStuff()
 	return false;
 }
 
-boolean ornateDowsingRod()
+boolean LX_ornateDowsingRod(boolean doing_desert_now)
 {
 	if(!get_property("auto_grimstoneOrnateDowsingRod").to_boolean())
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Grimstone Mask]))
+	if(!is_unrestricted($item[Grimstone Mask]) || !is_unrestricted($item[Ornate Dowsing Rod]))
 	{
-		set_property("auto_grimstoneOrnateDowsingRod", false);
+		set_property("auto_grimstoneOrnateDowsingRod", false);	//mask or rod are not valid
 		return false;
 	}
-	if(possessEquipment($item[UV-resistant compass]))
+	if(auto_my_path() == "Way of the Surprising Fist" || $class[Avatar of Boris] == my_class())
 	{
-		auto_log_warning("You have a UV-resistant compass for some raisin, I assume you don't want an Ornate Dowsing Rod.", "red");
-		set_property("auto_grimstoneOrnateDowsingRod", false);
+		set_property("auto_grimstoneOrnateDowsingRod", false);	//cannot equip offhand item in those paths
 		return false;
 	}
 	if(possessEquipment($item[Ornate Dowsing Rod]))
@@ -388,58 +387,89 @@ boolean ornateDowsingRod()
 		set_property("auto_grimstoneOrnateDowsingRod", false);
 		return false;
 	}
-	if(my_adventures() <= 6)
+	if(in_hardcore())		//will we be able to pull at any point in the run. not just right now (we might be out of pulls today)
 	{
-		return false;
+		if(!canChangeToFamiliar($familiar[Grimstone Golem]))	//no golem, or not allowed in path
+		{
+			set_property("auto_grimstoneOrnateDowsingRod", false);	
+			return false;
+		}
 	}
-	if(item_amount($item[Grimstone Mask]) == 0)
-	{
-		return false;
-	}
-	if(my_daycount() < 2)
+	
+	//because it requires continuous adventures in the same day, then we want to do pre do this before we even get to the desert.
+	//but we do not want to do it too early either. so we wait until we are at least day 2 and level 7 to get the dowsing rod.
+	//unless we are doing desert now. in which case we ignore this limitation and do it now
+	if(!doing_desert_now && (my_level() < 8 || my_daycount() < 2))
 	{
 		return false;
 	}
 	if(get_counters("", 0, 6) != "")
 	{
+		return false;	//do not waste a semirare
+	}
+	
+	if(item_amount($item[Grimstone Mask]) == 0 && !canChangeToFamiliar($familiar[Grimstone Golem]) && canPull($item[Grimstone Mask]))
+	{
+		pullXWhenHaveY($item[Grimstone Mask], 1, 0);		//pull the mask if you do not have it and cannot use the golem
+	}
+	if(item_amount($item[Grimstone Mask]) == 0)
+	{
+		return false;
+	}
+	
+	if(my_adventures() <= 6)
+	{
+		auto_log_info("I need at least 6 adv to get [Ornate Dowsing Rod] and I only have " + my_adventures(), "blue");
+		if(doing_desert_now)
+		{
+			if(fullness_left() + inebriety_left() > 0)
+			{
+				abort("I am trying to do desert now so I cannot delay getting [Ornate Dowsing Rod]. I still have stomch and and liver left. Eat and drink until at least 6 adv and then run me again");
+			}
+			if(isAboutToPowerlevel())
+			{
+				auto_log_info("I have nothing else to do except the desert. So I am ending the day early", "blue");
+				set_property("_auto_doneToday", true);
+				return true;	//want to restart the loop so it can properly exit it and do bedtime.
+			}
+		}
 		return false;
 	}
 
-	#Need to make sure we get our grimstone mask
 	auto_log_info("Acquiring a Dowsing Rod!", "blue");
-	set_property("choiceAdventure829", "1");
 	use(1, $item[grimstone mask]);
 
-	set_property("choiceAdventure822", "1");
-	set_property("choiceAdventure823", "1");
-	set_property("choiceAdventure824", "1");
-	set_property("choiceAdventure825", "1");
-	set_property("choiceAdventure826", "1");
 	while(item_amount($item[odd silver coin]) < 1)
 	{
-		autoAdv(1, $location[The Prince\'s Balcony]);
+		autoAdv($location[The Prince\'s Balcony]);
 	}
 	while(item_amount($item[odd silver coin]) < 2)
 	{
-		autoAdv(1, $location[The Prince\'s Dance Floor]);
+		autoAdv($location[The Prince\'s Dance Floor]);
 	}
 	while(item_amount($item[odd silver coin]) < 3)
 	{
-		autoAdv(1, $location[The Prince\'s Lounge]);
+		autoAdv($location[The Prince\'s Lounge]);
 	}
 	while(item_amount($item[odd silver coin]) < 4)
 	{
-		autoAdv(1, $location[The Prince\'s Kitchen]);
+		autoAdv($location[The Prince\'s Kitchen]);
 	}
 	while(item_amount($item[odd silver coin]) < 5)
 	{
-		autoAdv(1, $location[The Prince\'s Restroom]);
+		autoAdv($location[The Prince\'s Restroom]);
 	}
 
-	cli_execute("make ornate dowsing rod");
-	set_property("auto_grimstoneOrnateDowsingRod", false);
-	set_property("choiceAdventure805", "1");
-	return true;
+	set_property("auto_grimstoneOrnateDowsingRod", false);	//craft success = we done. fail = we ask user to make it
+	if(create(1, $item[Ornate Dowsing Rod]))
+	{
+		return true;
+	}
+	if(item_amount($item[Ornate Dowsing Rod]) == 0)
+	{
+		abort("Failed to craft [Ornate Dowsing Rod]. craft it manually and run me again");
+	}
+	return false;
 }
 
 boolean fancyOilPainting()

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -35,8 +35,7 @@ boolean auto_sausageGrind(int numSaus)
 boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 {
 	// Some paths are pretty meat-intensive early. Just in case...
-	boolean canDesert = (get_property("lastDesertUnlock").to_int() == my_ascensions());
-	if(my_turncount() < 90 || !canDesert)
+	if(my_turncount() < 90 || !isDesertAvailable())
 	{
 		return false;
 	}
@@ -475,10 +474,6 @@ boolean auto_spoonReadyToTuneMoon()
 		return false;
 	}
 
-	boolean isKnoll = $strings[mongoose, wallaby, vole] contains currsign;
-	boolean isCanadia = $strings[platypus, opossum, marmot] contains currsign;
-	boolean isGnomad = $strings[wombat, blender, packrat] contains currsign;
-
 	boolean toKnoll = $strings[mongoose, wallaby, vole] contains spoonsign;
 	boolean toCanadia = $strings[platypus, opossum, marmot] contains spoonsign;
 	boolean toGnomad = $strings[wombat, blender, packrat] contains spoonsign;
@@ -494,9 +489,9 @@ boolean auto_spoonReadyToTuneMoon()
 		return false;
 	}
 
-	if(isKnoll && !toKnoll)
+	if(inKnollSign() && !toKnoll)
 	{
-		if(get_property("lastDesertUnlock").to_int() < my_ascensions())
+		if(!isDesertAvailable())
 		{
 			// we want to get the meatcar via the knoll store
 			return false;
@@ -511,13 +506,13 @@ boolean auto_spoonReadyToTuneMoon()
 		}
 	}
 
-	if(isCanadia && !toCanadia && item_amount($item[logging hatchet]) == 0)
+	if(inCanadiaSign() && !toCanadia && item_amount($item[logging hatchet]) == 0)
 	{
 		// want to make sure we've grabbed the logging hatchet before switching away from canadia
 		return false;
 	}
 
-	if(isGnomad && !toGnomad && auto_is_valid($skill[Torso Awaregness]) && !auto_have_skill($skill[Torso Awaregness]))
+	if(inGnomeSign() && !toGnomad && auto_is_valid($skill[Torso Awaregness]) && !auto_have_skill($skill[Torso Awaregness]))
 	{
 		// we want to know about our torso before swapping away from gnomad signs
 		return false;

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1478,7 +1478,7 @@ boolean LM_edTheUndying()
 	if (!have_skill($skill[Even More Elemental Wards])) { 
 		// if we don't have the last Elemental Resistance Upgrade, we still need Ka
 		// Thus we shouldn't block quests that Shen might request as almost all of them are Ka zones.
-		if(my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished") {
+		if(allowSoftblockShen()) {
 			auto_log_warning("I was trying to avoid zones that Shen might need, but I still need Ka for upgrades.", "red");
 			set_property("auto_shenSkipLastLevel", my_level());
 			return true;

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -28,7 +28,6 @@ void ed_initializeSettings()
 		set_property("auto_getBeehive", false);
 		set_property("auto_getStarKey", false);
 		set_property("auto_grimstoneFancyOilPainting", false);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_holeinthesky", false);
 		set_property("auto_lashes", "");
 		set_property("auto_needLegs", false);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -45,7 +45,6 @@ void boris_initializeSettings()
 		auto_log_info("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
 		set_property("auto_cubeItems", false);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -6,7 +6,6 @@ void pete_initializeSettings()
 	{
 		set_property("auto_peteSkills", -1);
 		set_property("auto_cubeItems", false);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 	}

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -14,7 +14,6 @@ void bat_initializeSettings()
 		set_property("auto_cubeItems", false);
 		set_property("auto_getSteelOrgan", false);
 		set_property("auto_grimstoneFancyOilPainting", false);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_paranoia", 10);
 		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);

--- a/RELEASE/scripts/autoscend/paths/disguises_delimit.ash
+++ b/RELEASE/scripts/autoscend/paths/disguises_delimit.ash
@@ -7,7 +7,6 @@ void majora_initializeSettings()
 	{
 		set_property("auto_getBeehive", true);
 		set_property("auto_getBoningKnife", true);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -22,7 +22,6 @@ void glover_initializeSettings()
 		set_property("auto_getBeehive", true);
 		set_property("auto_getBoningKnife", true);
 		set_property("auto_dakotaFanning", true);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_ignoreFlyer", true);
 		set_property("gnasirProgress", get_property("gnasirProgress").to_int() | 16);
 

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -11,7 +11,6 @@ boolean koe_initializeSettings()
 	{
 		set_property("auto_bruteForcePalindome", in_hardcore());
 		set_property("auto_holeinthesky", false);
-		set_property("auto_grimstoneOrnateDowsingRod", "false");
 		set_property("auto_paranoia", 3);
 		set_property("auto_skipL12Farm", "true");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -486,7 +486,7 @@ boolean LM_bond()
 				}
 			}
 
-			if(get_property("lastDesertUnlock").to_int() < my_ascensions())
+			if(!isDesertAvailable())
 			{
 				if(my_meat() > 5000)
 				{

--- a/RELEASE/scripts/autoscend/paths/live_ascend_repeat.ash
+++ b/RELEASE/scripts/autoscend/paths/live_ascend_repeat.ash
@@ -1,13 +1,5 @@
 script "live_ascend_repeat.ash"
 
-void groundhog_initializeSettings()
-{
-	if(auto_my_path() == "Live. Ascend. Repeat.")
-	{
-		set_property("auto_grimstoneOrnateDowsingRod", false);
-	}
-}
-
 boolean groundhogSafeguard()
 {
 	if(auto_my_path() == "Live. Ascend. Repeat.")

--- a/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
+++ b/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
@@ -6,7 +6,6 @@ void fallout_initializeSettings()
 	{
 		set_property("auto_cubeItems", false);
 		set_property("auto_getBeehive", true);
-		set_property("auto_grimstoneOrnateDowsingRod", true);
 
 		if(item_amount($item[Deck of Every Card]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -13,7 +13,6 @@ void digimon_initializeSettings()
 		set_property("auto_getBeehive", false);
 		set_property("auto_getBoningKnife", false);
 		set_property("auto_cubeItems", false);
-		set_property("auto_grimstoneOrnateDowsingRod", false);
 		set_property("auto_hippyInstead", true);
 		set_property("auto_ignoreFlyer", true);
 		set_property("auto_useCubeling", false);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -60,7 +60,7 @@ boolean[location] shenSnakeLocations(int day, int n_items_returned)
 
 boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 {
-	if (get_property("auto_shenSkipLastLevel").to_int() >= my_level())
+	if (!allowSoftblockShen())
 	{
 		boolean[location] empty;
 		return empty;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -642,11 +642,14 @@ boolean L11_aridDesert()
 		desertBuff = $item[Ornate Dowsing Rod];
 		progress = 3;
 	}
-	if((get_property("bondDesert").to_boolean()) && ($location[The Arid\, Extra-Dry Desert].turns_spent > 0))
+	if(get_property("bondDesert").to_boolean())
 	{
 		progress += 2;
 	}
-	//TODO Avatar of sneaky pete black lightbulb gives +2 progress too
+	if(get_property("peteMotorbikeHeadlight") = "Blacklight Bulb")	//TODO verify spelling on this string
+	{
+		progress += 2;
+	}
 
 	if((have_effect($effect[Ultrahydrated]) > 0) || (get_property("desertExploration").to_int() == 0))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2186,7 +2186,7 @@ boolean L11_palindome()
 
 boolean L11_unlockPyramid()
 {
-  if (internalQuestStatus("questL11Desert") < 1 || get_property("desertExploration").to_int() < 100 || internalQuestStatus("questL11Pyramid") > 0)
+  if (internalQuestStatus("questL11Desert") < 1 || get_property("desertExploration").to_int() < 100 || internalQuestStatus("questL11Pyramid") > -1)
 	{
 		return false;
 	}
@@ -2217,7 +2217,11 @@ boolean L11_unlockPyramid()
 	}
 
 	//check results of above URL visit
-	if (internalQuestStatus("questL11Pyramid") < 0)		//unlock failed
+	if (internalQuestStatus("questL11Pyramid") > -1)
+	{
+		return true;	//unlock successful
+	}
+	else 		//unlock failed
 	{
 		cli_execute("refresh quests");		//maybe it worked and mafia did not notice?
 		if(internalQuestStatus("questL11Pyramid") > -1)
@@ -2241,7 +2245,8 @@ boolean L11_unlockPyramid()
 		}
 		abort("Tried to open the Pyramid but could not. could not verify the actual exploration amount of the desert");
 	}
-	return true;	//unlock successful
+	
+	return false;
 }
 
 boolean L11_unlockEd()

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -501,7 +501,10 @@ boolean L11_forgedDocuments()
 	}
 	if (my_meat() < npc_price($item[Forged Identification Documents]))
 	{
-		abort("Could not buy Forged Identification Documents, can not steal identities!");
+		if(isAboutToPowerlevel())
+		{
+			abort("Could not afford to buy Forged Identification Documents, can not steal identities!");
+		}
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2194,12 +2194,13 @@ boolean L11_unlockPyramid()
 	{
 		return false;	//ed starts with pyramid unlocked and cannot adventure there
 	}
-	//get staff of ed if possible. we are only checking one version of it because the other one is a path of ed exclusive
+	//get staff of ed if possible. we are only checking the non equipment version of it.
+	//the equipment version is actually ed the undying path exclusive
 	if(creatable_amount($item[[2325]Staff Of Ed]) > 0)
 	{
 		create(1, $item[[2325]Staff Of Ed]);
 	}
-	if(!possessEquipment($item[[2325]Staff Of Ed]))
+	if(item_amount($item[[2325]Staff Of Ed]) == 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -548,7 +548,10 @@ boolean L11_mcmuffinDiary()
 	}
 	if (my_adventures() < 4 || my_meat() < 500 || item_amount($item[Forged Identification Documents]) == 0)
 	{
-		abort("Could not vacation at the shore to find your fathers diary!");
+		if(isAboutToPowerlevel())
+		{
+			abort("Could not vacation at the shore to find your fathers diary!");
+		}
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -646,6 +646,7 @@ boolean L11_aridDesert()
 	{
 		progress += 2;
 	}
+	//TODO Avatar of sneaky pete black lightbulb gives +2 progress too
 
 	if((have_effect($effect[Ultrahydrated]) > 0) || (get_property("desertExploration").to_int() == 0))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -2,18 +2,12 @@
 
 boolean LX_bitchinMeatcar()
 {
-	if((item_amount($item[Bitchin\' Meatcar]) > 0) || (auto_my_path() == "Nuclear Autumn"))
+	if(isDesertAvailable())
 	{
 		return false;
 	}
-	if(get_property("lastDesertUnlock").to_int() == my_ascensions())
+	if(item_amount($item[Bitchin\' Meatcar]) > 0)
 	{
-		return false;
-	}
-	if(in_koe())
-	{
-		auto_log_info("The desert exploded, so no need to build a meatcar...");
-		set_property("lastDesertUnlock", my_ascensions());
 		return false;
 	}
 	
@@ -50,23 +44,6 @@ boolean LX_bitchinMeatcar()
 		return false;
 	}
 	
-	//if rich then just buy the desert pass
-	if((my_meat() >= (npc_price($item[Desert Bus Pass]) + 1000)) && isGeneralStoreAvailable())
-	{
-		auto_log_info("We're rich, let's take the bus instead of building a car.", "blue");
-		buyUpTo(1, $item[Desert Bus Pass]);
-		if(item_amount($item[Desert Bus Pass]) > 0)
-		{
-			return true;
-		}
-	}
-	
-	//plumbers should wait until they are rich enough to buy the desert pass
-	if(in_zelda())
-	{
-		return false;
-	}
-	
 	if(item_amount($item[Gnollish Toolbox]) > 0)
 	{
 		use(1, $item[Gnollish Toolbox]);
@@ -95,6 +72,54 @@ boolean LX_bitchinMeatcar()
 	
 	//could not adventure in degrassi knoll garage and could not unlock it. you are probably too early in the run and need to come back to it later.
 	return false;
+}
+
+boolean LX_unlockDesert()
+{
+	if(isDesertAvailable())
+	{
+		return false;
+	}
+	
+	if(auto_my_path() == "Nuclear Autumn")
+	{
+		if(isAboutToPowerlevel())
+		{
+			auto_log_info("We ran out of things to do. Trying to prematurely unlock Desert", "blue");
+		}
+		else
+		{
+			auto_log_info("In Nuclear Autumn you get a free desert pass at level 11. skipping unlocking it for now", "blue");
+			return false;
+		}
+	}
+	
+	//knollsign lets you buy the meatcar for less meat than a desert pass without spending any adv.
+	if(inKnollSign())
+	{
+		return LX_bitchinMeatcar();
+	}
+	
+	//if wealthy enough just buy the desert pass outright instead of spending adventures.
+	if(my_meat() >= (npc_price($item[Desert Bus Pass]) + 1000) && isGeneralStoreAvailable())
+	{
+		auto_log_info("We're rich, let's take the bus instead of building a car.", "blue");
+		buyUpTo(1, $item[Desert Bus Pass]);
+		if(item_amount($item[Desert Bus Pass]) > 0)
+		{
+			return true;
+		}
+	}
+	
+	//plumbers should wait until they are rich enough to buy the desert pass. As they have few uses for meat.
+	if(in_zelda() && !isAboutToPowerlevel())
+	{
+		auto_log_info("Plumbers have few uses for meat. Delaying desert unlock until we can buy a pass.", "blue");
+		return false;
+	}
+	
+	//spend adv to unlock the desert
+	if(LX_bitchinMeatcar()) return true;
 }
 
 boolean LX_desertAlternate()
@@ -173,7 +198,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if(!canDesert || !isGeneralStoreAvailable())
+	if(!isDesertAvailable() || !isGeneralStoreAvailable())
 	{
 		return LX_desertAlternate();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -119,7 +119,7 @@ boolean LX_unlockDesert()
 	}
 	
 	//spend adv to unlock the desert
-	if(LX_bitchinMeatcar()) return true;
+	return LX_bitchinMeatcar();
 }
 
 boolean LX_desertAlternate()
@@ -220,7 +220,7 @@ boolean LX_islandAccess()
 	}
 	while((item_amount($item[Shore Inc. Ship Trip Scrip]) < 3) && (my_meat() >= 500) && (item_amount($item[Dinghy Plans]) == 0))
 	{
-		doVacation();
+		LX_doVacation();
 	}
 	if(item_amount($item[Shore Inc. Ship Trip Scrip]) < 3)
 	{


### PR DESCRIPTION
desert unlocking, get compass, and a few other things
*desert unlocking made into its own function instead of piggy backing over bitchin meatcar function.
*boolean isDesertAvailable() created and used
*boolean inKnollSign() created and used
*boolean inCanadiaSign() created and used
*boolean inGnomeSign() created and used
*boolean allowSoftblockShen() created and used
*general refactoring of old code in regards to dowsing rod & compass in the desert.
*moved ornate dowsing rod NC handling to auto_choice_adv.ash
*moved doVacation NC handling to auto_choice_adv.ash
*verify you have enough meat and adventures left before vacationing in doVacation()
*if we are doing the desert right now, ignore the requirement to be at least day 2 to do the dowsing rod
*pull a grimstone mask to make a dowsing rod if possible and we cannot use a golem familiar. 9+ adv saved on a single pull is worth a pull
*fixed desert failing to grab a compass in hardcore.
*added check for property _auto_doneToday. which lets us inform doTasks() that it should stop early.
**if we only have under 7 adv left. and want to get dowsing rod, then we will finish the day early. saving those adv for tomorrow when we will ge the rod.
**there are probably some other places it should be used instead of an abort.
*instead of using 
`while(check1 && check2 && check3 && check4 && check5 && check6 && doTasks())`
to call the main loop which is doTasks(). We now use 
`while(doTasks())`
and those checks are instead done immediately at the start of doTasks().
each in its own if (making it far clearer to see where one check begins and another ends. as some checks involved multiple conditions grouped together in a ()).
And also with comments explaining what each check does.
*removed wearing a hardcoded outfit in aftercore.
*First try to do other things before aborting for lack of meat to buy forged identification papers.
** return false first, abort if isAboutToPowerlevel()
*refactor L11_unlockPyramid()
*if we fail to identify what mask the enemy is wearing in disguise delimit then abort instead of just spamming saucegeyser.

## How Has This Been Tested?

multiple disguise delimit hardcore runs
multiple actually ed the undying hardcore runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
