### PR TITLE
Some random fixes and tweaks

### DIFF
--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -22,17 +22,11 @@ Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
 Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
 Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
 #
-# Cat Burgler can charge up heists. 30 combats give it 2 charges.
+# Cat Burglar can charge up heists. 30 combats give it 2 charges.
 Cat Burglar	prop:_catBurglarCharge<30
 #
-# Drops many items. make sure we got 1 in stock of the banisher, as well as size 1 density 5 food/drink
-# Because it drops so many different items the odds of getting what we want are reduced. so lowered its priority
-Elf Operative	item:tryptophan dart<1
-Elf Operative	item:elf army field rations<1
-Elf Operative	item:martiny<1
-# drops size 1 density 4.5 food and drink. odds of drop are relatively low so it down here
-Garbage Fire	item:extra-toasted half sandwich<1
-Garbage Fire	item:mulled hobo wine<1
+# Melodramedary generating spit seems good
+#Melodramedary	prop:camelSpit<100 - Don't uncomment until we actally use it
 #
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
 Intergnat	item:BACON<150
@@ -58,33 +52,5 @@ Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 Blavious Kloop	prop:_kloopDrops<5
 # can drop 5 absinthe a day
 Green Pixie	prop:_absintheDrops<5
-# Drops robin's egg every 30 combats. +3 all res potion
-Rockin' Robin	item:robin\'s egg<1
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
 Galloping Grill	prop:_hotAshesDrops<5
-#
-# Below this line are familiars with no properties. meaning if you have it then it will be kept selected permanently.
-# Most of those also appear higher up in the file with properties. Meaning we use them until a select amount is grabbed first.
-#
-# Drops many items. among them: banish, restore, stun, damage, size 1 density 5 food/drink, -combat equip, all res +2 equip, +3XP equip, +15% meat equip
-Elf Operative
-# Drops more burning newspapers. one per 30 combats. also drops size 1 density 4.5 food and drink
-Garbage Fire
-# Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
-XO Skeleton
-# Drops BACON every combat
-Intergnat
-# Generates adventures after combat
-Reagnimated Gnome
-# Every 30 combats drops wax which makes a single size 2 density 4.25 food or drink 
-Optimistic Candle
-# Drops robin's egg every 30 combats. +3 all res potion
-Rockin' Robin
-# cheap IOTM derivative that drops many different things. many are junk, but it does have size 3 density 3.83 food which is better than nothing.
-Lil' Barrel Mimic
-# Once the hot ashes all dropped. remaining drops are not that useful.
-Galloping Grill
-# Can use to track phyllum, every 11 encounters from tracked phyllum results in a drop. Needs more code before it goes higher on the list
-Red-Nosed Snapper
-# 2% and 4% chance respectively to drop time's arrow and arrowgram.
-Obtuse Angel

--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -24,6 +24,7 @@ Intergnat
 Elf Operative
 Optimistic Candle
 Rockin' Robin
+God Lobster	item:God Lobster's Crown>0
 # Fairywhelps
 Pocket Professor
 Garbage Fire

--- a/BUILD/familiars/regen.dat
+++ b/BUILD/familiars/regen.dat
@@ -8,7 +8,9 @@
 Galloping Grill	prop:_hotAshesDrops<5
 # starfish that drops 5 tokens a day that can be exchanged for a spleen consumable that gives adv
 Rogue Program	prop:_tokenDrops<5
-# whelp. Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
+# Fairywhelps. Weight is better used on these and 2 of them drop useful items.
+Pocket Professor
+Garbage Fire
 XO Skeleton
 # Drops assorted stuff, mostly junk. has some awesome food. requires familiar equip brass bung spigot to regen HP/MP
 Lil' Barrel Mimic	item:brass bung spigot>0
@@ -28,10 +30,8 @@ Snow Angel
 Underworld Bonsai
 Star Starfish
 # Fairysuperwhelps
-Garbage Fire
 Choctopus
 # Superwhelps
-Melodramedary
 Plastic Pirate Skull
 Trick-or-Treating Tot
 # Fairywhelps

--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -1,16 +1,8 @@
 # Sombrero is desirable with a decent amount of ML
 Galloping Grill	ML:>=120
 Baby Sandworm	ML:>=120
+God Lobster	ML:>=120;item:God Lobster's Ring>0
 Hovering Sombrero	ML:>=120
-# Wanna get yummy chewables
-Golden Monkey	prop:_powderedGoldDrops<3
-Bloovian Groose	prop:_grooseDrops<3
-Unconscious Collective	prop:_dreamJarDrops<3
-Grim Brother	prop:_grimFairyTaleDrops<3
-# Might as well grab an egg
-Rockin' Robin	prop:rockinRobinProgress>=25
-# And some wax
-Optimistic Candle	prop:optimisticCandleProgress>=25
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
 Crimbo Shrub
 # Volleyballs with a multiplier

--- a/BUILD/monsters/banish.dat
+++ b/BUILD/monsters/banish.dat
@@ -35,7 +35,6 @@ Sabre-Toothed Goat
 Senile Lihc	loc:The Defiled Niche
 Slick Lihc	loc:The Defiled Niche
 Skeletal Sommelier
-Snow Queen
 Spooky mummy	class:Ed
 Spooky vampire	class:Ed
 Steam Elemental
@@ -46,4 +45,5 @@ Tomb Servant
 Triffid	class:Ed
 Wardr&ouml;b Nightstand
 Warehouse Janitor
-Upgraded Ram
+party skelteon
+basic lihc

--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -8,6 +8,7 @@ Morbid Skull
 Pygmy Bowler
 Pygmy Witch Surgeon
 pygmy witch accountant	loc:The Hidden Office Building
+pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
 Pygmy Janitor	!tavern:true
 Quiet Healer
 Tomb Rat
@@ -24,3 +25,6 @@ Dirty Old Lihc	prop:cyrptNicheEvilness>28
 Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
 Serialbus	item:bus pass<5
 CH Imp	item:imp air<5
