### PR TITLE
Misc Ed fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -362,21 +362,8 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 1023: // Like a Bat Into Hell (Actually Ed the Undying)
-			run_choice(1); // Enter the Underworld
-			auto_log_info("Ed died in combat " + get_property("_edDefeats").to_int() + " time(s)", "blue");
-			ed_shopping(); // "free" trip to the Underworld, may as well go shopping!
-			visit_url("place.php?whichplace=edunder&action=edunder_leave");
-			break;
 		case 1024:  // Like a Bat out of Hell (Actually Ed the Undying)
-			if (get_property("_edDefeats").to_int() < get_property("edDefeatAbort").to_int()) {
-				// resurrecting is still free.
-				run_choice(1, false); // UNDYING!
-			} else {
-				// resurrecting will cost Ka
-				run_choice(2); // Accept the cold embrace of death (Return to the Pyramid)
-				auto_log_info("Ed died in combat for reals!");
-				set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
-			}
+			edUnderworldChoiceHandler(choice);
 			break;
 		case 1060: // Temporarily Out of Skeletons (The Skeleton Store)
 			if (item_amount($item[Skeleton Store office key]) == 0) {
@@ -411,6 +398,14 @@ boolean auto_run_choice(int choice, string page)
 		case 1083: // Cogito Ergot Sum (post-post-Cake Lord in Madness Bakery)
 			run_choice(1);
 			break;
+		case 1115: // VYKEA! (VYKEA)
+			if (!get_property("_VYKEACafeteriaRaided").to_boolean() && auto_my_path() != "Community Service") {
+				run_choice(1); // get consumables
+			} else if (!get_property("_VYKEALoungeRaided").to_boolean()) {
+				run_choice(4); // get Wal-Mart gift certificates
+			} else {
+				run_choice(6); // skip
+			}
 		case 1310: // Granted a Boon (God Lobster)
 			int goal = get_property("_auto_lobsterChoice").to_int();
 			string search = "I'd like part of your regalia.";

--- a/RELEASE/scripts/autoscend/auto_cooking.ash
+++ b/RELEASE/scripts/autoscend/auto_cooking.ash
@@ -614,7 +614,7 @@ boolean consumeFortune()
 	}
 
 	// Don't get lucky numbers for the first semi-rare if we still need to adventure in the outskirts
-	if (my_turncount() < 80 && (internalQuestStatus("questL05Goblin") < 1 && item_amount($item[Knob Goblin encryption key]) < 1))
+	if (my_turncount() < 80 && (internalQuestStatus("questL05Goblin") < 1 && item_amount($item[Knob Goblin encryption key]) < 1) && !isActuallyEd())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -357,8 +357,9 @@ float simValue(string modifier)
 void equipMaximizedGear()
 {
 	finalizeMaximize();
-	auto_log_info("Maximizing: " + get_property("auto_maximize_current"), "blue");
+	backupSetting("logPreferenceChange", "false");
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
+	restoreSetting("logPreferenceChange");
 }
 
 void equipOverrides()
@@ -521,7 +522,9 @@ void equipRollover()
 	if(auto_have_familiar($familiar[Left-Hand Man]))
 		to_max += ",switch Left-Hand Man";
 
+	backupSetting("logPreferenceChange", "false");
 	maximize(to_max, false);
+	restoreSetting("logPreferenceChange");
 
 	if(!in_hardcore())
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -280,16 +280,6 @@ boolean auto_pre_adventure()
 		}
 	}
 
-	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {
-		equip($slot[Pants], $item[None]);
-		put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
-		if (is_wearing_outfit("Filthy Hippy Disguise")) {
-			abort("Tried to adventure in the Hippy Camp as Actually Ed the Undying wearing the Filthy Hippy Disguise (this is bad).");
-		} else {
-			auto_log_info("Took off the Filthy Hippy Disguise before adventuring in the Hippy Camp so we don't waste adventures on non-combats.");
-		}
-	}
-
 	if(place == $location[The Black Forest])
 	{
 		autoEquip($slot[acc3], $item[Blackberry Galoshes]);
@@ -458,6 +448,16 @@ boolean auto_pre_adventure()
 	// EQUIP MAXIMIZED GEAR
 	equipMaximizedGear();
 	cli_execute("checkpoint clear");
+
+	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {
+		equip($slot[Pants], $item[None]);
+		put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
+		if (is_wearing_outfit("Filthy Hippy Disguise")) {
+			abort("Tried to adventure in the Hippy Camp as Actually Ed the Undying wearing the Filthy Hippy Disguise (this is bad).");
+		} else {
+			auto_log_info("Took off the Filthy Hippy Disguise before adventuring in the Hippy Camp so we don't waste adventures on non-combats.");
+		}
+	}
 
 	// Last minute debug logging and a final MCD tweak just in case Maximizer did silly stuff
 	if(lowMLZones contains place)

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -132,8 +132,9 @@ boolean auto_pre_adventure()
 	}
 
 	// this calls the appropriate provider for +combat or -combat depending on the zone we are about to adventure in..
