### PR TITLE
Resoration changes to address wasting meat on NPC items when skills are available and MP is in abundance

### DIFF
--- a/RELEASE/data/autoscend_restoration.txt
+++ b/RELEASE/data/autoscend_restoration.txt
@@ -43,7 +43,7 @@
 42	Shake it Off	skill	ALL	0	0	0	All Negative	none
 43	Gelatinous Reconstruction	skill	13	0	0	0	Beaten Up	none
 44	Disco Nap	skill	20	0	0	0	none	none
-46	Lasagna Bandages	skill	15	0	0	0	none	none
+46	Lasagna Bandages	skill	20	0	0	0	none	none
 47	big rock	dwelling	4	5	0	0	none	none
 48	Newbiesport&trade; tent	dwelling	9	10	0	0	none	none
 49	Giant Pilgrim Hat	dwelling	14	15	0	0	none	Pyramid Power
@@ -104,6 +104,7 @@
 107	A Relaxing Hot Tub	clan	ALL	0	5	2	All Negative	none
 108	Psychokinetic Energy Blob	item	0	25	0	0	none	none
 109	Cloaca-Cola	item	0	12	0	0	none	none
+## Actually Ed the Undying restores
 110	Holy Spring Water	item	0	50	0	0	none	Spiritually Awake
 111	Spirit Beer	item	0	90	0	0	none	Spiritually Aware
 112	Sacramental Wine	item	0	180	0	0	none	Spiritually Awash

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2236,6 +2236,16 @@ boolean isMusGuildStoreAvailable()
 	return false;
 }
 
+boolean isMystGuildStoreAvailable() {
+	if ($classes[Pastamancer, Sauceror] contains my_class() && guild_store_available()) {
+		return true;
+	}
+	if (my_class() == $class[Accordion Thief] && my_level() >= 9 && guild_store_available()) {
+		return true;
+	}
+	return false;
+}
+
 boolean isArmoryAvailable()
 {
 	if(auto_my_path() == "Nuclear Autumn")

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -873,6 +873,7 @@ boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash
 boolean isGalaktikAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGeneralStoreAvailable();							//Defined in autoscend/auto_util.ash
 boolean isMusGuildStoreAvailable();							//Defined in autoscend/auto_util.ash
+boolean isMystGuildStoreAvailable(); 						//Defined in autoscend/auto_util.ash
 boolean isArmoryAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGhost(monster mon);								//Defined in autoscend/auto_util.ash
 boolean isGuildClass();										//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

- add meat_per_use values for restoration skills so they are better compared against NPC purchased items
- fix Disco Nap being considered too low when you have Adventurer of Leisure
- fix value for Lasagna Bandages being lower than the out of combat average
- add a function to check if the Myst class guild store is available so we can know if magical mystery juice is available as an MP restore.

Fixes #405 

## How Has This Been Tested?

Ran day 1 as Normal Sauceror in LKS. It only used skills to restore HP (as it should). Note I tested it mostly without the special handling for Sauceror first so I could make sure all classes will benefit. The Sauceror handling is due to Soul Food and Curse of the Weaksauce giving ridiculous amounts of MP.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
