### PR TITLE
update gremlins code to use new monster names

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20175; // WHen we initially parse a combat encounter and create a MonsterData, set the lastMOnster in the MonsterStatusTracker immediately, rather than waiting for it to be re-created later from the monster name.
+since r20188; // If automating an adventure leaves you in a choice, automate the choice
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20127; // Leaflet use is now tracked via "leafletCompleted" setting
+since r20175; // WHen we initially parse a combat encounter and create a MonsterData, set the lastMOnster in the MonsterStatusTracker immediately, rather than waiting for it to be re-created later from the monster name.
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2476,7 +2476,8 @@ string findBanisher(int round, monster enemy, string text)
 
 string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 {
-	if(!($monsters[A.M.C. gremlin, batwinged gremlin, erudite gremlin, spider gremlin, vegetable gremlin] contains enemy))
+	if(!($monsters[A.M.C. gremlin, batwinged gremlin, batwinged gremlin (tool), erudite gremlin, erudite gremlin (tool),
+	spider gremlin, spider gremlin (tool), vegetable gremlin, vegetable gremlin (tool)] contains enemy))
 	{
 		if (isActuallyEd())
 		{
@@ -2488,69 +2489,15 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	auto_log_info("auto_JunkyardCombatHandler: " + round, "brown");
 	if(round == 0)
 	{
-		set_property("auto_gremlinMoly", true);
+		set_property("auto_gremlinMoly", false);
 		set_property("auto_combatHandler", "");
 	}
 
 	string combatState = get_property("auto_combatHandler");
 	string edCombatState = get_property("auto_edCombatHandler");
 
-	if (isActuallyEd())
-	{
-		if(contains_text(edCombatState, "gremlinNeedBanish"))
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-	}
-
-	if(enemy == $monster[A.M.C. gremlin])
-	{
-		set_property("auto_gremlinMoly", false);
-	}
-
-	if(my_location() == $location[Next To That Barrel With Something Burning In It])
-	{
-		if(enemy == $monster[vegetable gremlin])
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-		else if(contains_text(text, "It does a bombing run over your head"))
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-	}
-	else if(my_location() == $location[Out By That Rusted-Out Car])
-	{
-		if(enemy == $monster[erudite gremlin])
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-		else if(contains_text(text, "It picks a beet off of itself and beats you with it"))
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-	}
-	else if(my_location() == $location[Over Where The Old Tires Are])
-	{
-		if(enemy == $monster[spider gremlin])
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-		else if(contains_text(text, "He uses the random junk around him"))
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-	}
-	else if(my_location() == $location[Near an Abandoned Refrigerator])
-	{
-		if(enemy == $monster[batwinged gremlin])
-		{
-			set_property("auto_gremlinMoly", false);
-		}
-		else if(contains_text(text, "It bites you in the fibula with its mandibles"))
-		{
-			set_property("auto_gremlinMoly", false);
-		}
+	if ($monsters[batwinged gremlin (tool), erudite gremlin (tool), spider gremlin (tool), vegetable gremlin (tool)] contains enemy) {
+		set_property("auto_gremlinMoly", true);
 	}
 
 	if (!contains_text(edCombatState, "gremlinNeedBanish") && !get_property("auto_gremlinMoly").to_boolean() && isActuallyEd())


### PR DESCRIPTION
# Description

- update gremlins code to use new monster names
- bump mafia version.

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/50261170/84737497-e5793780-af5c-11ea-95bb-102695a6bd06.png)
Gremlins worked. Waiting for the run to complete so I can see if the NS works too then we're good to go. This was tested on KoLMafia r20181.

+++ Shadow still not being recognised correctly in r20181 +++

Fixes: #433 
Fixes #313 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
