### PR TITLE
L11 stone wool check

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1073,7 +1073,11 @@ boolean L11_unlockHiddenCity() {
 		}
 		buffMaintain($effect[Stone-Faced], 0, 1, 1);
 		if (have_effect($effect[Stone-Faced]) == 0) {
-			abort("We do not smell like Stone nor have the face of one. We currently donut farm Stone Wool. Please get some");
+			if(isAboutToPowerlevel())	//we ran out of other things to do.
+			{
+				abort("We do not smell like Stone nor have the face of one. We currently donut farm Stone Wool. Please get some");
+			}
+			else return false;	//try to do other things first.
 		}
 	}
 	return autoAdv($location[The Hidden Temple]);


### PR DESCRIPTION
for L11 stone wool check, only abort for lack of stone wool if we have nothing else to do.
since at the moment we just use semirare to get stone wool. and we might encounter said semirare later on if we go do something else.
use isAboutToPowerlevel() to determine if we have other things to do or not.

## How Has This Been Tested?

tested it in an HC ed run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
