### PR TITLE
Better routing for LKS and some other related fixes

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -22,3 +22,5 @@ Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>28
 Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+Serialbus	item:bus pass<5
+CH Imp	item:imp air<5

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -115,6 +115,8 @@ sniff	20	Possessed Wine Rack
 sniff	21	Blue Oyster cultist
 sniff	22	Dirty Old Lihc	prop:cyrptNicheEvilness>28
 sniff	23	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+sniff	24	Serialbus	item:bus pass<5
+sniff	25	CH Imp	item:imp air<5
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -374,6 +374,18 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(5);
 			}
 			break;
+		case 1062: // Lots of Options (The Overgrown Lot)
+			string[int] options = available_choice_options();
+			if (options contains 1) {
+				run_choice(1); // get flowers for the doc
+			} else {
+				if (options contains 5) {
+					run_choice(5); // get booze from map to a hidden booze cache
+				} else {
+					run_choice(3); // get booze
+				}
+			}
+			break;
 		case 1082: // The "Rescue" (post-Cake Lord in Madness Bakery)
 			run_choice(1);
 			break;

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -274,6 +274,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 			case $monster[cabinet of Dr. Limpieza]:
 				set_property("auto_cabinetsencountered", get_property("auto_cabinetsencountered").to_int() + 1);
 				break;
+			case $monster[junksprite bender]:
+			case $monster[junksprite melter]:
+			case $monster[junksprite sharpener]:
+				set_property("auto_junkspritesencountered", get_property("auto_junkspritesencountered").to_int() + 1);
+				break;
 		}
 
 		set_property("auto_combatHandler", "");

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -182,7 +182,7 @@ string defaultMaximizeStatement()
 			}
 		}
 
-		if(auto_have_familiar($familiar[mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			res += ",2familiar weight";
 			if(my_familiar().familiar_weight() < 20)

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -317,7 +317,7 @@ boolean autoChooseFamiliar(location place)
 	}
 
 	// Killing jar saves adventures unlocking the Pyramid.
-	if ($location[The Haunted Library] == place && item_amount($item[killing jar]) < 1) {
+	if ($location[The Haunted Library] == place && item_amount($item[killing jar]) < 1 && (get_property("gnasirProgress").to_int() & 4) == 0 && get_property("desertExploration") < 100) {
 		famChoice = lookupFamiliarDatafile("item");
 	}
 

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -89,6 +89,11 @@ boolean auto_post_adventure()
 		}
 	}
 
+	if (my_location() == $location[The Old Landfill] && item_amount($item[funky junk key]) > 0) {
+		// got a key drop, reset the tracking property.
+		set_property("auto_junkspritesencountered", 0);
+	}
+
 	if(get_property("auto_disableAdventureHandling").to_boolean())
 	{
 		auto_log_info("Postadventure skipped by standard adventure handler.", "green");
@@ -451,7 +456,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 15, 1, 10);
 		// Only maintain skills in path with familiars
-		if(auto_have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			buffMaintain($effect[Leash of Linguini], 20, 1, 10);
 			if(regen > 10.0)
@@ -512,7 +517,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 20, 1, 10);
 		// Only Maintain skills in path with familiars
-		if(auto_have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			buffMaintain($effect[Leash of Linguini], 30, 1, 10);
 			if(regen > 10.0)
@@ -579,7 +584,7 @@ boolean auto_post_adventure()
 			buffMaintain(whatStatSmile(), 40, 1, 10);
 		}
 		// Only maintain in path with familiars
-		if(auto_have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);
 			if(regen > 4.0)
@@ -689,7 +694,7 @@ boolean auto_post_adventure()
 		}
 
 		// Only maintain in path with familiars
-		if(auto_have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			buffMaintain($effect[Empathy], 50, 1, 10);
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);
@@ -779,7 +784,7 @@ boolean auto_post_adventure()
 		}
 
 		// Only maintain in path with familiars
-		if(auto_have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliar())
 		{
 			buffMaintain($effect[Jingle Jangle Jingle], 120, 1, 2);
 		}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1,6 +1,17 @@
 script "auto_pre_adv.ash";
 import<autoscend.ash>
 
+void print_footer() {
+	auto_log_info("HP: " + my_hp() + "/" + my_maxhp() + ", MP: " + my_mp() + "/" + my_maxmp() + " Meat: " + my_meat(), "blue");
+	if (my_class() == $class[Sauceror]) {
+		auto_log_info("Soulsauce: " + my_soulsauce(), "blue");
+	}
+	auto_log_info("Familiar: " + my_familiar().to_string() + " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
+	auto_log_info("ML: " + monster_level_adjustment() + " Encounter: " + combat_rate_modifier() + " Init: " + initiative_modifier(), "blue");
+	auto_log_info("Exp Bonus: " + experience_bonus() + " Meat Drop: " + meat_drop_modifier() + " Item Drop: " + item_drop_modifier(), "blue");
+	auto_log_info("Resists: " + numeric_modifier("Hot Resistance") + "/" + numeric_modifier("Cold Resistance") + "/" + numeric_modifier("Stench Resistance") + "/" + numeric_modifier("Spooky Resistance") + "/" + numeric_modifier("Sleaze Resistance"), "blue");
+}
+
 boolean auto_pre_adventure()
 {
 	auto_log_debug("Running auto_pre_adv.ash");
@@ -46,11 +57,6 @@ boolean auto_pre_adventure()
 	if((get_property("_bittycar") == "") && (item_amount($item[Bittycar Meatcar]) > 0))
 	{
 		use(1, $item[Bittycar Meatcar]);
-	}
-
-	if((have_effect($effect[Coated in Slime]) > 0) && (place != $location[The Slime Tube]))
-	{
-		visit_url("clan_slimetube.php?action=chamois&pwd");
 	}
 
 	if((place == $location[The Broodling Grounds]) && (my_class() == $class[Seal Clubber]))
@@ -125,33 +131,10 @@ boolean auto_pre_adventure()
 		}
 	}
 
