### PR TITLE
Don't try to make a fancy oil painting if grimstone mask is unusable

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -78,6 +78,10 @@ boolean considerGrimstoneGolem(boolean bjornCrown)
 	{
 		return false;
 	}
+	if(!auto_is_valid($item[Grimstone Mask]))
+	{
+		return false;
+	}
 
 	if(bjornCrown && (get_property("_grimstoneMaskDropsCrown").to_int() != 0))
 	{
@@ -474,6 +478,10 @@ boolean fancyOilPainting()
 		return false;
 	}
 	if(my_adventures() <= 4)
+	{
+		return false;
+	}
+	if(!auto_is_valid($item[Grimstone Mask]) || !auto_is_valid($item[fancy oil painting]))
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

While running as a HC snake oiler, ran into an infinite loop that cluttered logs with complaints about not being able to reach the prince's balcony. Turned out that the script was trying to use a grimstone mask to get a Fancy oil painting, but grimstone mask is not usable outside of regular classes. The auto_is_valid() function already handles this use case correctly, so added some calls to auto_is_valid() before trying to get the fancy oil painting.

## How Has This Been Tested?

Issue was extremely reproducible, left me with a GB session log full of 18 million lines of the same warning. After purging that from the logs and implementing this fix, issue doesn't reoccur, even with grimstone mask in inventory. Though it was fixed for west of loathing, the fix should work for all paths that don't allow a grimstone mask.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
