### PR TITLE
fix infinite loop if you possess a hand in glove and try to acquireHP()

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1455,9 +1455,18 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
 	
 	//owning a hand in glove breaks maxHP tracking. need to check possession rather than equipped because unequipping it also breaks it. in fact it causes us to get stuck in an infinite loop of trying to restore hp when already at max HP.
 	//mafia devs think it is actually a kol bug so they won't fix it. https://kolmafia.us/showthread.php?25214
-	if(possessEquipment($item[hand in glove]))
+	if(possessEquipment($item[Hand in Glove]))
 	{
+		int initial_maxHP = my_maxhp();
 		cli_execute("refresh status");
+		if(initial_maxHP == my_maxhp())
+		{
+			auto_log_debug("I just refreshed status because I detected [Hand in Glove]. But it turned out to not have been necessary");
+		}
+		else
+		{
+			auto_log_debug("I just refreshed status because I detected [Hand in Glove] and it corrected my maxHP value. This prevented an infinite loop");
+		}
 	}
 
   boolean isMax = (goal == my_maxhp());

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1452,6 +1452,13 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests){
 	{
 		return false;
 	}
+	
+	//owning a hand in glove breaks maxHP tracking. need to check possession rather than equipped because unequipping it also breaks it. in fact it causes us to get stuck in an infinite loop of trying to restore hp when already at max HP.
+	//mafia devs think it is actually a kol bug so they won't fix it. https://kolmafia.us/showthread.php?25214
+	if(possessEquipment($item[hand in glove]))
+	{
+		cli_execute("refresh status");
+	}
 
   boolean isMax = (goal == my_maxhp());
 


### PR DESCRIPTION
fix infinite loop if you possess a hand in glove and try to acquireHP()
owning a hand in glove breaks maxHP tracking when equipping, unequipping, or smithness score changes.
We need to check possession rather than equipped because unequipping it also breaks it. unequipping specifically can get autoscend stuck in an infinite loop of trying to restore hp when already at max HP.
mafia devs say it is a kol bug so they won't add automatic refreshes
https://kolmafia.us/showthread.php?25214
so we need to work around this issue. The workaround is CLI command refresh status at the start of acquireHP function if we possess a hand in glove.

## How Has This Been Tested?

half of a day 1 of casual accordion thief which had gotten stuck in the infinite loop 3 times already before I applied this fix.
also added debug message on when it refreshed unnecessarily vs needed and it successfully gave me the needed message, meaning it detected that it fixed an incorrect maxHP value that would have likely caused an infinite loop.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
