### PR TITLE
abortCombat(string msg) created an used

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -3435,14 +3435,13 @@ string auto_saberTrickMeteorShowerCombatHandler(int round, monster enemy, string
 		}
 	}
 	return abortCombat("Unable to perform saber trick (meteor shower)");
-	return "";
 }
 
 monster ocrs_helper(string page)
 {
 	if(my_path() != "One Crazy Random Summer")
 	{
-		return abortCombat("Should not be in ocrs_helper if not on the path!");
+		auto_log_critical("Should not be in ocrs_helper if not on the path!");
 	}
 
 	string combatState = get_property("auto_combatHandler");

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -19,6 +19,15 @@ boolean containsCombat(item it);
 */
 
 // private prototypes
+
+string abortCombat(string msg)
+{
+	//abort() does not work in combat. instead we need the combat filter to return "abort" string.
+	//to use this function: return abortCombat("message goes here");
+	print(msg, "red");
+	return "abort";
+}
+
 boolean haveUsed(skill sk)
 {
 	return get_property("auto_combatHandler").contains_text("(sk" + sk.to_int().to_string() + ")");
@@ -287,7 +296,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(get_property("auto_diag_round").to_int() > 60)
 	{
-		abort("Somehow got to 60 rounds.... aborting");
+		return abortCombat("Somehow got to 60 rounds.... aborting");
 	}
 
 	if(my_path() == "One Crazy Random Summer")
@@ -325,7 +334,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 		else
 		{
-			abort("Failed to identify the mask worn by the monster [" + enemy + "]. Finish this combat manually then run me again");
+			return abortCombat("Failed to identify the mask worn by the monster [" + enemy + "]. Finish this combat manually then run me again");
 		}
 		
 		if((majora == 7) && canUse($skill[Swap Mask]))
@@ -338,7 +347,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			{
 				return "attack with weapon";
 			}
-			abort("May not be able to survive combat. Is swapping protest mask still not allowing us to do anything?");
+			return abortCombat("May not be able to survive combat. Is swapping protest mask still not allowing us to do anything?");
 		}
 		if(my_mask() == "protest mask" && canUse($skill[Swap Mask]))
 		{
@@ -474,7 +483,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			{
 				return "item " + $item[super deluxe mushroom];
 			}
-			abort("Oh no, I don't have any super deluxe mushrooms to deal with this shadow plumber :(");
+			return abortCombat("Oh no, I don't have any super deluxe mushrooms to deal with this shadow plumber :(");
 		}
 		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
 		{
@@ -503,7 +512,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			return "item " + $item[Rain-Doh Indigo Cup];
 		}
-		abort("Uh oh, I ran out of gauze garters and filthy poultices");
+		return abortCombat("Uh oh, I ran out of gauze garters and filthy poultices");
 	}
 
 	if(enemy == $monster[Wall Of Meat])
@@ -873,7 +882,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Turtleini], false);
 		}
-		abort("I am not sure how to finish this battle");
+		return abortCombat("I am not sure how to finish this battle");
 	}
 	
 	// Unique Heavy Rains Enemy that Reflects Spells.
@@ -971,7 +980,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			if((get_property("_badlyRomanticArrows").to_int() == 1) && (round <= 1) && (get_property("romanticTarget") != enemy))
 			{
-				abort("Have animator out but can not arrow");
+				return abortCombat("Have animator out but can not arrow");
 			}
 			if(enemy == $monster[modern zmobie])
 			{
@@ -1223,7 +1232,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(contains_text(combatState, "yellowray"))
 	{
-		abort("Ugh, where is my damn yellowray!!!");
+		return abortCombat("Ugh, where is my damn yellowray!!!");
 	}
 
 	if(item_amount($item[Green Smoke Bomb]) > 0)
@@ -1251,7 +1260,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		if(banishAction != "")
 		{
 			auto_log_info("Looking at banishAction: " + banishAction, "green");
-			#abort("Banisher considered here. Weee");
+			#return abortCombat("Banisher considered here. Weee");
 			#wait(10);
 			#banishAction = "";
 		}
@@ -1887,13 +1896,13 @@ string auto_combatHandler(int round, monster enemy, string text)
 				return useSkill($skill[Saucestorm], false);
 			}
 			//TODO check if our physical attack can deal elemental damage.
-			else abort("Not sure how to handle a physically resistent enemy wearing a welding mask.");
+			else return abortCombat("Not sure how to handle a physically resistent enemy wearing a welding mask.");
 		}
 		if(canSurvive(1.5) && round < 10)
 		{
 			return "attack with weapon";
 		}
-		abort("Not sure how to handle welding mask.");
+		return abortCombat("Not sure how to handle welding mask.");
 	}
 	if(majora == 25)	//tiki mask
 	{
@@ -2364,7 +2373,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			}
 			if(my_location() != $location[The Slime Tube])
 			{
-				abort("Could not handle monster, sorry");
+				return abortCombat("Could not handle monster, sorry");
 			}
 		}
 		if((monster_level_adjustment() > 150) && (my_mp() >= 45) && canUse($skill[Shell Up]) && (my_class() == $class[Turtle Tamer]))
@@ -2436,7 +2445,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 	}
 	else
 	{
-		abort("Some sort of problem occurred, it is past round 25 but we are still in non-gremlin combat...");
+		return abortCombat("Some sort of problem occurred, it is past round 25 but we are still in non-gremlin combat...");
 	}
 
 	if(attackMinor == "attack with weapon")
@@ -2669,7 +2678,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	int damageReceived = 0;
 	if (!isActuallyEd())
 	{
-		abort("Not in Actually Ed the Undying, this combat filter will result in massive suckage.");
+		return abortCombat("Not in Actually Ed the Undying, this combat filter will result in massive suckage.");
 	}
 
 	if (round == 0)
@@ -2719,7 +2728,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	if(get_property("auto_diag_round").to_int() > 60)
 	{
-		abort("Somehow got to 60 rounds.... aborting");
+		return abortCombat("Somehow got to 60 rounds.... aborting");
 	}
 
 	phylum type = monster_phylum(enemy);
@@ -3425,7 +3434,7 @@ string auto_saberTrickMeteorShowerCombatHandler(int round, monster enemy, string
 			return auto_combatSaberYR();
 		}
 	}
-	abort("Unable to perform saber trick (meteor shower)");
+	return abortCombat("Unable to perform saber trick (meteor shower)");
 	return "";
 }
 
@@ -3433,7 +3442,7 @@ monster ocrs_helper(string page)
 {
 	if(my_path() != "One Crazy Random Summer")
 	{
-		abort("Should not be in ocrs_helper if not on the path!");
+		return abortCombat("Should not be in ocrs_helper if not on the path!");
 	}
 
 	string combatState = get_property("auto_combatHandler");


### PR DESCRIPTION
abortCombat(string msg) created an used
using abort() in combat does not work. instead we need the combat filter function to return the string "abort"

replaced
`abort(msg);`
with
`return combatAbort(msg)`
which will use the above mentioned new function to first print the message and then return the string "abort" up the chain until it reaches run_combat() function itself.

## How Has This Been Tested?

i used a test script to verify this is the correct way to abort run_combat(filter).
but i have not tested it in autoscend yet. it might be that after run_combat aborts autoscend will not abort and instead recognize we are in combat and call it again.
tested in autoscend during a disguise delimit run where it successfully aborted instead of falling back on CCS

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
