### PR TITLE
cosmetics wraith not recognized as boss workaround

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2351,7 +2351,7 @@ boolean instakillable(monster mon)
 		Sssshhsssblllrrggghsssssggggrrgglsssshhssslblgl, Eldritch Tentacle,
 
 		// Other Monsters that Mafia returns as instakillable (or not a boss), that really aren't
-		Drunken Rat King
+		cosmetics wraith, Drunken Rat King
 	];
 
 	if(not_instakillable contains mon)


### PR DESCRIPTION
workaround for cosmetics wraith not being recognized as a boss. thus crashing autoscend when we waste an instakill on it such as stomp boots.

mafia bug: https://kolmafia.us/showthread.php?25190

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