+Camel Toe
+Skinflute
+Red Butler

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -27,7 +27,7 @@ drop	0	Fist Turkey	prop:_turkeyBooze<5
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
 drop	1	Puck Man	item:Yellow Pixel<20
 drop	2	Ms. Puck Man	item:Yellow Pixel<20
-# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
 drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
 drop	4	Rockin' Robin	prop:rockinRobinProgress>=25
@@ -41,72 +41,38 @@ drop	7	Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
 drop	8	Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
 drop	9	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
 #
-# Cat Burgler can charge up heists. 30 combats give it 2 charges.
+# Cat Burglar can charge up heists. 30 combats give it 2 charges.
 drop	10	Cat Burglar	prop:_catBurglarCharge<30
 #
-# Drops many items. make sure we got 1 in stock of the banisher, as well as size 1 density 5 food/drink
-# Because it drops so many different items the odds of getting what we want are reduced. so lowered its priority
-drop	11	Elf Operative	item:tryptophan dart<1
-drop	12	Elf Operative	item:elf army field rations<1
-drop	13	Elf Operative	item:martiny<1
-# drops size 1 density 4.5 food and drink. odds of drop are relatively low so it down here
-drop	14	Garbage Fire	item:extra-toasted half sandwich<1
-drop	15	Garbage Fire	item:mulled hobo wine<1
+# Melodramedary generating spit seems good
+#Melodramedary	prop:camelSpit<100 - Don't uncomment until we actally use it
 #
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
-drop	16	Intergnat	item:BACON<150
+drop	11	Intergnat	item:BACON<150
 #
 # Below this lines drops are not needed more of for the run and are just grabbing for profit.
 # Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
 #
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
-drop	17	Grim Brother	prop:_grimFairyTaleDrops<5
-drop	18	Pair of Stomping Boots	prop:_bootStomps<7
-drop	19	Baby Sandworm	prop:_aguaDrops<5
-drop	20	Bloovian Groose	prop:_grooseDrops<5
-drop	21	Golden Monkey	prop:_powderedGoldDrops<5
-drop	22	Unconscious Collective	prop:_dreamJarDrops<5
+drop	12	Grim Brother	prop:_grimFairyTaleDrops<5
+drop	13	Pair of Stomping Boots	prop:_bootStomps<7
+drop	14	Baby Sandworm	prop:_aguaDrops<5
+drop	15	Bloovian Groose	prop:_grooseDrops<5
+drop	16	Golden Monkey	prop:_powderedGoldDrops<5
+drop	17	Unconscious Collective	prop:_dreamJarDrops<5
 # psychoanalytic jar 1 per day.
-drop	23	Angry Jung Man	prop:_jungDrops<1
+drop	18	Angry Jung Man	prop:_jungDrops<1
 # grimstone mask 1 per day
-drop	24	Grimstone Golem	prop:_grimstoneMaskDrops<1
+drop	19	Grimstone Golem	prop:_grimstoneMaskDrops<1
 # tales of spelunking 1 per day
-drop	25	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
+drop	20	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 # can drop 5 devilish folio a day
-drop	26	Blavious Kloop	prop:_kloopDrops<5
+drop	21	Blavious Kloop	prop:_kloopDrops<5
 # can drop 5 absinthe a day
-drop	27	Green Pixie	prop:_absintheDrops<5
-# Drops robin's egg every 30 combats. +3 all res potion
-drop	28	Rockin' Robin	item:robin's egg<1
+drop	22	Green Pixie	prop:_absintheDrops<5
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
-drop	29	Galloping Grill	prop:_hotAshesDrops<5
-#
-# Below this line are familiars with no properties. meaning if you have it then it will be kept selected permanently.
-# Most of those also appear higher up in the file with properties. Meaning we use them until a select amount is grabbed first.
-#
-# Drops many items. among them: banish, restore, stun, damage, size 1 density 5 food/drink, -combat equip, all res +2 equip, +3XP equip, +15% meat equip
-drop	30	Elf Operative
-# Drops more burning newspapers. one per 30 combats. also drops size 1 density 4.5 food and drink
-drop	31	Garbage Fire
-# Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
-drop	32	XO Skeleton
-# Drops BACON every combat
-drop	33	Intergnat
-# Generates adventures after combat
-drop	34	Reagnimated Gnome
-# Every 30 combats drops wax which makes a single size 2 density 4.25 food or drink 
-drop	35	Optimistic Candle
-# Drops robin's egg every 30 combats. +3 all res potion
-drop	36	Rockin' Robin
-# cheap IOTM derivative that drops many different things. many are junk, but it does have size 3 density 3.83 food which is better than nothing.
-drop	37	Lil' Barrel Mimic
-# Once the hot ashes all dropped. remaining drops are not that useful.
-drop	38	Galloping Grill
-# Can use to track phyllum, every 11 encounters from tracked phyllum results in a drop. Needs more code before it goes higher on the list
-drop	39	Red-Nosed Snapper
-# 2% and 4% chance respectively to drop time's arrow and arrowgram.
-drop	40	Obtuse Angel
+drop	23	Galloping Grill	prop:_hotAshesDrops<5
 
 # We want to delevel, but don't want to deal damage
 gremlins	0	Nosy Nose
@@ -147,53 +113,54 @@ item	7	Intergnat
 item	8	Elf Operative
 item	9	Optimistic Candle
 item	10	Rockin' Robin
+item	11	God Lobster	item:God Lobster's Crown>0
 # Fairywhelps
-item	11	Pocket Professor
-item	12	Garbage Fire
-item	13	Dandy Lion
+item	12	Pocket Professor
+item	13	Garbage Fire
+item	14	Dandy Lion
 # Fairychauns
