### PR TITLE
Some misc bug fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -162,6 +162,7 @@ familiar lookupFamiliarDatafile(string type)
 	}
 	
 	//no suitable familiars found in datafile
+	auto_log_debug(`Could not find any "{type}" type familiars!`);
 	return $familiar[none];
 }
 
@@ -393,13 +394,15 @@ boolean autoChooseFamiliar(location place)
 			int spleen_drops_need = (spleen_left() + 3)/4;
 			int bound = (spleen_drops_need + spleenFamiliarsAvailable - 1) / spleenFamiliarsAvailable;
 			
-			if(spleenFamiliarsAvailable > 0) foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
+			if(spleenFamiliarsAvailable > 0)
 			{
-
-				if((fam.drops_today < bound) && canChangeToFamiliar(fam))
+				foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
 				{
-					famChoice = fam;
-					break;
+					if((fam.drops_today < bound) && canChangeToFamiliar(fam))
+					{
+						famChoice = fam;
+						break;
+					}
 				}
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -145,17 +145,17 @@ boolean auto_pre_adventure()
 
 	foreach i,mon in get_monsters(place)
 	{
-		if(auto_wantToYellowRay(mon, place))
+		if(auto_wantToYellowRay(mon, place) && !burningDelay)
 		{
 			adjustForYellowRayIfPossible(mon);
 		}
 
-		if(auto_wantToBanish(mon, place))
+		if(auto_wantToBanish(mon, place) && !burningDelay)
 		{
 			adjustForBanishIfPossible(mon, place);
 		}
 
-		if(auto_wantToReplace(mon, place))
+		if(auto_wantToReplace(mon, place) && !burningDelay)
 		{
 			adjustForReplaceIfPossible(mon);
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -614,14 +614,22 @@ generic_t zone_delay(location loc)
 		}
 		break;
 	case $location[The Hidden Apartment Building]:
-		value = 8 - loc.turns_spent;
-		retval._item = $item[Clara\'s Bell];
-		//Special case this
+		if (internalQuestStatus("questL11Curses") < 2) {
+			if (loc.turns_spent == 0) {
+				value = 8;
+			} else {
+				value = loc.turns_spent % 8;
+			}
+		}
 		break;
 	case $location[The Hidden Office Building]:
-		value = 10 - loc.turns_spent;
-		retval._item = $item[Clara\'s Bell];
-		//Special case?
+		if (internalQuestStatus("questL11Business") < 2) {
+			if (loc.turns_spent == 0) {
+				value = 5;
+			} else {
+				value = loc.turns_spent % 5;
+			}
+		}
 		break;
 	case $location[The Spooky Forest]:
 		value = 5 - loc.turns_spent;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -115,6 +115,7 @@ boolean shenShouldDelayZone(location loc);								//Defined in autoscend/auto_qu
 boolean LX_unlockHiddenTemple();
 boolean LX_unlockManorSecondFloor();
 boolean LX_unlockHauntedLibrary();
+boolean LX_unlockHauntedBilliardsRoom(boolean forceDelay);
 boolean LX_unlockHauntedBilliardsRoom();
 boolean LX_spookyravenManorFirstFloor();
 boolean LX_danceWithLadySpookyraven();

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1623,7 +1623,7 @@ boolean horsePreAdventure()
 	string desiredHorse = get_property("auto_desiredHorse");
 	if (desiredHorse == "")
 	{
-		desiredHorse = "dark";
+		return false;
 	}
 
 	if (desiredHorse != "normal"

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -368,10 +368,7 @@ boolean LX_lowkeySummer() {
 
 	// If we have the resources to do the Haunted Kitchen in the minimum adventures, we should do it sooner 
 	if (internalQuestStatus("questM20Necklace") == 0) {
-		backupSetting("auto_delayHauntedKitchen", true);
-		boolean advSpent = LX_unlockHauntedBilliardsRoom();
-		restoreSetting("auto_delayHauntedKitchen");
-		if (advSpent) { return true; }
+		return LX_unlockHauntedBilliardsRoom(true);
 	}
 
 	if (internalQuestStatus("questL12War") > -1) {

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -124,9 +124,9 @@ location lowkey_nextAvailableKeyDelayLocation()
 	foreach key in lowKeys
 	{
 		location loc = lowKeys[key];
-		if (lowkey_needKey(key) && zone_isAvailable(loc) && lowkey_keyDelayRemaining(loc) > 0)
+		if (lowkey_needKey(key) && zone_isAvailable(loc) && lowkey_keyDelayRemaining(loc) > 0 && loc.wanderers)
 		{
-			return lowKeys[key];
+			return loc;
 		}
 	}
 
@@ -280,12 +280,6 @@ boolean LX_findHelpfulLowKey()
 		if (lowkey_keyAdv($item[Music Box Key])) { return true; }
 	}
 
-	// Attributes. This is a nowander zone so burning delay here is unlikely.
-	//if (lowkey_keyAdv($item[Rabbit\'s foot key])) { return true; }
-
-	// food drops?
-	//if (lowkey_keyAdv($item[Anchovy can key])) { return true; }
-
 	return false;
 }
 
@@ -370,6 +364,14 @@ boolean LX_lowkeySummer() {
 	} else {
 		// Make sure Cobb's Knob is open so we can get the key.
 		if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
+	}
+
+	// If we have the resources to do the Haunted Kitchen in the minimum adventures, we should do it sooner 
+	if (internalQuestStatus("questM20Necklace") == 0) {
+		backupSetting("auto_delayHauntedKitchen", true);
+		boolean advSpent = LX_unlockHauntedBilliardsRoom();
+		restoreSetting("auto_delayHauntedKitchen");
+		if (advSpent) { return true; }
 	}
 
 	if (internalQuestStatus("questL12War") > -1) {
@@ -461,7 +463,12 @@ boolean LX_lowkeySummer() {
 	}
 
 	// Open up the top of the beanstalk.
-	if (L10_plantThatBean()) { return true; }
+	if (L10_plantThatBean()) {
+		return true;
+	} else if (internalQuestStatus("questL10Garbage") > -1) {
+		// make sure we can get an enchanted bean to open the beanstalk with if we can't open it.
+		if (L4_batCave()) { return true; }
+	}
 
 	// Should have the -combat key long before level 10 but lets just make sure.
 	if (possessEquipment($item[Key sausage])) {
@@ -492,10 +499,12 @@ boolean LX_lowkeySummer() {
 	if (possessEquipment($item[aqu&iacute;]) && possessEquipment($item[batting cage key])) {
 		if (LX_unlockHauntedBilliardsRoom()) { return true; }
 	} else {
-		// hot res for the Haunted Kitchen. aquí needs Desert Beach Access
-		if (lowkey_keyAdv($item[aqu&iacute;])) { return true; }
-		// stench res for the Haunted Kitchen
-		if (lowkey_keyAdv($item[batting cage key])) { return true; }
+		if (internalQuestStatus("questM20Necklace") == 0) {
+			// hot res for the Haunted Kitchen. aquí needs Desert Beach Access
+			if (lowkey_keyAdv($item[aqu&iacute;])) { return true; }
+			// stench res for the Haunted Kitchen
+			if (lowkey_keyAdv($item[batting cage key])) { return true; }
+		}
 	}
 
 	// Spookyraven quest steps that don't need -combat or resists, just monster killin' (or dancing with a ghost for stats).
@@ -515,6 +524,7 @@ boolean LX_lowkeySummer() {
 	if (L13_sorceressDoor() || L13_towerNSTower() || L13_towerNSNagamar() || L13_towerNSFinal()) { return true; }
 
 	// Release the softblock on quests that are waiting for Shen quest.
+	// If anyone ever gets this far in this path I will be both surprised and weirdly impressed.
 	if (my_level() > get_property("auto_shenSkipLastLevel").to_int() && get_property("questL11Shen") != "finished") {
 		auto_log_warning("I was trying to avoid zones that Shen might need, but I've run out of stuff to do.", "red");
 		set_property("auto_shenSkipLastLevel", my_level());

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -227,7 +227,9 @@ boolean LX_unlockHiddenTemple() {
 	return false;
 }
 
-boolean LX_unlockHauntedBilliardsRoom() {
+boolean LX_unlockHauntedBilliardsRoom(boolean forceDelay) {
+	// forceDelay will force the check for 9 hot res & 9 stench res to be used regardless of what
+	// auto_delayHauntedKitchen is set to.
 	if (internalQuestStatus("questM20Necklace") != 0) {
 		return false;
 	}
@@ -240,7 +242,7 @@ boolean LX_unlockHauntedBilliardsRoom() {
 		return false;
 	}
 	
-	boolean delayKitchen = get_property("auto_delayHauntedKitchen").to_boolean();
+	boolean delayKitchen = get_property("auto_delayHauntedKitchen").to_boolean() || forceDelay;
 	if (isAboutToPowerlevel()) {
 		// if we're at the point where we need to level up to get more quests other than this, we might as well just do this instead
 		delayKitchen = false;
@@ -270,6 +272,10 @@ boolean LX_unlockHauntedBilliardsRoom() {
 		}
 	}
 	return false;
+}
+
+boolean LX_unlockHauntedBilliardsRoom() {
+	return LX_unlockHauntedBilliardsRoom(false);
 }
 
 boolean LX_unlockHauntedLibrary()
@@ -1830,6 +1836,11 @@ boolean L11_shenCopperhead()
 
 	if (L11_shenStartQuest()) {
 		return true;
+	}
+
+	if (internalQuestStatus("questL11Shen") < 1) {
+		// if we haven't spoke to Shen for the first time yet, don't try to handle the quest.
+		return false;
 	}
 
 	if (internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1801,6 +1801,10 @@ boolean L11_shenStartQuest() {
 	{
 		return false;
 	}
+	if (my_daycount() < 2 || !allowSoftblockShen()) {
+		// if you're fast enough to open it on day 1, maybe wait until day 2
+		return false;
+	}
 	backupSetting("choiceAdventure1074", 1);
 	if (autoAdv($location[The Copperhead Club])) {
 		if (internalQuestStatus("questL11Shen") == 1) {
@@ -1942,6 +1946,10 @@ boolean L11_palindome()
 {
 	if (internalQuestStatus("questL11Palindome") < 0 || internalQuestStatus("questL11Palindome") > 5)
 	{
+		return false;
+	}
+
+	if (!possessEquipment($item[Talisman o' Namsilat])) {
 		return false;
 	}
 


### PR DESCRIPTION
# Description

- fix issue with delay burning in Hidden City zones we've already finished (reported in Discord)
- also don't try to adjust equipment for YR/Banish/Replace when delay burning (same issue as above)
- add more debug logging to familiar selection (might help trace issues if people switch it on)
- don't default Horsery to dark horse when an empty string is passed, treat as failure.
- don't speak to Shen until day 2 at the earliest as day 2 snakes are better for routing than day 1
- don't try to adventure in the palindome if you don't have the talisman o' namsilat
- make sure LKS key zones can accept wanderers if we try to burn delay in them.
- handful of tweaks to LKS routing.

## How Has This Been Tested?

Other than the delay burning stuff I've been running this in LKS and Ed for a while.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
