### PR TITLE
fix typo'd skill name.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3015,7 +3015,7 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 	}
 
 	// Glove charges are a limited per-day resource, lets do this last so we don't waste possible uses of Replace Enemy
-	if (tryEffects($effects[Triple-Sized])) {
+	if (tryEffects($effects[Invisible Avatar])) {
 		return result();
 	}
 


### PR DESCRIPTION
# Description

Single line change. Had wrong buff name. Reported in Discord.

## How Has This Been Tested?

Hasn't yet but I'm confident this fixes the issue.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
