### PR TITLE
depedence day rocket. as ed wait until island unlock

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -652,6 +652,10 @@ boolean dependenceDayClovers()
 	{
 		return false;	//it is not dependence day today
 	}
+	if(isActuallyEd() && get_property("lastIslandUnlock").to_int() != my_ascensions())
+	{
+		return false;	//buying it before unlocking the island on day 1 makes you too poor to unlock it on day 1 and adds days to the run
+	}
 	
 	auto_log_info("Today is Dependence Day and I want to use a [green rocket] for some clovers", "green");
 	if(item_amount($item[green rocket]) == 0 && my_meat() < npc_price($item[green rocket]))


### PR DESCRIPTION
otherwise it gets the green rocket on turn 1 and makes you too poor to unlock the island which extends the run by at least 1 day.

## How Has This Been Tested?

validates and runs on an ed run
but I can't really test the code itself until next dependence day when it starts breaking runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
