### PR TITLE
Mushroom Garden and Guzzlr handling

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1445,6 +1445,8 @@ boolean dailyEvents()
 		}
 	}
 
+	auto_getGuzzlrCocktailSet();
+
 	return true;
 }
 
@@ -2336,7 +2338,13 @@ int auto_freeCombatsRemaining(boolean print_remaining_fights)
 		count++;
 		debugPrint("Evoke Eldritch = 1");
 	}
-	
+
+	if (auto_canFightPiranhaPlant()) {
+		int temp = auto_piranhaPlantFightsRemaining();
+		count += temp;
+		debugPrint("Piranha Plant Fights = " + temp);
+	}
+
 	return count;
 }
 
@@ -2380,6 +2388,11 @@ boolean LX_freeCombats(boolean powerlevel)
 	if(disregardInstantKarma())
 	{
 		handleFamiliar("stat");
+	}
+
+	if (auto_canFightPiranhaPlant() || auto_canTendMushroomGarden()) {
+		auto_log_debug("LX_freeCombats is calling auto_mushroomGardenHandler()");
+		return auto_mushroomGardenHandler();
 	}
 
 	if(neverendingPartyRemainingFreeFights() > 0)

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1322,13 +1322,8 @@ generic_t zone_available(location loc)
 		retval._boolean = false;
 		break;
 
-
-	//Special cases that we are not going to worry too much about.
-	case $location[A Maze of Sewer Tunnels]:
-		if(my_adventures() >= 10)
-		{
-			retval._boolean = true;
-		}
+	case $location[Your Mushroom Garden]:
+		retval._boolean = (auto_piranhaPlantFightsRemaining() || auto_canTendMushroomGarden());
 		break;
 
 #	This is just to do a mass test.

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -249,6 +249,7 @@ boolean auto_getGuzzlrCocktailSet() {
 			if (get_property("questGuzzlr") == "unstarted" && get_property("_guzzlrPlatinumDeliveries").to_int() == 0 && !get_property("_guzzlrQuestAbandoned").to_boolean()) {
       	visit_url("inventory.php?tap=guzzlr", false);
       	run_choice(4); // take platinum quest
+				wait(1); // mafia's tracking breaks occasionally if you go too fast.
       	visit_url("inventory.php?tap=guzzlr", false);
       	run_choice(1); // abandon
       	run_choice(5); // leave the choice.

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -197,3 +197,66 @@ void auto_burnPowerfulGloveCharges()
 		auto_powerfulGloveStats();
 	}
 }
+
+boolean auto_canFightPiranhaPlant() {
+	int numMushroomFights = (in_zelda() ? 5 : 1);
+	if (auto_is_valid($item[packet of mushroom spores]) &&
+			get_campground() contains $item[packet of mushroom spores] &&
+			get_property("_mushroomGardenFights").to_int() < numMushroomFights) {
+		return true;
+	}
+	return false;
+}
+
+boolean auto_canTendMushroomGarden() {
+	if (auto_is_valid($item[packet of mushroom spores]) &&
+			get_campground() contains $item[packet of mushroom spores] &&
+			!get_property("_mushroomGardenVisited").to_boolean()) {
+		return true;
+	}
+	return false;
+}
+
+int auto_piranhaPlantFightsRemaining() {
+	if (auto_canFightPiranhaPlant()) {
+		int numMushroomFights = (in_zelda() ? 5 : 1);
+		return (numMushroomFights - get_property("_mushroomGardenFights").to_int());
+	}
+	return 0;
+}
+
+boolean auto_mushroomGardenHandler() {
+	if (auto_piranhaPlantFightsRemaining() > 0) {
+		return autoAdv($location[Your Mushroom Garden]);
+	} else if (auto_canTendMushroomGarden()) {
+		autoAdv($location[Your Mushroom Garden]);
+		// TODO: Malibu Stacey - move all this to a more central location after refactor
+		use(item_amount($item[colossal free-range mushroom]), $item[colossal free-range mushroom]);
+		use(item_amount($item[immense free-range mushroom]), $item[immense free-range mushroom]);
+		use(item_amount($item[giant free-range mushroom]), $item[giant free-range mushroom]);
+		use(item_amount($item[bulky free-range mushroom]), $item[bulky free-range mushroom]);
+		use(item_amount($item[plump free-range mushroom]), $item[plump free-range mushroom]);
+		use(item_amount($item[free-range mushroom]), $item[free-range mushroom]);
+		return true;
+	}
+	return false;
+}
+
+boolean auto_getGuzzlrCocktailSet() {
+	if (possessEquipment($item[Guzzlr tablet]) && auto_is_valid($item[Guzzlr tablet])) {
+		if (get_property("guzzlrGoldDeliveries").to_int() >= 5) {
+			auto_log_info("Getting a Guzzlr Cocktail Set (for all the good it will do).");
+			if (get_property("questGuzzlr") == "unstarted" && get_property("_guzzlrPlatinumDeliveries").to_int() == 0 && !get_property("_guzzlrQuestAbandoned").to_boolean()) {
+      	visit_url("inventory.php?tap=guzzlr", false);
+      	run_choice(4); // take platinum quest
+      	visit_url("inventory.php?tap=guzzlr", false);
+      	run_choice(1); // abandon
+      	run_choice(5); // leave the choice.
+				return true; // ponder on what else you could've spent the Mr. Accessory on instead.
+    	}
+		} else {
+			auto_log_info("You haven't unlocked the platinum Guzzlr quests yet. I wouldn't worry about it though as it's all but useless.");
+		}
+	}
+	return false;
+}


### PR DESCRIPTION
# Description

- Add fighting the free Piranha plant(s) and getting the mushroom filets if you have the Mushroom Garden installed.
- Add getting the Guzzlr cocktail set if you have the Guzzlr and have unlocked the Platinum quest (requires 5 Gold quests completed which also requires 5 Bronze quests completed).

## How Has This Been Tested?

Ran this over a handful of Normal LKS runs. Looks fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