-item	14	Fist Turkey
-item	15	Cat Burglar
-item	16	Angry Jung Man
-item	17	Grimstone Golem
-item	18	Adventurous Spelunker
-item	19	Blavious Kloop
-item	20	Hippo Ballerina
-item	21	Dancing Frog
-item	22	Coffee Pixie
-item	23	Attention-Deficit Demon
-item	24	Jitterbug
-item	25	Casagnova Gnome
-item	26	Psychedelic Bear
-item	27	Piano Cat
+item	15	Fist Turkey
+item	16	Cat Burglar
+item	17	Angry Jung Man
+item	18	Grimstone Golem
+item	19	Adventurous Spelunker
+item	20	Blavious Kloop
+item	21	Hippo Ballerina
+item	22	Dancing Frog
+item	23	Coffee Pixie
+item	24	Attention-Deficit Demon
+item	25	Jitterbug
+item	26	Casagnova Gnome
+item	27	Psychedelic Bear
+item	28	Piano Cat
 # Slightly special fairies
-item	28	Red-Nosed Snapper
-item	29	Pair of Stomping Boots
-item	30	Gelatinous Cubeling
-item	31	Steam-Powered Cheerleader
-item	32	Obtuse Angel
-item	33	Green Pixie
+item	29	Red-Nosed Snapper
+item	30	Pair of Stomping Boots
+item	31	Gelatinous Cubeling
+item	32	Steam-Powered Cheerleader
+item	33	Obtuse Angel
+item	34	Green Pixie
 # Elemental fairies
-item	34	Sleazy Gravy Fairy
-item	35	Stinky Gravy Fairy
-item	36	Flaming Gravy Fairy
-item	37	Frozen Gravy Fairy
-item	38	Spooky Gravy Fairy
+item	35	Sleazy Gravy Fairy
+item	36	Stinky Gravy Fairy
+item	37	Flaming Gravy Fairy
+item	38	Frozen Gravy Fairy
+item	39	Spooky Gravy Fairy
 # Physical damage fairy
-item	39	Bowlet
+item	40	Bowlet
 # Barely special fairies
-item	40	Mechanical Songbird
-item	41	Grouper Groupie
-item	42	Peppermint Rhino
+item	41	Mechanical Songbird
+item	42	Grouper Groupie
+item	43	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	43	Slimeling
+item	44	Slimeling
 # Turtles are cute
-item	44	Syncopated Turtle
+item	45	Syncopated Turtle
 # The original
-item	45	Baby Gravy Fairy
+item	46	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	46	Mutant Fire Ant
+item	47	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1
@@ -264,30 +231,30 @@ meat	39	Leprechaun
 regen	0	Galloping Grill	prop:_hotAshesDrops<5
 # starfish that drops 5 tokens a day that can be exchanged for a spleen consumable that gives adv
 regen	1	Rogue Program	prop:_tokenDrops<5
-# whelp. Drops x and o with no limit. 1 each per nine combats. makes density 4.5 food. density 4 booze. can skip building a bridge.
-regen	2	XO Skeleton
+# Fairywhelps. Weight is better used on these and 2 of them drop useful items.
+regen	2	Pocket Professor
+regen	3	Garbage Fire
+regen	4	XO Skeleton
 # Drops assorted stuff, mostly junk. has some awesome food. requires familiar equip brass bung spigot to regen HP/MP
-regen	3	Lil' Barrel Mimic	item:brass bung spigot>0
+regen	5	Lil' Barrel Mimic	item:brass bung spigot>0
 # It's a starfish with reduced activation rate, except it ALWAYS attacks on turn one, so that's probably more hits per battle on average in short battles? oh, and it's a sombrero too
-regen	4	Galloping Grill
+regen	6	Galloping Grill
 # A super starfish (50% activation instead of 33%)
-regen	5	Sausage Golem
+regen	7	Sausage Golem
 # A slightly boosted starfish, for pastamancers
-regen	6	Animated Macaroni Duck	class:Pastamancer
+regen	8	Animated Macaroni Duck	class:Pastamancer
 # Regular starfish
-regen	7	Unspeakachu
-regen	8	Twitching Space Critter
-regen	9	Rock Lobster
-regen	10	Animated Macaroni Duck
-regen	11	Midget Clownfish
-regen	12	Snow Angel
-regen	13	Underworld Bonsai
-regen	14	Star Starfish
+regen	9	Unspeakachu
+regen	10	Twitching Space Critter
+regen	11	Rock Lobster
+regen	12	Animated Macaroni Duck
+regen	13	Midget Clownfish
+regen	14	Snow Angel
+regen	15	Underworld Bonsai
+regen	16	Star Starfish
 # Fairysuperwhelps
-regen	15	Garbage Fire
-regen	16	Choctopus
+regen	17	Choctopus
 # Superwhelps
-regen	17	Melodramedary
 regen	18	Plastic Pirate Skull
 regen	19	Trick-or-Treating Tot
 # Fairywhelps
@@ -315,57 +282,49 @@ regen	30	Mosquito
 # Sombrero is desirable with a decent amount of ML
 stat	0	Galloping Grill	ML:>=120
 stat	1	Baby Sandworm	ML:>=120
-stat	2	Hovering Sombrero	ML:>=120
-# Wanna get yummy chewables
-stat	3	Golden Monkey	prop:_powderedGoldDrops<3
-stat	4	Bloovian Groose	prop:_grooseDrops<3
-stat	5	Unconscious Collective	prop:_dreamJarDrops<3
-stat	6	Grim Brother	prop:_grimFairyTaleDrops<3
-# Might as well grab an egg
-stat	7	Rockin' Robin	prop:rockinRobinProgress>=25
-# And some wax
-stat	8	Optimistic Candle	prop:optimisticCandleProgress>=25
+stat	2	God Lobster	ML:>=120;item:God Lobster's Ring>0
+stat	3	Hovering Sombrero	ML:>=120
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
-stat	9	Crimbo Shrub
+stat	4	Crimbo Shrub
 # Volleyballs with a multiplier
 #Baby Mutant Rattlesnake	grimdark:0
 #Baby Mutant Rattlesnake	grimdark:1
 # Fairyballs
