### PR TITLE
Bees Hate You fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -44,6 +44,7 @@ import <autoscend/paths/actually_ed_the_undying.ash>
 import <autoscend/paths/avatar_of_boris.ash>
 import <autoscend/paths/avatar_of_sneaky_pete.ash>
 import <autoscend/paths/avatar_of_west_of_loathing.ash>
+import <autoscend/paths/bees_hate_you.ash>
 import <autoscend/paths/casual.ash>
 import <autoscend/paths/community_service.ash>
 import <autoscend/paths/dark_gyffte.ash>
@@ -237,6 +238,7 @@ void initializeSettings()
 	koe_initializeSettings();
 	zelda_initializeSettings();
 	lowkey_initializeSettings();
+	bhy_initializeSettings();
 
 	set_property("auto_doneInitialize", my_ascensions());
 }
@@ -3214,6 +3216,8 @@ boolean doTasks()
 
 	//This just closets stuff so G-Lover does not mess with us.
 	if(LM_glover())						return true;
+	//This just closets stuff that bees don't like
+	if(LM_bhy())						return true;
 
 	tophatMaker();
 	xiblaxian_makeStuff();

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -783,6 +783,12 @@ string auto_combatHandler(int round, monster enemy, string text)
 			return useSkill($skill[CLEESH]);
 		}
 	}
+	
+	//Bees Hate You final boss
+	if(canUse($item[antique hand mirror]) && (enemy == $monster[Guy Made Of Bees]))
+	{
+		return useItem($item[antique hand mirror]);
+	}
 
 	//Heavy Rain boss debuff & Stunning
 	if($monsters[Big Wisnaqua, The Aquaman, The Rain King] contains enemy)

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1252,7 +1252,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(!inAftercore())
 	{
-		if(item_amount($item[short writ of habeas corpus]) > 0)
+		if(item_amount($item[short writ of habeas corpus]) > 0 && canUse($item[short writ of habeas corpus]))
 		{
 			if($monsters[Pygmy Orderlies, Pygmy Witch Lawyer, Pygmy Witch Nurse] contains enemy)
 			{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -251,6 +251,13 @@ void resetMaximize()
 			}
 		}
 	}
