### PR TITLE
Don't spam specific familiars with mumming trunk choices in every path

### DIFF
--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -3,6 +3,10 @@ script "g_lover.ash"
 
 void glover_initializeDay(int day)
 {
+	if (auto_my_path() != "G-Lover") {
+		return false;
+	}
+
 	if((item_amount($item[Mumming Trunk]) > 0) && !get_property("_mummifyDone").to_boolean())
 	{
 		mummifyFamiliar($familiar[Disgeist], "myst");


### PR DESCRIPTION
## Description
don't do this unless in G Lover. Also this is probably bad regardless but let's just let G Lover be bad and every other path can ignore these terrible choices.

## How Has This Been Tested?

Hasn't. No IotMs on test account & it's done for today regardless. However I suspect this is fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