-stat	10	Elf Operative
-stat	11	Optimistic Candle
-stat	12	Rockin' Robin
+stat	5	Elf Operative
+stat	6	Optimistic Candle
+stat	7	Rockin' Robin
 # Volleychauns
-stat	13	Golden Monkey
-stat	14	Bloovian Groose
-stat	15	Unconscious Collective
-stat	16	Grim Brother
-stat	17	Dramatic Hedgehog
-stat	18	Chauvinist Pig
-stat	19	Uniclops
-stat	20	Hunchbacked Minion
-stat	21	Nervous Tick
-stat	22	Cymbal-Playing Monkey
-stat	23	Cheshire Bat
+stat	8	Golden Monkey
+stat	9	Bloovian Groose
+stat	10	Unconscious Collective
+stat	11	Grim Brother
+stat	12	Dramatic Hedgehog
+stat	13	Chauvinist Pig
+stat	14	Uniclops
+stat	15	Hunchbacked Minion
+stat	16	Nervous Tick
+stat	17	Cymbal-Playing Monkey
+stat	18	Cheshire Bat
 # VolleyWhelps
-stat	24	Melodramedary
+stat	19	Melodramedary
 # Might as well build up weight for free runs, even though I'm pretty sure we don't use them...
-stat	25	Frumious Bandersnatch
+stat	20	Frumious Bandersnatch
 # Slightly special volleyballs
-stat	26	Reanimated Reanimator
-stat	27	God Lobster
-stat	28	Party Mouse
-stat	29	Lil' Barrel Mimic
-stat	30	Piranha Plant
-stat	31	Antique Nutcracker
+stat	21	Reanimated Reanimator
+stat	22	God Lobster
+stat	23	Party Mouse
+stat	24	Lil' Barrel Mimic
+stat	25	Piranha Plant
+stat	26	Antique Nutcracker
 # Fancy
-stat	32	Miniature Sword &amp; Martini Guy
+stat	27	Miniature Sword &amp; Martini Guy
 #Baby Mutant Rattlesnake	grimdark:2
 # Turtles are cute
-stat	33	Grinning Turtle
+stat	28	Grinning Turtle
 # His winning smile
-stat	34	Smiling Rat
+stat	29	Smiling Rat
 # The original
-stat	35	Blood-Faced Volleyball
+stat	30	Blood-Faced Volleyball
 
 yellowray	0	Crimbo Shrub
 # Nanorhino and He-Boulder would require a bit of extra doing to make work

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -39,18 +39,18 @@ banish	33	Sabre-Toothed Goat
 banish	34	Senile Lihc	loc:The Defiled Niche
 banish	35	Slick Lihc	loc:The Defiled Niche
 banish	36	Skeletal Sommelier
-banish	37	Snow Queen
-banish	38	Spooky mummy	class:Ed
-banish	39	Spooky vampire	class:Ed
-banish	40	Steam Elemental
-banish	41	Taco Cat
-banish	42	Tan Gnat
-banish	43	Tomb Asp
-banish	44	Tomb Servant
-banish	45	Triffid	class:Ed
-banish	46	Wardr&ouml;b Nightstand
-banish	47	Warehouse Janitor
-banish	48	Upgraded Ram
+banish	37	Spooky mummy	class:Ed
+banish	38	Spooky vampire	class:Ed
+banish	39	Steam Elemental
+banish	40	Taco Cat
+banish	41	Tan Gnat
+banish	42	Tomb Asp
+banish	43	Tomb Servant
+banish	44	Triffid	class:Ed
+banish	45	Wardr&ouml;b Nightstand
+banish	46	Warehouse Janitor
+banish	47	party skelteon
+banish	48	basic lihc
 
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber
@@ -101,22 +101,26 @@ sniff	6	Morbid Skull
 sniff	7	Pygmy Bowler
 sniff	8	Pygmy Witch Surgeon
 sniff	9	pygmy witch accountant	loc:The Hidden Office Building
-sniff	10	Pygmy Janitor	!tavern:true
-sniff	11	Quiet Healer
-sniff	12	Tomb Rat
-sniff	13	Blooper	loc:8-Bit Realm
-sniff	14	Bob Racecar	!sniffed:Racecar Bob
-sniff	15	Racecar Bob	!sniffed:Bob Racecar
-sniff	16	Government Scientist	class:Ed
-sniff	17	Green Ops Soldier	!path:Kingdom of Exploathing
-sniff	18	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
-sniff	19	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
-sniff	20	Possessed Wine Rack
-sniff	21	Blue Oyster cultist
-sniff	22	Dirty Old Lihc	prop:cyrptNicheEvilness>28
-sniff	23	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
-sniff	24	Serialbus	item:bus pass<5
-sniff	25	CH Imp	item:imp air<5
+sniff	10	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
+sniff	11	Pygmy Janitor	!tavern:true
+sniff	12	Quiet Healer
+sniff	13	Tomb Rat
+sniff	14	Blooper	loc:8-Bit Realm
+sniff	15	Bob Racecar	!sniffed:Racecar Bob
+sniff	16	Racecar Bob	!sniffed:Bob Racecar
+sniff	17	Government Scientist	class:Ed
+sniff	18	Green Ops Soldier	!path:Kingdom of Exploathing
+sniff	19	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
+sniff	20	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
+sniff	21	Possessed Wine Rack
+sniff	22	Blue Oyster cultist
+sniff	23	Dirty Old Lihc	prop:cyrptNicheEvilness>28
+sniff	24	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+sniff	25	Serialbus	item:bus pass<5
+sniff	26	CH Imp	item:imp air<5
+sniff	27	Camel Toe
+sniff	28	Skinflute
+sniff	29	Red Butler
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -912,7 +912,7 @@ boolean fortuneCookieEvent()
 			goal = $location[The Limerick Dungeon];
 		}
 
