### PR TITLE
hotfix for ninjas repeatedly failing due to new providers

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,5 +1,5 @@
 script "autoscend.ash";
-since r20210; // abort now works in combat filter function
+since r20232; // Melodramedary gives +1 desert exploration when equipped.
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/autoscend_migration.ash
+++ b/RELEASE/scripts/autoscend/autoscend_migration.ash
@@ -1,6 +1,6 @@
 script "autoscend_migration.ash"
 
-static string __autoscend_version = "1.4.1";
+static string __autoscend_version = "1.5.0";
 static int __autoscend_confirm_timeoutMS = 10000;
 static string __remove_sl_ascend_confirmation = "Looks like you have the old sl_ascend project installed as well. Would you like to remove it? (it is no longer maintained). Will default to false in 10 seconds.";
 static string __migrate_sl_ascend_properties_confirmation = "Looks like you may be migrating from sl_ascend. Starting with a fresh run using autoscend is adviable but we can try to migrate all the sl_ascend properties (results may vary). Will default to true in 10 seconds.";

--- a/RELEASE/scripts/autoscend/autoscend_migration.ash
+++ b/RELEASE/scripts/autoscend/autoscend_migration.ash
@@ -1,6 +1,6 @@
 script "autoscend_migration.ash"
 
-static string __autoscend_version = "1.5.0";
+static string __autoscend_version = "1.4.1";
 static int __autoscend_confirm_timeoutMS = 10000;
 static string __remove_sl_ascend_confirmation = "Looks like you have the old sl_ascend project installed as well. Would you like to remove it? (it is no longer maintained). Will default to false in 10 seconds.";
 static string __migrate_sl_ascend_properties_confirmation = "Looks like you may be migrating from sl_ascend. Starting with a fresh run using autoscend is adviable but we can try to migrate all the sl_ascend properties (results may vary). Will default to true in 10 seconds.";

--- a/RELEASE/scripts/autoscend/quests/level_8.ash
+++ b/RELEASE/scripts/autoscend/quests/level_8.ash
@@ -493,15 +493,7 @@ boolean L8_trapperNinjaLair()
 		return false;
 	}
 
-	if(in_hardcore())
-	{
-		if (isActuallyEd())
-		{
-			if((have_effect($effect[Taunt of Horus]) == 0) && (item_amount($item[Talisman of Horus]) == 0))
-			{
-				return false;
-			}
-		}
+	if (in_hardcore()) {
 		if((have_effect($effect[Thrice-Cursed]) > 0) || (have_effect($effect[Twice-Cursed]) > 0) || (have_effect($effect[Once-Cursed]) > 0))
 		{
 			return false;
@@ -513,36 +505,20 @@ boolean L8_trapperNinjaLair()
 			return false;
 		}
 
-		handleFamiliar("item");
-		asdonBuff($effect[Driving Obnoxiously]);
-		if(!providePlusCombat(25))
-		{
-			auto_log_warning("Could not uneffect for ninja snowmen, delaying", "red");
-			return false;
-		}
-
 		if (isActuallyEd() && !elementalPlanes_access($element[spooky]))
 		{
 			adjustEdHat("myst");
 		}
 
-		if(numeric_modifier("Combat Rate") <= 9.0)
-		{
-			autoEquip($slot[Back], $item[Carpe]);
-		}
-
-		if(numeric_modifier("Combat Rate") <= 0.0)
-		{
+		if (providePlusCombat(25, true, true) <= 0.0) {
 			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Ninja Snowmen.", "red");
-			equipBaseline();
 			return false;
 		}
 
-		if(!autoAdv(1, $location[Lair of the Ninja Snowmen]))
-		{
-			auto_log_warning("Seems like we failed the Ninja Snowmen unlock, reverting trapper setting", "red");
+		if (autoAdv($location[Lair of the Ninja Snowmen])) {
+			return true;
 		}
-		return true;
+		auto_log_warning("Seems like we failed the Ninja Snowmen unlock, reverting trapper setting", "red");
 	}
 	return false;
 }


### PR DESCRIPTION
# Description

Issue reported in Discord

> Getting this following every turn: `> [WARNING] - Could not uneffect for ninja snowmen, delaying`

I intentionally didn't make changes to L8_trapperNinjaLair() or L8_trapperGroar() when working on #453 as #443 is in progress but I should have. This addresses that oversight.

It does not address dying instantly to ninja snowman assassins however (and is not intended to, it is intended to allow the previous behaviour of doing the snowman route in hardcore when you can get +combat to work again).

Also added updating minimum mafia version to fix

>nukasevToday at 08:29
>autoscend updated automatically when I launched mafia, now I get an error when running autoscend: Bad familiar value: "Melodramedary" (level_11.ash, line 25)

and

>LaLaWingsToday at 17:59
>Huh, did a fresh install of autoscend and got this: 'Bad familiar value: "Melodramedary" (level_11.ash, line 25)'

## How Has This Been Tested?

~~Hasn't yet tbh. Test account is in Ed which will just get instagibbed by Assassins, is done for the day & has only just hit level 8 (ran out of adventures mining trapper ores). I can try testing it after rollover & watch it die repeatedly for "fun".~~
Works, as expected Ed gets instagibbed by Ninja Snowman Assassins but it's definitely trying to adventure there again so should  be working as before. Also found a delightful mafia bug where `expected_damage()` is horrifically wrong for some monsters.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
