### PR TITLE
remove use of "REALLY_NONE".

### DIFF
--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -347,16 +347,6 @@ void preAdvUpdateFamiliar(location place)
 		autoChooseFamiliar(place);
 	}
 	
-	//if we explicitly speficied that we want to not use a familiar this adventure.
-	if(get_property("auto_familiarChoice") == "REALLY_NONE")
-	{
-		if(my_familiar() != $familiar[none])
-		{
-			use_familiar($familiar[none]);
-		}
-		return;
-	}
-	
 	familiar famChoice = to_familiar(get_property("auto_familiarChoice"));
 	if(famChoice == $familiar[none])
 	{
@@ -373,7 +363,7 @@ void preAdvUpdateFamiliar(location place)
 	}
 	
 	//familiar equipment overrides
-	if((my_path() == "Heavy Rains"))
+	if(my_path() == "Heavy Rains")
 	{
 		autoEquip($slot[familiar], $item[miniature life preserver]);
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -253,6 +253,11 @@ boolean autoChooseFamiliar(location place)
 	{
 		return handleFamiliar($familiar[Machine Elf]);
 	}
+
+	// Can't take familiars with you to FantasyRealm
+	if (place == $location[The Bandit Crossroads]) {
+		return use_familiar($familiar[none]);
+	}
 	
 	//High priority checks that are too complicated for the datafile
 	familiar famChoice = $familiar[none];

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -116,13 +116,12 @@ boolean canChangeToFamiliar(familiar target)
 		return false;
 	}
 	
-	//handle a target of none. after we verified we are not breaking a 100% run to do so.
-	if(target == $familiar[none])
-	{
-		//on paths that do not allow familiars at all, trying to switch to $familiar[none] causes an exception.
-		return pathAllowsFamiliar();
+	// Don't allow switching to a target of none.
+	if(target == $familiar[none])	
+	{	
+		return false;	
 	}
-	
+
 	// if you reached this point, then auto_100familiar must not be set to anything, you are allowed to change familiar.
 	return true;
 }
@@ -202,8 +201,7 @@ boolean handleFamiliar(familiar fam)
 	}
 	if(fam == $familiar[none])
 	{
-		set_property("auto_familiarChoice", "REALLY_NONE");		//special handling for switching to familiar none.
-		return true;
+		return false;
 	}
 	if(get_property("auto_familiarChoice").to_familiar() == fam)	//this should go after $familiar[none] check
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -285,8 +285,6 @@ boolean fantasyRealmToken()
 	{
 		return false;
 	}
-	set_property("auto_disableFamiliarChanging", true);
-	use_familiar($familiar[none]);
 
 	if(possessEquipment($item[FantasyRealm G. E. M.]))
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -285,7 +285,8 @@ boolean fantasyRealmToken()
 	{
 		return false;
 	}
-	handleFamiliar($familiar[none]);
+	set_property("auto_disableFamiliarChanging", true);
+	use_familiar($familiar[none]);
 
 	if(possessEquipment($item[FantasyRealm G. E. M.]))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -991,7 +991,10 @@ boolean L13_towerNSTower()
 			uneffect($effect[Jalape&ntilde;o Saucesphere]);
 			uneffect($effect[Mayeaugh]);
 			uneffect($effect[Spiky Shell]);
-			handleFamiliar($familiar[none]);
+			if (!is100FamRun()) {
+				set_property("auto_disableFamiliarChanging", true);
+				use_familiar($familiar[none]);
+			}
 			buffMaintain($effect[Tomato Power], 0, 1, 1);
 			buffMaintain($effect[Seeing Colors], 0, 1, 1);
 			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -991,7 +991,7 @@ boolean L13_towerNSTower()
 			uneffect($effect[Jalape&ntilde;o Saucesphere]);
 			uneffect($effect[Mayeaugh]);
 			uneffect($effect[Spiky Shell]);
-			if (!is100FamRun()) {
+			if (canChangeFamiliar()) {
 				set_property("auto_disableFamiliarChanging", true);
 				use_familiar($familiar[none]);
 			}


### PR DESCRIPTION
# Description
Just set disableFamiliarChanging to true and use the mafia function to switch to no familiar.

## How Has This Been Tested?

Hasn't yet. Waiting for a 100% run to complete before I jump in to testing the familiar_handling branch.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