-		if (goal == $location[The Limerick Dungeon] && (get_property("semirareLocation") == goal || item_amount($item[Cyclops Eyedrops]) > 0 || get_property("lastFilthClearance").to_int() >= my_ascensions() || get_property("sidequestOrchardCompleted") != "none" || get_property("currentHippyStore") != "none" || isActuallyEd() || in_koe()))
+		if (goal == $location[The Limerick Dungeon] && (get_property("semirareLocation") == goal || item_amount($item[Cyclops Eyedrops]) > 0 || get_property("lastFilthClearance").to_int() >= my_ascensions() || get_property("sidequestOrchardCompleted") != "none" || get_property("currentHippyStore") != "none" || isActuallyEd() || in_koe() || item_amount($item[heart of the filthworm queen]) > 0))
 		{
 			goal = $location[The Copperhead Club];
 		}
@@ -3113,6 +3113,15 @@ void resetState() {
 	bat_formNone(); // Vampyre form tracking
 
 	resetMaximize();
+
+	if (canChangeToFamiliar($familiar[Left-Hand Man]) && familiar_equipped_equipment($familiar[Left-Hand Man]) != $item[none]) {
+		// Leaving something equipped on the Left-Hand man like the Latte is currently bugged in mafia
+		// as it will show any skills the equipment gives as available even when you have a completely different familiar
+		// see https://kolmafia.us/showthread.php?24780-April-2020-IOTM-sinistral-homunculus&p=158453&viewfull=1#post158453
+		auto_log_info(`Unequipping your {familiar_equipped_equipment($familiar[Left-Hand Man])} from the Left-Hand Man`, "blue");
+		use_familiar($familiar[Left-Hand Man]);
+		equip($slot[familiar], $item[none]);
+	}
 }
 
 boolean doTasks()
@@ -3359,7 +3368,7 @@ boolean doTasks()
 		if(LX_freeCombats()) return true;
 	}
 
-	if(catBurglarHeist())			return true;
+	catBurglarHeist(); // don't return true from this, isn't adventuring.
 	if(chateauPainting())			return true;
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -120,6 +120,29 @@ boolean autoOutfit(string toWear)
 	return pass;
 }
 
+boolean autoStripOutfit(string toRemove) {
+	// removes an outfit if you have it equipped
+
+	item[int] outfit_pieces = outfit_pieces(toRemove);
+	if (count(outfit_pieces) == 0 || !is_wearing_outfit(toRemove)) {
+		return false;
+	}
+	auto_log_info(`Removing your {toRemove} outfit as requested.`, "blue");
+	foreach _, piece in outfit_pieces {
+		if (to_slot(piece) != $slot[acc1]) {
+			equip(to_slot(piece), $item[none]);
+		} else {
+			foreach accSlot in $slots[acc1, acc2, acc3] {
+				if (equipped_item(accSlot) == piece) {
+					equip(accSlot, $item[none]);
+					break;
+				}
+			}
+		}
+	}
+	return is_wearing_outfit(toRemove);
+}
+
 boolean tryAddItemToMaximize(slot s, item it)
 {
 	if(!($slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar] contains s))
@@ -273,6 +296,10 @@ void finalizeMaximize()
 	if(auto_wantToEquipPowerfulGlove())
 	{
 		auto_forceEquipPowerfulGlove();
+	}
+	if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 8) {
+		// Save the first 8 sausage goblins for delay burning
+		addToMaximize("-equip " + $item[Kramco Sausage-o-Matic&trade;].to_string());
 	}
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -168,10 +168,21 @@ boolean auto_pre_adventure()
 
 	// Latte may conflict with certain quests. Ignore latte drops for the greater good.
 	boolean[location] IgnoreLatteDrop = $locations[The Haunted Boiler Room];
