### PR TITLE
fix lynyrd protestors amount calculating less than it should 

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1744,8 +1744,7 @@ boolean L11_redZeppelin()
 		float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
 		foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
 		{
-			if((item_amount(it) > 0) && can_equip(it))
-			{
+			if (possessEquipment(it) && can_equip(it)) {
 				lynyrd_protestors += 5;
 			}
 		}


### PR DESCRIPTION
# Description

Check was using `item_amount()` rather than `possessEquipment()` so it would calculate less than it should if you happened to be wearing some of them.

I really wish mafia would just make `item_amount()` work like `possessEquipment()` and create `inventory_amount()` that does what `item_amount()` does presently.

## How Has This Been Tested?

My LKS run was past this point when I noticed it had run 14 adventures in the zone when it should be only 6 with all 3 lynyrd items and the musk effect as it should be burning clovers. Validates fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