+	else if (item_amount($item[January's Garbage Tote]) > 0 && auto_my_path() == "Bees Hate You") {
+	// workaround mafia bug with the maximizer where it tries to equip tote items even though the tote is unusable
+	foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Tinsel Tights, Wad Of Used Tape, Makeshift Garbage Shirt] {
+		exclude(it);
+	}
+}
+
 	
 	set_property("auto_maximize_current", res);
 	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -104,13 +104,18 @@ boolean canChangeToFamiliar(familiar target)
 	{
 		return false;
 	}
+	// if this path doesn't allow this familiar, you can't change to it
+	if(!auto_is_valid(target))
+	{
+		return false;
+	}
 
 	// You are allowed to change to a familiar if it is also the goal of the current 100% run.
 	if(get_property("auto_100familiar").to_familiar() == target)
 	{
 		return true;
 	}
-	else if(!canChangeFamiliar())
+	if(!canChangeFamiliar())
 	{
 		// checks path limitations, as well as 100% runs for a diferent familiar than target
 		return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5133,10 +5133,6 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if(!is_unrestricted(source))
-	{
-		return false;
-	}
 	if((item_amount(source) < uses) && (my_path() != "Way of the Surprising Fist"))
 	{
 		if(historical_price(source) < 2000)
@@ -5344,6 +5340,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 			buff = $effect[Shield of the Pastalord];
 		}
 		break;
+	case $effect[Float Like a Butterfly, Smell Like a Bee]:
+		if(auto_my_path() == "Bees Hate You")
+		{
+			useItem = $item[honeypot];
+		}																						break;
 	case $effect[Florid Cheeks]:				useItem = $item[Henna Face Paint];				break;
 	case $effect[Football Eyes]:				useItem = $item[Black Facepaint];				break;
 	case $effect[Fortunate Resolve]:			useItem = $item[Resolution: Be Luckier];		break;
@@ -5948,35 +5949,6 @@ location solveDelayZone()
 	}
 
 	return burnZone;
-}
-
-boolean bees_hate_usable(string str)
-{
-	if(auto_my_path() != "Bees Hate You")
-	{
-		return true;
-	}
-
-	switch(str)
-	{
-	case "Cobb's Knob map":
-	case "ball polish":
-	case "black market map":
-	case "boring binder clip":
-	case "beehive":
-	case "electric boning knife":
-		return true;
-	}
-
-	if(contains_text(str, "b"))
-	{
-		return false;
-	}
-	if(contains_text(str, "B"))
-	{
-		return false;
-	}
-	return true;
 }
 
 boolean auto_is_valid(item it)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2073,7 +2073,7 @@ boolean cloverUsageFinish()
 	if(item_amount($item[Ten-Leaf Clover]) > 0)
 	{
 		auto_log_debug("Wandering adventure interrupted our clover adventure (" + my_location() + "), boo. Gonna have to do this again.");
-		if(auto_my_path() == "G-Lover")
+		if(auto_my_path() == "G-Lover" || auto_my_path() == "Bees Hate You")
 		{
 			put_closet(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2007,7 +2007,7 @@ int cloversAvailable()
 	retval += item_amount($item[Ten-Leaf Clover]);
 	retval += closet_amount($item[Ten-Leaf Clover]);
 
-	if(auto_my_path() == "G-Lover")
+	if(auto_my_path() == "G-Lover" || auto_my_path() == "Bees Hate You")
 	{
 		retval -= item_amount($item[Disassembled Clover]);
 	}
@@ -2038,7 +2038,7 @@ boolean cloverUsageInit()
 
 	if(item_amount($item[Disassembled Clover]) > 0)
 	{
-		if(auto_my_path() != "G-Lover")
+		if(auto_my_path() != "G-Lover" && auto_my_path() != "Bees Hate You")
 		{
 			use(1, $item[Disassembled Clover]);
 		}
@@ -4084,6 +4084,10 @@ boolean use_barrels()
 		return false;
 	}
 	if(inAftercore())
+	{
+		return false;
+	}
+	if(auto_my_path() == "Bees Hate You")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5959,7 +5959,6 @@ boolean bees_hate_usable(string str)
 
 	switch(str)
 	{
-	case "enchanted bean":
 	case "Cobb's Knob map":
 	case "ball polish":
 	case "black market map":

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1489,11 +1489,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		keep = 0;
 	}
 
-	if((item_amount($item[Louder Than Bomb]) > keep) && (!(used contains "louder than bomb")))
+	if((item_amount($item[Louder Than Bomb]) > keep) && (!(used contains "louder than bomb")) && auto_is_valid($item[Louder Than Bomb]))
 	{
 		return "item " + $item[Louder Than Bomb];
 	}
-	if((item_amount($item[Tennis Ball]) > keep) && (!(used contains "tennis ball")))
+	if((item_amount($item[Tennis Ball]) > keep) && (!(used contains "tennis ball")) && auto_is_valid($item[Tennis Ball]))
 	{
 		return "item " + $item[Tennis Ball];
 	}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1031,6 +1031,18 @@ generic_t zone_available(location loc)
 			retval._boolean = true;
 		}
 		break;
+	case $location[Wartime Frat House (Hippy Disguise)]:
+		if((internalQuestStatus("questL12War") == 0) && have_outfit("war hippy fatigues"))
+		{
+			retval._boolean = true;
+		}
+		break;
+	case $location[The Battlefield (Hippy Uniform)]:
+		if((internalQuestStatus("questL12War") >= 1) && (get_property("fratboysDefeated").to_int() < 1000) && have_outfit("war hippy fatigues") && (get_property("questL12War") != "finished"))
+		{
+			retval._boolean = true;
+		}
+		break;
 	case $location[Next to that Barrel with Something Burning in it]:
 	case $location[Near an Abandoned Refrigerator]:
 	case $location[Over Where the Old Tires Are]:

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1149,6 +1149,7 @@ string simpleCombatFilter(int round, string opp, string text);//Defined in autos
 void bhy_initializeSettings();								//Defined in autoscend/paths/bees_hate_you.ash
 boolean bees_hate_usable(string it);						//Defined in autoscend/paths/bees_hate_you.ash
 boolean LM_bhy();											//Defined in autoscend/paths/bees_hate_you.ash
+boolean L13_bhy_towerFinal();								//Defined in autoscend/paths/bees_hate_you.ash
 
 boolean LM_bond();											//Defined in autoscend/auto_bondmember.ash
 boolean bond_buySkills();									//Defined in autoscend/auto_bondmember.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1146,6 +1146,9 @@ boolean auto_toxicMascot();									//Defined in autoscend/auto_aftercore.ash
 boolean auto_trashNet();										//Defined in autoscend/auto_aftercore.ash
 string simpleCombatFilter(int round, string opp, string text);//Defined in autoscend/auto_aftercore.ash
 
+void bhy_initializeSettings();								//Defined in autoscend/paths/bees_hate_you.ash
+boolean bees_hate_usable(string it);						//Defined in autoscend/paths/bees_hate_you.ash
+boolean LM_bhy();											//Defined in autoscend/paths/bees_hate_you.ash
 
 boolean LM_bond();											//Defined in autoscend/auto_bondmember.ash
 boolean bond_buySkills();									//Defined in autoscend/auto_bondmember.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -25,6 +25,10 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
+	if(!bees_hate_usable(fam.to_string()))
+	{
+		return false;
+	}
 	familiar last = my_familiar();
 
 	int goal = 0;

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -25,7 +25,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
-	if(!bees_hate_usable(fam.to_string()))
+	if(!auto_is_valid(fam))
 	{
 		return false;
 	}
@@ -129,7 +129,10 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 	{
 		return false;
 	}
-
+	if(!auto_is_valid($item[Pantogram Pants])
+	{
+		return false;
+	}
 	int m = 0;
 	switch(st)
 	{
@@ -390,6 +393,10 @@ boolean kgbWasteClicks()
 		return false;
 	}
 	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
+	{
+		return false;
+	}
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase])
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -17,7 +17,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Mumming Trunk]))
+	if(!auto_is_valid($item[Mumming Trunk]))
 	{
 		return false;
 	}
