### PR TITLE
More BHY Fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2905,6 +2905,15 @@ boolean adventureFailureHandler()
 				tooManyAdventures = false;
 			}
 		}
+		
+		if(tooManyAdventures && in_bhy())
+		{
+			if($locations[A-Boo Peak, Twin Peak] contains my_location())
+			{
+				//bees prevent doing these quickly
+				tooManyAdventures = false;
+			}
+		}
 
 		if ($locations[The Haunted Gallery] contains my_location() && my_location().turns_spent < 100)
 		{

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -290,7 +290,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
-			if (auto_my_path() == "Bees Hate You" && item_amount($item[Antique Hand Mirror]) < 1) {
+			if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
 				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror
 			} else {
 				run_choice(1); // get moxie substats

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -274,7 +274,7 @@ void resetMaximize()
 			}
 		}
 	}
-	else if (item_amount($item[January's Garbage Tote]) > 0 && auto_my_path() == "Bees Hate You") {
+	else if (item_amount($item[January's Garbage Tote]) > 0 && in_bhy()) {
 	// workaround mafia bug with the maximizer where it tries to equip tote items even though the tote is unusable
 	foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Tinsel Tights, Wad Of Used Tape, Makeshift Garbage Shirt] {
 		exclude(it);

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -259,7 +259,7 @@ boolean autoChooseFamiliar(location place)
 	// Blackbird/Crow cut turns in the Black Forest but we only need to equip them
 	// if we don't have them in inventory.
 	if ($location[The Black Forest] == place) {
-		if (auto_my_path() != "Bees Hate You") {
+		if (!in_bhy()) {
 			if (item_amount($item[Reassembled Blackbird]) == 0 && canChangeToFamiliar($familiar[Reassembled Blackbird])) {
 				famChoice = $familiar[Reassembled Blackbird];
 			}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2015,7 +2015,7 @@ int cloversAvailable()
 	retval += item_amount($item[Ten-Leaf Clover]);
 	retval += closet_amount($item[Ten-Leaf Clover]);
 
-	if(auto_my_path() == "G-Lover" || auto_my_path() == "Bees Hate You")
+	if(auto_my_path() == "G-Lover" || in_bhy())
 	{
 		retval -= item_amount($item[Disassembled Clover]);
 	}
@@ -2046,7 +2046,7 @@ boolean cloverUsageInit()
 
 	if(item_amount($item[Disassembled Clover]) > 0)
 	{
-		if(auto_my_path() != "G-Lover" && auto_my_path() != "Bees Hate You")
+		if(auto_my_path() != "G-Lover" && !in_bhy())
 		{
 			use(1, $item[Disassembled Clover]);
 		}
@@ -2081,7 +2081,7 @@ boolean cloverUsageFinish()
 	if(item_amount($item[Ten-Leaf Clover]) > 0)
 	{
 		auto_log_debug("Wandering adventure interrupted our clover adventure (" + my_location() + "), boo. Gonna have to do this again.");
-		if(auto_my_path() == "G-Lover" || auto_my_path() == "Bees Hate You")
+		if(auto_my_path() == "G-Lover" || in_bhy())
 		{
 			put_closet(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
 		}
@@ -4095,7 +4095,7 @@ boolean use_barrels()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Bees Hate You")
+	if(in_bhy())
 	{
 		return false;
 	}
@@ -5353,7 +5353,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}
 		break;
 	case $effect[Float Like a Butterfly, Smell Like a Bee]:
-		if(auto_my_path() == "Bees Hate You")
+		if(in_bhy())
 		{
 			useItem = $item[honeypot];
 		}																						break;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1158,6 +1158,7 @@ boolean auto_toxicMascot();									//Defined in autoscend/auto_aftercore.ash
 boolean auto_trashNet();										//Defined in autoscend/auto_aftercore.ash
 string simpleCombatFilter(int round, string opp, string text);//Defined in autoscend/auto_aftercore.ash
 
+boolean in_bhy();											//Defined in autoscend/paths/bees_hate_you.ash
 void bhy_initializeSettings();								//Defined in autoscend/paths/bees_hate_you.ash
 boolean bees_hate_usable(string it);						//Defined in autoscend/paths/bees_hate_you.ash
 boolean LM_bhy();											//Defined in autoscend/paths/bees_hate_you.ash

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -1,9 +1,14 @@
 script "bees_hate_you.ash"
 
+boolean in_bhy()
+{
+	return (auto_my_path() == "Bees Hate You");
+}
+
 
 void bhy_initializeSettings()
 {
-	if(auto_my_path() == "Bees Hate You")
+	if(in_bhy())
 	{
 		set_property("auto_abooclover", false);
 		set_property("auto_wandOfNagamar", false);
@@ -16,7 +21,7 @@ void bhy_initializeSettings()
 
 boolean bees_hate_usable(string str)
 {
-	if(auto_my_path() != "Bees Hate You")
+	if(in_bhy())
 	{
 		return true;
 	}
@@ -53,7 +58,7 @@ boolean bees_hate_usable(string str)
 
 boolean LM_bhy()
 {
-	if(auto_my_path() != "Bees hate You")
+	if(in_bhy())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -21,7 +21,7 @@ void bhy_initializeSettings()
 
 boolean bees_hate_usable(string str)
 {
-	if(in_bhy())
+	if(!in_bhy())
 	{
 		return true;
 	}
@@ -58,7 +58,7 @@ boolean bees_hate_usable(string str)
 
 boolean LM_bhy()
 {
-	if(in_bhy())
+	if(!in_bhy())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -3,7 +3,7 @@ script "bees_hate_you.ash"
 
 void bhy_initializeSettings()
 {
-	if(auto_my_path() == "Bees hate You")
+	if(auto_my_path() == "Bees Hate You")
 	{
 		set_property("auto_abooclover", false);
 		set_property("auto_wandOfNagamar", false);
@@ -35,6 +35,8 @@ boolean bees_hate_usable(string str)
 	case "bullet-proof corduroys":
 	case "blackberry galoshes":
 	case "titanium assault umbrella":
+	case "Knob Goblin harem pants":
+	case "Knob Goblin harem veil":
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1512,7 +1512,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || in_boris() || (auto_my_path() == "Way of the Surprising Fist") || (auto_my_path() == "Bees Hate You") || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || in_boris() || (auto_my_path() == "Way of the Surprising Fist") || in_bhy() || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -171,7 +171,7 @@ int auto_estimatedAdventuresForDooks()
 	advCost -= $location[McMillicancuddy's Other Back 40].turns_spent;
 	
 	//these paths cannot use butterfly
-	if(auto_my_path() == "Bees Hate You" || auto_my_path() == "Pocket Familiars")
+	if(in_bhy() || auto_my_path() == "Pocket Familiars")
 	{
 		return advCost;
 	}
@@ -257,7 +257,7 @@ WarPlan auto_bestWarPlan()
 	boolean considerNuns = true;
 	boolean considerFarm = true;
 	
-	if(auto_my_path() == "Bees Hate You" || auto_my_path() == "Pocket Familiars")
+	if(in_bhy() || auto_my_path() == "Pocket Familiars")
 	{
 		considerArena = false;
 		considerJunkyard = false;
@@ -924,7 +924,7 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
-	if (in_koe() || auto_my_path() == "Pocket Familiars" || auto_my_path() == "Bees Hate You")
+	if (in_koe() || auto_my_path() == "Pocket Familiars" || in_bhy())
 	{
 		return false;
 	}
@@ -1707,7 +1707,7 @@ boolean L12_themtharHills()
 
 boolean LX_obtainChaosButterfly()
 {
-	if(auto_my_path() == "Bees Hate You" || auto_my_path() == "Pocket Familiars")
+	if(in_bhy() || auto_my_path() == "Pocket Familiars")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1100,7 +1100,7 @@ boolean L13_towerNSFinal()
 		return L13_towerFinalHeavyRains();
 	}
 	
-	if(auto_my_path() == "Bees Hate You")
+	if(in_bhy())
 	{
 		return L13_bhy_towerFinal();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_4.ash
+++ b/RELEASE/scripts/autoscend/quests/level_4.ash
@@ -112,7 +112,7 @@ boolean L4_batCave()
 		return false;
 	}
 
-	if (cloversAvailable() > 0 && batStatus <= 1 && auto_my_path() != "Bees Hate You")
+	if (cloversAvailable() > 0 && batStatus <= 1 && !in_bhy())
 	{
 		cloverUsageInit();
 		autoAdvBypass(31, $location[Guano Junction]);

--- a/RELEASE/scripts/autoscend/quests/level_7.ash
+++ b/RELEASE/scripts/autoscend/quests/level_7.ash
@@ -85,19 +85,8 @@ boolean L7_crypt()
 
 		bat_formBats();
 
-		januaryToteAcquire($item[broken champagne bottle]);
-		if(get_property("cyrptNookEvilness").to_int() > 26)
-		{
-			removeFromMaximize("-equip " + $item[broken champagne bottle]);
-		}
-		else if((numeric_modifier("item drop") < 400) && (item_amount($item[Broken Champagne Bottle]) > 0) && (get_property("cyrptNookEvilness").to_int() > 26))
-		{
-			autoEquip($item[broken champagne bottle]);
-		}
-
-		if(get_property("cyrptNookEvilness").to_int() >= 28)
-		{
-			useNightmareFuelIfPossible();
+		if (get_property("cyrptNookEvilness").to_int() > 26) {
+			januaryToteAcquire($item[broken champagne bottle]);
 		}
 
 		autoAdv(1, $location[The Defiled Nook]);

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -315,10 +315,9 @@ boolean L9_aBooPeak()
 	{
 		auto_log_info("A-Boo Peak (initial): " + get_property("booPeakProgress"), "blue");
 
-		if (clueAmt < 3 && item_amount($item[January\'s Garbage Tote]) > 0 && auto_is_valid($item[Broken Champagne Bottle]))
+		if (clueAmt < 3)
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
-			removeFromMaximize("-equip " + $item[Broken Champagne Bottle]);
 		}
 
 		return autoAdv(1, $location[A-Boo Peak]);
@@ -585,10 +584,9 @@ boolean L9_aBooPeak()
 	}
 	else
 	{
-		if ($location[A-Boo Peak].turns_spent < 10 && item_amount($item[January\'s Garbage Tote]) > 0 && auto_is_valid($item[Broken Champagne Bottle]))
+		if ($location[A-Boo Peak].turns_spent < 10)
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
-			removeFromMaximize("-equip " + $item[Broken Champagne Bottle]);
 		}
 
 		autoAdv(1, $location[A-Boo Peak]);

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -585,7 +585,7 @@ boolean L9_aBooPeak()
 	}
 	else
 	{
-		if ($location[A-Boo Peak].turns_spent < 10 && item_amount($item[January\'s Garbage Tote]) > 0)
+		if ($location[A-Boo Peak].turns_spent < 10 && item_amount($item[January\'s Garbage Tote]) > 0 && auto_is_valid($item[Broken Champagne Bottle]))
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
 			removeFromMaximize("-equip " + $item[Broken Champagne Bottle]);

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -334,7 +334,7 @@ boolean L9_aBooPeak()
 				booCloversOk = true;
 			}
 		}
-		else if(auto_my_path() == "Bees Hate You")
+		else if(in_bhy())
 		{
 			// bees hate clues, don't waste clovers on them
 			booCloversOk = false;
@@ -635,7 +635,7 @@ boolean L9_twinPeak()
 	//BHY specific prevent wandering bees from skipping the burning the hotel down choice and wasting turns
 	buffMaintain($effect[Float Like a Butterfly, Smell Like a Bee], 0, 1, 1);
 	
-	if(auto_my_path() == "Bees Hate You")
+	if(in_bhy())
 	{
 		// we can't make an oil jar to solve the quest, just adventure until the hotel is burned down
 		set_property("choiceAdventure606", "6"); // and flee the music NC

--- a/RELEASE/scripts/autoscend/quests/level_9.ash
+++ b/RELEASE/scripts/autoscend/quests/level_9.ash
@@ -315,7 +315,7 @@ boolean L9_aBooPeak()
 	{
 		auto_log_info("A-Boo Peak (initial): " + get_property("booPeakProgress"), "blue");
 
-		if (clueAmt < 3 && item_amount($item[January\'s Garbage Tote]) > 0)
+		if (clueAmt < 3 && item_amount($item[January\'s Garbage Tote]) > 0 && auto_is_valid($item[Broken Champagne Bottle]))
 		{
 			januaryToteAcquire($item[Broken Champagne Bottle]);
 			removeFromMaximize("-equip " + $item[Broken Champagne Bottle]);


### PR DESCRIPTION
# Description

Second pass of BHY fixes as I test the first set. So far:
Fixed knob goblin outfit to not cause an abort
Fixed preference override to actually override

Fixes #91

## How Has This Been Tested?

HC run of BHY as sauceror with most skills permed and many IOTMs
[sytras_20200728.txt](https://github.com/Loathing-Associates-Scripting-Society/autoscend/files/4986762/sytras_20200728.txt)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
