### PR TITLE
Don't waste clovers if we have enough A-boo Clues to complete the peak

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -321,8 +321,7 @@ boolean L9_aBooPeak()
 			removeFromMaximize("-equip " + $item[Broken Champagne Bottle]);
 		}
 
-		autoAdv(1, $location[A-Boo Peak]);
-		return true;
+		return autoAdv(1, $location[A-Boo Peak]);
 	}
 
 	boolean booCloversOk = false;
@@ -343,6 +342,7 @@ boolean L9_aBooPeak()
 
 	if (get_property("auto_abooclover").to_boolean() && clueAmt >= get_property("booPeakProgress").to_int()/30) {
 		// if you get lucky/have enough item drop to get 3 clues while getting to 90% haunted, don't waste a clover getting more.
+		auto_log_info("We have enough A-boo clues to clear the peak, lets not waste a clover");
 		set_property("auto_abooclover", false);
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -341,6 +341,11 @@ boolean L9_aBooPeak()
 		}
 	}
 
+	if (get_property("auto_abooclover").to_boolean() && clueAmt >= get_property("booPeakProgress").to_int()/30) {
+		// if you get lucky/have enough item drop to get 3 clues while getting to 90% haunted, don't waste a clover getting more.
+		set_property("auto_abooclover", false);
+	}
+
 	auto_log_info("A-Boo Peak: " + get_property("booPeakProgress"), "blue");
 	boolean clueCheck = ((clueAmt > 0) || (get_property("auto_aboopending").to_int() != 0));
 	if (get_property("auto_abooclover").to_boolean() && get_property("booPeakProgress").to_int() >= 30 && booCloversOk)


### PR DESCRIPTION
# Description

As title.

## How Has This Been Tested?

Hasn't yet. My test account is done for the day but conveniently it's level 11 in a normal LKS run with none of the peaks started so I'll give it a test after rollover by manually clovering to get 3 or more A-boo Clues after getting down to 90% hauntedness.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
