### PR TITLE
we should to visit the contest booth to find out what the contests are

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -225,6 +225,12 @@ boolean L13_towerNSContests()
 		visit_url("choice.php?pwd=&whichchoice=1022&option=1", true);
 		return true;
 	}
+	
+	//if you do not have a telescope you need to actually visit the contest booth once to find out what element and offstat is needed
+	if(get_property("nsChallenge1") == "none" || get_property("nsChallenge2") == "none")
+	{
+		visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
+	}
 
 	boolean crowd1Insufficient()
 	{


### PR DESCRIPTION
we should to visit the contest booth to find out what the contests are
if we do not have a telescope
otherwise it wastes too many turns by not properly optimizing.

## How Has This Been Tested?

`ash remove_property("nsChallenge1")`
`ash remove_property("nsChallenge2")`
then run the test code, it correctly identified that one of the above 2 is unknown and visited the contest booth first to make mafia update.
However, since it had already started the elemental challenge at the time it could not update it anymore that run. so I reset that one manually
according to prefref nsChallenge2 has the same default value as nsChallenge1 so I see no reason this won't work for it too

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
