### PR TITLE
add choosing of familiars by zone and add using stat familiars

### DIFF
--- a/BUILD/familiars/combat.dat
+++ b/BUILD/familiars/combat.dat
@@ -1,3 +1,0 @@
-# This is a list of familiars who increase the frequency of combat encounters
-# 1.25x fairy. increases combat frequency by floor(weight/6) to a maximum of +5%
-Jumpsuited Hound Dog

--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -42,7 +42,7 @@ Intergnat	item:BACON<150
 #
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
-Grim Brother	prop:_grimFairyTaleDrops<5;!prop_boolean:_auto_thisLoopPlusNoncombat
+Grim Brother	prop:_grimFairyTaleDrops<5
 Pair of Stomping Boots	prop:_bootStomps<7
 Baby Sandworm	prop:_aguaDrops<5
 Bloovian Groose	prop:_grooseDrops<5

--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -9,8 +9,7 @@ Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
 # 1.3x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>100
 # Jumpsuited Hound Dog is a 1.25x multiplier fairy that provides +combat.
-# most places do not want +combat so only use it when we explicitly do providePlusCombat
-Jumpsuited Hound Dog	prop_boolean:_auto_thisLoopPlusCombat
+# Jumpsuited Hound Dog DELIBERATELY not included because it provides usually unwanted +combat
 # 1.2x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
 # 1.1x multiplier fairy

--- a/BUILD/familiars/noncombat.dat
+++ b/BUILD/familiars/noncombat.dat
@@ -1,3 +1,0 @@
-# This is a list of familiars who decrease the frequency of combat encounters
-# reduces combat by -floor(weight/7.5) to a maximum of -10%.
-Disgeist

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -17,10 +17,6 @@ boss	2	Mu
 boss	3	Warbear Drone
 boss	4	Mosquito
 
-# This is a list of familiars who increase the frequency of combat encounters
-# 1.25x fairy. increases combat frequency by floor(weight/6) to a maximum of +5%
-combat	0	Jumpsuited Hound Dog
-
 # "drop" type is used when we want to grab a familiar that drops items themselves rather than boosting the odds of the enemy dropping items.
 #
 # First we grab up to small amount of various specific drops.
@@ -65,7 +61,7 @@ drop	16	Intergnat	item:BACON<150
 #
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
-drop	17	Grim Brother	prop:_grimFairyTaleDrops<5;!prop_boolean:_auto_thisLoopPlusNoncombat
+drop	17	Grim Brother	prop:_grimFairyTaleDrops<5
 drop	18	Pair of Stomping Boots	prop:_bootStomps<7
 drop	19	Baby Sandworm	prop:_aguaDrops<5
 drop	20	Bloovian Groose	prop:_grooseDrops<5
@@ -135,66 +131,65 @@ item	1	Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
 # 1.3x multiplier fairy
 item	2	Steam-Powered Cheerleader	prop:_cheerleaderSteam>100
 # Jumpsuited Hound Dog is a 1.25x multiplier fairy that provides +combat.
-# most places do not want +combat so only use it when we explicitly do providePlusCombat
-item	3	Jumpsuited Hound Dog	prop_boolean:_auto_thisLoopPlusCombat
+# Jumpsuited Hound Dog DELIBERATELY not included because it provides usually unwanted +combat
 # 1.2x multiplier fairy
-item	4	Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
+item	3	Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
 # 1.1x multiplier fairy
-item	5	Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
+item	4	Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
 # fairy that generates extra adventures
-item	6	Reagnimated Gnome
+item	5	Reagnimated Gnome
 # Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
-item	7	XO Skeleton
+item	6	XO Skeleton
 # Fairy that drops bacon with no limit. 1 per combat
-item	8	Intergnat
+item	7	Intergnat
 # Fairyballs
-item	9	Elf Operative
-item	10	Optimistic Candle
-item	11	Rockin' Robin
+item	8	Elf Operative
+item	9	Optimistic Candle
+item	10	Rockin' Robin
 # Fairywhelps
-item	12	Pocket Professor
-item	13	Garbage Fire
-item	14	Dandy Lion
+item	11	Pocket Professor
+item	12	Garbage Fire
+item	13	Dandy Lion
 # Fairychauns
