### PR TITLE
L8 refactored

### DIFF
--- a/BUILD/settings_extra/post.dat
+++ b/BUILD/settings_extra/post.dat
@@ -26,3 +26,5 @@ _auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actuall
 auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
 auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
+auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -47,6 +47,8 @@ post	24	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is
 post	25	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
 post	26	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 post	27	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
+post	28	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+post	29	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
 #
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -159,6 +159,7 @@ void initializeSettings() {
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
 	set_property("auto_doGalaktik", false);
+	set_property("auto_L8_ninjaSkip", false);
 	set_property("auto_haveSourceTerminal", false);
 	set_property("auto_hedge", "fast");
 	set_property("auto_hippyInstead", false);
@@ -2764,7 +2765,6 @@ boolean doTasks()
 	if(LX_spookyravenManorSecondFloor())			return true;
 	if(L3_tavern())						return true;
 	if(L6_friarsGetParts())				return true;
-	if(L8_trapperStart())				return true;
 	if(LX_hardcoreFoodFarm())			return true;
 
 	if(in_hardcore() && LX_steelOrgan())
@@ -2774,9 +2774,7 @@ boolean doTasks()
 
 	if(L7_crypt())						return true;
 	if(fancyOilPainting())				return true;
-	if(L8_trapperGround())				return true;
-	if(L8_trapperNinjaLair())			return true;
-	if(L8_trapperGroar())				return true;
+	if(L8_trapperQuest())				return true;
 	if(LX_steelOrgan())					return true;
 	if(L10_plantThatBean())				return true;
 	if(L12_preOutfit())					return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -159,7 +159,8 @@ void initializeSettings() {
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
 	set_property("auto_doGalaktik", false);
-	set_property("auto_L8_ninjaSkip", false);
+	set_property("auto_L8_ninjaAssassinFail", false);
+	set_property("auto_L8_extremeInstead", false);
 	set_property("auto_haveSourceTerminal", false);
 	set_property("auto_hedge", "fast");
 	set_property("auto_hippyInstead", false);

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -996,6 +996,11 @@ boolean auto_post_adventure()
 			auto_log_info("At the snojo, let's not keep going there and dying....", "red");
 			set_property("_snojoFreeFights", 10);
 		}
+		if(last_monster() == $monster[ninja snowman assassin])
+		{
+			auto_log_info("We were beaten up by a [ninja snowman assassin]. disabling ninja route", "red");
+			set_property("auto_L8_ninjaAssassinFail", true);
+		}
 		set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
 		use_skill(1, $skill[Tongue of the Walrus]);
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -734,18 +734,19 @@ boolean L7_crypt();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_08.ash
-boolean L8_trapperStart();
 boolean needOre();
 int getCellToMine(item oreGoal);
-boolean L8_trapperAdvance();
 boolean L8_getGoatCheese();
 boolean L8_getMineOres();
 void itznotyerzitzMineChoiceHandler(int choice);
-boolean L8_trapperGround();
 boolean L8_trapperExtreme();
 void theeXtremeSlopeChoiceHandler(int choice);
 boolean L8_trapperNinjaLair();
 boolean L8_trapperGroar();
+boolean L8_trapperPeak();
+boolean L8_trapperSlope();
+boolean L8_trapperGround();
+boolean L8_trapperTalk();
 boolean L8_trapperQuest();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -472,6 +472,7 @@ boolean L13_bhy_towerFinal();
 boolean inCasual();
 boolean inAftercore();
 boolean inPostRonin();
+boolean L8_slopeCasual();
 boolean LM_canInteract();
 
 ########################################################################################################
@@ -692,6 +693,7 @@ void standard_dnaPotions();
 //Defined in autoscend/paths/the_source.ash
 boolean theSource_initializeSettings();
 boolean theSource_buySkills();
+boolean L8_theSourceNinjaOracle();
 boolean LX_theSource();
 boolean theSource_oracle();
 boolean LX_attemptPowerLevelTheSource();
@@ -741,11 +743,11 @@ boolean L8_getMineOres();
 void itznotyerzitzMineChoiceHandler(int choice);
 boolean L8_trapperExtreme();
 void theeXtremeSlopeChoiceHandler(int choice);
+boolean L8_trapperSlopeSoftcore();
 boolean L8_trapperNinjaLair();
 boolean L8_trapperGroar();
 boolean L8_trapperPeak();
 boolean L8_trapperSlope();
-boolean L8_trapperGround();
 boolean L8_trapperTalk();
 boolean L8_trapperQuest();
 

--- a/RELEASE/scripts/autoscend/iotms/mr2012.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2012.ash
@@ -62,7 +62,7 @@ boolean handleRainDoh()
 		set_property("auto_doCombatCopy", "no");
 		if(count == 3)
 		{
-			set_property("auto_ninjasnowmanassassin", "1");
+			set_property("auto_ninjasnowmanassassin", true);
 		}
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1125,12 +1125,9 @@ boolean LX_ghostBusting()
 		}
 		if(goal == $location[Lair of the Ninja Snowmen])
 		{
-			if((item_amount($item[Ninja Rope]) == 0) || (item_amount($item[Ninja Carabiner]) == 0) || (item_amount($item[Ninja Crampons]) == 0))
+			if(L8_trapperNinjaLair())
 			{
-				if(L8_trapperNinjaLair())
-				{
-					return true;
-				}
+				return true;
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1442,7 +1442,7 @@ boolean LM_edTheUndying()
 		return true;
 	}
 	// L8 quest is all 1 Ka zones for Ed (unlikely to survive Ninja Snowmen Assassins so they don't count)
-	if (L8_trapperStart() || L8_trapperGround() || L8_trapperGroar())
+	if (L8_trapperQuest())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -22,6 +22,34 @@ boolean inPostRonin()
 	return false;
 }
 
