### PR TITLE
only equip ring of boring doors when its needed (5th and 10th turn)

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -384,7 +384,10 @@ boolean LX_phatLootToken()
 
 	auto_log_info("Phat Loot Token Get!", "blue");
 	set_property("choiceAdventure691", "2");
-	autoEquip($slot[acc3], $item[Ring Of Detect Boring Doors]);
+	if(get_property("_lastDailyDungeonRoom").to_int() == 4 || get_property("_lastDailyDungeonRoom").to_int() == 9)
+	{
+		autoEquip($slot[acc3], $item[Ring Of Detect Boring Doors]);
+	}
 
 	backupSetting("choiceAdventure692", 4);
 	if(item_amount($item[Platinum Yendorian Express Card]) > 0)
@@ -425,7 +428,7 @@ boolean LX_phatLootToken()
 	{
 		backupSetting("choiceAdventure693", 1);
 	}
-	if(equipped_amount($item[Ring of Detect Boring Doors]) > 0)
+	if(possessEquipment($item[Ring of Detect Boring Doors]))
 	{
 		backupSetting("choiceAdventure690", 2);
 		backupSetting("choiceAdventure691", 2);
@@ -438,10 +441,6 @@ boolean LX_phatLootToken()
 
 
 	autoAdv(1, $location[The Daily Dungeon]);
-	if(possessEquipment($item[Ring Of Detect Boring Doors]))
-	{
-		cli_execute("unequip acc3");
-	}
 	restoreSetting("choiceAdventure690");
 	restoreSetting("choiceAdventure691");
 	restoreSetting("choiceAdventure692");


### PR DESCRIPTION
only equip ring of boring doors when current progress is at 4 or 9. since it is only used on 5th and 10th visit

## How Has This Been Tested?

been using that if line in my aftercore script for a while now and it reliably equips the ring of boring doors only at the correct interval
also played with it for a day in autoscend and it works here too. only equipping the ring of boring doors when needed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