-item	15	Fist Turkey
-item	16	Cat Burglar
-item	17	Angry Jung Man
-item	18	Grimstone Golem
-item	19	Adventurous Spelunker
-item	20	Blavious Kloop
-item	21	Hippo Ballerina
-item	22	Dancing Frog
-item	23	Coffee Pixie
-item	24	Attention-Deficit Demon
-item	25	Jitterbug
-item	26	Casagnova Gnome
-item	27	Psychedelic Bear
-item	28	Piano Cat
+item	14	Fist Turkey
+item	15	Cat Burglar
+item	16	Angry Jung Man
+item	17	Grimstone Golem
+item	18	Adventurous Spelunker
+item	19	Blavious Kloop
+item	20	Hippo Ballerina
+item	21	Dancing Frog
+item	22	Coffee Pixie
+item	23	Attention-Deficit Demon
+item	24	Jitterbug
+item	25	Casagnova Gnome
+item	26	Psychedelic Bear
+item	27	Piano Cat
 # Slightly special fairies
-item	29	Red-Nosed Snapper
-item	30	Pair of Stomping Boots
-item	31	Gelatinous Cubeling
-item	32	Steam-Powered Cheerleader
-item	33	Obtuse Angel
-item	34	Green Pixie
+item	28	Red-Nosed Snapper
+item	29	Pair of Stomping Boots
+item	30	Gelatinous Cubeling
+item	31	Steam-Powered Cheerleader
+item	32	Obtuse Angel
+item	33	Green Pixie
 # Elemental fairies
-item	35	Sleazy Gravy Fairy
-item	36	Stinky Gravy Fairy
-item	37	Flaming Gravy Fairy
-item	38	Frozen Gravy Fairy
-item	39	Spooky Gravy Fairy
+item	34	Sleazy Gravy Fairy
+item	35	Stinky Gravy Fairy
+item	36	Flaming Gravy Fairy
+item	37	Frozen Gravy Fairy
+item	38	Spooky Gravy Fairy
 # Physical damage fairy
-item	40	Bowlet
+item	39	Bowlet
 # Barely special fairies
-item	41	Mechanical Songbird
-item	42	Grouper Groupie
-item	43	Peppermint Rhino
+item	40	Mechanical Songbird
+item	41	Grouper Groupie
+item	42	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	44	Slimeling
+item	43	Slimeling
 # Turtles are cute
-item	45	Syncopated Turtle
+item	44	Syncopated Turtle
 # The original
-item	46	Baby Gravy Fairy
+item	45	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
 
@@ -256,10 +251,6 @@ meat	37	Urchin Urchin
 meat	38	Cornbeefadon
 # The original
 meat	39	Leprechaun
-
-# This is a list of familiars who decrease the frequency of combat encounters
-# reduces combat by -floor(weight/7.5) to a maximum of -10%.
-noncombat	0	Disgeist
 
 # Typical starfish are better than whelps
 # Whelps on average restore .375*(weight+5)

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1188,7 +1188,6 @@ void initializeDay(int day)
 
 			makeStartingSmiths();
 
-			handleFamiliar("item");
 			equipBaseline();
 
 			handleBjornify($familiar[none]);
@@ -2406,7 +2405,6 @@ boolean LX_freeCombats(boolean powerlevel)
 		{
 			handleBjornify($familiar[Grinning Turtle]);
 		}
-		handleFamiliar($familiar[Machine Elf]);
 		adv_done = autoAdv(1, $location[The Deep Machine Tunnels]);
 		if(bjorn == $familiar[Machine Elf])
 		{
@@ -2507,7 +2505,6 @@ boolean Lsc_flyerSeals()
 			}
 		}
 
-		handleFamiliar("init");
 		boolean clubbedSeal = false;
 		if(doElement)
 		{
@@ -2544,7 +2541,6 @@ boolean Lsc_flyerSeals()
 				use(1, $item[ingot of seal-iron]);
 			}
 		}
-		handleFamiliar("item");
 		return clubbedSeal;
 	}
 	return false;
