### PR TITLE
rewrite providePlusCombat and providePlusNonCombat

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2719,7 +2719,7 @@ float providePlusCombat(int amt, boolean doEquips, boolean speculative) {
 		if (speculative) {
 			simMaximizeWith(max);
 		} else {
-			addToMaximize("200combat " + amt + "max");
+			addToMaximize(max);
 			simMaximize();
 		}
 		delta = simValue("Combat Rate") - numeric_modifier("Combat Rate");
@@ -2854,7 +2854,7 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		if (speculative) {
 			simMaximizeWith(max);
 		} else {
-			addToMaximize("-200combat " + amt + "max");
+			addToMaximize(max);
 			simMaximize();
 		}
 		delta = simValue("Combat Rate") - numeric_modifier("Combat Rate");
@@ -3028,7 +3028,7 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 		}
 		else
 		{
-			addToMaximize("500initiative " + amt + "max");
+			addToMaximize(max);
 			simMaximize();
 		}
 		delta = simValue("Initiative") - numeric_modifier("Initiative");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2318,7 +2318,7 @@ boolean instakillable(monster mon)
 	static boolean[monster] not_instakillable = $monsters[
 		// Cyrpt bosses
 		conjoined zmombie, gargantulihc, giant skeelton, huge ghuol,
-		
+
 		// time-spinner
 		Ancient Skeleton with Skin still on it, Apathetic Tyrannosaurus, Assembly Elemental, Cro-Magnon Gnoll, Krakrox the Barbarian, Wooly Duck,
 
@@ -6432,6 +6432,11 @@ element currentFlavour()
 	return $element[none];
 }
 
+void resetFlavour()
+{
+	set_property("_auto_tunedElement", "");
+}
+
 boolean setFlavour(element ele)
 {
 	if(!auto_have_skill($skill[Flavour of Magic]))
@@ -7203,3 +7208,13 @@ int poolSkillPracticeGains()
 	return count;
 }
 
+void resetThisLoop()
+{
+	//These settings should never persist into another turn, ever. They only track something for a single instance of the main loop.
+	//We use boolean instead of adventure count because of free combats.
+	
+	set_property("auto_doCombatCopy", "no");
+	set_property("_auto_thisLoopHandleFamiliar", false);	//have we called handleFamiliar this loop
+	set_property("auto_disableFamiliarChanging", false);	//disable autoscend making changes to familiar
+	set_property("auto_familiarChoice", "");				//which familiar do we want to switch to during pre_adventure
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -932,8 +932,10 @@ void picky_pulls();											//Defined in autoscend/auto_picky.ash
 void picky_startAscension();								//Defined in autoscend/auto_picky.ash
 skill preferredLibram();									//Defined in autoscend/auto_util.ash
 location provideAdvPHPZone();								//Defined in autoscend/auto_util.ash
+float providePlusCombat(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean providePlusCombat(int amt);							//Defined in autoscend/auto_util.ash
 boolean providePlusCombat(int amt, boolean doEquips);		//Defined in autoscend/auto_util.ash
+float providePlusNonCombat(int amt, boolean doEquips, boolean speculative); //Defined in autoscend/auto_util.ash
 boolean providePlusNonCombat(int amt);						//Defined in autoscend/auto_util.ash
 boolean providePlusNonCombat(int amt, boolean doEquips);	//Defined in autoscend/auto_util.ash
 boolean acquireCombatMods(int amt);							//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
# Description

rewrite providePlusCombat and providePlusNonCombat so they use the same pattern as the other providers

Fixes #400 

## How Has This Been Tested?

Running Normal LKS with these changes on #453 and have removed the early call to `equipMaximizedGear()`. Looks all good.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
