### PR TITLE
fixes #18

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -247,7 +247,8 @@ void resetMaximize()
 	// don't want to equip these items automatically
 	// snow suit bonus drops every 5 combats so is best saved for important things
 	// sword, and staph are text scramblers which cause errors in mafia tracking
-	foreach it in $items[sword behind inappropriate prepositions, staph of homophones, snow suit]
+	// bathysphere gives -20 lbs familiar weight. under certain circumstances maximizer decides to equip it
+	foreach it in $items[sword behind inappropriate prepositions, staph of homophones, snow suit, little bitty bathysphere]
 	{
 		if (possessEquipment(it))
 		{


### PR DESCRIPTION
under certain conditions maximizer will try to use littly bitty bathysphere which gives -20 lbs familiar weight.
https://kolmafia.us/showthread.php?23648
so add it to blacklisted items

fixes #18

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