@@ -3291,10 +3287,6 @@ boolean doTasks()
 		if((item_amount($item[ring of detect boring doors]) == 1) && (item_amount($item[eleven-foot pole]) == 1) && (item_amount($item[pick-o-matic lockpicks]) == 1))
 		{
 			set_property("auto_cubeItems", false);
-		}
-		if(get_property("auto_cubeItems").to_boolean() && (my_familiar() != $familiar[Gelatinous Cubeling]) && auto_have_familiar($familiar[Gelatinous Cubeling]))
-		{
-			handleFamiliar($familiar[Gelatinous Cubeling]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -249,12 +249,101 @@ boolean autoChooseFamiliar(location place)
 	
 	//High priority checks that are too complicated for the datafile
 	familiar famChoice = $familiar[none];
+
+	// Blackbird/Crow cut turns in the Black Forest but we only need to equip them
+	// if we don't have them in inventory.
+	if ($location[The Black Forest] == place) {
+		if (auto_my_path() != "Bees Hate You") {
+			if (item_amount($item[Reassembled Blackbird]) == 0 && canChangeToFamiliar($familiar[Reassembled Blackbird])) {
+				famChoice = $familiar[Reassembled Blackbird];
+			}
+		} else {
+			if (item_amount($item[Reconstituted Crow]) == 0 && canChangeToFamiliar($familiar[Reconstituted Crow])) {
+				famChoice = $familiar[Reconstituted Crow];
+			}
+		}
+	}
+
+	// Gremlins have special familiar handling.
+	if ($locations[Next to that Barrel with Something Burning in it, Out By that Rusted-Out Car, Over Where the Old Tires Are, Near an Abandoned Refrigerator] contains place) {
+		famChoice = lookupFamiliarDatafile("gremlins");
+	}
+
+	// places where item drop is required to help save adventures.
+	if ($locations[The Typical Tavern Cellar, The Beanbat Chamber, Cobb's Knob Harem, The Defiled Nook, The Goatlet, Itznotyerzitz Mine,
+	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Hospital, The Hidden Bowling Alley, The Haunted Wine Cellar,
+	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, The Red Zeppelin, Whitey's Grove, The Oasis, The Middle Chamber,
+	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,
+	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, 8-Bit Realm, The Degrassi Knoll Garage, The Old Landfill,
+	The Laugh Floor, Infernal Rackets Backstage] contains place) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// only need +item in the pirates cove if we're faming the outfit (may be farming insults here or getting the key in LKS otherwise)
+	if ($location[The Obligatory Pirate's Cove] == place && !possessOutfit("Swashbuckling Getup")) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// Only need +item in the F'c'le if we're getting the fledges (could still be getting the key in LKS)
+	if ($location[The F'c'le] == place && internalQuestStatus("questM12Pirate") < 6) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// The World's Biggest Jerk can send us here so only use +item if we're farming sonars.
+	if ($location[The Batrat and Ratbat Burrow] == place && internalQuestStatus("questL04Bat") < 3) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// only need +item on the extreme slope if we're faming the outfit.
+	if ($location[The eXtreme Slope] == place && !possessOutfit("eXtreme Cold-Weather Gear")) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
 	
+	// only use +item in A-Boo Peak when adventuring (so we don't accidentally override resistance familiars when doing The Horror).
+	if ($location[A-Boo Peak] == place && get_property("auto_aboopending").to_int() == 0) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// only need +item at Oil Peak if we need Bubblin' Crude (TODO: it might be useful in HC for food?).
+	if ($location[Oil Peak] == place &&
+	((get_property("twinPeakProgress").to_int() & 4) == 0 &&
+		item_amount($item[Jar Of Oil]) < 1 && item_amount($item[Bubblin\' Crude]) < 12))  {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// The World's Biggest Jerk can also send us here so only use +item if we're farming bridge parts.
+	if ($location[The Smut Orc Logging Camp] == place && internalQuestStatus("questL09Topping") < 1) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// Killing jar saves adventures unlocking the Pyramid.
+	if ($location[The Haunted Library] == place && item_amount($item[killing jar]) < 1) {
+		famChoice = lookupFamiliarDatafile("item");
+	}
+
+	// only need +item in the war camps if we are farming the outfit.
+	if ($locations[Wartime Frat House, Wartime Hippy Camp] contains place) {
+		if (!possessOutfit("Frat Warrior Fatigues") || !possessOutfit("War Hippy Fatigues")) {
+			famChoice = lookupFamiliarDatafile("item");
+		}
+	}
+
+	// places where meat drop is required to help save adventures.
+	if ($location[The Themthar Hills] == place) {
+		famChoice = lookupFamiliarDatafile("meat");
+	}
+	
+	// places where initiative is required to help save adventures.
+	if ($location[The Defiled Alcove] == place) {
+		famChoice = lookupFamiliarDatafile("init");
+	}
+
 	//Gelatinous Cubeling drops items that save turns in the daily dungeon
 	if(famChoice == $familiar[none] &&
 	canChangeToFamiliar($familiar[Gelatinous Cubeling]) &&
 	get_property("auto_useCubeling").to_boolean() &&
-	get_property("auto_cubeItems").to_boolean())
+	get_property("auto_cubeItems").to_boolean()
+	&& lookupFamiliarDatafile("item") != $familiar[Gelatinous Cubeling]) // don't farm the drops if this is the best +item familiar we have. We will get them regardless.
 	{
 		famChoice = $familiar[Gelatinous Cubeling];
 	}
@@ -296,10 +385,7 @@ boolean autoChooseFamiliar(location place)
 			
 			if(spleenFamiliarsAvailable > 0) foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
 			{
-				if(get_property("_auto_thisLoopPlusNoncombat").to_boolean() && fam == $familiar[Grim Brother])
-				{
-					continue;	//skip +combat familiars if we want -combat
-				}
+
 				if((fam.drops_today < bound) && canChangeToFamiliar(fam))
 				{
 					famChoice = fam;
@@ -330,6 +416,11 @@ boolean autoChooseFamiliar(location place)
 		famChoice = $familiar[Angry Jung Man];
 	}
 	
+	// places where meat drop is desirable due to high meat drop monsters.
+	if ($locations[The Boss Bat's Lair, Mist-Shrouded Peak, The Filthworm Queen's Chamber] contains place) {
+		famChoice = lookupFamiliarDatafile("meat");
+	}
+
 	//if critically low on MP and meat. use restore familiar to avoid going bankrupt
 	boolean poor = my_meat() < 1000;
 	if(internalQuestStatus("questL11MacGuffin") < 2)
@@ -347,20 +438,14 @@ boolean autoChooseFamiliar(location place)
 		famChoice = lookupFamiliarDatafile("drop");
 	}
 	
-	//select the best familiar that improves the odds of the enemy dropping an item
-	if(famChoice == $familiar[none])
-	{
-		famChoice = lookupFamiliarDatafile("item");
+	// Stats from combats makes runs go faster apparently.
+	if (famChoice == $familiar[none] && (my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean())) {
+		famChoice = lookupFamiliarDatafile("stat");
 	}
 	
-	//fallback choices
-	if(famChoice == $familiar[none])
-	{
-		famChoice = lookupFamiliarDatafile("meat");
-	}
-	if(famChoice == $familiar[none] && canChangeToFamiliar($familiar[Mosquito]))
-	{
-		famChoice = $familiar[Mosquito];
+	// fallback to regen if nothing else. At worst the player will have something like a Ghuol Whelp or Starfish.
+	if (famChoice == $familiar[none]) {
+		famChoice = lookupFamiliarDatafile("regen");
 	}
 
 	return handleFamiliar(famChoice);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2716,7 +2716,6 @@ boolean providePlusCombat(int amt, boolean doEquips)
 	{
 		return true;
 	}
-	set_property("_auto_thisLoopPlusCombat", true);		//track if this was called this loop. my_turncount() won't work due to free fights
 	
 	//we do not need to repeatedly simulate equipment. do it once now and a second time if we change the maximizer string.
 	simMaximize();
@@ -2741,20 +2740,6 @@ boolean providePlusCombat(int amt, boolean doEquips)
 	{
 		uneffect(eff);
 		if(are_we_done()) return true;
-	}
-	
-	if(!get_property("_auto_thisLoopHandleFamiliar").to_boolean())	//do not overwrite an already chosen familiar.
-	{
-		familiar target_fam = lookupFamiliarDatafile("combat");
-		if(target_fam != $familiar[none])		//do we have a valid -combat familiar
-		{
-			handleFamiliar(target_fam);			//avoid flip flop
-			if(my_familiar() != target_fam)
-			{
-				use_familiar(target_fam);
-			}
-			if(are_we_done()) return true;
-		}
 	}
 	
 	if(doEquips)
@@ -2802,7 +2787,6 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 		return true;
 	}
 	amt = -1 * amt;
-	set_property("_auto_thisLoopPlusNoncombat", true);		//track if this was called this loop. my_turncount() won't work due to free fights
 
 	//we do not need to repeatedly simulate equipment. do it once now and a second time if we change the maximizer string.
 	simMaximize();
@@ -2826,20 +2810,6 @@ boolean providePlusNonCombat(int amt, boolean doEquips)
 	{
 		uneffect(eff);
 		if(are_we_done()) return true;
-	}
-	
-	if(!get_property("_auto_thisLoopHandleFamiliar").to_boolean())	//do not overwrite an already chosen familiar.
-	{
-		familiar target_fam = lookupFamiliarDatafile("noncombat");
-		if(target_fam != $familiar[none])		//do we have a valid -combat familiar
-		{
-			handleFamiliar(target_fam);			//avoid flip flop
-			if(my_familiar() != target_fam)
-			{
-				use_familiar(target_fam);
-			}
-			if(are_we_done()) return true;
-		}
 	}
 	
 	if(doEquips)
@@ -3241,7 +3211,6 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		if(resfam != $familiar[none])
 		{
 			// need to use now so maximizer will see it
-			familiar currentFamiliar = my_familiar();
 			use_familiar(resfam);
 			if(resfam == $familiar[Trick-or-Treating Tot])
 			{
@@ -3253,10 +3222,11 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 			{
 				delta[ele] = simValue(ele + " Resistance") - numeric_modifier(ele + " Resistance");
 			}
-			use_familiar(currentFamiliar);
 		}
-		if(pass())
+		if(pass()) {
+			handleFamiliar(resfam);
 			return result();
+		}
 	}
 
 	if(doEquips)
@@ -7095,8 +7065,6 @@ void resetThisLoop()
 	//We use boolean instead of adventure count because of free combats.
 	
 	set_property("auto_doCombatCopy", "no");
-	set_property("_auto_thisLoopPlusCombat", false);		//have we called providePlusCombat this loop
-	set_property("_auto_thisLoopPlusNoncombat", false);		//have we called providePlusNonCombat this loop
 	set_property("_auto_thisLoopHandleFamiliar", false);	//have we called handleFamiliar this loop
 	set_property("auto_disableFamiliarChanging", false);	//disable autoscend making changes to familiar
 	set_property("auto_familiarChoice", "");				//which familiar do we want to switch to during pre_adventure

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -81,7 +81,6 @@ boolean L10_airship()
 	}
 
 	autoAdv($location[The Penultimate Fantasy Airship]);
-	handleFamiliar("item");
 	return true;
 }
 
@@ -130,14 +129,6 @@ boolean L10_basement()
 		set_property("choiceAdventure669", "1"); // The Fast and the Furry-ous: Open Ground floor (with Umbrella) or Neckbeard Choice
 	}
 
-	if(auto_have_familiar($familiar[Ms. Puck Man]))
-	{
-		handleFamiliar($familiar[Ms. Puck Man]);
-	}
-	else if(auto_have_familiar($familiar[Puck Man]))
-	{
-		handleFamiliar($familiar[Puck Man]);
-	}
 	if(!auto_forceNextNoncombat())
 	{
 		providePlusNonCombat(25);
@@ -153,7 +144,6 @@ boolean L10_basement()
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 	resetMaximize();
 	
-	handleFamiliar("item");
 
 	if(contains_text(get_property("lastEncounter"), "The Fast and the Furry-ous"))
 	{
@@ -235,15 +225,6 @@ boolean L10_ground()
 		set_property("choiceAdventure1026", 2); // Home on the Free Range: Get Electric Boning Knife then Skip
 	}
 
-	if(auto_have_familiar($familiar[Ms. Puck Man]))
-	{
-		handleFamiliar($familiar[Ms. Puck Man]);
-	}
-	else if(auto_have_familiar($familiar[Puck Man]))
-	{
-		handleFamiliar($familiar[Puck Man]);
-	}
-
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 	providePlusNonCombat(25);
 
@@ -256,7 +237,6 @@ boolean L10_ground()
 	}
 
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Ground Floor)]);
-	handleFamiliar("item");
 	return true;
 }
 
@@ -325,14 +305,12 @@ boolean L10_topFloor()
 		set_property("choiceAdventure679", 1);
 	}
 
