### PR TITLE
Testing a hypothesis that mafia encounters a race condition.

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -350,18 +350,21 @@ int auto_saberChargesAvailable()
 string auto_combatSaberBanish()
 {
 	set_property("_auto_saberChoice", 1);
+	wait(3);
 	return "skill " + $skill[Use the Force];
 }
 
 string auto_combatSaberCopy()
 {
 	set_property("_auto_saberChoice", 2);
+	wait(3);
 	return "skill " + $skill[Use the Force];
 }
 
 string auto_combatSaberYR()
 {
 	set_property("_auto_saberChoice", 3);
+	wait(3);
 	return "skill " + $skill[Use the Force];
 }
 


### PR DESCRIPTION
# Description

My guess is that the Force Saber choiceAdventureScript issue is a race condition in mafia as the property being set is always missing from the logs we get of failures so lets try slowing it down & seeing if it makes a difference. At worst, it adds 15 seconds extra each day for anyone who has the saber and does nothing.

Fixes #313 (potentially, well works around it rather than fixes it)

## How Has This Been Tested?

It hasn't. I don't have the saber on my testing account. But I'm quite confident those 3 lines aren't going to cause catastrophic failure.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