@@ -117,7 +117,7 @@ boolean pantogramPants()
 
 boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int misc)
 {
-	if(!is_unrestricted($item[Portable Pantogram]))
+	if(!auto_is_valid($item[Portable Pantogram]))
 	{
 		return false;
 	}
@@ -126,10 +126,6 @@ boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int mis
 		return false;
 	}
 	if(possessEquipment($item[Pantogram Pants]))
-	{
-		return false;
-	}
-	if(!auto_is_valid($item[Pantogram Pants])
 	{
 		return false;
 	}
@@ -392,11 +388,7 @@ boolean kgbWasteClicks()
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
-	{
-		return false;
-	}
-	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase])
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase]))
 	{
 		return false;
 	}
@@ -623,7 +615,7 @@ boolean kgbSetup()
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase]))
 	{
 		return false;
 	}
@@ -768,7 +760,7 @@ boolean kgb_getMartini(string page, boolean dontCare)
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase]))
 	{
 		return false;
 	}
@@ -897,7 +889,7 @@ boolean kgbDial(int dial, int curVal, int target)
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase]))
 	{
 		return false;
 	}
@@ -939,7 +931,7 @@ boolean solveKGBMastermind()
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Kremlin\'s Greatest Briefcase]))
+	if(!auto_is_valid($item[Kremlin\'s Greatest Briefcase]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -322,6 +322,10 @@ boolean songboomSetting(int option)
 	{
 		return false;
 	}
+	if(auto_my_path() == "Bees Hate You")
+	{
+		return false;
+	}
 	if(get_property("_boomBoxSongsLeft").to_int() == 0)
 	{
 		if(option != 6)

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -561,15 +561,11 @@ boolean catBurglarHeist()
 
 boolean cheeseWarMachine(int stats, int it, int eff, int potion)
 {
-	if(!is_unrestricted($item[Bastille Battalion Control Rig]))
+	if(!auto_is_valid($item[Bastille Battalion Control Rig]))
 	{
 		return false;
 	}
 	if(item_amount($item[Bastille Battalion Control Rig]) == 0)
-	{
-		return false;
-	}
-	if(!auto_is_valid($item[Bastille Battalion Control Rig]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -201,7 +201,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 
 boolean fantasyRealmAvailable()
 {
-	if(!is_unrestricted($item[FantasyRealm membership packet]))
+	if(!auto_is_valid($item[FantasyRealm membership packet]))
 	{
 		return false;
 	}
@@ -214,7 +214,7 @@ boolean fantasyRealmAvailable()
 
 boolean fantasyRealmToken()
 {
-	if(!is_unrestricted($item[FantasyRealm membership packet]))
+	if(!auto_is_valid($item[FantasyRealm membership packet]))
 	{
 		return false;
 	}
@@ -314,15 +314,11 @@ boolean songboomSetting(string goal)
 
 boolean songboomSetting(int option)
 {
-	if(!is_unrestricted($item[SongBoom&trade; BoomBox]))
+	if(!auto_is_valid($item[SongBoom&trade; BoomBox]))
 	{
 		return false;
 	}
 	if(item_amount($item[SongBoom&trade; BoomBox]) == 0)
-	{
-		return false;
-	}
-	if(auto_my_path() == "Bees Hate You")
 	{
 		return false;
 	}
@@ -394,7 +390,7 @@ boolean songboomSetting(int option)
 
 void auto_setSongboom()
 {
-	if(!is_unrestricted($item[SongBoom&trade; BoomBox]))
+	if(!auto_is_valid($item[SongBoom&trade; BoomBox]))
 	{
 		return;
 	}
@@ -573,7 +569,7 @@ boolean cheeseWarMachine(int stats, int it, int eff, int potion)
 	{
 		return false;
 	}
-	if(!auto_is_valid($item[Bastille Battalion Control Rig])
+	if(!auto_is_valid($item[Bastille Battalion Control Rig]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -573,6 +573,10 @@ boolean cheeseWarMachine(int stats, int it, int eff, int potion)
 	{
 		return false;
 	}
+	if(!auto_is_valid($item[Bastille Battalion Control Rig])
+	{
+		return false;
+	}
 	if(get_property("_bastilleGames").to_int() != 0)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -201,7 +201,7 @@ boolean godLobsterCombat(item it, int goal, string option)
 
 boolean fantasyRealmAvailable()
 {
-	if(!auto_is_valid($item[FantasyRealm membership packet]))
+	if(!is_unrestricted($item[FantasyRealm membership packet]))
 	{
 		return false;
 	}
@@ -214,7 +214,7 @@ boolean fantasyRealmAvailable()
 
 boolean fantasyRealmToken()
 {
-	if(!auto_is_valid($item[FantasyRealm membership packet]))
+	if(!is_unrestricted($item[FantasyRealm membership packet]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -7,7 +7,7 @@ void bhy_initializeSettings()
 	{
 		set_property("auto_abooclover", false);
 		set_property("auto_wandOfNagamar", false);
-		set_property("auto_hippyInstead", false);
+		set_property("auto_hippyInstead", true);
 		set_property("auto_getBeehive", true);
 		set_property("auto_getBoningKnife", true);
 		set_property("auto_ignoreFlyer", true);

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -29,11 +29,12 @@ boolean bees_hate_usable(string str)
 	case "boring binder clip":
 	case "beehive":
 	case "electric boning knife":
-	case "Ninja carabiner":
+	case "ninja carabiner":
+	case "Orcish baseball cap":
 	case "reinforced beaded headband":
 	case "bullet-proof corduroys":
-	case "round purple sunglasses":
-
+	case "blackberry galoshes":
+	case "titanium assault umbrella":
 		return true;
 	}
 
@@ -54,9 +55,9 @@ boolean LM_bhy()
 	{
 		return false;
 	}
-	// maximizer tries to use garbage tote to make unwieldable items and then bombs when equipping them
+	// pension check keeps trying to be used
 	// we can't turn disassembled clovers back into ten-leaf ones
-	foreach it in $items[January's Garbage Tote,Ten-Leaf Clover]
+	foreach it in $items[black pension check,ten-leaf clover]
 	{
 		if(item_amount(it) > 0)
 		{

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -1,0 +1,68 @@
+script "bees_hate_you.ash"
+
+
+void bhy_initializeSettings()
+{
+	if(auto_my_path() == "Bees hate You")
+	{
+		set_property("auto_abooclover", false);
+		set_property("auto_wandOfNagamar", false);
+		set_property("auto_hippyInstead", false);
+		set_property("auto_getBeehive", true);
+		set_property("auto_getBoningKnife", true);
+		set_property("auto_ignoreFlyer", true);
+	}
+}
+
+boolean bees_hate_usable(string str)
+{
+	if(auto_my_path() != "Bees Hate You")
+	{
+		return true;
+	}
+
+	switch(str)
+	{
+	case "Cobb's Knob map":
+	case "ball polish":
+	case "black market map":
+	case "boring binder clip":
+	case "beehive":
+	case "electric boning knife":
+	case "Ninja carabiner":
+	case "reinforced beaded headband":
+	case "bullet-proof corduroys":
+	case "round purple sunglasses":
+
+		return true;
+	}
+
+	if(contains_text(str, "b"))
+	{
+		return false;
+	}
+	if(contains_text(str, "B"))
+	{
+		return false;
+	}
+	return true;
+}
+
+boolean LM_bhy()
+{
+	if(auto_my_path() != "Bees hate You")
+	{
+		return false;
+	}
+	// maximizer tries to use garbage tote to make unwieldable items and then bombs when equipping them
+	// we can't turn disassembled clovers back into ten-leaf ones
+	foreach it in $items[January's Garbage Tote,Ten-Leaf Clover]
+	{
+		if(item_amount(it) > 0)
+		{
+			put_closet(item_amount(it), it);
+		}
+	}
+
+	return false;
+}

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -67,3 +67,46 @@ boolean LM_bhy()
 
 	return false;
 }
+
+boolean L13_bhy_towerFinal()
+{
+	//Prepare for and defeat the final boss for a Bees hate You run. Which has special rules for engagement.
+	if (internalQuestStatus("questL13Final") != 11)
+	{
+		return false;
+	}
+	
+	if (item_amount($item[antique hand mirror]) < 1 )
+	{
+		abort("Need the [antique hand mirror] to defeat the guy made of bees. Please get one from the jewelry of the animated rustic nightstand and try again.");
+	}
+	
+	cli_execute("scripts/autoscend/auto_pre_adv.ash");
+	set_property("auto_disableAdventureHandling", true);
+	autoAdvBypass("place.php?whichplace=nstower&action=ns_10_sorcfight", $location[Noob Cave]);
+	
+	if(last_monster() != $monster[Guy Made Of Bees])
+	{
+		abort("Failed to start the battle with Guy Made Of Bees");
+	}
+	if(have_effect($effect[Beaten Up]) > 0)
+	{
+		abort("The Guy Made Of Bees beat me up! Please finish him off manually");
+	}
+	if(get_property("auto_stayInRun").to_boolean())
+	{
+		abort("User wanted to stay in run (auto_stayInRun), we are done.");
+	}
+	else
+	{
+		visit_url("place.php?whichplace=nstower&action=ns_11_prism");
+		if(inAftercore())
+		{
+			abort("All done. King Ralph has been freed");
+		}
+		abort("Tried to break prism but failed");
+	}
+	abort("How did I reach this line? I should have fought [Guy Made Of Bees]");
+	return false;
+	
+}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -15,14 +15,8 @@ boolean L10_plantThatBean()
 		set_property("questL10Garbage", "step1");
 		return true;
 	}
-	if(item_amount($item[Enchanted Bean]) > 0 && auto_is_valid($item[Enchanted Bean]))
+	if(item_amount($item[Enchanted Bean]) > 0)
 	{
-		use(1, $item[Enchanted Bean]);
-		return true;
-	} else if(item_amount($item[Enchanted Bean]) > 0)
-	{ 
-		//can't use the bean, but we can visit coffee grounds directly to plant it
-		auto_log_info("Planting magic bean without using it!", "blue");
 		visit_url("place.php?whichplace=plains&action=garbage_grounds");
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -15,9 +15,15 @@ boolean L10_plantThatBean()
 		set_property("questL10Garbage", "step1");
 		return true;
 	}
-	if(item_amount($item[Enchanted Bean]) > 0)
+	if(item_amount($item[Enchanted Bean]) > 0 && auto_is_valid($item[Enchanted Bean]))
 	{
 		use(1, $item[Enchanted Bean]);
+		return true;
+	} else if(item_amount($item[Enchanted Bean]) > 0)
+	{ 
+		//can't use the bean, but we can visit coffee grounds directly to plant it
+		auto_log_info("Planting magic bean without using it!", "blue");
+		visit_url("place.php?whichplace=plains&action=garbage_grounds");
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1504,7 +1504,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || in_boris() || (auto_my_path() == "Way of the Surprising Fist") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || in_boris() || (auto_my_path() == "Way of the Surprising Fist") || (auto_my_path() == "Bees Hate You") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -925,7 +925,7 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
-	if (in_koe() || auto_my_path() == "Pocket Familiars")
+	if (in_koe() || auto_my_path() == "Pocket Familiars" || auto_my_path() == "Bees Hate You")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -121,7 +121,7 @@ int auto_warKillsPerBattle(int sidequests)
 
 int auto_estimatedAdventuresForChaosButterfly()
 {
-	// Returns an ESTIMATE of how manny adventures it will take to acquire a chaos butterfly.
+	// Returns an ESTIMATE of how many adventures it will take to acquire a chaos butterfly.
 	
 	if(get_property("chaosButterflyThrown").to_boolean() || item_amount($item[chaos butterfly]) > 0)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1100,6 +1100,11 @@ boolean L13_towerNSFinal()
 		return L13_towerFinalHeavyRains();
 	}
 	
+	if(auto_my_path() == "Bees Hate You")
+	{
+		return L13_bhy_towerFinal();
+	}
+	
 	if(auto_my_path() == "The Source")
 	{
 		acquireMP(200, 0);

--- a/RELEASE/scripts/autoscend/quests/level_4.ash
+++ b/RELEASE/scripts/autoscend/quests/level_4.ash
@@ -18,7 +18,8 @@ boolean L4_batCave()
 	int batStatus = internalQuestStatus("questL04Bat");
 	if(batStatus < 3)
 	{
-		if(item_amount($item[Sonar-In-A-Biscuit]) > 0)
+		boolean can_use_baiscuit = auto_is_valid($item[Sonar-In-A-Biscuit]);
+		if(can_use_baiscuit && item_amount($item[Sonar-In-A-Biscuit]) > 0)
 		{
 			if(use(1, $item[Sonar-In-A-Biscuit]))
 			{
@@ -31,7 +32,7 @@ boolean L4_batCave()
 				cli_execute("refresh inv");
 			}
 		}
-		else if(can_interact())
+		else if(can_use_baiscuit && can_interact())
 		{
 			//if in post ronin or in casual, buy and use [Sonar-In-A-Biscuit] if cheaper than 500 meat.
 			if(buyUpTo(1, $item[Sonar-In-A-Biscuit], 500))

--- a/RELEASE/scripts/autoscend/quests/level_4.ash
+++ b/RELEASE/scripts/autoscend/quests/level_4.ash
@@ -18,8 +18,8 @@ boolean L4_batCave()
 	int batStatus = internalQuestStatus("questL04Bat");
 	if(batStatus < 3)
 	{
-		boolean can_use_baiscuit = auto_is_valid($item[Sonar-In-A-Biscuit]);
-		if(can_use_baiscuit && item_amount($item[Sonar-In-A-Biscuit]) > 0)
+		boolean can_use_biscuit = auto_is_valid($item[Sonar-In-A-Biscuit]);
+		if(can_use_biscuit && item_amount($item[Sonar-In-A-Biscuit]) > 0)
 		{
 			if(use(1, $item[Sonar-In-A-Biscuit]))
 			{
@@ -32,7 +32,7 @@ boolean L4_batCave()
 				cli_execute("refresh inv");
 			}
 		}
-		else if(can_use_baiscuit && can_interact())
+		else if(can_use_biscuit && can_interact())
 		{
 			//if in post ronin or in casual, buy and use [Sonar-In-A-Biscuit] if cheaper than 500 meat.
 			if(buyUpTo(1, $item[Sonar-In-A-Biscuit], 500))

--- a/RELEASE/scripts/autoscend/quests/level_4.ash
+++ b/RELEASE/scripts/autoscend/quests/level_4.ash
@@ -112,7 +112,7 @@ boolean L4_batCave()
 		return false;
 	}
 
-	if (cloversAvailable() > 0 && batStatus <= 1)
+	if (cloversAvailable() > 0 && batStatus <= 1 && auto_my_path() != "Bees Hate You")
 	{
 		cloverUsageInit();
 		autoAdvBypass(31, $location[Guano Junction]);

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -334,6 +334,11 @@ boolean L9_aBooPeak()
 				booCloversOk = true;
 			}
 		}
+		else if(auto_my_path() == "Bees Hate You")
+		{
+			// bees hate clues, don't waste clovers on them
+			booCloversOk = false;
+		}
 		else
 		{
 			booCloversOk = true;
@@ -627,6 +632,15 @@ boolean L9_twinPeak()
 	}
 	
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);		//heavy rains specific reduce item drop penalty by 10%
+	//BHY specific prevent wandering bees from skipping the burning the hotel down choice and wasting turns
+	buffMaintain($effect[Float Like a Butterfly, Smell Like a Bee], 0, 1, 1);
+	
+	if(auto_my_path() == "Bees Hate You")
+	{
+		// we can't make an oil jar to solve the quest, just adventure until the hotel is burned down
+		set_property("choiceAdventure606", "6"); // and flee the music NC
+		return autoAdv($location[Twin Peak]);
+	}
 
 	int progress = get_property("twinPeakProgress").to_int();
 	boolean needStench = ((progress & 1) == 0);
@@ -755,6 +769,10 @@ boolean L9_oilPeak()
 
 	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
 	{
+		if (!auto_is_valid($item[Bubblin\' Crude]))
+		{
+			return false;
+		}
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean needJar = ((oilProgress & 4) == 0);
 


### PR DESCRIPTION
# Description

Don't try to use forbidden items and familiars in paths like BHY. 
Use auto_is_valid() instead of is_unrestricted() in several older iotms because auto_is_valid already checks for bees (and other special path) restrictions
Don't try to complete impossible quest sections and don't skip any mandatory quests in BHY.
Make sure to have an antique hand mirror instead of a wand for the final battle. (obtaining the antique hand mirror is left as an exercise for the user).

Fixes #91

## How Has This Been Tested?
Completed a bees hate you softcore run as sauceror with most skills permed and IOTMs since 2015. These changes fix aborts, infinite loops, and quests that never start in bees hate you that were trivial to reproduce. I have no idea how optimal these are, just trying to get the path to be better supported. Session log attached.
[sytras_20200724.txt](https://github.com/Loathing-Associates-Scripting-Society/autoscend/files/4974709/sytras_20200724.txt)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