+	boolean burningDelay = (auto_voteMonster(true) || isOverdueDigitize() || auto_sausageGoblin());
 	generic_t combatModifier = zone_combatMod(place);
-	if (combatModifier._boolean) {
+	if (combatModifier._boolean && !burningDelay && !auto_haveQueuedForcedNonCombat()) {
 		acquireCombatMods(combatModifier._int, true);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -176,7 +176,10 @@ boolean autoMaximize(string req, boolean simulate)
 		tcrs_maximize_with_items(req);
 #		user_confirm("Beep");
 	}
-	return maximize(req, simulate);
+	backupSetting("logPreferenceChange", "false");
+	boolean didmax = maximize(req, simulate);
+	restoreSetting("logPreferenceChange");
+	return didmax;
 }
 
 boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
@@ -187,7 +190,10 @@ boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
 		tcrs_maximize_with_items(req);
 #		user_confirm("Beep");
 	}
-	return maximize(req, maxPrice, priceLevel, simulate);
+	backupSetting("logPreferenceChange", "false");
+	boolean didmax = maximize(req, maxPrice, priceLevel, simulate);
+	restoreSetting("logPreferenceChange");
+	return didmax;
 }
 
 aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate, boolean includeEquip)
@@ -198,7 +204,10 @@ aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulat
 #		user_confirm("Beep");
 		tcrs_maximize_with_items(req);
 	}
-	return maximize(req, maxPrice, priceLevel, simulate, includeEquip);
+	backupSetting("logPreferenceChange", "false");
+	aggregate maxrecord = maximize(req, maxPrice, priceLevel, simulate, includeEquip);
+	restoreSetting("logPreferenceChange");
+	return maxrecord;
 }
 
 void debugMaximize(string req, int meat)
@@ -7165,7 +7174,9 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//but I am labeling them seperate from buffs in case we ever need to split this function.
 	
 	//if you have something that reduces the cost of casting buffs, wear it now.
+	backupSetting("logPreferenceChange", "false");
 	maximize("-mana cost, -tie", false);
+	restoreSetting("logPreferenceChange");
 	
 	//Passive damage
 	if(passive_dmg_allowed)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2977,13 +2977,13 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		return result();
 	}
 
