### PR TITLE
fix infinite loop when trying to do vacation without enough adventures

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -218,9 +218,9 @@ boolean LX_islandAccess()
 	{
 		abort("Dude, we got Dinghy Plans... we should not be here....");
 	}
-	while((item_amount($item[Shore Inc. Ship Trip Scrip]) < 3) && (my_meat() >= 500) && (item_amount($item[Dinghy Plans]) == 0))
+	while(item_amount($item[Shore Inc. Ship Trip Scrip]) < 3 &&  item_amount($item[Dinghy Plans]) == 0)
 	{
-		LX_doVacation();
+		if(!LX_doVacation()) break;		//tries to vacation and if fails it will break the loop
 	}
 	if(item_amount($item[Shore Inc. Ship Trip Scrip]) < 3)
 	{


### PR DESCRIPTION
fix infinite loop when trying to do vacation without enough adventures

Fixes issue reported in discord

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