+boolean L8_slopeCasual()
+{
+	//casual and postronin should mallbuy everything needed to skip this zone
+	if(!can_interact())
+	{
+		return false;	//does not have unrestricted mall access. we are not in casual or postronin
+	}
+	foreach it in $items[Ninja Carabiner, Ninja Crampons, Ninja Rope,		//ninja climbing gear needed to climb the slope
+	eXtreme scarf, eXtreme mittens, snowboarder pants]						//outfit ensures you can reach 5 cold res needed
+	{
+		if(!buyUpTo(1, it))	//try to buy it or verify we already own it. if fails then do as below
+		{
+			if(my_meat() < mall_price(it))
+			{
+				auto_log_info("Can not afford to buy [" +it+ "] to climb the slope. Go do something else", "red");
+				return false;
+			}
+			abort("Mysteriously failed to buy [" +it+ "]. Buy it manually and run me again");
+		}
+	}
+	if(L8_trapperPeak())	//try to unlock peak
+	{
+		return true;	//successfully finished this part of the quest
+	}
+	abort("Mysteriously failed to unlock the mountain peak in trapper quest in casual or postronin. please unlock it and run me again");
+	return false;
+}
+
 boolean LM_canInteract()
 {
 	//this function is called early once every loop of doTasks() in autoscend.ash to do things when we have unlimited mall access

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -5,7 +5,7 @@ void hr_initializeSettings()
 		#Rain Man (Heavy Rains) Related settings
 		set_property("auto_holeinthesky", false);
 		set_property("auto_mountainmen", "");
-		set_property("auto_ninjasnowmanassassin", "");
+		set_property("auto_ninjasnowmanassassin", false);	//are we done with ninja snowman assassins
 		set_property("auto_orcishfratboyspy", "");
 		set_property("auto_warhippyspy", "");
 
@@ -48,7 +48,7 @@ boolean routineRainManHandler()
 	{
 		return rainManSummon($monster[mountain man], false, false);
 	}
-	if(get_property("auto_ninjasnowmanassassin") == "")
+	if(!get_property("auto_ninjasnowmanassassin").to_boolean())
 	{
 		return rainManSummon($monster[ninja snowman assassin], true, false);
 	}
@@ -330,13 +330,13 @@ boolean rainManSummon(monster target, boolean copy, boolean wink)
 		count = count + min(item_amount($item[ninja carabiner]), 1);
 		if(count == 3)
 		{
-			set_property("auto_ninjasnowmanassassin", "1");
+			set_property("auto_ninjasnowmanassassin", true);
 			#already have all ninja gear
 			return false;
 		}
 		if(count == 2)
 		{
-			set_property("auto_ninjasnowmanassassin", "1");
+			set_property("auto_ninjasnowmanassassin", true);
 			copy = false;
 		}
 		wink = false;

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -541,39 +541,16 @@ boolean LM_bond()
 
 		if((internalQuestStatus("questL08Trapper") < 2) && (my_level() >= 8))
 		{
-			if(item_amount($item[Goat Cheese]) == 0)
+			if(item_amount($item[Goat Cheese]) < 2)
 			{
-				L8_trapperStart();
-				set_property("auto_combatDirective", "start;(olfaction)");
-				if((get_property("_kgbTranquilizerDartUses").to_int() < 3) && (item_amount($item[Kremlin\'s Greatest Briefcase]) > 0))
-				{
-					equip($slot[acc3], $item[Kremlin\'s Greatest Briefcase]);
-				}
-				if(L8_trapperGround())
-				{
-					set_property("auto_combatDirective", "");
-					return true;
-				}
-				set_property("auto_combatDirective", "");
+				if(L8_trapperGround()) return true;
 			}
 			else if(item_amount($item[Goat Cheese]) == 2)
 			{
 				auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 				return timeSpinnerCombat($monster[Dairy Goat]);
 			}
-			else if(item_amount(to_item(get_property("trapperOre"))) == 1)
-			{
-				while(acquireHermitItem($item[Ten-Leaf Clover]));
-				use(1, $item[Disassembled Clover]);
-				backupSetting("cloverProtectActive", false);
-				autoAdvBypass(270, $location[Itznotyerzitz Mine]);
-				restoreSetting("cloverProtectActive");
-				return true;
-			}
-			else if(item_amount(to_item(get_property("trapperOre"))) == 3)
-			{
-				return L8_trapperGround();
-			}
+			if(L8_trapperGround()) return true;
 		}
 		if(my_level() >= 9)
 		{

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -156,7 +156,6 @@ boolean bond_initializeDay(int day)
 			{
 				cli_execute("teatree " + $item[Cuppa Sobrie Tea]);
 			}
-			L8_trapperGround();
 			//Digitize a blooper? Time spin it?
 			equipBaseline();
 
@@ -539,18 +538,14 @@ boolean LM_bond()
 			}
 		}
 
-		if((internalQuestStatus("questL08Trapper") < 2) && (my_level() >= 8))
+		if(internalQuestStatus("questL08Trapper") == 0 || internalQuestStatus("questL08Trapper") == 1)
 		{
-			if(item_amount($item[Goat Cheese]) < 2)
-			{
-				if(L8_trapperGround()) return true;
-			}
-			else if(item_amount($item[Goat Cheese]) == 2)
+			if(item_amount($item[Goat Cheese]) == 2 && timeSpinnerRemaining() >= 3)
 			{
 				auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
-				return timeSpinnerCombat($monster[Dairy Goat]);
+				if(timeSpinnerCombat($monster[Dairy Goat])) return true;
 			}
-			if(L8_trapperGround()) return true;
+			if(L8_trapperQuest()) return true;
 		}
 		if(my_level() >= 9)
 		{

--- a/RELEASE/scripts/autoscend/paths/the_source.ash
+++ b/RELEASE/scripts/autoscend/paths/the_source.ash
@@ -168,12 +168,9 @@ boolean LX_theSource()
 		}
 		if(goal == $location[Lair of the Ninja Snowmen])
 		{
-			if((item_amount($item[Ninja Rope]) == 0) || (item_amount($item[Ninja Carabiner]) == 0) || (item_amount($item[Ninja Crampons]) == 0))
+			if(L8_trapperNinjaLair())
 			{
-				if(L8_trapperNinjaLair())
-				{
-					return true;
-				}
+				return true;
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/paths/the_source.ash
+++ b/RELEASE/scripts/autoscend/paths/the_source.ash
@@ -75,6 +75,36 @@ boolean theSource_buySkills()
 	return false;
 }
 
+boolean L8_theSourceNinjaOracle()
+{
+	//handles the scenario where we want do the oracle quest and the target is the ninja snowmen lair
+	//in this case we do not mind if we can not beat the assassins. but if we can we would rather not waste adventures.
+	if(internalQuestStatus("questL08Trapper") == -1)	//quest not even started. zone not accessible
+	{
+		return false;
+	}
+	if(internalQuestStatus("questL08Trapper") > 2)		//done with the slope this ascension so just adventure in the lair
+	{
+		return autoAdv($location[Lair of the Ninja Snowmen]);
+	}
+	if(internalQuestStatus("questL08Trapper") < 2)		//try to advance quest to step2 to unlock the ninja snowman lair
+	{
+		return L8_trapperQuest();		//if we fail to advance quest we want to go do something else. we are probably delaying
+	}
+	
+	if(have_effect($effect[Thrice-Cursed]) > 0 || have_effect($effect[Twice-Cursed]) > 0 || have_effect($effect[Once-Cursed]) > 0)
+	{
+		return false;									//delaying to not disrupt hidden city
+	}
+	if(shenShouldDelayZone($location[Lair of the Ninja Snowmen]))
+	{
+		auto_log_debug("Delaying Lair of the Ninja Snowmen in case of Shen.");
+		return false;
+	}
+	
+	return autoAdv($location[Lair of the Ninja Snowmen]);
+}
+
 boolean LX_theSource()
 {
 	if(my_path() != "The Source")
@@ -168,10 +198,7 @@ boolean LX_theSource()
 		}
 		if(goal == $location[Lair of the Ninja Snowmen])
 		{
-			if(L8_trapperNinjaLair())
-			{
-				return true;
-			}
+			return L8_theSourceNinjaOracle();
 		}
 
 		if((goal == $location[The Red Zeppelin]) && (internalQuestStatus("questL11Ron") < 3))

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -1,16 +1,3 @@
-boolean L8_trapperStart()
-{
-	if (internalQuestStatus("questL08Trapper") != 0)
-	{
-		return false;
-	}
-
-	auto_log_info("Let's meet the trapper.", "blue");
-
-	visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
-	return true;
-}
-
 boolean needOre()
 {
 	//Determines if we need ore for the trapper or not.
@@ -222,24 +209,9 @@ int getCellToMine(item oreGoal) {
 	return potentialCells[random(numPotentials)];
 }
 
-boolean L8_trapperAdvance()
-{
-	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 1)
-	{
-		return false;
-	}
-	if (item_amount(get_property("trapperOre").to_item()) >= 3 && item_amount($item[Goat Cheese]) >= 3)
-	{
-		auto_log_info("Giving Trapper goat cheese and " + get_property("trapperOre").to_item(), "blue");
-		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
-		return true;
-	}
-	return false;
-}
-
 boolean L8_getGoatCheese()
 {
-	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 1)
+	if(internalQuestStatus("questL08Trapper") != 1)		//step1 = we spoke to trapper to unlock goatlet
 	{
 		return false;
 	}
@@ -261,7 +233,7 @@ boolean L8_getGoatCheese()
 
 boolean L8_getMineOres()
 {
-	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 1)
+	if(internalQuestStatus("questL08Trapper") != 1)		//step1 = we spoke to trapper to learn what ores he wants
 	{
 		return false;
 	}
@@ -411,26 +383,9 @@ void itznotyerzitzMineChoiceHandler(int choice) {
 	}
 }
 
-boolean L8_trapperGround()
-{
-	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 1)
-	{
-		return false;
-	}
-	if (L8_getGoatCheese() || L8_getMineOres() || L8_trapperAdvance())
-	{
-		return true;
-	}
-	return false;
-}
-
 boolean L8_trapperExtreme()
 {
-	if(get_property("currentExtremity").to_int() >= 3)
-	{
-		return false;
-	}
-	if (internalQuestStatus("questL08Trapper") != 2)
+	if(internalQuestStatus("questL08Trapper") != 2)
 	{
 		return false;
 	}
@@ -438,14 +393,23 @@ boolean L8_trapperExtreme()
 	{
 		return false;
 	}
-
-	if (possessOutfit("eXtreme Cold-Weather Gear", true)) {
+	if(L8_trapperPeak())
+	{
+		return true;		//unlock peak if ready to do so.
+	}
+	
+	//we should equip the extreme outfit if we have it
+	if (possessOutfit("eXtreme Cold-Weather Gear", true))	//own and can equip
+	{
 		autoOutfit("eXtreme Cold-Weather Gear");
-	} else if (possessOutfit("eXtreme Cold-Weather Gear")) {
+	}
+	else if (possessOutfit("eXtreme Cold-Weather Gear"))	//just own. thanks to else can not equip
+	{
 		auto_log_warning("I can not wear the eXtreme Gear, I'm just not awesome enough :(", "red");
 		return false;
 	}
-
+	
+	//try to get extreme points
 	auto_log_info("Penguin Tony Hawk time. Extreme!! SSX Tricky!!", "blue");
 	return autoAdv($location[The eXtreme Slope]);
 }
@@ -499,165 +463,265 @@ void theeXtremeSlopeChoiceHandler(int choice) {
 
 boolean L8_trapperNinjaLair()
 {
-	if (internalQuestStatus("questL08Trapper") != 2)
+	//adventure in the lair of the ninja snowmen to find and fight ninja snowman assassins
+	if(internalQuestStatus("questL08Trapper") != 2)
 	{
 		return false;
 	}
-
-	if(!have_skill($skill[Rain Man]) && (pulls_remaining() >= 3) && (internalQuestStatus("questL08Trapper") < 3))
+	if(get_property("auto_L8_ninjaSkip").to_boolean())
+	{
+		return false;	//this ascension we are skipping ninja route
+	}
+	if(L8_trapperPeak())
+	{
+		return true;	//unlock peak if ready to do so.
+	}
+	
+	if(isActuallyEd() && in_hardcore())
+	{
+		auto_log_info("Hardcore Ed prefers to do the extreme slope", "blue");
+		set_property("auto_L8_ninjaSkip", true);		//give up on ninja route for this ascension
+		return true;
+	}
+	
+	//pull ninja climbing gear to skip the slope.
+	if(!in_hardcore() &&	//must be in softcore to allow pulls
+	!have_skill($skill[Rain Man]) &&	//if we have rain man skill we will copy assassins
+	get_property("sourceOracleTarget").to_location() != $location[Lair of the Ninja Snowmen])	//Source oracle target is this zone
 	{
 		foreach it in $items[Ninja Carabiner, Ninja Crampons, Ninja Rope]
 		{
 			pullXWhenHaveY(it, 1, 0);
+			if(pulls_remaining() == 0 && item_amount(it) == 0)
+			{
+				return false;	//out of pulls in softcore. come back tomorrow
+			}
 		}
-	}
-
-	if((item_amount($item[Ninja Rope]) >= 1) && (item_amount($item[Ninja Carabiner]) >= 1) && (item_amount($item[Ninja Crampons]) >= 1))
-	{
-		return false;
 	}
 
 	if(get_property("_sourceTerminalDigitizeMonster") == $monster[Ninja Snowman Assassin])
 	{
 		if(loopHandler("_auto_digitizeAssassinTurn", "_auto_digitizeAssassinCounter", "Potentially unable to do anything while waiting on digitized Ninja Snowman Assassin.", 10))
 		{
-			auto_log_info("Have a digitized Ninja Snowman Assassin, let's put off the Ninja Snowman Lair", "blue");
+			auto_log_info("Have a digitized Ninja Snowman Assassin, let's put off the Ninja Snowmen Lair", "blue");
 		}
 		return false;
 	}
 
-	if (in_hardcore()) {
-		if((have_effect($effect[Thrice-Cursed]) > 0) || (have_effect($effect[Twice-Cursed]) > 0) || (have_effect($effect[Once-Cursed]) > 0))
+	if((have_effect($effect[Thrice-Cursed]) > 0) || (have_effect($effect[Twice-Cursed]) > 0) || (have_effect($effect[Once-Cursed]) > 0))
+	{
+		return false;
+	}
+
+	if (shenShouldDelayZone($location[Lair of the Ninja Snowmen]))
+	{
+		auto_log_debug("Delaying Lair of the Ninja Snowmen in case of Shen.");
+		return false;
+	}
+
+	//can we provide enough combat bonus to make it worthwhile trying to get snowman assassins?
+	if(providePlusCombat(25, true, true) <= 0.0)	//ninja snowman does not show up if +combat is not greater than 0
+	{
+		if(isAboutToPowerlevel())
 		{
-			return false;
-		}
-
-		if (shenShouldDelayZone($location[Lair of the Ninja Snowmen]))
-		{
-			auto_log_debug("Delaying Lair of the Ninja Snowmen in case of Shen.");
-			return false;
-		}
-
-		if (isActuallyEd() && !elementalPlanes_access($element[spooky]))
-		{
-			adjustEdHat("myst");
-		}
-
-		if (providePlusCombat(25, true, true) <= 0.0) {
-			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Ninja Snowmen.", "red");
-			return false;
-		}
-
-		if (autoAdv($location[Lair of the Ninja Snowmen])) {
+			auto_log_info("Something is keeping us from getting a suitable combat rate for ninja snowman assassin. we can only reach: " + numeric_modifier("Combat Rate") + ". Since we are about to powerlevel we are giving up on ninja route", "red");
+			set_property("auto_L8_ninjaSkip", true);		//give up on ninja route for this ascension
 			return true;
 		}
-		auto_log_warning("Seems like we failed the Ninja Snowmen unlock, reverting trapper setting", "red");
+		else
+		{
+			auto_log_warning("Something is keeping us from getting a suitable combat rate for ninja snowman assassin. we can only reach: " + numeric_modifier("Combat Rate") + ". Will delay and try again later", "red");
+		}
+		return false;
 	}
+	
+	//buff
+	if (isActuallyEd() && !elementalPlanes_access($element[spooky]))
+	{
+		adjustEdHat("myst");
+	}
+	
+	if(autoAdv($location[Lair of the Ninja Snowmen]))
+	{
+		return true;
+	}
+	auto_log_warning("Mysteriously failed to adventure in [Lair of the Ninja Snowmen]", "red");
 	return false;
 }
 
 boolean L8_trapperGroar()
 {
-	if (internalQuestStatus("questL08Trapper") < 2 || internalQuestStatus("questL08Trapper") > 5)
+	//do the peak portion of L8 trapper quest.
+	if(internalQuestStatus("questL08Trapper") < 3 || internalQuestStatus("questL08Trapper") > 4)
 	{
-		// if we haven't returned the goat cheese and ore
-		// to the trapper yet, don't try to ascend the peak.
+		return false;	//peak not yet unlocked or we are done with groar
+	}
+	
+	//error catching for if we are actually on step5 and mafia did not notice.
+	if(item_amount($item[Groar\'s Fur]) > 0 || item_amount($item[Winged Yeti Fur]) > 0)
+	{
+		auto_log_info("Quest tracking error detected. Mafia thinks we are in step4 of questL08Trapper but we are in fact in step5. Correcting. Current Path = " +my_path(), "red");
+		set_property("questL08Trapper", "step5");
+		return true;
+	}
+	
+	int [element] resGoal;
+	resGoal[$element[cold]] = 5;
+	// try getting resistance without equipment before bothering to change gear
+	if(provideResistances(resGoal, false) || provideResistances(resGoal, true))
+	{
+		auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
+		addToMaximize("2000cold resistance 5max");
+		return autoAdv($location[Mist-shrouded Peak]);
+	}
+	return false;
+}
+
+boolean L8_trapperPeak()
+{
+	//unlock the peak in the trapper quest
+	if(internalQuestStatus("questL08Trapper") != 2)
+	{
 		return false;
 	}
-
-	boolean canGroar = false;
-
-	if((item_amount($item[Ninja Rope]) >= 1) && (item_amount($item[Ninja Carabiner]) >= 1) && (item_amount($item[Ninja Crampons]) >= 1))
+	
+	//unlock peak using ninja climbing gear
+	if(item_amount($item[Ninja Rope]) > 0 && item_amount($item[Ninja Carabiner]) > 0 && item_amount($item[Ninja Crampons]) > 0)
 	{
-		canGroar = true;
-		//If we can not get enough cold resistance, maybe we need to do extreme path.
+		int [element] resGoal;
+		resGoal[$element[cold]] = 5;
+		if(provideResistances(resGoal, true))
+		{
+			equipMaximizedGear();
+			visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");	//unlock peak. advancing to step 4.
+			set_property("auto_ninjasnowmanassassin", true);		//heavy rains. are we done copying them
+		}
+		else
+		{
+			//TODO get outfit
+			//TODO does TCRS have a problem with the outfit still not being enough? look into it
+		}
+		
+		if(internalQuestStatus("questL08Trapper") == 3)
+		{
+			return true;	//successfully unlocked peak
+		}
+		else
+		{
+			abort("Mysteriously failed to climb the slope using ninja climbing gear");
+		}
 	}
-	if((internalQuestStatus("questL08Trapper") == 2) && (get_property("currentExtremity").to_int() == 3))
+	
+	//unlock peak using extremeness
+	if(get_property("currentExtremity").to_int() >= 3)
 	{
 		// TODO: There are some reports of this breaking in TCRS, when cold-weather
 		// gear is not sufficient to have 5 cold resistance. Use a maximizer statement?
 		if(outfit("eXtreme Cold-Weather Gear"))
 		{
-			string temp = visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");
+			visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");
 			return true;
 		}
 	}
-	if((internalQuestStatus("questL08Trapper") >= 3) && (get_property("currentExtremity").to_int() == 0))
+	
+	return false;
+}
+
+boolean L8_trapperSlope()
+{
+	//climb the slope and reach the peak in L8 trapper quest. either via ninja snowmen lair or via the extreme slope
+	//climbing the slope is step2 of the quest. when you unlock the peak it advances to step3
+	if(internalQuestStatus("questL08Trapper") != 2)
 	{
-		canGroar = true;
+		return false;
 	}
 
-	// Just in case
-	cli_execute("refresh quests");
-
-	//What is our potential +Combat score.
-	//TODO: Use that instead of the Avatar/Hound Dog checks.
-
-	if(!canGroar && in_hardcore() && ((auto_my_path() == "Avatar of Sneaky Pete") || !canChangeToFamiliar($familiar[Jumpsuited Hound Dog])))
+	if(L8_trapperPeak())
 	{
-		if(L8_trapperExtreme())
-		{
-			return true;
-		}
+		return true;		//unlock peak if ready to do so.
 	}
-	if(isAboutToPowerlevel())
+	
+	if(get_property("auto_L8_ninjaSkip").to_boolean())	//we are skipping ninja route this ascension
 	{
-		if(L8_trapperExtreme())
-		{
-			return true;
-		}
+		if(L8_trapperExtreme()) return true;	//try to climb slope via extreme path
 	}
+	if(L8_trapperNinjaLair()) return true;	//try to climb slope via ninja path
+	
+	return false;
+}
 
-	if((item_amount($item[Groar\'s Fur]) > 0) || (item_amount($item[Winged Yeti Fur]) > 0) || (internalQuestStatus("questL08Trapper") == 5))
+boolean L8_trapperGround()
+{
+	//do the ground portion of L8 trapper quest
+	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 1)
 	{
-		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
-		if(item_amount($item[Dense Meat Stack]) >= 5)
-		{
-			auto_autosell(5, $item[Dense Meat Stack]);
-		}
-		council();
+		return false;
+	}
+	
+	//talk to trapper if needed. grab the goat cheese and ore for the trapper if needed during step1 of the quest
+	if(L8_trapperTalk() || L8_getGoatCheese() || L8_getMineOres())
+	{
 		return true;
-	}
-
-	if(canGroar)
-	{
-		int [element] resGoal;
-		resGoal[$element[cold]] = 5;
-		// try getting resistance without equipment before bothering to change gear
-		if(provideResistances(resGoal, false) || provideResistances(resGoal, true))
-		{
-			if (internalQuestStatus("questL08Trapper") == 2)
-			{
-				set_property("auto_ninjasnowmanassassin", "1");
-				visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
-				visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");
-			}
-
-			auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
-			if (item_amount($item[Groar\'s Fur]) == 0 && item_amount($item[Winged Yeti Fur]) == 0)
-			{
-				addToMaximize("2000cold resistance 5max");
-				//If this returns false, we might have finished already, can we check this?
-				return autoAdv($location[Mist-shrouded Peak]);
-			}
-			else
-			{
-				visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
-				auto_autosell(5, $item[dense meat stack]);
-				council();
-			}
-			return true;
-		}
 	}
 	return false;
 }
 
-boolean L8_trapperQuest() {
+boolean L8_trapperTalk()
+{
+	//talk to the trapper to advance the L8 quest.
+	int initial_step = internalQuestStatus("questL08Trapper");
+	if(initial_step != 0 && initial_step != 1 && initial_step != 5)
+	{
+		return false;	//only need to talk to trapper at steps 0, 1, and 5
+	}
+
+	if(initial_step == 0)		//step0 == quest started. we do not know what ores we need yet.
+	{
+		auto_log_info("Talkint to the trapper to find out what kind of Ore he wants", "blue");
+		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");		//talk to the trapper to advance quest
+	}
+	if(initial_step == 1)		//step1 == we know what ore to get. so go get ore and cheese
+	{
+		if(item_amount(get_property("trapperOre").to_item()) >= 3 && item_amount($item[Goat Cheese]) >= 3)
+		{
+			//turn in ore and cheese to advance from step1 to step2
+			auto_log_info("Giving Trapper goat cheese and " + get_property("trapperOre").to_item(), "blue");
+			visit_url("place.php?whichplace=mclargehuge&action=trappercabin");		//talk to the trapper to advance quest
+		}
+		else
+		{
+			return false;		//not enough cheese or ore yet. go get them
+		}
+	}
+	if(initial_step == 5)
+	{
+		//finish the quest
+		visit_url("place.php?whichplace=mclargehuge&action=trappercabin");
+		council();
+	}
+	
+	//error checking
+	if(initial_step == internalQuestStatus("questL08Trapper"))		//we failed to advance. try refreshing quests
+	{
+		auto_log_info("we visited trapper but failed to advance the quest from step" +initial_step+ ". Refreshing quests", "red");
+		cli_execute("refresh quests");
+	}
+	if(initial_step == internalQuestStatus("questL08Trapper"))		//refreshing quests did not solve the problem
+	{
+		abort("We were unable to advance the quest when talking to the trapper for some reason");
+	}
+	return true;
+}
+
+boolean L8_trapperQuest()
+{
+	//do the entire L8 trapper quest
 	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 5)
 	{
 		return false;
 	}
-	if (L8_trapperStart() || L8_getGoatCheese() || L8_getMineOres() || L8_trapperAdvance() || L8_trapperNinjaLair() || L8_trapperGroar())
+
+	if(L8_trapperTalk() || L8_trapperGround() || L8_trapperSlope() || L8_trapperGroar())
 	{
 		return true;
 	}


### PR DESCRIPTION
* L8 quest heavily refactored.
* added lots of commends for documentation
* auto_ninjasnowmanassassin should be a boolean. it is used for heavy rains path to track if we are done summoning snowman assassins.
* auto_L8_ninjaAssassinFail used to track inability to fight snowmen assassins.
** if beaten up by a ninja snowman assassin set it
** we need to make this predictive as well in future PR
* auto_L8_extremeInstead used to track not wanting to adventure in the ninja lair
** need a 2nd variable because we might be able to fight them using copiers. We might be unable to encounter them in the lair due to +combat being too low
* boolean L8_trapperSlope() created. it is used to specifically handle the 2nd stage of the L8 quest which is climbing the slope.
** calls special handling for hardcore, postronin, softcore. also chooses between ninja route or extreme route
** hardcore ed avoiding ninja snowmen for now until we can make a calculating function that determines if we will get 1 hit killed by the ninjas. Previously relied on calling L8_trapperGroar() which contained backtracking code to go back to extreme slope. since that backtracking code was removed as part of the refactor there is now an ed specific check and settings adjustment
** if we can not get a positive +combat give up on snowman assassin. previously we would do a maximize simulate every time and then when it failed fallover to extreme slope. Now we do a maximizer, if it fails go adventure somewhere else, if we ran out of somewhere elses to adventure then mark the ninja route for skipping and do not do any more maximize simulations for it, going directly to the extreme slop every time.
* boolean L8_trapperTalk() created
** L8_trapperStart() absorbed by boolean L8_trapperTalk()
** L8_trapperAdvance() absorbed by boolean L8_trapperTalk()
** portion of L8_trapperGroar() moved to boolean L8_trapperTalk()
** added code to verify success or failure as well as automatically correct quest tracking if needed
* boolean L8_trapperPeak() created
** finishes step2 and advances you to step3 by unlocking the peak when appropriate.
** Needed to accommodate the messy nature of step2 of the quest. and the various special handling functions it has.
* mr2016.ash removed unnecessary and incomplete quest state check for ghostbusting in ninja snowmen lair. the called function performs those same checks better
* the_source.ash removed unnecessary and incomplete quest state check for ninja snowmen lair. the called function performs those same checks better
* autoscend.ash make use of L8_trapperQuest() instead of the multiple components of it
* boolean L8_slopeCasual() created. dedicated casual and postascension handling
** mallbuy everything for slope. delay if can't afford it
* boolean L8_trapperSlopeSoftcore() created. dedicated softcore handling.
** will ensure we still do pulls even if we cannot fight the assassins
** added fallback for L8_trapperSlopeSoftcore() failing to unlock with all the ninja climbing gear. in that case fallback on doing L8_trapperExtreme() until we get the outfit
** softcore ed will now use pulls to skip the slope climbing step.
** the source will now not use pulls while we are doing an oracle quest in ninja snowmen lair, only once the oracle quest is finished do we pull any missing parts.
** ninja climbing gear pulls made more robust
* cleaner handling of source and heavy rains paths. both will now pull items if we cannot fight the assassins
* boolean L8_theSourceNinjaOracle() created.
** handles ninja snowmen lair in the source path when it is also the goal of the oracle quest
* license_to_adventure.ash dickstab fixes
** incorrectly calling L8_trapperGround() we do not just call adv spending functions. we put them in an if and return true if they successfully did a thing. we should never call an adventure spending function from the initialize function
** timespinner infinite loop. did not check if we actually own a time spinner, or if it has adv remaining.
*** currently commented out the use of timespinner. will uncomment the fixed function after PR #610 is merged
* license to adventure other fixes related to L8
* L8_trapperGround() function removed.

## How Has This Been Tested?

HC seal clubber in class act 2 with 0 IOTMs
several sauceror standard ascensions with all IOTMs
big and heavy rains ascension with lots of IOTMs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
