### PR TITLE
Bean issue #459

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -11,8 +11,8 @@ boolean L10_plantThatBean()
 	string page = visit_url("place.php?whichplace=plains");
 	if(contains_text(page, "place.php?whichplace=beanstalk"))
 	{
-		auto_log_warning("I have no bean but I see a stalk here. Okies. I'm ok with that", "blue");
-		visit_url("place.php?whichplace=beanstalk");
+		auto_log_warning("I see the beanstalk has already been planted. fixing questL10Garbage to step1", "blue");
+		set_property("questL10Garbage", "step1");
 		return true;
 	}
 	if(item_amount($item[Enchanted Bean]) > 0)

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -2,7 +2,7 @@ script "level_10.ash"
 
 boolean L10_plantThatBean()
 {
-	if (internalQuestStatus("questL10Garbage") < 0 || internalQuestStatus("questL10Garbage") > 0)
+	if(internalQuestStatus("questL10Garbage") != 0)
 	{
 		return false;
 	}


### PR DESCRIPTION
try to fix infinite loop when trying to plant the bean

Fixes #459

## How Has This Been Tested?

validates
I can't reproduce the bug so I am asking the person who reported it to test it.... I do have the idea of manually "producing" the bug via property manipulation such as CLI `set questL10Garbage = started` when it is in step1
I will also test to make sure this does not break anything else by doing some runs with it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