-	handleFamiliar("init");
 	if(!auto_forceNextNoncombat())
 	{
 		providePlusNonCombat(25);
 	}
 	autoEquip($item[mohawk wig]);
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
-	handleFamiliar("item");
 
 	if (internalQuestStatus("questL10Garbage") > 9)
 	{
@@ -381,20 +359,11 @@ boolean L10_holeInTheSkyUnlock()
 	set_property("choiceAdventure678", 3);
 	set_property("choiceAdventure676", 4);
 
-	if(auto_have_familiar($familiar[Ms. Puck Man]))
-	{
-		handleFamiliar($familiar[Ms. Puck Man]);
-	}
-	else if(auto_have_familiar($familiar[Puck Man]))
-	{
-		handleFamiliar($familiar[Puck Man]);
-	}
 	if(!auto_forceNextNoncombat())
 	{
 		providePlusNonCombat(25);
 	}
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
-	handleFamiliar("item");
 
 	return true;
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -439,11 +439,6 @@ boolean L11_blackMarket()
 
 	autoEquip($slot[acc3], $item[Blackberry Galoshes]);
 
-	if((my_ascensions() == 0) || (item_amount($item[Reassembled Blackbird]) == 0))
-	{
-		handleFamiliar($familiar[Reassembled Blackbird]);
-	}
-
 	//If we want the Beehive, and don\'t have enough adventures, this is dangerous.
 	if (get_property("auto_getBeehive").to_boolean() && my_adventures() < 3) {
 		return false;
@@ -721,7 +716,6 @@ boolean L11_aridDesert()
 		{
 			autoEquip(desertBuff);
 		}
-		handleFamiliar("init");
 		set_property("choiceAdventure805", 1);
 		int need = 100 - get_property("desertExploration").to_int();
 		auto_log_info("Need for desert: " + need, "blue");
@@ -904,7 +898,6 @@ boolean L11_aridDesert()
 		}
 
 		autoAdv(1, $location[The Arid\, Extra-Dry Desert]);
-		handleFamiliar("item");
 
 		if(contains_text(get_property("lastEncounter"), "A Sietch in Time"))
 		{
@@ -1366,7 +1359,6 @@ boolean L11_hiddenCity()
 	if (item_amount($item[stone triangle]) == 4) {
 		auto_log_info("Fighting the out-of-work spirit", "blue");
 		acquireHP();
-		handleFamiliar("init");
 		return autoAdv($location[A Massive Ziggurat]);
 	}
 	
@@ -1495,8 +1487,6 @@ boolean L11_mauriceSpookyraven()
 		if (!auto_forceNextNoncombat()) {
 			providePlusNonCombat(25, true);
 		}
-
-		handleFamiliar("init");
 
 		return autoAdv($location[The Haunted Ballroom]);
 	}
@@ -2018,7 +2008,6 @@ boolean L11_palindome()
 	{
 		if(item_amount($item[Wet Stunt Nut Stew]) == 0)
 		{
-			handleFamiliar("item");
 			equipBaseline();
 			if((item_amount($item[Bird Rib]) == 0) || (item_amount($item[Lion Oil]) == 0))
 			{
@@ -2339,7 +2328,6 @@ boolean L11_unlockEd()
 		{
 			auto_sourceTerminalEnhance("items");
 		}
-		handleFamiliar("item");
 	}
 
 	if(get_property("controlRoomUnlock").to_boolean())

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -781,7 +781,6 @@ boolean L12_filthworms()
 	}
 	if(item_amount($item[Heart of the Filthworm Queen]) > 0)
 	{
-		handleFamiliar("meat");
 		return false;
 	}
 
@@ -861,9 +860,6 @@ boolean L12_filthworms()
 			buffMaintain($effect[Wet and Greedy], 0, 1, 1);
 		}
 		buffMaintain($effect[Frosty], 0, 1, 1);
-		
-		handleFamiliar("item");
-		handleServant("item");
 		
 		addToMaximize("200item");
 		
@@ -999,7 +995,6 @@ boolean L12_gremlins()
 	{
 		bat_formMist();
 	}
-	handleFamiliar("gremlins");
 	songboomSetting("dr");
 	if(item_amount($item[molybdenum hammer]) == 0)
 	{
@@ -1024,7 +1019,6 @@ boolean L12_gremlins()
 		autoAdv(1, $location[near an abandoned refrigerator], "auto_JunkyardCombatHandler");
 		return true;
 	}
-	handleFamiliar("item");
 	warOutfit(true);
 	visit_url("bigisland.php?action=junkman&pwd");
 	return true;
@@ -1072,7 +1066,6 @@ boolean L12_sonofaBeach()
 		auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 		if(chateaumantegna_usePainting())
 		{
-			handleFamiliar("item");
 			return true;
 		}
 	}
