### PR TITLE
cubeling fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -90,7 +90,6 @@ void initializeSettings()
 	set_location($location[none]);
 	invalidateRestoreOptionCache();
 
-	set_property("auto_useCubeling", true);
 	set_property("auto_100familiar", $familiar[none]);
 	if(my_familiar() != $familiar[none])
 	{
@@ -98,10 +97,6 @@ void initializeSettings()
 		if(userAnswer)
 		{
 			set_property("auto_100familiar", my_familiar());
-		}
-		if(!canChangeFamiliar())
-		{
-			set_property("auto_useCubeling", false);
 		}
 	}
 
@@ -142,7 +137,6 @@ void initializeSettings()
 	set_property("auto_cookie", -1);
 	set_property("auto_copies", "");
 	set_property("auto_crackpotjar", "");
-	set_property("auto_cubeItems", true);
 	set_property("auto_dakotaFanning", false);
 	set_property("auto_day_init", 0);
 	set_property("auto_day1_dna", "");
@@ -3313,14 +3307,6 @@ boolean doTasks()
 
 	dna_sorceressTest();
 	dna_generic();
-
-	if(get_property("auto_useCubeling").to_boolean())
-	{
-		if((item_amount($item[ring of detect boring doors]) == 1) && (item_amount($item[eleven-foot pole]) == 1) && (item_amount($item[pick-o-matic lockpicks]) == 1))
-		{
-			set_property("auto_cubeItems", false);
-		}
-	}
 
 	if((my_daycount() == 1) && ($familiar[Fist Turkey].drops_today < 5) && auto_have_familiar($familiar[Fist Turkey]))
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -228,7 +228,6 @@ void initializeSettings()
 	florist_initializeSettings();
 	ed_initializeSettings();
 	boris_initializeSettings();
-	jello_initializeSettings();
 	bond_initializeSettings();
 	fallout_initializeSettings();
 	pete_initializeSettings();

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -92,19 +92,11 @@ boolean settingFixer()
 	{
 		set_property("auto_killingjar", "finished");
 	}
-	if(get_property("auto_useCubeling") == "yes")
-	{
-		set_property("auto_useCubeling", true);
-	}
 	if(get_property("auto_sonata") == "finished")
 	{
 		set_property("auto_sonata", "");
 	}
 
-	if(get_property("auto_useCubeling") == "no")
-	{
-		set_property("auto_useCubeling", false);
-	}
 	if(get_property("auto_wandOfNagamar") == "yes")
 	{
 		set_property("auto_wandOfNagamar", true);
@@ -178,14 +170,8 @@ boolean settingFixer()
 		set_property("auto_aftercore", true);
 	}
 
-	if(get_property("auto_cubeItems") == "")
-	{
-		set_property("auto_cubeItems", true);
-	}
-	if(get_property("auto_cubeItems") == "done")
-	{
-		set_property("auto_cubeItems", false);
-	}
+	remove_property("auto_cubeItems");
+	remove_property("auto_useCubeling");
 
 	if(get_property("auto_xiblaxianChoice") == "")
 	{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -473,3 +473,16 @@ boolean haveSpleenFamiliar()
 	}
 	return false;
 }
+
+boolean wantCubeling()
+{
+	//do we still want to use a gelatinous cubeling familiar so that it will drop the daily dungeon tools
+	if(!canChangeToFamiliar($familiar[Gelatinous Cubeling]))
+	{
+		return false;	//can not use it so we do not want it.
+	}
+	
+	boolean need_lockpicks = item_amount($item[pick-o-matic lockpicks]) == 0 && item_amount($item[Platinum Yendorian Express Card]) == 0;
+	boolean need_ring = !possessEquipment($item[Ring of Detect Boring Doors]);	//do not try for a second one if you already have one
+	return item_amount($item[eleven-foot pole]) == 0 || need_ring || need_lockpicks;
+}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -351,10 +351,8 @@ boolean autoChooseFamiliar(location place)
 
 	//Gelatinous Cubeling drops items that save turns in the daily dungeon
 	if(famChoice == $familiar[none] &&
-	canChangeToFamiliar($familiar[Gelatinous Cubeling]) &&
-	get_property("auto_useCubeling").to_boolean() &&
-	get_property("auto_cubeItems").to_boolean()
-	&& lookupFamiliarDatafile("item") != $familiar[Gelatinous Cubeling]) // don't farm the drops if this is the best +item familiar we have. We will get them regardless.
+	wantCubeling() &&
+	lookupFamiliarDatafile("item") != $familiar[Gelatinous Cubeling]) // don't farm the drops if this is the best +item familiar we have. We will get them regardless.
 	{
 		famChoice = $familiar[Gelatinous Cubeling];
 	}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -917,11 +917,6 @@ boolean auto_post_adventure()
 		}
 	}
 
