### PR TITLE
casual fix not unlocking spookyraven 2nd floor

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -370,7 +370,7 @@ boolean LX_unlockManorSecondFloor() {
 		return false;
 	}
 
-	if (!hasSpookyravenLibraryKey() || possessEquipment($item[ghost of a necklace])) {
+	if (!hasSpookyravenLibraryKey()) {
 		return false;
 	}
 


### PR DESCRIPTION
do not skip unlocking 2nd floor of spookyraven manor just because you have ghost of a necklace.
this seems to be some sort of error correction that assumes that if we have a ghost of a necklace it means we must have finished this quest already. However we already use mafia tracking on this quest to check the state of it. And you can have ghost of a necklace either as a manual pull in softcore or as a result of being in casual.
So this method of error correction only introduces errors instead of fixing them.

## How Has This Been Tested?

got stuck in casual run with autoscend thinking there is nothing left to do. applied this fix and it did the haunted library

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