-	if(!inAftercore())
-	{
-		if(($locations[Barrrney\'s Barrr, The Black Forest, The F\'c\'le, Monorail Work Site] contains place))
-		{
-			acquireCombatMods(zone_combatMod(place)._int, true);
-		}
-		if(place == $location[Sonofa Beach] && !auto_voteMonster())
-		{
-			acquireCombatMods(zone_combatMod(place)._int, true);
-		}
-
-		if($locations[Whitey\'s Grove] contains place)
-		{
-			acquireCombatMods(zone_combatMod(place)._int, true);
-		}
-
-		if($locations[A Maze of Sewer Tunnels, The Castle in the Clouds in the Sky (Basement), The Castle in the Clouds in the Sky (Ground Floor), The Castle in the Clouds in the Sky (Top Floor), The Dark Elbow of the Woods, The Dark Heart of the Woods, The Dark Neck of the Woods, The Defiled Alcove, The Defiled Cranny, The Extreme Slope, The Haunted Ballroom, The Haunted Bathroom, The Haunted Billiards Room, The Haunted Gallery, The Hidden Hospital, The Hidden Park, The Ice Hotel, Inside the Palindome, The Obligatory Pirate\'s Cove, The Penultimate Fantasy Airship, The Poop Deck, The Spooky Forest, Super Villain\'s Lair, Twin Peak, The Upper Chamber, Wartime Hippy Camp, Wartime Hippy Camp (Frat Disguise)] contains place)
-		{
-			acquireCombatMods(zone_combatMod(place)._int, true);
-		}
-	}
-	else
-	{
-		if((get_property("questL11Spare") == "finished") && (place == $location[The Hidden Bowling Alley]) && (item_amount($item[Bowling Ball]) > 0))
-		{
-			put_closet(item_amount($item[Bowling Ball]), $item[Bowling Ball]);
-		}
+	// this calls the appropriate provider for +combat or -combat depending on the zone we are about to adventure in..
+	generic_t combatModifier = zone_combatMod(place);
+	if (combatModifier._boolean) {
+		acquireCombatMods(combatModifier._int, true);
 	}
 
 	if(monster_level_adjustment() > 120)
@@ -328,7 +311,7 @@ boolean auto_pre_adventure()
 	generic_t itemNeed = zone_needItem(place);
 	if(itemNeed._boolean)
 	{
-		addToMaximize("50item " + ceil(itemNeed._float) + "max");
+		addToMaximize("50item " + (ceil(itemNeed._float) + 100.0) + "max"); // maximizer treats item drop as 100 higher than it actually is for some reason.
 		simMaximize();
 		float itemDrop = simValue("Item Drop");
 		if(itemDrop < itemNeed._float)
@@ -472,7 +455,7 @@ boolean auto_pre_adventure()
 		januaryToteAcquire($item[Wad Of Used Tape]);
 	}
 
-// EQUIP MAXIMIZED GEAR
+	// EQUIP MAXIMIZED GEAR
 	equipMaximizedGear();
 	cli_execute("checkpoint clear");
 
@@ -532,6 +515,7 @@ boolean auto_pre_adventure()
 		change_mcd(mcd_target);
 	}
 
+	print_footer();
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -460,7 +460,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
         meat_per_mp = meat_per_mp * 0.95; // this isn't quite right for discounted Doc Galaktik but I don't care.
       }
       if (isMystGuildStoreAvailable()) {
-        int mmj_cost = auto_have_skill($skill[Five Finger Discount]) ? 100 : 95;
+        int mmj_cost = auto_have_skill($skill[Five Finger Discount]) ? 95 : 100;
         int mmj_mp_restored = my_level() * 1.5 + 5;
         float mmj_meat_per_mp = mmj_cost / mmj_mp_restored;
         meat_per_mp = min(meat_per_mp, mmj_meat_per_mp);
@@ -556,7 +556,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
   // TODO: doesnt account properly for multiuse situations where we could have more blood skill casts and less waste than this formula suggests
   float blood_skill_opportunity_casts(float goal){
     boolean bloodBondAvailable = auto_have_skill($skill[Blood Bond]) &&
-      auto_have_familiar($familiar[Mosquito]) && //checks if player can use familiars in this run
+      pathAllowsFamiliar() && //checks if player can use familiars in this run
       my_maxhp() > hp_cost($skill[Blood Bond]) &&
       goal > ((9-hp_regen())*10) && // blood bond drains hp after combat, make sure we dont accidentally kill the player
       get_property("auto_restoreUseBloodBond").to_boolean();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -620,6 +620,15 @@ boolean startMeatsmithSubQuest()
 	return false;
 }
 
+boolean finishMeatsmithSubQuest() {
+	if (internalQuestStatus("questM23Meatsmith") == 1) {
+		visit_url("shop.php?whichshop=meatsmith");
+		run_choice(2);
+		return true;
+	}
+	return false;
+}
+
 boolean startGalaktikSubQuest()
 {
 	if(auto_my_path() == "Nuclear Autumn")
@@ -637,6 +646,20 @@ boolean startGalaktikSubQuest()
 		temp = visit_url("shop.php?whichshop=doc&action=talk");
 		temp = visit_url("choice.php?pwd=&whichchoice=1064&option=1");
 		return true;
+	}
+	return false;
+}
+
+boolean finishGalaktikSubQuest() {
+	if (item_amount($item[fraudwort]) >= 3 && item_amount($item[shysterweed]) >= 3 && item_amount($item[swindleblossom]) >= 3) {
+		string temp = visit_url("shop.php?whichshop=doc");
+		if (temp.contains_text("What did you need, again?")) {
+			visit_url("shop.php?whichshop=doc&action=talk");
+		}
+		run_choice(2);
+		if (internalQuestStatus("questM24Doc") > 1) {
+			return true;
+		}
 	}
 	return false;
 }
@@ -6447,11 +6470,6 @@ element currentFlavour()
 	return $element[none];
 }
 
-void resetFlavour()
-{
-	set_property("_auto_tunedElement", "");
-}
-
 boolean setFlavour(element ele)
 {
 	if(!auto_have_skill($skill[Flavour of Magic]))
@@ -7223,13 +7241,3 @@ int poolSkillPracticeGains()
 	return count;
 }
 
-void resetThisLoop()
-{
-	//These settings should never persist into another turn, ever. They only track something for a single instance of the main loop.
-	//We use boolean instead of adventure count because of free combats.
-	
-	set_property("auto_doCombatCopy", "no");
-	set_property("_auto_thisLoopHandleFamiliar", false);	//have we called handleFamiliar this loop
-	set_property("auto_disableFamiliarChanging", false);	//disable autoscend making changes to familiar
-	set_property("auto_familiarChoice", "");				//which familiar do we want to switch to during pre_adventure
-}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -35,12 +35,13 @@ boolean LX_joinPirateCrew();
 boolean LX_fledglingPirateIsYou();
 boolean LX_unlockBelowdecks();
 boolean LX_pirateQuest();
-boolean LX_acquireLegendaryEpicWeapon();
+boolean LX_acquireEpicWeapon();
 boolean LX_hardcoreFoodFarm();
 boolean LX_melvignShirt();
 boolean LX_attemptPowerLevel();
 boolean LX_attemptFlyering();
 boolean LX_bitchinMeatcar();
+boolean LX_unlockDesert();
 boolean LX_meatMaid();								//Defined in autoscend/quests/level_any.ash
 boolean dependenceDayClovers();						//Defined in autoscend/quests/level_any.ash
 boolean LX_craftAcquireItems();
@@ -71,19 +72,25 @@ boolean L2_mosquito();
 boolean L3_tavern();
 
 boolean L4_batCave();
+
 boolean L5_haremOutfit();
 boolean L5_findKnob();
 boolean L5_goblinKing();
 boolean L5_getEncryptionKey();
+boolean L5_slayTheGoblinKing();
+
 boolean L6_dakotaFanning();
 boolean L6_friarsGetParts();
-boolean L8_trapperStart();
+
 boolean L7_crypt();
+
+boolean L8_trapperStart();
 boolean L8_trapperGround();
 boolean L8_trapperNinjaLair();
 boolean L8_trapperExtreme();
 boolean L8_trapperGroar();
 boolean L8_trapperQuest();
+
 boolean L9_chasmBuild();
 boolean L9_highLandlord();
 boolean L9_aBooPeak();
@@ -104,7 +111,14 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake();					//Defined in autoscen
 boolean shenShouldDelayZone(location loc);								//Defined in autoscend/auto_quest_level_11.ash
 
 boolean LX_unlockHiddenTemple();
+boolean LX_unlockManorSecondFloor();
+boolean LX_unlockHauntedLibrary();
+boolean LX_unlockHauntedBilliardsRoom();
 boolean LX_spookyravenManorFirstFloor();
+boolean LX_danceWithLadySpookyraven();
+boolean LX_getLadySpookyravensFinestGown();
+boolean LX_getLadySpookyravensDancingShoes();
+boolean LX_getLadySpookyravensPowderPuff();
 boolean LX_spookyravenManorSecondFloor();
 boolean L11_palindome();
 boolean L11_hiddenCity();
@@ -118,6 +132,7 @@ boolean L11_mcmuffinDiary();
 boolean L11_unlockHiddenCity();
 boolean L11_hiddenCityZones();
 boolean L11_talismanOfNam();
+boolean L11_shenStartQuest();
 boolean L11_shenCopperhead();
 boolean L11_ronCopperhead();
 boolean L11_redZeppelin();
@@ -172,6 +187,7 @@ boolean L12_sonofaFinish();									//Defined in autoscend/auto_quest_level_12.a
 boolean L12_gremlins();										//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_orchardFinalize();								//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_finalizeWar();									//Defined in autoscend/auto_quest_level_12.ash
+boolean L12_clearBattlefield();
 
 //Defined in autoscend/auto_quest_level_13.ash
 boolean LX_getDigitalKey();
@@ -397,7 +413,6 @@ location[int] ListInsertInorder(location[int] list, location what);//Defined in 
 int ListFind(location[int] list, location what);			//Defined in autoscend/auto_list.ash
 int ListFind(location[int] list, location what, int idx);	//Defined in autoscend/auto_list.ash
 location ListOutput(location[int] list);					//Defined in autoscend/auto_list.ash
-void resetThisLoop();										//Defined in autoscend/auto_util.ash
 int [item] auto_get_campground();								//Defined in autoscend/auto_util.ash
 boolean basicAdjustML();									//Defined in autoscend/auto_util.ash
 boolean beatenUpResolution();								//Defined in autoscend.ash
@@ -987,6 +1002,8 @@ boolean startArmorySubQuest();								//Defined in autoscend/auto_util.ash
 boolean startGalaktikSubQuest();							//Defined in autoscend/auto_util.ash
 boolean startMeatsmithSubQuest();							//Defined in autoscend/auto_util.ash
 boolean startHippyBoatmanSubQuest();						//Defined in autoscend/auto_util.ash
+boolean finishMeatsmithSubQuest();						//Defined in autoscend/auto_util.ash
+boolean finishGalaktikSubQuest();						//Defined in autoscend/auto_util.ash
 string statCard();											//Defined in autoscend/auto_util.ash
 int stomach_left();											//Defined in autoscend/auto_util.ash
 boolean theSource_buySkills();								//Defined in autoscend/auto_theSource.ash
@@ -1223,7 +1240,6 @@ boolean L13_sorceressDoorLowKey(); // Defined in autoscend/paths/low_key_summer.
 boolean LX_lowkeySummer(); // Defined in autoscend/paths/low_key_summer.ash
 
 element currentFlavour(); // Defined in autoscend/auto_util.ash
-void resetFlavour(); // Defined in autoscend/auto_util.ash
 boolean setFlavour(element ele); // Defined in autoscend/auto_util.ash
 boolean executeFlavour(); // Defined in autoscend/auto_util.ash
 boolean autoFlavour(location place); // Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -1,29 +1,30 @@
 script "low_key_summer.ash"
 
+// These are listed in the order they will be iterated (item id ascending) to make debugging easier.
 location[item] lowKeys;
 lowKeys[$item[Clown car key]] = $location[The \"Fun\" House];
-lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
-lowKeys[$item[Ice Key]] = $location[The Icy Peak];
-lowKeys[$item[Demonic key]] = $location[Pandamonium Slums];
-lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
-lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
-lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];
-lowkeys[$item[Kekekey]] = $location[The Valley of Rof L\'m Fao];
-lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
-lowKeys[$item[Music Box Key]] = $location[The Haunted Nursery];
-lowKeys[$item[Actual skeleton key]] = $location[The Skeleton Store];
 lowKeys[$item[Batting cage key]] = $location[The Bat Hole Entrance];
-lowKeys[$item[Anchovy can key]] = $location[The Haunted Pantry];
-lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
-lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
-lowKeys[$item[Key sausage]] = $location[Cobb\'s Knob Kitchens];
-lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
-lowKeys[$item[Black rose key]] = $location[The Haunted Conservatory];
-lowKeys[$item[scrap metal key]] = $location[The Old Landfill];
-lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
 lowKeys[$item[aqu&iacute;]] = $location[South of the Border];
 lowKeys[$item[Knob labinet key]] = $location[Cobb\'s Knob Laboratory];
+lowKeys[$item[Weremoose key]] = $location[Cobb\'s Knob Menagerie, Level 2];
+lowKeys[$item[Peg key]] = $location[The Obligatory Pirate\'s Cove];
+lowkeys[$item[Kekekey]] = $location[The Valley of Rof L\'m Fao];
+lowKeys[$item[Rabbit\'s foot key]] = $location[The Dire Warren];
+lowKeys[$item[knob shaft skate key]] = $location[The Knob Shaft];
+lowKeys[$item[Ice Key]] = $location[The Icy Peak];
+lowKeys[$item[Anchovy can key]] = $location[The Haunted Pantry];
+lowKeys[$item[cactus key]] = $location[The Arid\, Extra-Dry Desert];
+lowKeys[$item[F\'c\'le sh\'c\'le k\'y]] = $location[The F\'c\'le];
+lowKeys[$item[Treasure chest key]] = $location[Belowdecks];
+lowKeys[$item[Demonic key]] = $location[Pandamonium Slums];
+lowKeys[$item[Key sausage]] = $location[Cobb\'s Knob Kitchens];
 lowKeys[$item[Knob treasury key]] = $location[Cobb\'s Knob Treasury];
+lowKeys[$item[scrap metal key]] = $location[The Old Landfill];
+lowKeys[$item[Black rose key]] = $location[The Haunted Conservatory];
+lowKeys[$item[Actual skeleton key]] = $location[The Skeleton Store];
+lowKeys[$item[Music Box Key]] = $location[The Haunted Nursery];
+lowKeys[$item[Deep-fried key]] = $location[Madness Bakery];
+lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
 
 boolean in_lowkeysummer()
 {
@@ -170,7 +171,7 @@ boolean lowkey_keyAdv(item key)
 
 boolean lowkey_zoneUnlocks()
 {
-	if(startHippyBoatmanSubQuest())
+	if (startHippyBoatmanSubQuest())
 	{
 		// opens The Old Landfill for scrap metal key (+20% to all Moxie Gains)
 		return true;
@@ -182,13 +183,13 @@ boolean lowkey_zoneUnlocks()
 		return true;
 	}
 
-	if (startGalaktikSubQuest())
+	if (startGalaktikSubQuest() || finishGalaktikSubQuest())
 	{
-		// opens The Overgrown Lot for discarded bike lock key (+10 MP,  4-5 MP regen)
+		// opens The Overgrown Lot for discarded bike lock key (+10 MP, 4-5 MP regen)
 		return true;
 	}
 
-	if (startMeatsmithSubQuest()) {
+	if (startMeatsmithSubQuest() || finishMeatsmithSubQuest()) {
 		// opens The Skeleton Store for actual skeleton key (100 DA, 10 DR)
 		return true;
 	}
@@ -235,20 +236,17 @@ boolean LX_findHelpfulLowKey()
 	if (lowkey_keyAdv($item[Treasure chest key])) { return true; }
 
 	// +meat. Knob treasury key needs Cobb's Knob Access. Kekekey needs The Valley of Rof L'm Fao access.
-	if (lowkey_keyAdv($item[Knob treasury key])) { return true; }
 	if (lowkey_keyAdv($item[Kekekey])) { return true; }
+	if (my_primestat() != $stat[Mysticality] || possessEquipment($item[Demonic key])) {
+		// all these locations unlock at the same time but for a myst class we should only get
+		//  the -combat key from Cobb's Knob (above) to speed up the friars before we have the +20% myst xp key
+		if (lowkey_keyAdv($item[Knob treasury key])) { return true; }
 
-	// Knob key to unlock shaft for +adv. needs Cobb's Knob Access
-	if (item_amount($item[Cobb\'s Knob lab key]) < 1 && lowkey_keyAdv($item[Knob labinet key])) { return true; }
+		// +adv. Knob shaft skate key needs Cobb's Knob lab key for access to Knob Shaft
+		if (lowkey_keyAdv($item[Knob shaft skate key])) { return true; }
 
-	// +adv. Knob shaft skate key needs Cobb's Knob lab key for access to Knob Shaft
-	if (lowkey_keyAdv($item[Knob shaft skate key])) { return true; }
-
-	if (internalQuestStatus("questM20Necklace") < 1) {
-		// hot res for the Haunted Kitchen. aquí needs Desert Beach Access
-		if (lowkey_keyAdv($item[aqu&iacute;])) { return true; }
-		// stench res for the Haunted Kitchen
-		if (lowkey_keyAdv($item[batting cage key])) { return true; }
+		// Knob labinet key to unlock Menagerie. needs Cobb's Knob lab key for access to the lab
+		if (item_amount($item[Cobb\'s Knob Menagerie key]) < 1 && lowkey_keyAdv($item[Knob labinet key])) { return true; }
 	}
 
 	if (internalQuestStatus("questL09Topping") > 0 && internalQuestStatus("questL09Topping") < 3) {
@@ -303,8 +301,6 @@ boolean L13_sorceressDoorLowKey()
 		return false;
 	}
 
-	// TODO: Handle the standard keys
-
 	location loc = lowkey_nextAvailableKeyLocation();
 
 	if (loc == $location[none])
@@ -333,16 +329,198 @@ boolean L13_sorceressDoorLowKey()
 }
 
 boolean LX_lowkeySummer() {
-	if (!in_lowkeysummer()) {
-		return false;
+
+	if (!in_lowkeysummer()) { return false; }
+
+	// Guild access
+	if (LX_guildUnlock()) { return true; }
+
+	// Find keys that help us save adventures in quests.
+	if (LX_findHelpfulLowKey()) { return true; }
+
+	// Cobb's Knob unlocks a lot of zones which contain generally useful keys for all classes (-combat, +meat, +adv).
+	// Also the +20% to all Muscle Gains key unlocks here.
+	if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
+
+	if (my_primestat() == $stat[Mysticality] && possessEquipment($item[Key sausage])) {
+		// Myst classes want access to Pandamonium Slums to find the demonic key (+20% to all Mysticality Gains).
+		// Get the -combat key first.
+		if (L6_friarsGetParts()) { return true; }
 	}
 
+	// Island access for all classes. also farm the +20% to all Moxie Gains key
+	// (adventuring will be handled by LX_findHelpfulLowKey() for moxie classes but this'll complete the quest)
+	if (LX_hippyBoatman()) { return true; }
+
+	// Desert access, Daily Dungeon and other early random stuff.
+	if (LX_loggingHatchet() || LX_unlockDesert() || LX_lockPicking() || LX_phatLootToken()) { return true; }
+
+	// Get the Steel Organ if the user wants it (probably good in this path since turnbloat).
+	if (LX_steelOrgan()) { return true; }
+	
+	// Get the -combat key before attempting the Friars or the Spooky Forest. Also high priority to unlock the hidden temple for SR.
+	if (possessEquipment($item[Key sausage])) {
+		if (L6_friarsGetParts()
+			|| L2_mosquito()
+			|| LX_unlockHiddenTemple()
+			|| LX_unlockHauntedLibrary()
+			|| LX_getLadySpookyravensDancingShoes()
+			|| LX_getLadySpookyravensPowderPuff()) { return true; }
+	} else {
+		// Make sure Cobb's Knob is open so we can get the key.
+		if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
+	}
+
+	if (internalQuestStatus("questL12War") > -1) {
+		// Don't start the war unless we've acquired the key from Belowdecks first as it gives +item.
+		if (possessEquipment($item[Treasure Chest key])) {
+			if (L12_preOutfit() || L12_getOutfit() || L12_startWar() || L12_flyerFinish()) { return true; }
+		} else {
+			// Make sure Belowdecks is open so we can get the key.
+			if (LX_pirateQuest()) { return true; }
+		}
+
+		// Get the +combat key before attempting Sonofa Beach.
+		if (possessEquipment($item[Music Box Key])) {
+			if (L12_sonofaBeach() || L12_sonofaFinish()) { return true; }
+		} else {
+			// Make sure Spookyraven Third Floor is open so we can get the key.
+			if (LX_spookyravenManorFirstFloor() || LX_spookyravenManorSecondFloor()) { return true; }
+		}
+
+		// Get the +meat keys before attempting Themthar Hills.
+		if (possessEquipment($item[Knob treasury key]) && possessEquipment($item[Kekekey])) {
+			if (L12_themtharHills()) { return true; }
+		} else {
+			// Make sure Cobb's Knob is open so we can get the key.
+			if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
+			// Make sure The Valley is open so we can get the key.
+			if (L9_chasmBuild() || L9_highLandlord()) { return true; }
+		}
+
+		// Do the rest of the war. Should have the +item key already before we start the war.
+		if (L12_gremlins() || L12_filthworms() || L12_orchardFinalize() || L12_farm() || L12_finalizeWar()) { return true; }
+	}
+
+	// Start the macguffin quest as we need it to unlock Belowdecks.
+	if (L11_blackMarket() || L11_forgedDocuments() || L11_mcmuffinDiary() || L11_getBeehive()) { return true; }
+
+	// Lock in the Shen zones as soon as we can.
+	if (L11_shenStartQuest()) { return true; }
+
+	if (internalQuestStatus("questL09Topping") > -1) {
+		// Get the Cold Damage key before doing the Orcs
+		// This gets blocked by the Shen softlock so do it as soon as we feasibly can as one of the +meat keys requires the L9 quest finished.
+		if (possessEquipment($item[Ice Key])) {
+			if (L9_chasmBuild()) { return true; }
+		} else {
+			// Make sure the Icy Peak is available so we can get the key
+			if (L8_trapperQuest()) { return true; }
+		}
+		// Get the ML keys before doing Oil peak and Spooky Res key before doing Aboo Peak (should have Cold Res key already for the Orc Chasm).
+		if (possessEquipment($item[F\'c\'le sh\'c\'le k\'y]) 
+				&& possessEquipment($item[Clown car key])
+				&& possessEquipment($item[Weremoose key])) {
+			if (L9_highLandlord()) { return true; }
+		} else {
+			// Make sure the F'c'le is open so we can get the key
+			if (LX_pirateOutfit() || LX_joinPirateCrew()) { return true; }
+			// Make sure the "Fun" House is open so we can get the key
+			if (LX_acquireEpicWeapon()) { return true; }
+		}
+	}
+
+	if (internalQuestStatus("questL11MacGuffin") > -1) {
+		// open the hidden city up.
+		if (L11_nostrilOfTheSerpent() || L11_unlockHiddenCity()) { return true; }
+
+		// +item helps with getting fulminate ingredients, Hidden City drops and Copperhead/Zeppelin.
+		if (possessEquipment($item[Treasure Chest key])) {
+			if (L11_talismanOfNam() || L11_mauriceSpookyraven()) { return true; }
+		} else {
+			// Make sure Belowdecks is open so we can get the key.
+			if (LX_pirateQuest()) { return true; }
+		}
+
+		// Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+		if (LX_spookyravenManorFirstFloor() || LX_spookyravenManorSecondFloor()) { return true; }
+
+		// Murder pygmies for the ancient amulet.
+		if (L11_hiddenCityZones() || L11_hiddenCity()) { return true; }
+
+		// Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+		if (L11_palindome() || L11_aridDesert() || L11_unlockPyramid()) { return true; }
+		// should do the tavern before trying to do the pyramid so we can use any tangles we get lucky with.
+		if (internalQuestStatus("questL03Rat") > 2) {
+			if (L11_unlockEd() || L11_defeatEd()) { return true; }
+		} else {
+			set_property("auto_forceTavern", true);
+			if (L3_tavern()) { return true; }
+		}
+	}
+
+	// Open up the top of the beanstalk.
+	if (L10_plantThatBean()) { return true; }
+
+	// Should have the -combat key long before level 10 but lets just make sure.
+	if (possessEquipment($item[Key sausage])) {
+		if (L10_airship() || L10_basement() || L10_ground() || L10_topFloor() || L10_holeInTheSkyUnlock()) { return true; }
+	} else {
+		// Make sure Cobb's Knob is open so we can get the key.
+		if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
+	}
+
+	// Ascend the peak.
+	if (L8_trapperQuest()) { return true; }
+
+	// -combat and ML keys help with 2 of these zones but this quest is a monolithic function.
+	// TODO: split it up into zones then guard with possession of keys.
+	if (L7_crypt()) { return true; }
+
+	// Finish off the Goblin King.
+	if (L5_slayTheGoblinKing()) { return true; }
+
+	// Show the Boss bat who's boss.
+	if (L4_batCave()) { return true; }
+
+	// Fix that dripping tap.
+	if (L3_tavern()) { return true; }
+
+	// this quest and these zones are open either from the start or level 4.
+	// so lets do this if we have nothing better to do yet.
+	if (possessEquipment($item[aqu&iacute;]) && possessEquipment($item[batting cage key])) {
+		if (LX_unlockHauntedBilliardsRoom()) { return true; }
+	} else {
+		// hot res for the Haunted Kitchen. aquí needs Desert Beach Access
+		if (lowkey_keyAdv($item[aqu&iacute;])) { return true; }
+		// stench res for the Haunted Kitchen
+		if (lowkey_keyAdv($item[batting cage key])) { return true; }
+	}
+
+	// Spookyraven quest steps that don't need -combat or resists, just monster killin' (or dancing with a ghost for stats).
+	if (LX_danceWithLadySpookyraven() || LX_getLadySpookyravensFinestGown() || LX_unlockManorSecondFloor()) { return true; }
+
+	if (L12_clearBattlefield()) { return true; } // This is a mess and if it's not last, it screws up the war massively.
+
 	// Stuff we need to do in this path to unlock key zones.
-	if (LX_pirateQuest()) {
+	if (LX_pirateQuest()) { return true; }
+	if (LX_acquireEpicWeapon()) { return true; }
+
+	// If literally nothing better to do, go find some of the keys we don't actually care about but have to find anyway.
+	location loc = lowkey_nextAvailableKeyLocation();
+	if (loc != $location[none] && autoAdv(loc)) { return true; }
+
+	// unlock the door, climb the tower, commit sorceresscide.
+	if (L13_sorceressDoor() || L13_towerNSTower() || L13_towerNSNagamar() || L13_towerNSFinal()) { return true; }
+
+	// Release the softblock on quests that are waiting for Shen quest.
+	if (my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished") {
+		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
+		set_property("auto_shenSkipLastLevel", my_level());
 		return true;
 	}
-	if (LX_acquireLegendaryEpicWeapon()) {
-		return true;
-	}
+
+	if (LX_attemptPowerLevel()) { return true; }
+	
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -62,15 +62,6 @@ boolean L10_airship()
 	{
 		bat_formBats();
 	}
-	else
-	{
-		providePlusNonCombat(25);
-
-		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
-		buffMaintain($effect[Snow Shoes], 0, 1, 1);
-		buffMaintain($effect[Fishy\, Oily], 0, 1, 1);
-		buffMaintain($effect[Gummed Shoes], 0, 1, 1);
-	}
 
 	if (isActuallyEd() && $location[The Penultimate Fantasy Airship].turns_spent < 1)	
 	{	
@@ -129,10 +120,8 @@ boolean L10_basement()
 		set_property("choiceAdventure669", "1"); // The Fast and the Furry-ous: Open Ground floor (with Umbrella) or Neckbeard Choice
 	}
 
-	if(!auto_forceNextNoncombat())
-	{
-		providePlusNonCombat(25);
-	}
+	auto_forceNextNoncombat();
+
 	if((my_class() == $class[Gelatinous Noob]) && auto_have_familiar($familiar[Robortender]))
 	{
 		if(!have_skill($skill[Bendable Knees]) && (item_amount($item[Bottle of Gregnadigne]) == 0))
@@ -226,7 +215,6 @@ boolean L10_ground()
 	}
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
-	providePlusNonCombat(25);
 
 	if((my_class() == $class[Gelatinous Noob]) && auto_have_familiar($familiar[Robortender]))
 	{
@@ -305,10 +293,7 @@ boolean L10_topFloor()
 		set_property("choiceAdventure679", 1);
 	}
 
-	if(!auto_forceNextNoncombat())
-	{
-		providePlusNonCombat(25);
-	}
+	auto_forceNextNoncombat();
 	autoEquip($item[mohawk wig]);
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 
@@ -359,10 +344,7 @@ boolean L10_holeInTheSkyUnlock()
 	set_property("choiceAdventure678", 3);
 	set_property("choiceAdventure676", 4);
 
-	if(!auto_forceNextNoncombat())
-	{
-		providePlusNonCombat(25);
-	}
+	auto_forceNextNoncombat();
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 
 	return true;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -111,7 +111,6 @@ boolean LX_unlockHiddenTemple() {
 	// TODO: add a check for delay burning
 	auto_log_info("Attempting to make the Hidden Temple less hidden.", "blue");
 	pullXWhenHaveY($item[Spooky-Gro Fertilizer], 1, 0);
-	providePlusNonCombat(25, true);
 	if (autoAdv($location[The Spooky Forest])) {
 		if (item_amount($item[Spooky Temple map]) > 0 && item_amount($item[Spooky-Gro Fertilizer]) > 0 && item_amount($item[Spooky Sapling]) > 0) {
 			use(1, $item[Spooky Temple Map]);
@@ -249,10 +248,7 @@ boolean LX_unlockHauntedLibrary()
 	//+3 pool skill & +1 training gains. speculative_pool_skill() already assumed we would use it if we can.
 	buffMaintain($effect[Chalky Hand], 0, 1, 1);
 
-	if(!auto_forceNextNoncombat())
-	{
-		providePlusNonCombat(25, true);
-	}
+	auto_forceNextNoncombat();
 	auto_log_info("It's billiards time!", "blue");
 	return autoAdv($location[The Haunted Billiards Room]);
 }
@@ -293,15 +289,15 @@ boolean LX_spookyravenManorFirstFloor() {
 }
 
 boolean LX_danceWithLadySpookyraven() {
-	if (internalQuestStatus("questM21Dance") != 2) {
+	if (internalQuestStatus("questM21Dance") < 2 || internalQuestStatus("questM21Dance") > 3) {
 		return false;
 	}
 
-	if (item_amount($item[Lady Spookyraven\'s Powder Puff]) != 1 && item_amount($item[Lady Spookyraven\'s Dancing Shoes]) != 1 && item_amount($item[Lady Spookyraven\'s Finest Gown]) != 1) {
-		return false;
+	if (item_amount($item[Lady Spookyraven\'s Powder Puff]) == 1 && item_amount($item[Lady Spookyraven\'s Dancing Shoes]) == 1 && item_amount($item[Lady Spookyraven\'s Finest Gown]) == 1) {
+		visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 	}
+
 	auto_log_info("Finished Spookyraven, just dancing with the lady.", "blue");
-	visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 	if (autoAdv($location[The Haunted Ballroom])) {
 		if (in_lowkeysummer()) {
 			// need to open the Haunted Nursery for the music box key.
@@ -312,7 +308,7 @@ boolean LX_danceWithLadySpookyraven() {
 	return false;
 }
 
-boolean getLadySpookyravensFinestGown() {
+boolean LX_getLadySpookyravensFinestGown() {
 	if (internalQuestStatus("questM21Dance") != 1) {
 		return false;
 	}
@@ -340,7 +336,7 @@ boolean getLadySpookyravensFinestGown() {
 	return false;
 }
 
-boolean getLadySpookyravensDancingShoes() {
+boolean LX_getLadySpookyravensDancingShoes() {
 	if (internalQuestStatus("questM21Dance") != 1) {
 		return false;
 	}
@@ -355,10 +351,8 @@ boolean getLadySpookyravensDancingShoes() {
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
-	if ($location[The Haunted Gallery].turns_spent >= 5) {
-		if (!auto_forceNextNoncombat()) {
-			providePlusNonCombat(25, true);
-		}
+	if (!zone_delay($location[The Haunted Gallery])._boolean) {
+		auto_forceNextNoncombat();
 	}
 	if (autoAdv($location[The Haunted Gallery])) {
 		return true;
@@ -366,7 +360,7 @@ boolean getLadySpookyravensDancingShoes() {
 	return false;
 }
 
-boolean getLadySpookyravensPowderPuff() {
+boolean LX_getLadySpookyravensPowderPuff() {
 	if (internalQuestStatus("questM21Dance") != 1) {
 		return false;
 	}
@@ -379,10 +373,8 @@ boolean getLadySpookyravensPowderPuff() {
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 
-	if ($location[The Haunted Bathroom].turns_spent >= 5) {
-		if (!auto_forceNextNoncombat()) {
-			providePlusNonCombat(25, true);
-		}
+	if (!zone_delay($location[The Haunted Bathroom])._boolean) {
+		auto_forceNextNoncombat();
 	}
 	if (autoAdv($location[The Haunted Bathroom])) {
 		return true;
@@ -395,7 +387,7 @@ boolean LX_spookyravenManorSecondFloor()
 	if (get_property("lastSecondFloorUnlock").to_int() < my_ascensions()) {
 		return false;
 	}
-	if (LX_danceWithLadySpookyraven() || getLadySpookyravensFinestGown() || getLadySpookyravensDancingShoes() || getLadySpookyravensPowderPuff()) {
+	if (LX_danceWithLadySpookyraven() || LX_getLadySpookyravensFinestGown() || LX_getLadySpookyravensDancingShoes() || LX_getLadySpookyravensPowderPuff()) {
 		return true;
 	}
 	return false;
@@ -438,11 +430,6 @@ boolean L11_blackMarket()
 		set_property("auto_getBeehive", false);
 	}
 
-	if(auto_my_path() != "Live. Ascend. Repeat.")
-	{
-		providePlusCombat(5, true);
-	}
-
 	autoEquip($slot[acc3], $item[Blackberry Galoshes]);
 
 	//If we want the Beehive, and don\'t have enough adventures, this is dangerous.
@@ -476,18 +463,13 @@ boolean L11_getBeehive()
 
 	auto_log_info("Must find a beehive!", "blue");
 
-	if (!auto_forceNextNoncombat()) {
-		providePlusNonCombat(25, true);
-	}
+	auto_forceNextNoncombat();
 	boolean advSpent = autoAdv($location[The Black Forest]);
 	if(item_amount($item[beehive]) > 0)
 	{
 		set_property("auto_getBeehive", false);
 	}
-	if (advSpent) {
-		return true;
-	}
-	return false;
+	return advSpent;
 }
 
 boolean L11_forgedDocuments()
@@ -1410,11 +1392,6 @@ boolean L11_hiddenCityZones()
 	}
 
 	if (needMachete || needRelocate) {
-		// Try to get the NC so that we can relocate Janitors and get items quickly
-		if ($location[The Hidden Park].turns_spent < 6 && !auto_forceNextNoncombat()) {
-			// Machete NC is guaranteed on the 7th adventure here
-			providePlusNonCombat(25, true);
-		}
 		return autoAdv($location[The Hidden Park]);
 	}
 
@@ -1490,10 +1467,9 @@ boolean L11_mauriceSpookyraven()
 			return false;
 		}
 
-		if (!auto_forceNextNoncombat()) {
-			providePlusNonCombat(25, true);
+		if (!zone_delay($location[The Haunted Ballroom])._boolean) {
+			auto_forceNextNoncombat();
 		}
-
 		return autoAdv($location[The Haunted Ballroom]);
 	}
 	if(item_amount($item[recipe: mortar-dissolving solution]) == 0)
@@ -1692,8 +1668,6 @@ boolean L11_redZeppelin()
 	buffMaintain($effect[Blood-Gorged], 0, 1, 1);
 	pullXWhenHaveY($item[deck of lewd playing cards], 1, 0);
 
-	providePlusNonCombat(25);
-
 	if(item_amount($item[Flamin\' Whatshisname]) > 0)
 	{
 		backupSetting("choiceAdventure866", 3);
@@ -1841,6 +1815,29 @@ boolean L11_ronCopperhead()
 	return false;
 }
 
+boolean L11_shenStartQuest() {
+	// as the first adventure in the Copperhead Club is always the first Shen NC
+	// we can adventure there once as soon as it's open to start the quest and lock in
+	// our zones
+	if (internalQuestStatus("questL11Shen") != 0)
+	{
+		return false;
+	}
+	if (autoAdv($location[The Copperhead Club])) {
+		if (internalQuestStatus("questL11Shen") == 1) {
+			set_property("auto_shenStarted", my_daycount());
+			auto_log_info("It seems Shen has given us a quest.", "blue");
+			auto_log_info("I am going to avoid the following zones until Shen tells me to go there or until I run out of other things to do:");
+			int linec = 1;
+			foreach z, _ in shenZonesToAvoidBecauseMaybeSnake() {
+				auto_log_info(linec++ + ". " + z);
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
 boolean L11_shenCopperhead()
 {
 	if (internalQuestStatus("questL11Shen") < 0 || internalQuestStatus("questL11Shen") > 7)
@@ -1850,7 +1847,11 @@ boolean L11_shenCopperhead()
 
 	set_property("choiceAdventure1074", 1);
 
-	if (internalQuestStatus("questL11Shen") == 0 || internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)
+	if (L11_shenStartQuest()) {
+		return true;
+	}
+
+	if (internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)
 	{
 		if (item_amount($item[Crappy Waiter Disguise]) > 0 && have_effect($effect[Crappily Disguised as a Waiter]) == 0 && !in_tcrs())
 		{
@@ -1858,11 +1859,11 @@ boolean L11_shenCopperhead()
 
 			// default to getting unnamed cocktails to turn into Flamin' Whatsisnames.
 			int behindtheStacheOption = 4;
-			if (item_amount($item[priceless diamond]) > 0 || item_amount($item[Red Zeppelin Ticket]) > 0 || (internalQuestStatus("questL11Shen") == 6 && item_amount($item[unnamed cocktail]) > 0))
+			if (item_amount($item[priceless diamond]) > 0 || item_amount($item[Red Zeppelin Ticket]) > 0 || my_meat() > 10000 ||  (internalQuestStatus("questL11Shen") == 6 && item_amount($item[unnamed cocktail]) > 0))
 			{
 				if (get_property("copperheadClubHazard") != "lantern")
 				{
-					// got priceless diamond or zeppelin ticket so lets burn the place down (and make Flamin' Whatsisnames)
+					// got priceless diamond or zeppelin ticket (or we are rich) so lets burn the place down (and make Flamin' Whatsisnames)
 					behindtheStacheOption = 3;
 				}
 			}
@@ -1877,16 +1878,8 @@ boolean L11_shenCopperhead()
 			set_property("choiceAdventure855", behindtheStacheOption);
 		}
 
-		if (!maximizeContains("-10ml"))
-		{
-			addToMaximize("-10ml");
-		}
-		boolean retval = autoAdv($location[The Copperhead Club]);
-		if (maximizeContains("-10ml"))
-		{
-			removeFromMaximize("-10ml");
-		}
-		return retval;
+		addToMaximize("-10ml");
+		return autoAdv($location[The Copperhead Club]);
 	}
 
 	if((internalQuestStatus("questL11Shen") == 1) || (internalQuestStatus("questL11Shen") == 3) || (internalQuestStatus("questL11Shen") == 5))

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -731,8 +731,6 @@ boolean L12_startWar()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 	
-	providePlusNonCombat(25);
-
 	if((my_path() != "Dark Gyffte") && (my_mp() > 50) && have_skill($skill[Incredible Self-Esteem]) && !get_property("_incredibleSelfEsteemCast").to_boolean())
 	{
 		use_skill(1, $skill[Incredible Self-Esteem]);
@@ -860,8 +858,6 @@ boolean L12_filthworms()
 			buffMaintain($effect[Wet and Greedy], 0, 1, 1);
 		}
 		buffMaintain($effect[Frosty], 0, 1, 1);
-		
-		addToMaximize("200item");
 		
 		//craft IOTM derivative that gives high item bonus
 		if((!possessEquipment($item[A Light That Never Goes Out])) && (item_amount($item[Lump of Brituminous Coal]) > 0))
@@ -1087,13 +1083,6 @@ boolean L12_sonofaBeach()
 
 	if(auto_my_path() != "Live. Ascend. Repeat.")
 	{
-		if(!providePlusCombat(25, true))
-		{
-			auto_log_warning("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
-			equipBaseline();
-			return false;
-		}
-
 		if(equipped_item($slot[acc1]) == $item[over-the-shoulder folder holder])
 		{
 			if((item_amount($item[Ass-Stompers of Violence]) > 0) && (equipped_item($slot[acc1]) != $item[Ass-Stompers of Violence]) && can_equip($item[Ass-Stompers of Violence]))
@@ -1234,12 +1223,6 @@ boolean L12_sonofaPrefix()
 
 	if(auto_my_path() != "Live. Ascend. Repeat.")
 	{
-		if(!providePlusCombat(25))
-		{
-			auto_log_warning("Failure in +Combat acquisition or -Combat shrugging (lobsterfrogman), delaying", "red");
-			return false;
-		}
-
 		if(equipped_item($slot[acc1]) == $item[over-the-shoulder folder holder])
 		{
 			if((item_amount($item[Ass-Stompers of Violence]) > 0) && (equipped_item($slot[acc1]) != $item[Ass-Stompers of Violence]) && can_equip($item[Ass-Stompers of Violence]))
@@ -1548,16 +1531,8 @@ boolean L12_themtharHills()
 	}
 	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
 	songboomSetting("meat");
-
-	if(!canChangeFamiliar())
-	{
-		addToMaximize("200meat drop");
-	}
-	else
-	{
-		addToMaximize("200meat drop,switch Hobo Monkey,switch rockin' robin,switch adventurous spelunker,switch Grimstone Golem,switch Fist Turkey,switch Unconscious Collective,switch Golden Monkey,switch Angry Jung Man,switch Leprechaun,switch cat burglar");
-		handleFamiliar(my_familiar());
-	}
+	handleFamiliar("meat");
+	addToMaximize("200meat drop");
 
 	if(get_property("auto_useWishes").to_boolean())
 	{
@@ -1623,6 +1598,7 @@ boolean L12_themtharHills()
 		// if we're in a 100% run, this property returns "none" which will unequip our familiar and ruin a 100% run.
 		use_familiar(to_familiar(get_property("auto_familiarChoice")));
 	}
+	equipMaximizedGear();
 	float meatDropHave = meat_drop_modifier();
 
 	if (isActuallyEd() && have_skill($skill[Curse of Fortune]) && item_amount($item[Ka Coin]) > 0)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -649,13 +649,15 @@ boolean L13_sorceressDoor()
 		return false;
 	}
 
+	if (LX_getDigitalKey() || LX_getStarKey()) {
+		return true;
+	}
+
 	// Low Key Summer has an entirely different door.
 	if (in_lowkeysummer())
 	{
 		return L13_sorceressDoorLowKey();
 	}
-
-	if(LX_getDigitalKey()) return true;
 
 	string page = visit_url("place.php?whichplace=nstower_door");
 	if(contains_text(page, "ns_lock6"))
@@ -956,14 +958,10 @@ boolean L13_towerNSTower()
 		{
 			cli_execute("concert 2");
 		}
-		if(!canChangeFamiliar())
-		{
-			addToMaximize("200meat drop");
-		}
-		else
-		{
-			addToMaximize("200meat drop,switch hobo monkey,switch rockin' robin,switch adventurous spelunker,switch grimstone golem,switch fist turkey,switch unconscious collective,switch golden monkey,switch angry jung man,switch leprechaun,switch cat burglar");
-		}
+		
+		handleFamiliar("meat");
+		addToMaximize("200meat drop");
+		
 		if(my_class() == $class[Seal Clubber])
 		{
 			autoEquip($item[Meat Tenderizer is Murder]);

--- a/RELEASE/scripts/autoscend/quests/level_2.ash
+++ b/RELEASE/scripts/autoscend/quests/level_2.ash
@@ -8,7 +8,6 @@ boolean L2_mosquito()
 	}
 	// Arboreal Respite choice adventure has a delay of 5 adventures.
 	// TODO: add a check for delay burning?
-	providePlusNonCombat(25, true);
 	auto_log_info("Trying to find a mosquito.", "blue");
 	if (autoAdv($location[The Spooky Forest])) {
 		if (internalQuestStatus("questL02Larva") > 0 || item_amount($item[mosquito larva]) > 0)

--- a/RELEASE/scripts/autoscend/quests/level_5.ash
+++ b/RELEASE/scripts/autoscend/quests/level_5.ash
@@ -148,3 +148,8 @@ boolean L5_goblinKing()
 	}
 	return advSpent;
 }
+
+boolean L5_slayTheGoblinKing() {
+	if (L5_getEncryptionKey() || L5_findKnob() || L5_haremOutfit() || L5_goblinKing()) {  return true; }
+	return false;
+}

--- a/RELEASE/scripts/autoscend/quests/level_6.ash
+++ b/RELEASE/scripts/autoscend/quests/level_6.ash
@@ -11,9 +11,6 @@ boolean L6_friarsGetParts()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 
-	buffMaintain($effect[Snow Shoes], 0, 1, 1);
-	buffMaintain($effect[Gummed Shoes], 0, 1, 1);
-
 	if($location[The Dark Heart of the Woods].turns_spent == 0)
 	{
 		visit_url("friars.php?action=friars&pwd");
@@ -30,8 +27,6 @@ boolean L6_friarsGetParts()
 	{
 		autoEquip($slot[Shirt], $item[none]);
 	}
-
-	providePlusNonCombat(25);
 
 	if(auto_have_familiar($familiar[Space Jellyfish]) && (get_property("_spaceJellyfishDrops").to_int() < 2))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_7.ash
+++ b/RELEASE/scripts/autoscend/quests/level_7.ash
@@ -172,8 +172,6 @@ boolean L7_crypt()
 
 		auto_MaxMLToCap(auto_convertDesiredML(149), true);
 
-		providePlusNonCombat(25);
-
 		addToMaximize("200ml " + auto_convertDesiredML(149) + "max");
 		autoAdv(1, $location[The Defiled Cranny]);
 		return true;

--- a/RELEASE/scripts/autoscend/quests/level_8.ash
+++ b/RELEASE/scripts/autoscend/quests/level_8.ash
@@ -318,7 +318,6 @@ boolean L8_getMineOres()
 	} else {
 		if (!possessOutfit("Mining Gear")) {
 			auto_log_info("Getting Mining Gear.", "blue");
-			providePlusNonCombat(25);
 			return autoAdv($location[Itznotyerzitz Mine]);
 		} else if (possessOutfit("Mining Gear", true)) {
 			equipMaximizedGear();
@@ -415,7 +414,6 @@ boolean L8_trapperExtreme()
 	}
 
 	auto_log_info("Penguin Tony Hawk time. Extreme!! SSX Tricky!!", "blue");
-	providePlusNonCombat(25);
 	return autoAdv($location[The eXtreme Slope]);
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -625,7 +625,6 @@ boolean L9_twinPeak()
 	{
 		handleBjornify($familiar[Grimstone Golem]);
 	}
-	providePlusNonCombat(25);
 	
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);		//heavy rains specific reduce item drop penalty by 10%
 
@@ -818,12 +817,6 @@ boolean L9_oilPeak()
 		{
 			asdonBuff($effect[Driving Wastefully]);
 		}
-	}
-
-	// Help protect ourselves against not getting enough crudes if tackling cartels
-	if(simMaximizeWith("1000ml 100min"))
-	{
-		addToMaximize("120item");
 	}
 
 	addToMaximize("1000ml " + auto_convertDesiredML(100) + "max");

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -247,7 +247,7 @@ boolean LX_hippyBoatman() {
 		return false;
 	}
 
-	if (get_property("questM19Hippy") == "finished") {  // TODO: replace this with internalQuestStatus when you have the steps
+	if (internalQuestStatus("questM19Hippy") > 3) {
 		return false;
 	}
 
@@ -264,26 +264,40 @@ boolean LX_hippyBoatman() {
 		return true;
 	}
 
-	if (autoAdv($location[The Old Landfill])) {
-		if (item_amount($item[Old Claw-Foot Bathtub]) > 0 && item_amount($item[Old Clothesline Pole]) > 0 && item_amount($item[Antique Cigar Sign]) > 0 && item_amount($item[Worse Homes and Gardens]) > 0) {
-			create(1, $item[junk junk]);
-			visit_url("place.php?whichplace=woods&action=woods_hippy");
+	if (item_amount($item[Old Claw-Foot Bathtub]) > 0 && item_amount($item[Old Clothesline Pole]) > 0 && item_amount($item[Antique Cigar Sign]) > 0 && item_amount($item[Worse Homes and Gardens]) > 0) {
+		create(1, $item[junk junk]);
+		visit_url("place.php?whichplace=woods&action=woods_hippy");
+		if (internalQuestStatus("questM19Hippy") > 3) {
+			return true;
 		}
-		return true;
+		abort("Failed to create the junk junk or finish the quest for some reason!");
 	}
-	return false;
+
+	return autoAdv($location[The Old Landfill]);
 }
 
 void oldLandfillChoiceHandler(int choice) {
 	if (choice == 794) { // Once More Unto the Junk
-		if (item_amount($item[Old Claw-Foot Bathtub]) == 0) {
-			run_choice(1); // go to The Bathroom of Ten Men (#795)
-		} else if(item_amount($item[Old Clothesline Pole]) == 0) {
-			run_choice(2); // go to The Den of Iquity (#796)
-		} else if(item_amount($item[Antique Cigar Sign]) == 0) {
-			run_choice(3); // go to Let's Workshop This a Little (#797)
+		if (item_amount($item[junk junk]) == 0) {
+			if (item_amount($item[Old Claw-Foot Bathtub]) == 0) {
+				run_choice(1); // go to The Bathroom of Ten Men (#795)
+			} else if(item_amount($item[Old Clothesline Pole]) == 0) {
+				run_choice(2); // go to The Den of Iquity (#796)
+			} else if(item_amount($item[Antique Cigar Sign]) == 0) {
+				run_choice(3); // go to Let's Workshop This a Little (#797)
+			} else {
+				run_choice(1); // go to The Bathroom of Ten Men (#795)
+			}
 		} else {
-			run_choice(1); // go to The Bathroom of Ten Men (#795)
+			// TODO: Add handling to get the eternal car battery
+			// doesn't look like there's mafia tracking for it yet.
+			if (item_amount($item[tangle of copper wire]) == 0) {
+				run_choice(2); // go to The Den of Iquity (#796)
+			} else if (item_amount($item[Junk-Bond]) == 0) {
+				run_choice(3); // go to Let's Workshop This a Little (#797)
+			} else {
+				run_choice(1); // go to The Bathroom of Ten Men (#795)
+			}
 		}
 	} else if (choice == 795) { // The Bathroom of Ten Men
 		if (item_amount($item[Old Claw-Foot Bathtub]) == 0) {

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -42,6 +42,133 @@ boolean LX_artistQuest()
 	return false;
 }
 
+boolean LX_unlockThinknerdWarehouse(boolean spend_resources)
+{
+	//unlocks [The Thinknerd Warehouse], returns true if successful or adv is spent
+	//much easier to do if you already have torso awaregness
+	
+	if(internalQuestStatus("questM22Shirt") > -1)
+	{
+		return false;
+	}
+	
+	auto_log_debug("Trying to unlock [The Thinknerd Warehouse] with spend_resources set to " + spend_resources);
+	
+	//unlocking is a multi step process. We want to try things in reverse to conserve resources and in case some steps were already complete.
+	
+	boolean useLetter()
+	{
+		if(item_amount($item[Letter for Melvign the Gnome]) > 0)
+		{
+			if(use(1, $item[Letter for Melvign the Gnome]))
+			{
+				auto_log_debug("Successfully unlocked the [The Thinknerd Warehouse]");
+				return true;
+			}
+			else
+			{
+				abort("Somehow failed to use [Letter for Melvign the Gnome]... aborting to prevent infinite loops");
+			}
+		}
+		return false;
+	}
+	
+	item target_shirt = $item[none];
+	boolean hasShirt = false;
+	
+	//one time initial scan of inventory
+	foreach it in get_inventory()
+	{
+		if(to_slot(it) == $slot[shirt])
+		{
+			target_shirt = it;
+			hasShirt = true;
+			break;
+		}
+	}
+		
+	boolean useShirtThenLetter()
+	{
+		if(!hasShirt)
+		{
+			return false;
+		}
+		string temp = visit_url("inv_equip.php?pwd&which=2&action=equip&whichitem=" + target_shirt.to_int());
+		if(useLetter()) return true;
+		auto_log_error("For some reason LX_unlockThinknerdWarehouse failed when trying to use the shirt [" + target_shirt + "] to get [Letter for Melvign the Gnome] to start the quest", "red");
+		return false;
+	}
+	void getShirtWhenHaveNone(item it)
+	{
+		if(hasShirt) return;
+		if(canPull(it))
+		{
+			if(pullXWhenHaveY(it, 1, 0))
+			{
+				target_shirt = it;
+				hasShirt = true;
+			}
+		}
+		else if(creatable_amount(it) > 0 && (spend_resources || knoll_available()))
+		{
+			if(create(1, it))
+			{
+				target_shirt = it;
+				hasShirt = true;
+			}
+		}
+	}
+	
+	//if you already had a shirt or a letter, then just unlock the quest now
+	if(useLetter()) return true;
+	if(useShirtThenLetter()) return true;
+	
+	//Try to acquire a shirt.
+	
+	//IOTM that does not require a pull
+	januaryToteAcquire($item[Letter For Melvign The Gnome]);	//no stats and no pull required
+	if(useLetter()) return true;
+	
+	//TODO, make the following IOTM foldables actually work
+	//getShirtWhenHaveNone($item[flaming pink shirt])		//foldable IOTM that requires torso awaregness.
+	//getShirtWhenHaveNone($item[origami pasties])			//foldable IOTM that requires torso awaregness.
+	//getShirtWhenHaveNone($item[sugar shirt])				//libram summons sugar sheet, multiuse 1 with torso awaregness to get sugar shirt
+	
+	//Shirts to pull
+	getShirtWhenHaveNone($item[Sneaky Pete\'s leather jacket]);		//useful IOTM shirt with no state requirements to wear
+	getShirtWhenHaveNone($item[Sneaky Pete\'s leather jacket (collar popped)]);
+	getShirtWhenHaveNone($item[Professor What T-Shirt]);			//you likely have it, no requirements to wear, very cheap in mall
+	
+	//Shirts to smith. Will likely cost 1 adv unless in knoll sign.
+	getShirtWhenHaveNone($item[white snakeskin duster]);		//7 mus req
+	getShirtWhenHaveNone($item[clownskin harness]);				//15 mus req
+	getShirtWhenHaveNone($item[demonskin jacket]);				//25 mus req
+	getShirtWhenHaveNone($item[gnauga hide vest]);				//25 mus req
+	getShirtWhenHaveNone($item[tuxedo shirt]);					//35 mus req
+	getShirtWhenHaveNone($item[yak anorak]);					//42 mus req
+	getShirtWhenHaveNone($item[hipposkin poncho]);				//45 mus req
+	getShirtWhenHaveNone($item[lynyrdskin tunic]);				//70 mus req
+	getShirtWhenHaveNone($item[bat-ass leather jacket]);		//77 mus req
+
+	//wish for a shirt
+	if(spend_resources && wishesAvailable() > 0 && shouldUseWishes() && item_amount($item[blessed rustproof +2 gray dragon scale mail]) == 0)
+	{
+		makeGenieWish("for a blessed rustproof +2 gray dragon scale mail");
+		target_shirt = $item[blessed rustproof +2 gray dragon scale mail];
+		hasShirt = true;
+	}
+	
+	//TODO adventure somewhere to acquire shirt
+	//if(spend_resources && hasTorso())
+	
+	//did we succeeded in getting a shirt? use it and then the letter.
+	if(useShirtThenLetter()) return true;
+	
+	//sadness, we couldn't unlock this zone.
+	auto_log_debug("Failed to unlock [The Thinknerd Warehouse]");
+	return false;
+}
+
 boolean LX_melvignShirt()
 {
 	//Do the quest [The Shirt Off His Lack of Back] to get the skill [Torso Awaregness] from melvign the gnome.	
@@ -136,15 +263,6 @@ boolean LX_steelOrgan()
 	{
 		if((!possessEquipment($item[Observational Glasses]) || item_amount($item[Imp Air]) < 5) && item_amount($item[Azazel\'s Tutu]) == 0)
 		{
-			if(!possessEquipment($item[Observational Glasses]))
-			{
-				uneffect($effect[The Sonata of Sneakiness]);
-				buffMaintain($effect[Hippy Stench], 0, 1, 1);
-				buffMaintain($effect[Carlweather\'s Cantata of Confrontation], 10, 1, 1);
-				buffMaintain($effect[Musk of the Moose], 10, 1, 1);
-				# Should we check for -NC stuff and deal with it?
-				# We need a Combat Modifier controller
-			}
 			autoAdv(1, $location[The Laugh Floor]);
 		}
 		else if(((item_amount($item[Azazel\'s Unicorn]) == 0) || (item_amount($item[Bus Pass]) < 5)) && (item_amount($item[Azazel\'s Tutu]) == 0))
@@ -218,16 +336,6 @@ boolean LX_steelOrgan()
 				return true;
 			}
 
-			if(item_amount($item[Azazel\'s Unicorn]) == 0)
-			{
-				uneffect($effect[Carlweather\'s Cantata of Confrontation]);
-				buffMaintain($effect[The Sonata of Sneakiness], 20, 1, 1);
-				buffMaintain($effect[Smooth Movements], 10, 1, 1);
-			}
-			else
-			{
-				uneffect($effect[The Sonata of Sneakiness]);
-			}
 			autoAdv(1, $location[Infernal Rackets Backstage]);
 		}
 		else if((item_amount($item[Azazel\'s Lollipop]) == 0) && (item_amount($item[Azazel\'s Tutu]) == 0))
@@ -363,18 +471,20 @@ boolean LX_pirateOutfit() {
 	if (get_property("lastIslandUnlock").to_int() < my_ascensions()) {
 		return LX_islandAccess();
 	}
+	if (possessEquipment($item[peg key]) && !in_hardcore()) {
+		// if we have the key, just pull any outfit parts we are still missing
+		foreach _, it in outfit_pieces("Swashbuckling Getup") {
+			pullXWhenHaveY(it, 1, 0);
+		}
+	}
 	if (possessOutfit("Swashbuckling Getup")) {
-		if (item_amount($item[The Big Book Of Pirate Insults]) == 0 && my_meat() > npc_price($item[The Big Book Of Pirate Insults])) {
+		if (possessOutfit("Swashbuckling Getup", true) && item_amount($item[The Big Book Of Pirate Insults]) == 0 && my_meat() > npc_price($item[The Big Book Of Pirate Insults])) {
 			buyUpTo(1, $item[The Big Book Of Pirate Insults]);
 		}
 		return false;
 	}
 	auto_log_info("Searching for a pirate outfit.", "blue");
-	providePlusNonCombat(25, true);
-	if (autoAdv($location[The Obligatory Pirate\'s Cove])) {
-		return true;
-	}
-	return false;
+	return autoAdv($location[The Obligatory Pirate\'s Cove]);
 }
 
 void piratesCoveChoiceHandler(int choice) {
@@ -527,9 +637,6 @@ boolean LX_joinPirateCrew() {
 	if (internalQuestStatus("questM12Pirate") == -1 || internalQuestStatus("questM12Pirate") == 1 || internalQuestStatus("questM12Pirate") == 3) {
 		auto_log_info("Findin' the Cap'n", "blue");
 		autoOutfit("Swashbuckling Getup");
-		if (numPirateInsults() >= 6) {
-			providePlusNonCombat(25, true);
-		}
 		autoAdv($location[Barrrney\'s Barrr]); // this returns false on the Cap'n Caronch adventures for some reason.
 		return true;
 	} else if (internalQuestStatus("questM12Pirate") == 0) {
@@ -541,12 +648,15 @@ boolean LX_joinPirateCrew() {
 		auto_log_info("Attempting to infiltrate the frat house", "blue");
 		boolean infiltrationReady = false;
 		if (possessOutfit("Frat Boy Ensemble", true))  {
-			autoOutfit("Frat Boy Ensemble");
+			auto_log_info("We have the Frat Boy Ensemble, begin infiltration!", "blue");
+			outfit("Frat Boy Ensemble");
 			infiltrationReady = true;
 		} else if (possessEquipment($item[mullet wig]) && item_amount($item[briefcase]) > 0) {
+			auto_log_info("We have a mullet wig and a briefcase, begin infiltration!", "blue");
 			autoForceEquip($item[mullet wig]);
 			infiltrationReady = true;
 		} else if (possessEquipment($item[frilly skirt]) && item_amount($item[hot wing]) > 2) {
+			auto_log_info("We have hot wings and a frilly skirt, begin infiltration!", "blue");
 			autoForceEquip($item[frilly skirt]);
 			infiltrationReady = true;
 		}
@@ -554,10 +664,12 @@ boolean LX_joinPirateCrew() {
 		if (!infiltrationReady) {
 			if (item_amount($item[hot wing]) > 2) {
 				if (knoll_available() && my_meat() > npc_price($item[frilly skirt])) {
+					auto_log_info("We have hot wings but no frilly skirt. Lets go shopping!", "blue");
 					buyUpTo(1, $item[frilly skirt]);
 					autoForceEquip($item[frilly skirt]);
 					infiltrationReady = true;
 				} else {
+					auto_log_info("We have hot wings but no frilly skirt. Lets go to the gym!", "blue");
 					if (internalQuestStatus("questM01Untinker") == -1) {
 						visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
 					}
@@ -586,7 +698,6 @@ boolean LX_joinPirateCrew() {
 		} else {
 			auto_log_info("Insult gathering party.", "blue");
 			addToMaximize("-outfit Swashbuckling Getup");
-			providePlusCombat(25, true);
 			if (autoAdv($location[The Obligatory Pirate\'s Cove])) {
 				return true;
 			}
@@ -627,11 +738,7 @@ boolean LX_fledglingPirateIsYou() {
 
 	auto_log_info("F'c'le t'me!", "blue");
 	autoOutfit("Swashbuckling Getup");
-	providePlusCombat(25, true);
-	if (autoAdv($location[The F\'c\'le])) {
-		return true;
-	}
-	return false;
+	return autoAdv($location[The F\'c\'le]);
 }
 
 void fcleChoiceHandler(int choice) {
@@ -667,11 +774,7 @@ boolean LX_unlockBelowdecks() {
 
 	auto_log_info("Swordfish? Every password was swordfish!", "blue");
 	autoEquip($item[pirate fledges]);
-	providePlusNonCombat(25, true);
-	if (autoAdv($location[The Poop Deck])) {
-		return true;
-	}
-	return false;
+	return autoAdv($location[The Poop Deck]);
 }
 
 boolean LX_pirateQuest() {
@@ -681,14 +784,14 @@ boolean LX_pirateQuest() {
 	return false;
 }
 
-item[class] legendaryEpicWeapons;
-legendaryEpicWeapons[$class[Seal Clubber]] = $item[Hammer of Smiting];
-legendaryEpicWeapons[$class[Turtle Tamer]] = $item[Chelonian Morningstar];
-legendaryEpicWeapons[$class[Pastamancer]] = $item[Greek Pasta Spoon of Peril];
-legendaryEpicWeapons[$class[Sauceror]] = $item[17-alarm Saucepan];
-legendaryEpicWeapons[$class[Disco Bandit]] = $item[Shagadelic Disco Banjo];
-legendaryEpicWeapons[$class[Accordion Thief]] = $item[Squeezebox of the Ages];
-// usage: item legendaryEpicWeapon = legendaryEpicWeapons[my_class()];
+item[class] epicWeapons;
+epicWeapons[$class[Seal Clubber]] = $item[Hammer of Smiting];
+epicWeapons[$class[Turtle Tamer]] = $item[Chelonian Morningstar];
+epicWeapons[$class[Pastamancer]] = $item[Greek Pasta Spoon of Peril];
+epicWeapons[$class[Sauceror]] = $item[17-alarm Saucepan];
+epicWeapons[$class[Disco Bandit]] = $item[Shagadelic Disco Banjo];
+epicWeapons[$class[Accordion Thief]] = $item[Squeezebox of the Ages];
+// usage: item epicWeapon = epicWeapons[my_class()];
 
 item[class] starterWeapons;
 starterWeapons[$class[Seal Clubber]] = $item[seal-clubbing club];
@@ -699,7 +802,7 @@ starterWeapons[$class[Disco Bandit]] = $item[disco ball];
 starterWeapons[$class[Accordion Thief]] = $item[stolen accordion];
 // usage: item starterWeapon = starterWeapons[my_class()];
 
-boolean LX_acquireLegendaryEpicWeapon()
+boolean LX_acquireEpicWeapon()
 {
 	if (internalQuestStatus("questG04Nemesis") > 4)
 	{
@@ -712,6 +815,7 @@ boolean LX_acquireLegendaryEpicWeapon()
 	if(internalQuestStatus("questG04Nemesis") < 0)
 	{
 		visit_url("guild.php?place=scg");	//start quest
+		visit_url("guild.php?place=scg"); // No really, start the quest.
 		cli_execute("refresh quests");		//fixes buggy tracking. confirmed still in mafia r20143
 		if (internalQuestStatus("questG04Nemesis") < 0)
 		{
@@ -719,9 +823,7 @@ boolean LX_acquireLegendaryEpicWeapon()
 		}
 	}
 
-	if (item_amount(legendaryEpicWeapons[my_class()]) > 0) {
-		return false;
-	}
+	if (item_amount(epicWeapons[my_class()]) > 0) { return false; }
 
 	if (internalQuestStatus("questG04Nemesis") == 4) {
 		visit_url("guild.php?place=scg");
@@ -735,17 +837,12 @@ boolean LX_acquireLegendaryEpicWeapon()
 
 	addToMaximize("-equip " + starterWeapons[my_class()].to_string());
 
-	if (autoAdv($location[The Unquiet Garves])) {
-		return true;
-	}
-	return false;
+	return autoAdv($location[The Unquiet Garves]);
 }
 
 // TODO: Add the rest of the Nemesis quest with a flag to enable doing it in-run?
 boolean LX_NemesisQuest()
 {
-	if(LX_guildUnlock()) return true;
-	if(LX_acquireLegendaryEpicWeapon()) return true;
-	
+	if (LX_guildUnlock() || LX_acquireEpicWeapon()) { return true; }
 	return false;
 }


### PR DESCRIPTION
# Description
- change calls to `auto_have_familiar($familiar[Mosquito])` to `pathAllowsFamiliar()` as the former returns false in 100% familiar runs and was being used to check if familiars are allowed in the current run (which screwed 100% runs out of some buffs and other things for no reason)
- reinstate calling `equipMaximizedGear()` at the start of each loop iteration until the issues with flip-flopping equipment is addressed.
- add NC handling for the Overgrown Lot
- add drop tracking for junksprites similar to unstable fulminate ingredient drop tracking
- add printing a "footer" at the end of our pre-adventure handling since a lot can change between the header being printed and actually adventuring and this is when we actually care about what certain values are.
- fix combat modifiers and item drops for many zones.
- add function to start the Shen Copperhead quest so we can lock in the zones he will send us to as early as possible.
- remove unnecessary calls to `providePlusCombat()` and `providePlusNonCombat()` from quest handling
- use zone_delay() to check delay where relevant.
- rename LegendaryEpicWeapon to EpicWeapon because it was wrong when I originally wrote it.

## How Has This Been Tested?

Running Normal Sauceror LKS at present. Day 1 completed about to start day 2. Putting this up early as there's a large number of changes (normally I'd have at least one full run done but my previous run was ruined by #445 )

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