-	if(get_property("auto_cubeItems").to_boolean() && (item_amount($item[Ring Of Detect Boring Doors]) == 1) && (item_amount($item[Eleven-Foot Pole]) == 1) && (item_amount($item[Pick-O-Matic Lockpicks]) == 1))
-	{
-		set_property("auto_cubeItems", false);
-	}
-
 	if(!inAftercore())
 	{
 		if((my_daycount() == 1) && (my_bjorned_familiar() != $familiar[grim brother]) && (get_property("_grimFairyTaleDropsCrown").to_int() == 0) && (have_familiar($familiar[grim brother])) && (equipped_item($slot[back]) == $item[Buddy Bjorn]) && (my_familiar() != $familiar[Grim Brother]))

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -25,7 +25,6 @@ boolean LX_hippyBoatman();
 boolean LX_lockPicking();
 float estimateDailyDungeonAdvNeeded();				//Defined in autoscend/quests/level_any.ash
 boolean LX_fatLootToken();							//Defined in autoscend/quests/level_any.ash
-boolean wantCubeling();								//Defined in autoscend/quests/level_any.ash
 boolean LX_dailyDungeonToken();						//Defined in autoscend/quests/level_any.ash
 boolean LX_islandAccess();
 boolean fancyOilPainting();
@@ -268,6 +267,7 @@ boolean handleFamiliar(string type);						//Defined in autoscend/auto_familiar.a
 boolean handleFamiliar(familiar fam);						//Defined in autoscend/auto_familiar.ash
 boolean autoChooseFamiliar(location place);					//Defined in autoscend/auto_familiar.ash
 boolean haveSpleenFamiliar();								//Defined in autoscend/auto_familiar.ash
+boolean wantCubeling();										//Defined in autoscend/auto_familiar.ash
 
 
 //Do we have a some item either equipped or in inventory (not closet or hagnk\'s.

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -25,6 +25,7 @@ boolean LX_hippyBoatman();
 boolean LX_lockPicking();
 float estimateDailyDungeonAdvNeeded();				//Defined in autoscend/quests/level_any.ash
 boolean LX_fatLootToken();							//Defined in autoscend/quests/level_any.ash
+boolean wantCubeling();								//Defined in autoscend/quests/level_any.ash
 boolean LX_dailyDungeonToken();						//Defined in autoscend/quests/level_any.ash
 boolean LX_islandAccess();
 boolean fancyOilPainting();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -910,7 +910,6 @@ int jello_absorbsLeft();									//Defined in autoscend/auto_jellonewbie.ash
 int gnoobAbsorbCost(item it);								//Defined in autoscend/auto_jellonewbie.ash
 void jello_buySkills();										//Defined in autoscend/auto_jellonewbie.ash
 boolean in_gnoob();											//Defined in autoscend/auto_jellonewbie.ash
-void jello_initializeSettings();							//Defined in autoscend/auto_jellonewbie.ash
 string[item] jello_lister();								//Defined in autoscend/auto_jellonewbie.ash
 string[item] jello_lister(string goal);						//Defined in autoscend/auto_jellonewbie.ash
 void jello_startAscension(string page);						//Defined in autoscend/auto_jellonewbie.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -1066,10 +1066,6 @@ boolean deck_useScheme(string action)
 
 		if(card == "key")
 		{
-			if(my_daycount() == 1)
-			{
-				set_property("auto_cubeItems", false);
-			}
 			if(towerKeyCount() >= 3)
 			{
 				continue;

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -23,7 +23,6 @@ void ed_initializeSettings()
 	if (isActuallyEd())
 	{
 		set_property("auto_crackpotjar", "done");
-		set_property("auto_cubeItems", false);
 		set_property("auto_day1_dna", "finished");
 		set_property("auto_getBeehive", false);
 		set_property("auto_getStarKey", false);
@@ -33,7 +32,6 @@ void ed_initializeSettings()
 		set_property("auto_needLegs", false);
 		set_property("auto_renenutet", "");
 		set_property("auto_servantChoice", "");
-		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 
 		set_property("auto_edSkills", -1);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -44,8 +44,6 @@ void boris_initializeSettings()
 	{
 		auto_log_info("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
-		set_property("auto_cubeItems", false);
-		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 
 		# Mafia r16876 does not see the Boris Helms in storage and will not pull them.

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -5,8 +5,6 @@ void pete_initializeSettings()
 	if(my_path() == "Avatar of Sneaky Pete")
 	{
 		set_property("auto_peteSkills", -1);
-		set_property("auto_cubeItems", false);
-		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 	}
 }

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -11,11 +11,9 @@ void bat_initializeSettings()
 {
 	if(my_path() == "Dark Gyffte")
 	{
-		set_property("auto_cubeItems", false);
 		set_property("auto_getSteelOrgan", false);
 		set_property("auto_grimstoneFancyOilPainting", false);
 		set_property("auto_paranoia", 10);
-		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 		set_property("auto_bat_desiredForm", "");
 	}

--- a/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
+++ b/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
@@ -5,14 +5,6 @@ boolean in_gnoob()
 	return my_class() == $class[Gelatinous Noob];
 }
 
-void jello_initializeSettings()
-{
-	if(in_gnoob())
-	{
-		set_property("auto_cubeItems", false);
-	}
-}
-
 void jello_startAscension(string page)
 {
 	if(contains_text(page, "Welcome to the Kingdom, Gelatinous Noob"))

--- a/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
+++ b/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
@@ -4,13 +4,7 @@ void fallout_initializeSettings()
 {
 	if(my_path() == "Nuclear Autumn")
 	{
-		set_property("auto_cubeItems", false);
 		set_property("auto_getBeehive", true);
-
-		if(item_amount($item[Deck of Every Card]) > 0)
-		{
-			set_property("auto_useCubeling", false);
-		}
 	}
 }
 

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -11,7 +11,6 @@ boolean zelda_initializeSettings()
 	{
 		set_property("auto_getBeehive", true);
 		set_property("auto_wandOfNagamar", false);
-		set_property("auto_useCubeling", true);
 		// TODO: Remove when quest handling is correct.
 		set_property("auto_paranoia", 1);
 	}

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -10,12 +10,9 @@ void digimon_initializeSettings()
 {
 	if(auto_my_path() == "Pocket Familiars")
 	{
-		set_property("auto_getBeehive", false);
 		set_property("auto_getBoningKnife", false);
-		set_property("auto_cubeItems", false);
 		set_property("auto_hippyInstead", true);
 		set_property("auto_ignoreFlyer", true);
-		set_property("auto_useCubeling", false);
 		set_property("auto_wandOfNagamar", false);
 	}
 }

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -428,20 +428,29 @@ boolean LX_fatLootToken()
 	
 	return false;
 }
+
+boolean wantCubeling()
+{
+	//do we still want to use a gelatinous cubeling familiar so that it will drop the daily dungeon tools
+	if(!canChangeToFamiliar($familiar[Gelatinous Cubeling]))
+	{
+		return false;	//can not use it so we do not want it.
+	}
 	
+	boolean need_lockpicks = item_amount($item[pick-o-matic lockpicks]) == 0 && item_amount($item[Platinum Yendorian Express Card]) == 0;
+	boolean need_ring = !possessEquipment($item[Ring of Detect Boring Doors]);	//do not try for a second one if you already have one
+	return item_amount($item[eleven-foot pole]) == 0 || need_ring || need_lockpicks;
+}
+
 boolean LX_dailyDungeonToken()
 {
 	if(get_property("dailyDungeonDone").to_boolean())
 	{
 		return false;	// already done today
 	}
-	
-	if(!possessEquipment($item[Ring of Detect Boring Doors]) || item_amount($item[Eleven-Foot Pole]) == 0 || item_amount($item[Pick-O-Matic Lockpicks]) == 0)
+	if(wantCubeling())
 	{
-		if(canChangeToFamiliar($familiar[Gelatinous Cubeling]))
-		{
-			return false;	//we can switch to cubeling so wait until we have all the tools before doing daily dungeon
-		}
+		return false;	//can switch to cubeling so wait until we have all the tool drops before doing daily dungeon
 	}
 	
 	if(can_interact())		//if you can not use cubeling then mallbuy missing tools in casual and postronin

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -429,19 +429,6 @@ boolean LX_fatLootToken()
 	return false;
 }
 
-boolean wantCubeling()
-{
-	//do we still want to use a gelatinous cubeling familiar so that it will drop the daily dungeon tools
-	if(!canChangeToFamiliar($familiar[Gelatinous Cubeling]))
-	{
-		return false;	//can not use it so we do not want it.
-	}
-	
-	boolean need_lockpicks = item_amount($item[pick-o-matic lockpicks]) == 0 && item_amount($item[Platinum Yendorian Express Card]) == 0;
-	boolean need_ring = !possessEquipment($item[Ring of Detect Boring Doors]);	//do not try for a second one if you already have one
-	return item_amount($item[eleven-foot pole]) == 0 || need_ring || need_lockpicks;
-}
-
 boolean LX_dailyDungeonToken()
 {
 	if(get_property("dailyDungeonDone").to_boolean())


### PR DESCRIPTION
*removed jello initialization as it was only used to set auto_cubeItems to false, which is incorrect. we actually want the cube item drops in that path so we can do the daily dungeon. currently behavior resulted in getting stuck at the door with nothing left to do and not fat loot tokens for keys
*boolean wantCubeling() created and used. It determines if we want to use the gelatinous cubeling familiar for its drops.
**remove setting auto_cubeItems
**remove setting auto_useCubeling
**fix casual and postronin getting stuck on cubeling forever. it prioritizes the cubeling to get the drop, but the check for the drops was checking item amount == 1, instead of >0. in casual it failed because you had more than 1.
**fix avatar paths not pulling cubeling drops in softcore or postronin.

fixes #105

## How Has This Been Tested?

day 1 of softcore gnoob.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
