### PR TITLE
Bugfix for delay burning issue with sausage goblins

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -132,7 +132,7 @@ boolean auto_pre_adventure()
 	}
 
 	// this calls the appropriate provider for +combat or -combat depending on the zone we are about to adventure in..
-	boolean burningDelay = (auto_voteMonster(true) || isOverdueDigitize() || auto_sausageGoblin());
+	boolean burningDelay = ((auto_voteMonster(true) || isOverdueDigitize() || auto_sausageGoblin()) && place == solveDelayZone());
 	generic_t combatModifier = zone_combatMod(place);
 	if (combatModifier._boolean && !burningDelay && !auto_haveQueuedForcedNonCombat()) {
 		acquireCombatMods(combatModifier._int, true);


### PR DESCRIPTION
# Description

we're only burning delay if we're adventuring in the zone solveDelayZone() returns.

Fixes #527 

## How Has This Been Tested?

It hasn't been tested massively as I'd need to jump into a non-LKS run and the account I could test this in is day 2 of LKS. Validates and runs fine though. 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