@@ -1140,7 +1133,6 @@ boolean L12_sonofaBeach()
 
 	autoAdv(1, $location[Sonofa Beach]);
 	set_property("auto_doCombatCopy", "no");
-	handleFamiliar("item");
 
 	if (isActuallyEd() && my_hp() == 0)
 	{
@@ -1186,7 +1178,6 @@ boolean L12_sonofaPrefix()
 		auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 		if(chateaumantegna_usePainting())
 		{
-			handleFamiliar("stat");
 			return true;
 		}
 	}
@@ -1311,7 +1302,6 @@ boolean L12_sonofaPrefix()
 	autoAdv(1, $location[Sonofa Beach]);
 	set_property("auto_combatDirective", "");
 	set_property("auto_doCombatCopy", "no");
-	handleFamiliar("item");
 
 	if (isActuallyEd() && my_hp() == 0)
 	{
@@ -1400,7 +1390,6 @@ boolean L12_lastDitchFlyer()
 		}
 		else
 		{
-			handleFamiliar("item");
 			if(LX_getStarKey())
 			{
 				return true;
@@ -1604,12 +1593,6 @@ boolean L12_themtharHills()
 	}
 	asdonBuff($effect[Driving Observantly]);
 
-	if (isActuallyEd()) {
-		handleServant("meat");
-	} else {
-		handleFamiliar("meat");
-	}
-	
 	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
@@ -1674,7 +1657,6 @@ boolean L12_themtharHills()
 
 			if(failNuns)
 			{
-				handleFamiliar("item");
 				set_property("auto_skipNuns", "true");
 				return false;
 			}
@@ -1739,7 +1721,6 @@ boolean L12_themtharHills()
 		diffMeat = diffMeat * 1.2;
 		average = average * 1.2;
 	}
