### PR TITLE
couple of tweaks to consumption

### DIFF
--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -844,7 +844,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	int[item] large_owned;
 	int[item] craftables;
 
-	boolean[item] blacklist = $items[Cursed Punch];
+	boolean[item] blacklist = $items[Cursed Punch, Unidentified Drink];
 	boolean[item] craftable_blacklist;
 
 	// If we have 2 sticks of firewood, the current knapsack-solver
@@ -963,7 +963,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				// Is this a good estimate of how many adventures a pull is worth? I don't know!
 				// This could be a property, I don't know.
-				actions[n].desirability -= 6.0;
+				actions[n].desirability -= 5.0;
 			}
 			if (type == SL_ORGAN_STOMACH && auto_is_valid($item[special seasoning]))
 			{


### PR DESCRIPTION
# Description

- tweak the desirability for pulled consumables a little lower
I noticed the consumption code favours Advanced Cocktail Crafting booze over better stuff it could pull. Tracked it down to the desirability modifier causing it to value better consumables far lower than it probably should.

- also exclude the unidentified drink as the adventure gain range is wild (6-20 from size 3!)
Like WTF is this thing even? Mafia lists it as 4.33 adv/liver which is mathematically correct but that range is horrific! Not counting the Ode bonus, I've seen it give 9 or less adventures on more than one occasion (and one that gave 15).

## How Has This Been Tested?

Been running these a while. Pulled them out of #453 as I'm still addressing LKS things on that so it may be a while before it's ready to merge and stuff like this shouldn't need to wait for everything else.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