-	if((auto_latteDropWanted(place)) && (!(IgnoreLatteDrop contains place)))
-	{
-		auto_log_info('We want to get the "' + auto_latteDropName(place) + '" ingredient for our latte from ' + place + ", so we're bringing it along.", "blue");
-		autoEquip($item[latte lovers member\'s mug]);
+	if (auto_latteDropWanted(place) && !(IgnoreLatteDrop contains place)) {
+		if (auto_sausageGoblin()) {
+			// Burning delay using a Sausage Goblin. Can't hold both the Kramco and the Latte, we only have one off-hand!
+			if (canChangeToFamiliar($familiar[Left-Hand Man])) {
+				// If we can use the Left-Hand man, we can get a two-fer with both the Kramco and Latte
+				// Hurrah! We found an actual use for it, it's not useless after all!
+				auto_log_info('We want to get the "' + auto_latteDropName(place) + '" ingredient for our Latte from ' + place + ", and we're buring delay using the Kramco so your Left-Hand Man will be bringing your Latte along!", "blue");				handleFamiliar($familiar[Left-Hand Man]);
+				handleFamiliar($familiar[Left-Hand Man]);
+				use_familiar($familiar[Left-Hand Man]); // update familiar already called so have to force.
+				autoEquip($slot[familiar], $item[latte lovers member\'s mug]);
+			}
+		} else {
+			auto_log_info('We want to get the "' + auto_latteDropName(place) + '" ingredient for our Latte from ' + place + ", so we're bringing it along.", "blue");
+			autoEquip($item[latte lovers member\'s mug]);
+		}
 	}
 
 	if(in_zelda())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1372,7 +1372,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 
 	//Peel out with Extra-Smelly Muffler, note 10 limit, increased to 30 with Racing Slicks
 
-	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent") && get_property("_auto_maximize_equip_off-hand") != "")
+	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent"))
 	{
 		return "skill " + $skill[Throw Latte on Opponent];
 	}
@@ -1439,6 +1439,14 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Reflex Hammer];
 	}
+
+	if ((inCombat ? have_equipped($item[Fourth of May cosplay saber]) : possessEquipment($item[Fourth of May cosplay saber])) && auto_saberChargesAvailable() > 0 && !(used contains "Saber Force")) {
+		// can't use the force on uncopyable monsters
+		if (enemy == $monster[none] || enemy.copyable) {
+			return auto_combatSaberBanish();
+		}
+	}
+
 	if((inCombat ? auto_have_skill($skill[KGB Tranquilizer Dart]) : possessEquipment($item[Kremlin\'s Greatest Briefcase])) && (get_property("_kgbTranquilizerDartUses").to_int() < 3) && (my_mp() >= mp_cost($skill[KGB Tranquilizer Dart])) && (!(used contains "KGB tranquilizer dart")))
 	{
 		boolean useIt = true;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -608,7 +608,7 @@ generic_t zone_delay(location loc)
 		value = 5 - loc.turns_spent;
 		break;
 	case $location[The Hidden Park]:
-		if(!possessEquipment($item[Antique Machete]) && !possessEquipment($item[Muculent Machete]))
+		if(!possessEquipment($item[Antique Machete]) && !possessEquipment($item[Muculent Machete]) && in_hardcore())
 		{
 			value = 6 - loc.turns_spent;
 		}
@@ -672,6 +672,14 @@ generic_t zone_delay(location loc)
 	case $location[The Castle in the Clouds in the Sky (Ground Floor)]:
 		value = 10 - loc.turns_spent;
 		break;
+	case $location[The Haunted Pantry]:
+		if (isGuildClass() && my_primestat() == $stat[mysticality]) {
+			value = 5 - loc.turns_spent;
+		}
+	case $location[The Sleazy Back Alley]:
+		if (isGuildClass() && my_primestat() == $stat[moxie]) {
+			value = 5 - loc.turns_spent;
+		}
 	default:
 		retval._error = true;
 		break;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -172,6 +172,7 @@ int auto_warTotalBattles(WarPlan plan, int remaining);		//Defined in autoscend/a
 int auto_warTotalBattles(WarPlan plan);						//Defined in autoscend/auto_quest_level_12.ash
 boolean warAdventure();										//Defined in autoscend/auto_quest_level_12.ash
 boolean haveWarOutfit();									//Defined in autoscend/auto_quest_level_12.ash
+boolean warOutfit(boolean immediate);
 boolean warOutfit();										//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_sonofaPrefix();									//Defined in autoscend/auto_quest_level_12.ash
 boolean L12_themtharHills();								//Defined in autoscend/auto_quest_level_12.ash
@@ -640,6 +641,7 @@ boolean autoEquip(slot s, item it); //Defined in autoscend/auto_equipment.ash
 boolean autoEquip(item it); //Defined in autoscend/auto_equipment.ash
 boolean autoForceEquip(slot s, item it); //Defined in autoscend/auto_equipment.ash
 boolean autoForceEquip(item it); //Defined in autoscend/auto_equipment.ash
+boolean autoStripOutfit(string toRemove);
 boolean tryAddItemToMaximize(slot s, item it); //Defined in autoscend/auto_equipment.ash
 string defaultMaximizeStatement(); //Defined in autoscend/auto_equipment.ash
 void resetMaximize(); //Defined in autoscend/auto_equipment.ash
@@ -716,6 +718,7 @@ boolean auto_latteRefill(string want1, string want2); // Defined in autoscend/au
 boolean auto_latteRefill(string want1, boolean force); // Defined in autoscend/auto_mr2018.ash
 boolean auto_latteRefill(string want1); // Defined in autoscend/auto_mr2018.ash
 boolean auto_latteRefill(); // Defined in autoscend/auto_mr2018.ash
+boolean auto_haveVotingBooth();
 boolean auto_voteSetup();										//Defined in autoscend/iotms/auto_mr2018.ash
 boolean auto_voteSetup(int candidate);						//Defined in autoscend/iotms/auto_mr2018.ash
 boolean auto_voteSetup(int candidate, int first, int second);	//Defined in autoscend/iotms/auto_mr2018.ash
@@ -733,6 +736,7 @@ boolean auto_sausageGrind(int numSaus); // Defined in autoscend/auto_mr2019.ash
 boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll); // Defined in autoscend/auto_mr2019.ash
 boolean auto_sausageEatEmUp(int maximumToEat); // Defined in autoscend/auto_mr2019.ash
 boolean auto_sausageEatEmUp(); // Defined in autoscend/auto_mr2019.ash
+boolean auto_haveKramcoSausageOMatic();
 boolean auto_sausageGoblin(); // Defined in autoscend/auto_mr2019.ash
 boolean auto_sausageGoblin(location loc); // Defined in autoscend/auto_mr2019.ash
 boolean auto_sausageGoblin(location loc, string option); // Defined in autoscend/auto_mr2019.ash
@@ -757,6 +761,7 @@ boolean auto_beachUseFreeCombs();	// Defined in autoscend/auto_mr2019.ash
 effect auto_beachCombHeadEffect(string name); // Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayAvailable();	// Defined in autoscend/auto_mr2019.ash
 boolean auto_campawayGrabBuffs();	// Defined in autoscend/auto_mr2019.ash
+boolean auto_havePillKeeper();
 int auto_pillKeeperUses();						//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeperFreeUseAvailable();	//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeperAvailable();			//Defined in autoscend/iotms/auto_mr2019.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -407,7 +407,7 @@ void auto_setSongboom()
 		// Once we've started the war, we want to be able to micromanage songs
 		// for Gremlins and Nuns. Don't break this for them.
 	}
-	else if (!isActuallyEd() && internalQuestStatus("questL07Cyrptic") < 1 && get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
+	else if (!isActuallyEd() && !auto_havePillKeeper() && internalQuestStatus("questL07Cyrptic") < 1 && get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
 	{
 		songboomSetting("nightmare");
 	}
@@ -487,6 +487,19 @@ item[monster] catBurglarHeistDesires()
 	 * PREADVENTURE IF WE NEED THE BURGLE.
 	 */
 	item[monster] wannaHeists;
+
+	if (!canChangeToFamiliar($familiar[XO Skeleton]) && get_property("sidequestOrchardCompleted") == "none") {
+		// Can't hugpocket? 1 turn filthworms is still a thing you can do!
+		if (have_effect($effect[Filthworm Larva Stench]) == 0 && item_amount($item[Filthworm Hatchling Scent Gland]) == 0) {
+			wannaHeists[$monster[larval filthworm]] = $item[Filthworm Hatchling Scent Gland];
+		}
+		if (have_effect($effect[Filthworm Drone Stench]) == 0 && item_amount($item[Filthworm Drone Scent Gland]) == 0) {
+			wannaHeists[$monster[filthworm drone]] = $item[Filthworm Drone Scent Gland];
+		}
+		if (have_effect($effect[Filthworm Guard Stench]) == 0 && item_amount($item[Filthworm Royal Guard Scent Gland]) == 0) {
+			wannaHeists[$monster[filthworm royal guard]] = $item[Filthworm Royal Guard Scent Gland];
+		}
+	}
 
 	item oreGoal = to_item(get_property("trapperOre"));
 	if (oreGoal != $item[none] && item_amount(oreGoal) < 3 && internalQuestStatus("questL08Trapper") < 2 && in_hardcore())
@@ -1152,6 +1165,10 @@ boolean auto_latteRefill()
 	return auto_latteRefill("");
 }
 
+boolean auto_haveVotingBooth() {
+	return ((get_property("_voteToday").to_boolean() || get_property("voteAlways").to_boolean()) && auto_is_valid($item[voter registration form]));
+}
+
 boolean auto_voteSetup()
 {
 	return auto_voteSetup(0,0,0);
@@ -1236,7 +1253,7 @@ boolean auto_voteMonster(boolean freeMon, location loc)
 
 boolean auto_voteMonster(boolean freeMon, location loc, string option)
 {
-	if(!get_property("_voteToday").to_boolean() && !get_property("voteAlways").to_boolean())
+	if(!auto_haveVotingBooth())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -177,6 +177,13 @@ boolean auto_sausageEatEmUp() {
 	return auto_sausageEatEmUp(0);
 }
 
+boolean auto_haveKramcoSausageOMatic() {
+	if (possessEquipment($item[Kramco Sausage-o-Matic&trade;]) && auto_can_equip($item[Kramco Sausage-o-Matic&trade;])) {
+		return true;
+	}
+	return false;
+}
+
 boolean auto_sausageGoblin()
 {
 	return auto_sausageGoblin($location[none], "");
@@ -193,11 +200,7 @@ boolean auto_sausageGoblin(location loc, string option)
 	// by all sorts stuff like superlikelies, wanderers and semi-rares.
 	// The good news is, being overridden just means adventure there again to get it
 
-	if(!possessEquipment($item[Kramco Sausage-o-Matic&trade;]))
-	{
-		return false;
-	}
-	if(!auto_can_equip($item[Kramco Sausage-o-Matic&trade;]))
+	if(!auto_haveKramcoSausageOMatic())
 	{
 		return false;
 	}
@@ -207,13 +210,7 @@ boolean auto_sausageGoblin(location loc, string option)
 	// x is the number of goblins you've already encountered that day.
 	// spoilered by The Dictator in ASS Discord #iotm-discussion
 	// intervals are therefore 0, 7, 10, 13, 16, 19, 23, 33, 55, 95, 128...
-	// cut off delay burning after the 8th as the interval gets very large from #9
 	int sausageFights = get_property("_sausageFights").to_int();
-	if (sausageFights >= 8)
-	{
-		return false;
-	}
-
 	float numerator = (total_turns_played() - get_property("_lastSausageMonsterTurn").to_float()) + 1.0;
 	float denominator = 5.0 + (sausageFights * 3.0) + (max(0.0, sausageFights - 5.0))**3.0;
 	if (sausageFights > 0 && (numerator / denominator) < 1.0)
@@ -729,11 +726,13 @@ boolean auto_campawayGrabBuffs()
 	return true;
 }
 
+boolean auto_havePillKeeper() {
+	return (possessEquipment($item[Eight Days a Week Pill Keeper]) && is_unrestricted($item[Unopened Eight Days a Week Pill Keeper]));
+}
+
 int auto_pillKeeperUses()
 {
-	if (0 == equipmentAmount($item[Eight Days a Week Pill Keeper])
-		|| (!is_unrestricted($item[Unopened Eight Days a Week Pill Keeper])))
-	{
+	if (!auto_havePillKeeper()) {
 		return 0;
 	}
 	return spleen_left()/3 + 1 - get_property("_freePillKeeperUsed").to_boolean().to_int();

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -244,19 +244,18 @@ boolean auto_mushroomGardenHandler() {
 
 boolean auto_getGuzzlrCocktailSet() {
 	if (possessEquipment($item[Guzzlr tablet]) && auto_is_valid($item[Guzzlr tablet])) {
-		if (get_property("guzzlrGoldDeliveries").to_int() >= 5) {
+		if (get_property("guzzlrGoldDeliveries").to_int() >= 5
+		&& get_property("questGuzzlr") == "unstarted"
+		&& get_property("_guzzlrPlatinumDeliveries").to_int() == 0
+		&& !get_property("_guzzlrQuestAbandoned").to_boolean()) {
 			auto_log_info("Getting a Guzzlr Cocktail Set (for all the good it will do).");
-			if (get_property("questGuzzlr") == "unstarted" && get_property("_guzzlrPlatinumDeliveries").to_int() == 0 && !get_property("_guzzlrQuestAbandoned").to_boolean()) {
-      	visit_url("inventory.php?tap=guzzlr", false);
-      	run_choice(4); // take platinum quest
-				wait(1); // mafia's tracking breaks occasionally if you go too fast.
-      	visit_url("inventory.php?tap=guzzlr", false);
-      	run_choice(1); // abandon
-      	run_choice(5); // leave the choice.
-				return true; // ponder on what else you could've spent the Mr. Accessory on instead.
-    	}
-		} else {
-			auto_log_info("You haven't unlocked the platinum Guzzlr quests yet. I wouldn't worry about it though as it's all but useless.");
+			visit_url("inventory.php?tap=guzzlr", false);
+			run_choice(4); // take platinum quest
+			wait(1); // mafia's tracking breaks occasionally if you go too fast.
+			visit_url("inventory.php?tap=guzzlr", false);
+			run_choice(1); // abandon
+			run_choice(5); // leave the choice.
+			return true; // ponder on what else you could've spent the Mr. Accessory on instead.
 		}
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1275,17 +1275,18 @@ boolean L11_hiddenCity()
 	{
 		auto_log_info("The idden [sic] office!", "blue");
 
-		if((item_amount($item[Boring Binder Clip]) == 1) && (item_amount($item[McClusky File (Page 5)]) == 1))
-		{
-			visit_url("inv_use.php?pwd=&which=3&whichitem=6694");
-			cli_execute("refresh inv");
+		if (creatable_amount($item[McClusky file (complete)]) > 0) {
+			create(1, $item[McClusky file (complete)]);
+		}
+
+		boolean workingHoliday = ($location[The Hidden Office Building].turns_spent > 0 && $location[The Hidden Office Building].turns_spent % 5 == 0);
+
+		if (!workingHoliday && item_amount($item[McClusky file (complete)]) > 0 && auto_canForceNextNoncombat()) {
+			auto_forceNextNoncombat();
 		}
 
 		auto_log_info("Hidden Office Progress: " + get_property("hiddenOfficeProgress"), "blue");
-		backupSetting("autoCraft", false);
-		boolean advSpent = autoAdv($location[The Hidden Office Building]);
-		restoreSetting("autoCraft");
-		return advSpent;
+		return autoAdv($location[The Hidden Office Building]);
 	}
 
 	if (internalQuestStatus("questL11Spare") < 2)
@@ -1895,7 +1896,7 @@ boolean L11_shenCopperhead()
 		case $item[Murphy\'s Rancid Black Flag]:		goal = $location[The Castle in the Clouds in the Sky (Top Floor)];	break;
 		case $item[The Eye of the Stars]:				goal = $location[The Hole in the Sky];								break;
 		case $item[The Lacrosse Stick of Lacoronado]:	goal = $location[The Smut Orc Logging Camp];						break;
-		case $item[The Shield of Brook]:				goal = $location[The VERY Unquiet Garves];							break;
+		case $item[The Shield of Brook]:				goal = $location[The Unquiet Garves];							break;
 		}
 		if(goal == $location[none])
 		{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -865,13 +865,12 @@ boolean L12_filthworms()
 			buyUpTo(1, $item[third-hand lantern]);
 			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[third-hand lantern]);
 		}
-		
-		//fold and remove maximizer block on using IOTM with 9 charges a day that doubles item drop chance
-		if(januaryToteAcquire($item[Broken Champagne Bottle]))
-		{
-			equip($item[Broken Champagne Bottle]);
+
+		if (!canChangeToFamiliar($familiar[XO Skeleton]) && catBurglarHeistsLeft() < 1) {
+			//fold and remove maximizer block on using IOTM with 9 charges a day that doubles item drop chance
+			januaryToteAcquire($item[Broken Champagne Bottle]);
 		}
-		
+
 		if(auto_my_path() == "Live. Ascend. Repeat.")
 		{
 			equipMaximizedGear();
@@ -990,7 +989,6 @@ boolean L12_gremlins()
 	// this keeps us from accidentally killing gremlins
 	addToMaximize("-familiar");
 
-	#Put a different shield in here.
 	auto_log_info("Doing them gremlins", "blue");
 	addToMaximize("20dr,1da 1000max,3hp,-3ml");
 	acquireHP();

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -698,6 +698,9 @@ boolean LX_joinPirateCrew() {
 		} else {
 			auto_log_info("Insult gathering party.", "blue");
 			addToMaximize("-outfit Swashbuckling Getup");
+			// If we're wearing the pirate outfit already, autoAdv will fail to adventure
+			// in the cove since the zone isn't available unless we remove it (which wouldn't happen until auto_pre_adv runs)
+			autoStripOutfit("Swashbuckling Getup");
 			if (autoAdv($location[The Obligatory Pirate\'s Cove])) {
 				return true;
 			}


### PR DESCRIPTION
# Description

- Lots of tweaks to familiars. Mostly removing the Fairyballs from a whole lot of places they don't need to be as they dominate familiar selection otherwise. Tweaked regen familiars so the Fairywhelps are higher and grouped together (above XO Skeleton). Removed a bunch of drop farming from the stat familiars (they don't need to be in both drop and stat).
- add "new" monsters in the Cyrpt to the banish list ("new" because the were added on the 1st of January 2020 which was a full 8 months ago).
- Add Red Butler, Skinflute and Camel Toe to sniff monsters and a duplicate of pygmy witch accountant since it's optimal to sniff when we have thrice-cursed already.
- More Left-Hand Man support. Use it to grab Latte ingredients if burning delay. Also unequip whatever it is equipped with when we start a new loop iteration due to a mafia bug.
- Exclude Kramco from equipment until we've fought the first 8 sausage goblins so we can use them to burn delay. Also don't cut off delay burning arbitrarily.
- Fix Latte Banishing to actually work more often than it currently does. Add Saber to banishers.
- Don't burn delay in the Hidden Park in Normal, machetes will be pulled.
- add Filthworm glands to the list of stuff we heist with Cat Burglar (if we don't have an XO Skeleton and have heists to use).
- tidy up Guzzlr cocktail set acquisition logic.
- Force non-combat in the Hidden Apartment Building if we have the complete McClusky File
- Fix issue where insult farming in the Pirate Cove would fail the first time due to you still wearing the pirate outfit (and thus the location being unavailable).
- Some tidying of Voting Booth, Kramco and Pill Keeper checks and other misc stuff.

Fixes #37, #295 

## How Has This Been Tested?

Been running Normal LKS & Normal G-Lover with these (and more) changes.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
