### PR TITLE
Race condition hypothesis proven false

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3088,6 +3088,7 @@ boolean doTasks()
 	//These settings should never persist into another turn, ever.
 	set_property("auto_doCombatCopy", "no");
 	set_property("auto_disableFamiliarChanging", false);
+	set_property("choiceAdventure1387", -1); // using the force non-combat
 
 	print_header();
 

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -453,9 +453,6 @@ boolean auto_run_choice(int choice, string page)
 		case 1342: // Torpor (Dark Gyffte)
 			bat_reallyPickSkills(20);
 			break;
-		case 1387: // Using the Force (Fourth of May Cosplay Saber)
-			run_choice(get_property("_auto_saberChoice").to_int());
-			break;
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -349,22 +349,19 @@ int auto_saberChargesAvailable()
 
 string auto_combatSaberBanish()
 {
-	set_property("_auto_saberChoice", 1);
-	wait(3);
+	set_property("choiceAdventure1387", 1);
 	return "skill " + $skill[Use the Force];
 }
 
 string auto_combatSaberCopy()
 {
-	set_property("_auto_saberChoice", 2);
-	wait(3);
+	set_property("choiceAdventure1387", 2);
 	return "skill " + $skill[Use the Force];
 }
 
 string auto_combatSaberYR()
 {
-	set_property("_auto_saberChoice", 3);
-	wait(3);
+	set_property("choiceAdventure1387", 3);
 	return "skill " + $skill[Use the Force];
 }
 


### PR DESCRIPTION
# Description
As the race condition hypothesis test returned a negative result, lets try just not using the choiceAdventureScript as it is the thing that appears to be failing us here.
Lets rely on mafia to handle the post-combat choice if we set the choiceAdventure property appropriately as I can verify this works without issue in aftercore as my end of day script does something almost identical without any issues.

Fixes #313 (potentially, well works around it rather than fixes it).

## How Has This Been Tested?

Again, it hasn't. I don't have the saber on my testing account.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
