### PR TITLE
disguise delimit identify [your shadow] mask

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -337,6 +337,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 				auto_log_info("Found mask: " + majora, "green");
 			}
 		}
+		else if(enemy == $monster[Your Shadow])	//matcher fails on your shadow and it always wears mask 1.
+		{
+			majora = 1;
+			auto_log_info("Found mask: 1", "green");
+		}
 		else
 		{
 			return abortCombat("Failed to identify the mask worn by the monster [" + enemy + "]. Finish this combat manually then run me again");


### PR DESCRIPTION
disguise delimit identify [your shadow] mask
this prevents aborting for unidentified mask

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
