### PR TITLE
Ensure skill restores and item restores are being compared correctly.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -600,14 +600,21 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
   }
 
   float total_meat_used(){
-    if(metadata.type != "item"){
+    if(metadata.type != "item" && metadata.type != "skill"){
       return -1.0;
     }
-    item i = to_item(metadata.name);
-    float needed = max(0.0, total_uses_needed() - item_amount(i));
-    int price = npc_price(i);
-    if(can_interact()){
-      price = min(price, auto_mall_price(i));
+    float needed;
+    int price;
+    if(metadata.type == "item") {
+      item i = to_item(metadata.name);
+      needed = max(0.0, total_uses_needed() - item_amount(i));
+      price = npc_price(i);
+      if(can_interact()){
+        price = min(price, auto_mall_price(i));
+      }
+    } else if (metadata.type == "skill"){
+      needed = total_uses_needed();
+      price = meat_per_use();
     }
 
     if(price == 0){

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -604,20 +604,15 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
       return -1.0;
     }
     float needed;
-    int price;
     if(metadata.type == "item") {
       item i = to_item(metadata.name);
       needed = max(0.0, total_uses_needed() - item_amount(i));
-      price = npc_price(i);
-      if(can_interact()){
-        price = min(price, auto_mall_price(i));
-      }
     } else if (metadata.type == "skill"){
       needed = total_uses_needed();
-      price = meat_per_use();
     }
 
-    if(price == 0){
+    float price = get_value("meat_per_use");
+    if(price < 0.001){
       return -1.0;
     }
     return price * needed;


### PR DESCRIPTION
# Description

This PR continues to address #405. I was still seeing some of the behavior described in that issue, and I think this PR fixes it. The optimization objective of `hp_per_meat_spent` was using `total_meat_used`, not `meat_per_use`. This integrates Malibu Stacey's `meat_per_use` implementation into `total_meat_used` for skills.

## How Has This Been Tested?

Casual run. More testing is incoming.

## Checklist:

- [x] My code follows the style guidelines of this project. (At least, I think it does.)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