-	handleFamiliar("item");
 	return true;
 }
 
@@ -1903,7 +1884,6 @@ boolean L12_clearBattlefield()
 	{
 		if (internalQuestStatus("questL12HippyFrat") < 2 && get_property("hippiesDefeated").to_int() < 333 && get_property("fratboysDefeated").to_int() < 333 && possessOutfit("Frat Warrior Fatigues", true))
 		{
-			handleFamiliar("item");
 			if(haveWarOutfit())
 			{
 				warOutfit(false);
@@ -1978,7 +1958,6 @@ boolean L12_clearBattlefield()
 				use(1, $item[Stuffing Fluffer]);
 				return true;
 			}
-			handleFamiliar("item");
 			warOutfit(false);
 			return warAdventure();
 		}
@@ -1986,7 +1965,6 @@ boolean L12_clearBattlefield()
 		if (get_property("hippiesDefeated").to_int() < 192 && get_property("fratboysDefeated").to_int() < 192 && internalQuestStatus("questL12War") == 1)
 		{
 			auto_log_info("Getting to the nunnery/junkyard", "blue");
-			handleFamiliar("item");
 			warOutfit(false);
 			return warAdventure();
 		}
@@ -1994,7 +1972,6 @@ boolean L12_clearBattlefield()
 		if ((get_property("sidequestNunsCompleted") != "none" || get_property("auto_skipNuns").to_boolean()) && (get_property("hippiesDefeated").to_int() < 1000 && get_property("fratboysDefeated").to_int() < 1000) && internalQuestStatus("questL12War") == 1)
 		{
 			auto_log_info("Doing the wars.", "blue");
-			handleFamiliar("item");
 			warOutfit(false);
 			return warAdventure();
 		}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -199,11 +199,6 @@ boolean LX_getStarKey()
 			set_property("choiceAdventure1221", 2 + (my_ascensions() % 2));
 		}
 	}
