### PR TITLE
add workaround for mafia not recognizing the bosses from the crowd of…

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2318,6 +2318,9 @@ boolean instakillable(monster mon)
 	static boolean[monster] not_instakillable = $monsters[
 		// Cyrpt bosses
 		conjoined zmombie, gargantulihc, giant skeelton, huge ghuol,
+		
+		// crowd of adventurers bosses at the tower tests
+		Tasmanian Dervish, Mr. Loathing, The Mastermind, Seannery the Conman, The Lavalier, Leonard, Arthur Frankenstein, Mrs. Freeze, Odorous Humongous,
 
 		// time-spinner
 		Ancient Skeleton with Skin still on it, Apathetic Tyrannosaurus, Assembly Elemental, Cro-Magnon Gnoll, Krakrox the Barbarian, Wooly Duck,


### PR DESCRIPTION
add workaround for mafia not recognizing the bosses from the crowd of adventurers as bosses

workaround for this mafia bug:
https://kolmafia.us/showthread.php?25190

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
