### PR TITLE
Couple of tweaks to combat rate providers

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2805,6 +2805,8 @@ float providePlusCombat(int amt, boolean doEquips, boolean speculative) {
 
 	if (get_property("_horsery") == "dark horse") {
 		horseNone();
+		delta += (-1.0 * numeric_modifier("Horsery:dark horse", "Combat Rate")); // horsery changes don't happen until pre-adventure so this needs to be manually added otherwise it won't count.
+		auto_log_debug("We " + (speculative ? "can remove" : "will remove") + " Dark Horse, we will have " + result());
 	} else {
 		horseMaintain();
 	}
@@ -2815,6 +2817,9 @@ float providePlusCombat(int amt, boolean doEquips, boolean speculative) {
 	void handleEffect(effect eff) {
 		if (speculative) {
 			delta += numeric_modifier(eff, "Combat Rate");
+			if (eff == $effect[Musk of the Moose] && have_effect($effect[Smooth Movements]) > 0) {
+				delta += (-1.0 * numeric_modifier($effect[Smooth Movements], "Combat Rate")); // numeric_modifer doesn't take into account uneffecting the opposite skill so we have to add it manually.
+			}
 		}
 		auto_log_debug("We " + (speculative ? "can gain" : "just gained") + " " + eff.to_string() + ", now we have " + result());
 	}
@@ -2941,14 +2946,22 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		}
 	}
 
-	horseDark();
-	if(pass()) {
-		return result();
+	if (isHorseryAvailable() && my_meat() > horseCost() && get_property("_horsery") != "dark horse") {
+		horseDark();
+		delta += (-1.0 * numeric_modifier("Horsery:dark horse", "Combat Rate")); // horsery changes don't happen until pre-adventure so this needs to be manually added otherwise it won't count.
+		auto_log_debug("We " + (speculative ? "can gain" : "will gain") + " Dark Horse, we will have " + result());
+		if(pass()) {
+			return result();
+		}
 	}
+
 
 	void handleEffect(effect eff) {
 		if (speculative) {
 			delta += (-1.0 * numeric_modifier(eff, "Combat Rate"));
+			if (eff == $effect[Smooth Movements] && have_effect($effect[Musk of the Moose]) > 0) {
+				delta += numeric_modifier($effect[Musk of the Moose], "Combat Rate"); // numeric_modifer doesn't take into account uneffecting the opposite skill so we have to add it manually.
+			}
 		}
 		auto_log_debug("We " + (speculative ? "can gain" : "just gained") + " " + eff.to_string() + ", now we have " + result());
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2804,10 +2804,12 @@ float providePlusCombat(int amt, boolean doEquips, boolean speculative) {
 	}
 
 	if (get_property("_horsery") == "dark horse") {
-		horseNone();
+		if (!speculative) {
+			horseNone();
+		}
 		delta += (-1.0 * numeric_modifier("Horsery:dark horse", "Combat Rate")); // horsery changes don't happen until pre-adventure so this needs to be manually added otherwise it won't count.
 		auto_log_debug("We " + (speculative ? "can remove" : "will remove") + " Dark Horse, we will have " + result());
-	} else {
+	} else if (!speculative) {
 		horseMaintain();
 	}
 	if(pass()) {
@@ -2947,12 +2949,16 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 	}
 
 	if (isHorseryAvailable() && my_meat() > horseCost() && get_property("_horsery") != "dark horse") {
-		horseDark();
+		if (!speculative) {
+			horseDark();
+		}
 		delta += (-1.0 * numeric_modifier("Horsery:dark horse", "Combat Rate")); // horsery changes don't happen until pre-adventure so this needs to be manually added otherwise it won't count.
 		auto_log_debug("We " + (speculative ? "can gain" : "will gain") + " Dark Horse, we will have " + result());
-		if(pass()) {
-			return result();
-		}
+	} else if (!speculative) {
+		horseMaintain();
+	}
+	if(pass()) {
+		return result();
 	}
 
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -787,6 +787,7 @@ boolean auto_canFightPiranhaPlant();
 boolean auto_canTendMushroomGarden();
 
 boolean getSpaceJelly();					//Defined in autoscend/iotms/auto_mr2017.ash
+boolean isHorseryAvailable();
 int horseCost();											//Defined in autoscend/iotms/auto_mr2017.ash
 string horseNormalize(string horseText); // Defined in autoscend/auto_mr2017.ash
 boolean getHorse(string type);								//Defined in autoscend/iotms/auto_mr2017.ash


### PR DESCRIPTION
# Description

I was reviewing IotM use in an LKS run and noticed it was still using Powerful Glove charges for Invisible Avatar occasionally (and ending up on 27% combat rate) even when it had the key sausage, smooth movements, sonata of sneakiness and horsery available which is sufficient to hit the 25% soft cap. 

- fix use of horsery in providers
- also tweak speculative values when we have Musk of the Moose/Smooth Movements since they are removed by each other.

## How Has This Been Tested?

Ran LKS day 3 with these changes (and G-Lover but 0 IotMs).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