-	else
-	{
-		handleFamiliar("item");
-	}
-	
 	return autoAdv(1, $location[The Hole In The Sky]);
 }
 
@@ -488,7 +483,6 @@ boolean L13_towerNSContests()
 		}
 	}
 
-	handleFamiliar("item");
 	equipBaseline();
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_01_crowd1"))
@@ -933,10 +927,6 @@ boolean L13_towerNSTower()
 				set_property("auto_getBeehive", true);
 				auto_log_warning("I probably failed the Wall of Skin, I assume that I tried without a beehive. Well, I'm going back to get it.", "red");
 			}
-			else
-			{
-				handleFamiliar("item");
-			}
 		}
 		else
 		{
@@ -1029,10 +1019,6 @@ boolean L13_towerNSTower()
 				auto_log_warning("Could not towerkill Wall of Bones, reverting to Boning Knife", "red");
 				acquireHP();
 				set_property("auto_getBoningKnife", true);
-			}
-			else
-			{
-				handleFamiliar("item");
 			}
 		}
 		else if((item_amount($item[Electric Boning Knife]) > 0) || (auto_my_path() == "Pocket Familiars"))

--- a/RELEASE/scripts/autoscend/quests/level_7.ash
+++ b/RELEASE/scripts/autoscend/quests/level_7.ash
@@ -46,7 +46,6 @@ boolean L7_crypt()
 
 	if((get_property("cyrptAlcoveEvilness").to_int() > 0) && ((get_property("cyrptAlcoveEvilness").to_int() <= get_property("auto_waitingArrowAlcove").to_int()) || (get_property("cyrptAlcoveEvilness").to_int() <= 25)) && edAlcove && canGroundhog($location[The Defiled Alcove]))
 	{
-		handleFamiliar("init");
 
 		if((get_property("_badlyRomanticArrows").to_int() == 0) && auto_have_familiar($familiar[Reanimated Reanimator]) && (my_daycount() == 1))
 		{
@@ -82,7 +81,6 @@ boolean L7_crypt()
 	{
 		auto_log_info("The Nook!", "blue");
 		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
-		handleFamiliar("item");
 		autoEquip($item[Gravy Boat]);
 
 		bat_formBats();

--- a/RELEASE/scripts/autoscend/quests/level_8.ash
+++ b/RELEASE/scripts/autoscend/quests/level_8.ash
@@ -268,7 +268,6 @@ boolean L8_getGoatCheese()
 	}
 
 	auto_log_info("Yay for goat cheese!", "blue");
-	handleFamiliar("item");
 	if(get_property("_sourceTerminalDuplicateUses").to_int() == 0)
 	{
 		auto_sourceTerminalEducate($skill[Extract], $skill[Duplicate]);
@@ -351,7 +350,6 @@ boolean L8_getMineOres()
 		if (!possessOutfit("Mining Gear")) {
 			auto_log_info("Getting Mining Gear.", "blue");
 			providePlusNonCombat(25);
-			handleFamiliar("item");
 			return autoAdv($location[Itznotyerzitz Mine]);
 		} else if (possessOutfit("Mining Gear", true)) {
 			equipMaximizedGear();
@@ -406,7 +404,6 @@ boolean L8_trapperExtreme()
 
 	auto_log_info("Penguin Tony Hawk time. Extreme!! SSX Tricky!!", "blue");
 	providePlusNonCombat(25);
-	handleFamiliar("item");
 	return autoAdv($location[The eXtreme Slope]);
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -565,14 +565,12 @@ boolean L9_aBooPeak()
 			{
 				use(1, $item[Scroll of Drastic Healing]);
 			}
-			handleFamiliar("item");
 			handleBjornify(priorBjorn);
 			return true;
 		}
 
 		auto_log_info("Nevermind, that peak is too scary!", "green");
 		equipBaseline();
-		handleFamiliar("item");
 		handleBjornify(priorBjorn);
 	}
 	else
@@ -781,7 +779,6 @@ boolean L9_oilPeak()
 	}
 
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
-	handleFamiliar("init");
 
 	auto_MaxMLToCap(auto_convertDesiredML(100), true);
 
@@ -842,7 +839,6 @@ boolean L9_oilPeak()
 			uneffect($effect[Driving Wastefully]);
 		}
 	}
