### PR TITLE
disguises delimit bear verb orgy handling

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2367,7 +2367,7 @@ boolean LX_freeCombats(boolean powerlevel)
 		auto_freeCombatsRemaining(true);		//print remaining free combats.
 		auto_log_warning("Too few adventures to safely automate free combats", "red");
 		auto_log_warning("If we lose your last adv on a free combat the remaining free combats are wasted", "red");
-		auto_log_warning("This should only happen if you lost a free fight. If you did not then please report this", "red");
+		auto_log_warning("This error should only occur if you lost a free fight. If you did not then please report this", "red");
 		abort("Please perform the remaining free combats manually then run me again");
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1238,7 +1238,6 @@ boolean L13_towerNSNagamar()
 	{
 		return false;
 	}
-	
 	if(item_amount($item[Wand of Nagamar]) > 0)
 	{
 		set_property("auto_wandOfNagamar", false);
@@ -1255,6 +1254,14 @@ boolean L13_towerNSNagamar()
 		else
 		{
 			auto_log_warning("Buying [Wand of Nagamar] using rare Meat Isotopes failed even thought we had 30 isotopes... trying alternatives", "red");
+		}
+	}
+	if(auto_my_path() == "Disguises Delimit" && internalQuestStatus("questL13Final") == 12)
+	{
+		cli_execute("refresh quests");
+		if(internalQuestStatus("questL13Final") != 12)
+		{
+			abort("In this specific ascension [naughty sorceress \(3\)] is wearing a mask that makes kol base game fail to advance the quest to step 12. Which means that bear verb orgy is impossible for this specific run. Manually grab a [Ten-Leaf Clover] from [Barrel Full of Barrels] then use it to get a [Wand of Nagamar] manually and run me again");
 		}
 	}
 	


### PR DESCRIPTION
*disguises delimit don't waste all adventures if the naughty sorceress 3rd form is wearing one of the masks that prevent her from advancing the quest to step 12. making bear verb orgy impossible in that specific ascension
**Since we have not fully spaded which masks do this. this is handled by looking at the quest state. If mafia thinks we are at quest state 12 it means mafia thinks we unlocked bear verb orgy by losing to NS 3rd form. At that point we refresh quests, that causes mafia to recognize we are on step 11 not 12 according to the quest log. which indicates that in this particular disguises delimit ascension the NS 3rd form is wearing a mask that is preventing bear verb orgy. at which point we abort and tell the user to fix it manually by getting a wand (in such a run the only way to get a wand is via clovering the castle basement. the fact we did not do it mean we have no clover. so the fix is to get a clover from the barrel full of barrels, use it to get a wand, then run autoscend again... or just kill the NS yourself)

Fixes #419

## How Has This Been Tested?

I played with it for a bit but I have yet to hit the scenario it is meant to handle. if my hypothesis on the cause is correct there is only 6/23 chance of bear verb orgy being broken per disguises delimit ascension. and even then some runs we manage to preserve a clover automatically so this has even lower chances to occur

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