-	if (auto_birdModifier("Combat Rate") > 0) {
+	if ((-1.0 * auto_birdModifier("Combat Rate")) > 0) {
 		if (tryEffects($effects[Blessing of the Bird])) {
 			return result();
 		}
 	}
 
-	if (auto_favoriteBirdModifier("Combat Rate") > 0) {
+	if ((-1.0 * auto_favoriteBirdModifier("Combat Rate")) > 0) {
 		if (tryEffects($effects[Blessing of Your Favorite Bird])) {
 			return result();
 		}
@@ -5907,20 +5907,12 @@ location solveDelayZone()
 	int[location] delayableZones = zone_delayable();
 	int amt = count(delayableZones);
 	location burnZone = $location[none];
-	if(amt != 0)
-	{
-		int index = 0;
-		if(amt > 1)
-		{
-			index = random(amt);
-		}
-		foreach idx in delayableZones
-		{
-			if(index == 0)
-			{
-				burnZone = idx;
+	if (count(delayableZones) != 0) {
+		// find the delayable zone with the lowest delay left.
+		foreach loc, delay in delayableZones {
+			if (burnZone == $location[none] || delay < delayableZones[burnZone]) {
+				burnZone = loc;
 			}
-			index--;
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1296,3 +1296,4 @@ void fcleChoiceHandler(int choice);
 void itznotyerzitzMineChoiceHandler(int choice);
 void theeXtremeSlopeChoiceHandler(int choice);
 void dailyDungeonChoiceHandler(int choice, string[int] options);	//Defined in autoscend/quests/level_any.ash
+void edUnderworldChoiceHandler(int choice);

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -134,7 +134,9 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
+		backupSetting("logPreferenceChange", "false");
 		maximize("mp,-tie", false);
+		restoreSetting("logPreferenceChange");
 	}
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...
 	// but meh.

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -45,7 +45,6 @@ void ed_initializeSettings()
 
 		set_property("desertExploration", 100);
 		set_property("nsTowerDoorKeysUsed", "Boris's key,Jarlsberg's key,Sneaky Pete's key,Richard's star key,skeleton key,digital key");
-		set_property("auto_delayHauntedKitchen", true);
 	}
 }
 
@@ -54,7 +53,7 @@ void ed_initializeSession()
 	if (isActuallyEd())
 	{
 		// the following settings will affect combat automation
-		// see auto_choice_adv.ash for where and how they are used.
+		// see edUnderworldChoiceHandler() for where and how they are used.
 		backupSetting("choiceAdventure1023", "");
 		backupSetting("choiceAdventure1024", "");
 		backupSetting("edDefeatAbort", "3");
@@ -169,62 +168,6 @@ boolean L13_ed_towerHandler()
 		}
 		return true;
 	}
-	else
-	{
-		if(haveAnyIotmAlternativeRestSiteAvailable() && doFreeRest())
-		{
-			cli_execute("scripts/autoscend/auto_post_adv.ash");
-			return true;
-		}
-		auto_log_warning("Please check your quests, but you might just not be at level 13 yet in order to continue.", "red");
-		if((my_level() < 13) && elementalPlanes_access($element[spooky]))
-		{
-			boolean tryJungle = false;
-			if(have_effect($effect[Jungle Juiced]) > 0)
-			{
-				tryJungle = true;
-			}
-
-			if(((my_inebriety() + 1) < inebriety_limit()) && (item_amount($item[Coinspiracy]) > 0) && (have_effect($effect[Jungle Juiced]) == 0))
-			{
-				buyUpTo(1, $item[Jungle Juice]);
-				autoDrink(1, $item[Jungle Juice]);
-				tryJungle = true;
-			}
-
-			buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-			if(my_primestat() == $stat[Mysticality])
-			{
-				buffMaintain($effect[Perspicacious Pressure], 0, 1, 1);
-				buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
-				buffMaintain($effect[Erudite], 0, 1, 1);
-			}
-
-			if(tryJungle)
-			{
-				autoAdv(1, $location[The Deep Dark Jungle]);
-			}
-			else
-			{
-				if(item_amount($item[Personal Ventilation Unit]) > 0)
-				{
-					autoEquip($slot[acc2], $item[Personal Ventilation Unit]);
-				}
-				autoAdv(1, $location[The Secret Government Laboratory]);
-			}
-			return true;
-		}
-		else if((my_level() < 13) && elementalPlanes_access($element[stench]))
-		{
-			autoAdv(1, $location[Pirates of the Garbage Barges]);
-			return true;
-		}
-		else
-		{
-			auto_log_info("We must be missing a sidequest. We can't find the jerk adventurer. Must pretend we are alive...", "blue");
-		}
-	}
-
 	return false;
 }
 
@@ -241,7 +184,7 @@ boolean L13_ed_councilWarehouse()
 
 	if(item_amount($item[7965]) == 0)
 	{
-		autoAdv(1, $location[The Secret Council Warehouse]);
+		autoAdv($location[The Secret Council Warehouse]);
 	}
 	else
 	{
@@ -1140,7 +1083,7 @@ boolean L1_ed_island()
 	}
 
 	buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-	autoAdv(1, $location[The Secret Government Laboratory]);
+	autoAdv($location[The Secret Government Laboratory]);
 	if(item_amount($item[Bottle-Opener Keycard]) > 0)
 	{
 		use(1, $item[Bottle-Opener Keycard]);
@@ -1164,61 +1107,23 @@ boolean L1_ed_islandFallback()
 		}
 	}
 
-	if(!get_property("lovebugsUnlocked").to_boolean())
-	{
-		if(my_turncount() == 0)
-		{
-			while((my_mp() < mp_cost($skill[Storm of the Scarab])) && (my_mp() < my_maxmp()) && (my_meat() > 1500))
-			{
-				buyUpTo(1, $item[Doc Galaktik\'s Invigorating Tonic], 90);
-				use(1, $item[Doc Galaktik\'s Invigorating Tonic]);
-			}
-		}
-		else if(my_turncount() == 1)
-		{
-			if((is_unrestricted($item[Clan Pool Table])) && (get_property("_poolGames").to_int() < 3) && (item_amount($item[Clan VIP Lounge Key]) > 0))
-			{
-				visit_url("clan_viplounge.php?preaction=poolgame&stance=2");
-				visit_url("clan_viplounge.php?preaction=poolgame&stance=2");
-				visit_url("clan_viplounge.php?preaction=poolgame&stance=2");
-			}
-		}
-	}
-
 	if (neverendingPartyAvailable())
 	{
 		return neverendingPartyPowerlevel();
 	}
 	if(elementalPlanes_access($element[stench]))
 	{
-		autoAdv(1, $location[Pirates of the Garbage Barges]);
-		return true;
+		return autoAdv($location[Pirates of the Garbage Barges]);
 	}
 	if(elementalPlanes_access($element[cold]))
 	{
-		if(get_property("_VYKEALoungeRaided").to_boolean())
-		{
-			if(get_property("_VYKEACafeteriaRaided").to_boolean())
-			{
-				set_property("choiceAdventure1115", 6);
-			}
-			else
-			{
-				set_property("choiceAdventure1115", 1);
-			}
-		}
-		else
-		{
-			set_property("choiceAdventure1115", 9);
-		}
-		autoAdv(1, $location[VYKEA]);
-		return true;
+		return autoAdv($location[VYKEA]);
 	}
 	if(elementalPlanes_access($element[hot]))
 	{
 		//Maybe this is a good choice?
 		set_property("choiceAdventure1094", 5);
-		autoAdv(1, $location[The SMOOCH Army HQ]);
+		autoAdv($location[The SMOOCH Army HQ]);
 		set_property("choiceAdventure1094", 2);
 		return true;
 	}
@@ -1244,14 +1149,8 @@ boolean L1_ed_islandFallback()
 	
 	if (have_skill($skill[Upgraded Legs]) || item_amount($item[Ka coin]) >= 10)
 	{
-		if(have_outfit("Filthy Hippy Disguise") && is_wearing_outfit("Filthy Hippy Disguise"))
-		{
-			equip($slot[Pants], $item[None]);
-			put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
-			equipBaseline();
-		}
 		auto_change_mcd(11);
-		boolean retVal = autoAdv(1, $location[Hippy Camp]);
+		boolean retVal = autoAdv($location[Hippy Camp]);
 		if (item_amount($item[Filthy Corduroys]) > 0)
 		{
 			if (closet_amount($item[Filthy Corduroys]) > 0)
@@ -1290,12 +1189,9 @@ boolean L1_ed_islandFallback()
 		return retVal;
 	}
 	set_property("auto_needLegs", true);
-	if (!maximizeContains("-10ml"))
-	{
-		addToMaximize("-10ml");
-		auto_change_mcd(0);
-	}
-	return autoAdv(1, $location[The Outskirts of Cobb\'s Knob]);
+	addToMaximize("-10ml");
+	auto_change_mcd(0);
+	return autoAdv($location[The Outskirts of Cobb\'s Knob]);
 }
 
 boolean L9_ed_chasmStart()
@@ -1495,4 +1391,26 @@ boolean LM_edTheUndying()
 		return true;
 	}
 	return false;
+}
+
+void edUnderworldChoiceHandler(int choice) {
+	auto_log_debug(`edUnderworldChoiceHandler Running choice {choice}`, "blue");
+	if (choice == 1023) { // Like a Bat Into Hell
+		run_choice(1); // Enter the Underworld
+		auto_log_info("Ed died in combat " + get_property("_edDefeats").to_int() + " time(s)", "blue");
+		ed_shopping(); // "free" trip to the Underworld, may as well go shopping!
+		visit_url("place.php?whichplace=edunder&action=edunder_leave");
+	} else if (choice == 1024) { // Like a Bat out of Hell
+		if (get_property("_edDefeats").to_int() < get_property("edDefeatAbort").to_int()) {
+			// resurrecting is still free.
+			run_choice(1, false); // UNDYING!
+		} else {
+			// resurrecting will cost Ka
+			run_choice(2); // Accept the cold embrace of death (Return to the Pyramid)
+			auto_log_info("Ed died in combat for reals!");
+			set_property("auto_beatenUpCount", get_property("auto_beatenUpCount").to_int() + 1);
+		}
+	} else {
+		abort("unhandled choice in edUnderworldChoiceHandler");
+	}
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -241,23 +241,22 @@ boolean LX_unlockHauntedBilliardsRoom() {
 	}
 	
 	boolean delayKitchen = get_property("auto_delayHauntedKitchen").to_boolean();
-	if(isAboutToPowerlevel())
-	{
+	if (isAboutToPowerlevel()) {
 		// if we're at the point where we need to level up to get more quests other than this, we might as well just do this instead
 		delayKitchen = false;
 	}
-	if(delayKitchen)
-	{
+	if (delayKitchen) {
 		int [element] resGoals;
 		resGoals[$element[hot]] = 9;
 		resGoals[$element[stench]] = 9;
 		// check to see if we can acquire sufficient hot and stench res for the kitchen
 		int [element] resPossible = provideResistances(resGoals, true, true);
 		delayKitchen = (resPossible[$element[hot]] < 9 || resPossible[$element[stench]] < 9);
-		if (delayKitchen && isActuallyEd()) {
-			// If we already have all the elemental wards as ed we're probably not going to get any better, so might as well get it over with
-			delayKitchen = !have_skill($skill[Even More Elemental Wards]);
-		}
+	}
+
+	if (delayKitchen && isActuallyEd()) {
+		// If we already have all the elemental wards as ed we're probably not going to get any better, so might as well get it over with
+		delayKitchen = !have_skill($skill[Even More Elemental Wards]);
 	}
 
 	if (!delayKitchen) {

--- a/RELEASE/scripts/autoscend/quests/level_7.ash
+++ b/RELEASE/scripts/autoscend/quests/level_7.ash
@@ -24,7 +24,7 @@ boolean L7_crypt()
 	boolean edAlcove = true;
 	if (isActuallyEd())
 	{
-		edAlcove = (have_skill($skill[More Legs]) && (expected_damage($monster[modern zmobie]) + 1) < my_maxhp());
+		edAlcove = (have_skill($skill[More Legs]) && (expected_damage($monster[modern zmobie]) + 15) < my_maxhp());
 	}
 
 	if((get_property("romanticTarget") != $monster[modern zmobie]) && (get_property("auto_waitingArrowAlcove").to_int() < 50))

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -420,7 +420,7 @@ boolean LX_fatLootToken()
 		if(fantasyRealmToken()) return true;
 	}
 	if(LX_dailyDungeonToken()) return true;
-	if(get_property("dailyDungeonDone").to_boolean())
+	if(get_property("dailyDungeonDone").to_boolean() && my_daycount() > 1)
 	{
 		//wait until daily dungeon is done before considering doing fantasy realm
 		if(fantasyRealmToken()) return true;


### PR DESCRIPTION
# Description

- don't use Curse of Fortune on brigands unless we're sure we'll kill it that round (we lose the bonus meat drop if we resurrect)
- removed other pointless casts of Curse of Fortune, tidy up a few things and add some comments/log messages.
- re-add Ed eating fortune cookies for the first SR window as it's almost certain he'll be farming Ka. May revisit later.
- add ownership check to horsery so there's no property changing console spam for people who don't have it.
- don't force auto_delayHauntedKitchen as Ed as it then 'sticks' for users from that point on.
- clean up some Ed functions.
- add more of a buffer to check for whether we'll survive a hit from the modern zmobie as Ed since expected_damage() isn't reliable (TODO: replace with some BatBrain/zlib calls)
- move Ed's underworld handling out of auto_choice_adv into a handler function
- move VYKEA NC handling to auto_choice_adv and fix trying to use a non-existent choice (reported in Discord).
- stop the maximizer spamming us when logPreferenceChange is enabled

## How Has This Been Tested?

Been running these changes since before I stated working on #500 so there's been 3 full HC Ed runs thus far & they look good. There's still more work to do as my runs have all been just over the 4 day mark (last 2 needed 6 and 10 adventures respectively, first was 25 adventures faster than the last but still ran to day 4) but this will do for now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
