### PR TITLE
piratequest fix Frat Boy Ensemble outfit

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -114,9 +114,9 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(1);
 			} else if (equipped_amount($item[mullet wig]) == 1 && item_amount($item[briefcase]) > 0) {
 				run_choice(2);
-			} else {
+			} else if (equipped_amount($item[frilly skirt]) == 1 && item_amount($item[hot wing]) > 2) {
 				run_choice(3);
-			}
+			} else abort("I tried to infiltrate the orcish frat house without being equipped for the job");
 			break;
 		case 189: // O Cap'm, My Cap'm (The Poop Deck)
 			run_choice(2); // skip

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -550,7 +550,7 @@ boolean LX_joinPirateCrew() {
 		auto_log_info("Attempting to infiltrate the frat house", "blue");
 		boolean infiltrationReady = false;
 		if (possessOutfit("Frat Boy Ensemble", true))  {
-			outfit("Frat Boy Ensemble");
+			autoOutfit("Frat Boy Ensemble");
 			infiltrationReady = true;
 		} else if (possessEquipment($item[mullet wig]) && item_amount($item[briefcase]) > 0) {
 			autoForceEquip($item[mullet wig]);
@@ -588,7 +588,7 @@ boolean LX_joinPirateCrew() {
 			// this is held together with duct tape and hopes and dreams.
 			// it can and will fail but it will have to do for now.
 			auto_log_info("Beer Pong time.", "blue");
-			outfit("Swashbuckling Getup");
+			autoOutfit("Swashbuckling Getup");
 			backupSetting("choiceAdventure187", "0");
 			tryBeerPong();
 			return true;


### PR DESCRIPTION
fixes trying to do pirate quest with Frat Boy Ensemble outfit in inventory.
*when handling choice adventure 188 do not assume that we are able to do choice 3 if 1 and 2 are unavailable.
*use autoOutfit instead of outfit for wearing the pirate quest outfits. Otherwise maximizer will just unequip them before we adventure.

## How Has This Been Tested?

used test script and ashq calls to call the functions in question it in aftercore.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
