### PR TITLE
add Mosquito as the absolute default failover for regen familiars

### DIFF
--- a/BUILD/familiars/regen.dat
+++ b/BUILD/familiars/regen.dat
@@ -29,7 +29,6 @@ Underworld Bonsai
 Star Starfish
 # Fairysuperwhelps
 Garbage Fire
-XO Skeleton
 Choctopus
 # Superwhelps
 Plastic Pirate Skull
@@ -53,3 +52,5 @@ Pottery Barn Owl
 # Regular old whelps
 Pet Cheezling
 Ghuol Whelp
+# The absolute default that everyone should have after their first run
+Mosquito

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -285,30 +285,31 @@ regen	13	Underworld Bonsai
 regen	14	Star Starfish
 # Fairysuperwhelps
 regen	15	Garbage Fire
-regen	16	XO Skeleton
-regen	17	Choctopus
+regen	16	Choctopus
 # Superwhelps
-regen	18	Plastic Pirate Skull
-regen	19	Trick-or-Treating Tot
+regen	17	Plastic Pirate Skull
+regen	18	Trick-or-Treating Tot
 # Fairywhelps
-regen	20	Dandy Lion
+regen	19	Dandy Lion
 # Special whelps
-regen	21	Ms. Puck Man
-regen	22	Puck Man
-regen	23	Squamous Gibberer
-regen	24	He-Boulder
-regen	25	Cotton Candy Carnie
+regen	20	Ms. Puck Man
+regen	21	Puck Man
+regen	22	Squamous Gibberer
+regen	23	He-Boulder
+regen	24	Cotton Candy Carnie
 # Slightly better whelp for saucerors
-regen	26	Pet Cheezling	class:Sauceror
+regen	25	Pet Cheezling	class:Sauceror
 # Whelps with a multiplier, why not I guess
 #Mutant Gila Monster	grimdark:0
 #Mutant Gila Monster	grimdark:1
 # Marginally special whelps
 #Mutant Gila Monster	grimdark:2
-regen	27	Pottery Barn Owl
+regen	26	Pottery Barn Owl
 # Regular old whelps
-regen	28	Pet Cheezling
-regen	29	Ghuol Whelp
+regen	27	Pet Cheezling
+regen	28	Ghuol Whelp
+# The absolute default that everyone should have after their first run
+regen	29	Mosquito
 
 # Sombrero is desirable with a decent amount of ML
 stat	0	Galloping Grill	ML:>=120


### PR DESCRIPTION
##  Description

So it turns out when I wrote "At worst the player will have something like a Ghuol Whelp or Starfish." I was wrong. Some players don't bother getting the very basic familiars, some of which are practically free. Actually some of them _do_ get the familiars, **they just don't bother putting them in their terrariums** :angry: 

also remove duplicate XO Skeleton entry from regen familiars (didn't matter anyway but consistency).

## How Has This Been Tested?

It hasn't. I'd have to create a new account entirely to test this which I'm not going to. Lets assume anyone who doesn't put the Mosquito in their terrarium is not worth our time.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
