### PR TITLE
yellow ray

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1243,11 +1243,6 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(contains_text(combatState, "yellowray"))
-	{
-		abort("Ugh, where is my damn yellowray!!!");
-	}
-
 	if(item_amount($item[Green Smoke Bomb]) > 0)
 	{
 		if($monsters[Animated Possessions, Natural Spider] contains enemy)
@@ -2970,7 +2965,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if (!contains_text(combatState, "yellowray") && canYellowRay(enemy) && auto_wantToYellowRay(enemy, my_location()))
+	if(!contains_text(combatState, "yellowray") && auto_wantToYellowRay(enemy, my_location()))
 	{
 		string combatAction = yellowRayCombatString(enemy, true);
 		if(combatAction != "")

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -2983,7 +2983,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 			{
 				auto_log_warning("Unable to track yellow ray behavior: " + combatAction, "red");
 			}
-			if(combatAction == ("skill " + $skill[Asdon Martin: Missile Launcher]))
+			if(combatAction == useSkill($skill[Asdon Martin: Missile Launcher], false))
 			{
 				set_property("_missileLauncherUsed", true);
 			}


### PR DESCRIPTION
*remove a redundant abort when yellow ray fails that happens after the yr block function.
**it already gives a warning if it fails inside the yr function block. and sometimes you just do not have a yr
*ed combat yellow ray checked should not check canYellowRay(monster). that function is actually a pre-combat prep for yellow ray not a check if you can yellowray, it just produces errors during combat as it tries to acquire items which cannot be done during combat. modified to match the non ed combat function.
*take an old update for asdon martin yr (daily missile launcher) handling and apply it to ed combat handler as well

## How Has This Been Tested?

several HC ed on different accounts
day 3 of 3 of SC ed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
