### PR TITLE
fix MCD flip flopping when not set to max (e.g. Orc Chasm).

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3677,12 +3677,14 @@ boolean auto_change_mcd(int mcd, boolean immediately)
 	}
 	mcd = min(mcd, best);
 	int next = max(0, mcd);
+	
+	set_property("auto_mcd_target", next); // if we return without setting this, we will flip-flop the mcd every adventure...
+
 	if(next == current_mcd())
 	{
 		return true;
 	}
 	
-	set_property("auto_mcd_target", next);
 	if(immediately)
 	{
 		return change_mcd(next);


### PR DESCRIPTION
# Description

As title. Noticed every second adventure in the Orc Chasm it had 10 ML when it should have 0. The print_footer() in #453 really helps spot stuff like this.

## How Has This Been Tested?

Running Normal LKS. Seems good now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
