### PR TITLE
grimstone mask fix. also UV compass and ornate dowsing rod should test auto_can_equip

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -131,11 +131,6 @@ boolean evokeEldritchHorror(string option);
 boolean evokeEldritchHorror();
 boolean auto_change_mcd(int mcd);
 boolean basicAdjustML();
-boolean auto_is_valid(item it);
-boolean auto_is_valid(familiar fam);
-boolean auto_is_valid(skill sk);
-boolean auto_can_equip(item it);
-boolean auto_can_equip(item it, slot s);
 boolean auto_badassBelt();
 int auto_convertDesiredML(int DML);
 boolean auto_setMCDToCap();
@@ -5801,6 +5796,12 @@ boolean auto_is_valid(item it)
 		else if(!expectGhostReport() && !haveGhostReport())
 			return false;
 	}
+	if(it == $item[Grimstone Mask])
+	{
+		if(!isGuildClass())		//it seems like all non core classes are disallowed. need to spade this to verify if any class is exempt
+			return false;
+	}
+	
 	return bees_hate_usable(it.to_string()) && is_unrestricted(it);
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -371,14 +371,9 @@ boolean LX_ornateDowsingRod(boolean doing_desert_now)
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Grimstone Mask]) || !is_unrestricted($item[Ornate Dowsing Rod]))
+	if(!auto_is_valid($item[Grimstone Mask]) || !auto_can_equip($item[Ornate Dowsing Rod]))
 	{
 		set_property("auto_grimstoneOrnateDowsingRod", false);	//mask or rod are not valid
-		return false;
-	}
-	if(auto_my_path() == "Way of the Surprising Fist" || $class[Avatar of Boris] == my_class())
-	{
-		set_property("auto_grimstoneOrnateDowsingRod", false);	//cannot equip offhand item in those paths
 		return false;
 	}
 	if(possessEquipment($item[Ornate Dowsing Rod]))

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -195,10 +195,7 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
-	
-	// can't equip kramko sausage grinder during certain paths, return false in those paths
-	
-	if (auto_my_path() == "Way of the Surprising Fist" || in_boris())
+	if(!auto_can_equip($item[Kramco Sausage-o-Matic&trade;]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -566,9 +566,13 @@ boolean L11_mcmuffinDiary()
 boolean L11_getUVCompass()
 {
 	//acquire a [UV-resistant compass] if needed
-	if(possessEquipment($item[Ornate Dowsing Rod]) && is_unrestricted($item[Ornate Dowsing Rod]))
+	if(possessEquipment($item[Ornate Dowsing Rod]) && auto_can_equip($item[Ornate Dowsing Rod]))
 	{
 		return false;		//already have a dowsing rod. we do not need a compass.
+	}
+	if(!auto_can_equip($item[UV-resistant compass]))
+	{
+		return false;
 	}
 	if(possessEquipment($item[UV-resistant compass]))
 	{
@@ -577,10 +581,6 @@ boolean L11_getUVCompass()
 	if(in_koe())
 	{
 		return false;		//impossible to get compass in this path. [The Shore, Inc] is unavailable
-	}
-	if(auto_my_path() == "Way of the Surprising Fist" || $class[Avatar of Boris] == my_class())
-	{
-		return false;		//cannot equip offhand item in these paths
 	}
 
 	if(item_amount($item[Shore Inc. Ship Trip Scrip]) == 0)


### PR DESCRIPTION
*auto_is_valid will identify grimstone mask as invalid if you are playing as any non-core class.
as vampyre shows a generic message that says only core classes are allowed to use. (unlike the tested older paths who showed path specific messages explaining why they cannot use it).
**This does need spading to see if an exception exists.
*UV compass and ornate dowsing rod check for auto_can_equip instead of checking is_unrestricted. This allows them to also catch paths in which you are forbidden to equip offhand items by the path rules (boris and way of surprising fist). And will be more robust going forward.

The first issue cropped up because I added the ability to pull a grimstone mask for the dowsing rod, as it saves 9+ adv in desert from 1 pull. Avatar paths could never get a grimstone mask as a drop due to not allowing familiars, so this was never an issue for them. But now that we can pull a mask we need to check to make sure the class in question can use it.

## How Has This Been Tested?

working on it

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