-	handleFamiliar("item");
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -145,14 +145,6 @@ boolean LX_steelOrgan()
 				# Should we check for -NC stuff and deal with it?
 				# We need a Combat Modifier controller
 			}
-			if(item_amount($item[Imp Air]) >= 5)
-			{
-				handleFamiliar($familiar[Jumpsuited Hound Dog]);
-			}
-			else
-			{
-				handleFamiliar("item");
-			}
 			autoAdv(1, $location[The Laugh Floor]);
 		}
 		else if(((item_amount($item[Azazel\'s Unicorn]) == 0) || (item_amount($item[Bus Pass]) < 5)) && (item_amount($item[Azazel\'s Tutu]) == 0))
@@ -236,7 +228,6 @@ boolean LX_steelOrgan()
 			{
 				uneffect($effect[The Sonata of Sneakiness]);
 			}
-			handleFamiliar("item");
 			autoAdv(1, $location[Infernal Rackets Backstage]);
 		}
 		else if((item_amount($item[Azazel\'s Lollipop]) == 0) && (item_amount($item[Azazel\'s Tutu]) == 0))


### PR DESCRIPTION
# Description

- Use +item familiars in zones when they're needed rather than just blindly using +item familiars.
- Add +stats familiars to the fallback choices when nothing else applies because levelling is somewhat useful in-run I've heard.
- add +meat familiars to the fallback choices for zones where the monsters have high meat drop.
- remove almost all other calls to `handleFamiliar()`. Some are left as they're specific familiar overrides or specific to the task (e.g. wishing for a moutain man calls `handleFamiliar("item");` then `handleFamiliar("Cat Burglar");`)
- remove the use of Stooper and Jumpsuited Hound Dog for +/-combat. They unnecessarily soak up familiar experience and farming drops/stats will be more beneficial across the whole run when +item/+meat/+init is not required.
- only farm the Cubeling drops if it's not going to be used as your +item familiar anyway (as in, you have something better when we call `handleFamiliar("item");`)
- Fixed provideResistances to use resistance familiars.

## How Has This Been Tested?

Ran day 1 of a normal LKS run (0 IotMs). 
![image](https://user-images.githubusercontent.com/50261170/84827436-52321780-afd9-11ea-9a6b-e17ab66662c5.png)
Ended with it just breaking level 8. The pathing could do with work but that's not the fault of these changes.

I noticed it was switching away from the Exotic Parrot every second adventure when doing the Haunted Kitchen so consider that an in-progress issue as it could affect doing A-Boo Clues too (which would be very annoying, the Haunted Kitchen is only a difference of 1 or 2 adventures).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
