### PR TITLE
BHY Antique Hand Mirror changes

### DIFF
--- a/BUILD/monsters/banish.dat
+++ b/BUILD/monsters/banish.dat
@@ -1,7 +1,7 @@
 A.M.C. Gremlin
 Animated Mahogany Nightstand
 Animated Possessions
-Animated Rustic Nightstand
+Animated Rustic Nightstand	!path:Bees Hate You
 Bubblemint Twins	!class:Ed
 Bullet Bill
 Burly Sidekick	item:Mohawk Wig>0

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -5,7 +5,7 @@
 banish	0	A.M.C. Gremlin
 banish	1	Animated Mahogany Nightstand
 banish	2	Animated Possessions
-banish	3	Animated Rustic Nightstand
+banish	3	Animated Rustic Nightstand	!path:Bees Hate You
 banish	4	Bubblemint Twins	!class:Ed
 banish	5	Bullet Bill
 banish	6	Burly Sidekick	item:Mohawk Wig>0

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -290,7 +290,11 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
-			run_choice(1); // get moxie substats
+			if (auto_my_path() == "Bees Hate You" && item_amount($item[Antique Hand Mirror]) < 1) {
+				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror
+			} else {
+				run_choice(1); // get moxie substats
+			}
 			break;
 		case 880: // One Elegant Nightstand (The Haunted Bedroom)
 			if (internalQuestStatus("questM21Dance") < 2 && item_amount($item[Lady Spookyraven\'s Finest Gown]) == 0) {


### PR DESCRIPTION
# Description

- Fight the Remains of a Jilted Mistress for the Antique Hand Mirror (needed for NS replacement)
- Don't banish the Animated Rustic Nightstand in BHY so we can do the above.

## How Has This Been Tested?

Untested personally but @mattgiltaji say's he'll be starting a new BHY run & can test it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
