### PR TITLE
Fix trying to burn mana on Pre-adventure in Dark Gryffte

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -487,11 +487,15 @@ boolean auto_pre_adventure()
 		acquireHP();
 	}
 
-	int wasted_mp = my_mp() + mp_regen() - my_maxmp();
-	if(wasted_mp > 0 && my_mp() > 400)
+	//my_mp is broken in Dark Gyffte
+	if (auto_my_path() != "Dark Gyffte")
 	{
-		auto_log_info("Burning " + wasted_mp + " MP...");
-		cli_execute("burn " + wasted_mp);
+		int wasted_mp = my_mp() + mp_regen() - my_maxmp();
+		if(wasted_mp > 0 && my_mp() > 400)
+		{
+			auto_log_info("Burning " + wasted_mp + " MP...");
+			cli_execute("burn " + wasted_mp);
+		}
 	}
 	borisWastedMP();
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -488,7 +488,7 @@ boolean auto_pre_adventure()
 	}
 
 	//my_mp is broken in Dark Gyffte
-	if (auto_my_path() != "Dark Gyffte")
+	if (my_class() != $class[Vampyre])
 	{
 		int wasted_mp = my_mp() + mp_regen() - my_maxmp();
 		if(wasted_mp > 0 && my_mp() > 400)


### PR DESCRIPTION
# Description

In Dark Gyffte we end up aborting if we try to burn mana on Librams/whatever else.


## How Has This Been Tested?

Tested in multiple Dark Gyffte runs,

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
