### PR TITLE
gnoob blacklist and cubeling handling

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -476,10 +476,14 @@ boolean haveSpleenFamiliar()
 
 boolean wantCubeling()
 {
-	//do we still want to use a gelatinous cubeling familiar so that it will drop the daily dungeon tools
+	//do we still want to use a gelatinous cubeling familiar specifically for it to drop the daily dungeon tools
 	if(!canChangeToFamiliar($familiar[Gelatinous Cubeling]))
 	{
 		return false;	//can not use it so we do not want it.
+	}
+	if(get_property("cubelingProgress").to_int() > 11)
+	{
+		return false;	//cubeling already dropped tools in this ascension. It cannot drop more until you ascend again.
 	}
 	
 	boolean need_lockpicks = item_amount($item[pick-o-matic lockpicks]) == 0 && item_amount($item[Platinum Yendorian Express Card]) == 0;

--- a/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
+++ b/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
@@ -91,6 +91,10 @@ void jello_buySkills()
 
 	boolean[item] blacklist;
 	
+	if(item_amount($item[Pick-O-Matic lockpicks]) == 1)
+	{
+		blacklist[$item[Pick-O-Matic lockpicks]] = true;	//do not absorb our last lockpick. could have more than 1 in postronin
+	}
 	if(internalQuestStatus("questL10Garbage") < 2 && item_amount($item[Enchanted Bean]) == 1)
 	{
 		blacklist[$item[Enchanted Bean]] = true;	//need to keep our only enchanted bean to be planted


### PR DESCRIPTION
*blacklist your last set of lockpicks from being absorbed as gnoob
*boolean wantCubeling() check if cubeling already dropped items this ascension.

## How Has This Been Tested?

ash calls and validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
