### PR TITLE
only try casting blood skills if you actually have some

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1148,7 +1148,9 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
     }
     boolean success = true;
     foreach sk, times in to_cast{
-      success &= use_skill(times, sk);
+      if (sk != $skill[none]) {
+        success &= use_skill(times, sk);
+      }
     }
     return success;
   }

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1117,6 +1117,9 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 
   boolean use_opportunity_blood_skills(int hp_restored_per_use, int final_hp)
   {
+    if (!auto_have_skill($skill[Blood Bond]) && !auto_have_skill($skill[Blood Bond])) {
+      return false;
+    }
     int restored = my_hp() + hp_restored_per_use;
     int waste = min(my_hp()-1, restored-my_maxhp());
     if(waste <= 0) return true;
@@ -1148,9 +1151,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
     }
     boolean success = true;
     foreach sk, times in to_cast{
-      if (sk != $skill[none]) {
-        success &= use_skill(times, sk);
-      }
+      success &= use_skill(times, sk);
     }
     return success;
   }


### PR DESCRIPTION
# Description

Stops the `Could not find a known, usable skill of yours uniquely matching "# null"` messages happening repeatedly as we no longer blindly try to `use_skill` on skills we may not either have or have access to in the current path.

Fixes #382 

## How Has This Been Tested?

Running an LKS run on a character with none of the Booke skills. Looks fixed as the spam is gone (and I tested it while debugging by printing the skill it was trying to use in that loop and the number of times).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
