### PR TITLE
fix error introduced by #438

### DIFF
--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -579,7 +579,7 @@ boolean LX_joinPirateCrew() {
 			// this is held together with duct tape and hopes and dreams.
 			// it can and will fail but it will have to do for now.
 			auto_log_info("Beer Pong time.", "blue");
-			autoOutfit("Swashbuckling Getup");
+			outfit("Swashbuckling Getup");	//do not use autoOutfit since we use visit_url in tryBeerPong which skips maximizer
 			backupSetting("choiceAdventure187", "0");
 			tryBeerPong();
 			return true;


### PR DESCRIPTION
fix error introduced by #438 by partially reverting it

## How Has This Been Tested?

validates
is a reverting of code to an older known to work code.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
