### PR TITLE
get clovers on dependence day from green rocket

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2609,6 +2609,7 @@ boolean LX_hardcoreFoodFarm()
 
 boolean LX_craftAcquireItems()
 {
+	dependenceDayClovers();
 	if((item_amount($item[Ten-Leaf Clover]) > 0) && glover_usable($item[Ten-Leaf Clover]))
 	{
 		use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -45,7 +45,8 @@ boolean LX_melvignShirt();
 boolean LX_attemptPowerLevel();
 boolean LX_attemptFlyering();
 boolean LX_bitchinMeatcar();
-boolean LX_meatMaid();
+boolean LX_meatMaid();								//Defined in autoscend/quests/level_any.ash
+boolean dependenceDayClovers();						//Defined in autoscend/quests/level_any.ash
 boolean LX_craftAcquireItems();
 boolean LX_freeCombats();
 boolean LX_freeCombats(boolean powerlevel);

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -515,3 +515,24 @@ boolean LX_meatMaid()
 	}
 	return false;
 }
+
+boolean dependenceDayClovers()
+{
+	if(get_property("_fireworkUsed").to_boolean())
+	{
+		return false;	//only 1 firework per day allowed
+	}
+	if(holiday() != "Dependence Day")	//TODO verify spelling
+	{
+		return false;	//it is not dependence day today
+	}
+	auto_log_info("Today is Dependence Day and I want to use a [green rocket] for some clovers", "green");
+	if(my_meat() < npc_price($item[green rocket]))
+	{
+		auto_log_info("I can't afford a [green rocket]. I will try again later");
+		return false;	//not enough meat to buy it
+	}
+	
+	buyUpTo(1, $item[green rocket]);
+	return use(1, $item[green rocket]);
+}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -522,7 +522,7 @@ boolean dependenceDayClovers()
 	{
 		return false;	//only 1 firework per day allowed
 	}
-	if(holiday() != "Dependence Day")	//TODO verify spelling
+	if(holiday() != "Dependence Day")
 	{
 		return false;	//it is not dependence day today
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -526,13 +526,18 @@ boolean dependenceDayClovers()
 	{
 		return false;	//it is not dependence day today
 	}
+	
 	auto_log_info("Today is Dependence Day and I want to use a [green rocket] for some clovers", "green");
-	if(my_meat() < npc_price($item[green rocket]))
+	if(item_amount($item[green rocket]) == 0 && my_meat() < npc_price($item[green rocket]))
 	{
 		auto_log_info("I can't afford a [green rocket]. I will try again later");
-		return false;	//not enough meat to buy it
+		return false;
 	}
 	
 	buyUpTo(1, $item[green rocket]);
-	return use(1, $item[green rocket]);
+	if(item_amount($item[green rocket]) > 0)
+	{
+		return use(1, $item[green rocket]);
+	}
+	return false;
 }


### PR DESCRIPTION
# Description

get clovers on dependence day from green rocket 

Fixes #347 

## How Has This Been Tested?

I verified the function was called back when it was unusable due to mafia issue.
after mafia issue was resolved I was already overdrunk, so I tested it via a test function that called `https://kolmafia.us/showthread.php?25200`

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
