### PR TITLE
Red-Nosed Snapper handling.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2413,6 +2413,9 @@ boolean LX_freeCombats(boolean powerlevel)
 		else
 		{
 			auto_log_debug("LX_freeCombats is calling neverendingPartyCombat()");
+			if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+				changeSnapperPhylum($phylum[dude]);
+			}
 			if(neverendingPartyCombat()) return true;
 		}
 	}
@@ -3128,6 +3131,8 @@ void resetState() {
 	set_property("auto_januaryToteAcquireCalledThisTurn", false); // january tote item switching
 
 	horseDefault(); // horsery tracking
+
+	set_property("auto_snapperPhylum", ""); // Red-Nosed Snapper phylum tracking
 
 	bat_formNone(); // Vampyre form tracking
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2414,7 +2414,7 @@ boolean LX_freeCombats(boolean powerlevel)
 		{
 			auto_log_debug("LX_freeCombats is calling neverendingPartyCombat()");
 			if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-				changeSnapperPhylum($phylum[dude]);
+				auto_changeSnapperPhylum($phylum[dude]);
 			}
 			if(neverendingPartyCombat()) return true;
 		}
@@ -3132,7 +3132,7 @@ void resetState() {
 
 	horseDefault(); // horsery tracking
 
-	set_property("auto_snapperPhylum", ""); // Red-Nosed Snapper phylum tracking
+	set_property("auto_snapperPhylum", ""); // internal Red-Nosed Snapper phylum tracking. Ensures we only change it maximum once per adventure (and don't lose charges)
 
 	bat_formNone(); // Vampyre form tracking
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2413,7 +2413,8 @@ boolean LX_freeCombats(boolean powerlevel)
 		else
 		{
 			auto_log_debug("LX_freeCombats is calling neverendingPartyCombat()");
-			if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			if (handleFamiliar($familiar[Red-Nosed Snapper]))
+			{
 				auto_changeSnapperPhylum($phylum[dude]);
 			}
 			if(neverendingPartyCombat()) return true;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -307,6 +307,7 @@ boolean auto_pre_adventure()
 
 	bat_formPreAdventure();
 	horsePreAdventure();
+	snapperPreAdventure(place);
 
 	generic_t itemNeed = zone_needItem(place);
 	if(itemNeed._boolean)

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -307,7 +307,7 @@ boolean auto_pre_adventure()
 
 	bat_formPreAdventure();
 	horsePreAdventure();
-	snapperPreAdventure(place);
+	auto_snapperPreAdventure(place);
 
 	generic_t itemNeed = zone_needItem(place);
 	if(itemNeed._boolean)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1330,7 +1330,8 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Breathe Out];
 	}
 
-	if (item_amount($item[human musk]) > 0 && (!(used contains "human musk")) && auto_is_valid($item[human musk]) && get_property("_humanMuskUses").to_int() < 3) {
+	if (item_amount($item[human musk]) > 0 && (!(used contains "human musk")) && auto_is_valid($item[human musk]) && get_property("_humanMuskUses").to_int() < 3)
+	{
 		return `item {$item[human musk].to_string()}`;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1330,6 +1330,10 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Breathe Out];
 	}
 
+	if (item_amount($item[human musk]) > 0 && (!(used contains "human musk")) && auto_is_valid($item[human musk]) && get_property("_humanMuskUses").to_int() < 3) {
+		return `item {$item[human musk].to_string()}`;
+	}
+
 	//We want to limit usage of these much more than the others.
 	if(!($monsters[Natural Spider, Tan Gnat, Tomb Servant, Upgraded Ram] contains enemy))
 	{
@@ -1457,7 +1461,7 @@ string yellowRayCombatString(monster target, boolean inCombat)
 		{
 			return "skill " + $skill[Flash Headlight];
 		}
-		foreach it in $items[Golden Light, Pumpkin Bomb, Unbearable Light, Viral Video]
+		foreach it in $items[Golden Light, Pumpkin Bomb, Unbearable Light, Viral Video, micronova]
 		{
 			if((item_amount(it) > 0) && auto_is_valid(it))
 			{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -764,8 +764,8 @@ boolean auto_pillKeeperFreeUseAvailable();	//Defined in autoscend/iotms/auto_mr2
 boolean auto_pillKeeperAvailable();			//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeper(int pill);			//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeper(string pill);		//Defined in autoscend/iotms/auto_mr2019.ash
-boolean changeSnapperPhylum(phylum toChange);
-boolean snapperPreAdventure(location loc);
+boolean auto_changeSnapperPhylum(phylum toChange);
+boolean auto_snapperPreAdventure(location loc);
 
 boolean auto_haveBirdADayCalendar();
 boolean auto_birdOfTheDay();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -764,6 +764,8 @@ boolean auto_pillKeeperFreeUseAvailable();	//Defined in autoscend/iotms/auto_mr2
 boolean auto_pillKeeperAvailable();			//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeper(int pill);			//Defined in autoscend/iotms/auto_mr2019.ash
 boolean auto_pillKeeper(string pill);		//Defined in autoscend/iotms/auto_mr2019.ash
+boolean changeSnapperPhylum(phylum toChange);
+boolean snapperPreAdventure(location loc);
 
 boolean auto_haveBirdADayCalendar();
 boolean auto_birdOfTheDay();

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -940,3 +940,82 @@ void auto_deliberate_pizza()
 		to_string(best_plan.ing4) + "\n  ");
 	auto_log_info("For " + auto_pizza_unclamped_advs(best_plan) + " adventures.");
 }
+
+boolean changeSnapperPhylum(phylum toChange) {
+
+	if (!canChangeToFamiliar($familiar[Red-Nosed Snapper]) || toChange == $phylum[none]) {
+		return false;
+	}
+	string phylumString = (toChange == $phylum[mer-kin] ? "merkin" : toChange.to_string());
+	set_property("auto_snapperPhylum", phylumString);
+	return true;
+}
+
+boolean snapperPreAdventure(location loc) {
+	if (my_familiar() != $familiar[Red-Nosed Snapper]) {
+		return false;
+	}
+	
+	string desiredPhylum = get_property("auto_snapperPhylum");
+	if (desiredPhylum != "merkin" && desiredPhylum != "" && desiredPhylum.to_phylum() == $phylum[none]) {
+		auto_log_warning(`auto_snapperPhylum was set to bad value: {desiredPhylum}. Should be a valid phylum.`, "red");
+		remove_property("auto_snapperPhylum");
+		return false;
+	}
+
+	if (get_property("redSnapperPhylum") == desiredPhylum) {
+		auto_log_debug(`Red-Nosed Snapper is already guiding you towards {desiredPhylum}`);
+		return false;
+	}
+
+	// this is mainly in case autoChooseFamiliar switches to the Snapper due to no "better" +item familiars being available
+	// It is preferred that you do not rely on this to change phylum in a quest, call changeSnapperPhylum in the quest handling code instead.
+	if (desiredPhylum == "" && get_property("redSnapperProgress").to_int() < 7) {
+		switch (loc) {
+			case $location[The Penultimate Fantasy Airship]:
+			case $location[The Hidden Park]:
+			case $location[The Hidden Hospital]:
+			case $location[The Hidden Office Building]:
+			case $location[The Hidden Apartment Building]:
+			case $location[The Hidden Bowling Alley]:
+			case $location[The Copperhead Club]:
+			case $location[A Mob of Zeppelin Protesters]:
+			case $location[The Red Zeppelin]:
+			case $location[Inside the Palindome]:
+			case $location[The Neverending Party]:
+			case $location[South of The Border]:
+			case $location[The Valley of Rof L'm Fao]:
+				desiredPhylum = $phylum[dude].to_string(); // human musk (banisher)
+				break;
+			case $location[The Hole in the Sky]:
+				desiredPhylum = $phylum[constellation].to_string(); // micronova (yellow ray)
+				break;
+			case $location[The Smut Orc Logging Camp]:
+				desiredPhylum = $phylum[orc].to_string(); // boot flask (size 3 awesome booze)
+				break;
+			case $location[The Outskirts of Cobb's Knob]:
+			case $location[Cobb's Knob Barracks]:
+			case $location[Cobb's Knob Kitchens]:
+			case $location[Cobb's Knob Harem]:
+			case $location[Cobb's Knob Treasury]:
+			case $location[Cobb's Knob Laboratory]:
+				desiredPhylum = $phylum[goblin].to_string(); // guffin (size 3 awesome food)
+				break;
+			case $location[The "Fun" House]:
+				desiredPhylum = $phylum[horror].to_string(); // powdered madness (free kill)
+				break;
+			case $location[Twin Peak]:
+				// this is actually a dude heavy zone *but* we want to fight the topiary monsters for rusty hedge trimmers.
+				desiredPhylum = $phylum[beast].to_string();
+				break;
+			default:
+				auto_log_info(`Going to {loc} with the Red-Nosed Snapper without setting a phylum. This is not necessarily bad but it might be worth checking.`, "blue");
+				return false;
+		}
+	}
+
+	visit_url("familiar.php?action=guideme&pwd");
+	visit_url(`choice.php?pwd&whichchoice=1396&option=1&cat={desiredPhylum}`);
+	auto_log_info(`Red-Nosed Snapper is now guiding you towards {desiredPhylum}`, "blue");
+	return true;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -941,7 +941,7 @@ void auto_deliberate_pizza()
 	auto_log_info("For " + auto_pizza_unclamped_advs(best_plan) + " adventures.");
 }
 
-boolean changeSnapperPhylum(phylum toChange) {
+boolean auto_changeSnapperPhylum(phylum toChange) {
 
 	if (!canChangeToFamiliar($familiar[Red-Nosed Snapper]) || toChange == $phylum[none]) {
 		return false;
@@ -951,7 +951,7 @@ boolean changeSnapperPhylum(phylum toChange) {
 	return true;
 }
 
-boolean snapperPreAdventure(location loc) {
+boolean auto_snapperPreAdventure(location loc) {
 	if (my_familiar() != $familiar[Red-Nosed Snapper]) {
 		return false;
 	}
@@ -970,7 +970,7 @@ boolean snapperPreAdventure(location loc) {
 
 	// this is mainly in case autoChooseFamiliar switches to the Snapper due to no "better" +item familiars being available
 	// It is preferred that you do not rely on this to change phylum in a quest, call changeSnapperPhylum in the quest handling code instead.
-	if (desiredPhylum == "" && get_property("redSnapperProgress").to_int() < 7) {
+	if (desiredPhylum == "" && get_property("redSnapperProgress").to_int() == 0) {
 		switch (loc) {
 			case $location[The Penultimate Fantasy Airship]:
 			case $location[The Hidden Park]:

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -941,9 +941,15 @@ void auto_deliberate_pizza()
 	auto_log_info("For " + auto_pizza_unclamped_advs(best_plan) + " adventures.");
 }
 
-boolean auto_changeSnapperPhylum(phylum toChange) {
+boolean auto_changeSnapperPhylum(phylum toChange)
+{
+  // Calling this function with a suitable phylum (anything other than none)
+	// will cause the Red-Nosed Snapper to be changed to that phylum during pre-Adventure handling.
+	// This will overwrite any current phylum, losing all progress towards that item (this is intended)
+	// You have been warned.
 
-	if (!canChangeToFamiliar($familiar[Red-Nosed Snapper]) || toChange == $phylum[none]) {
+	if (!canChangeToFamiliar($familiar[Red-Nosed Snapper]) || toChange == $phylum[none])
+	{
 		return false;
 	}
 	string phylumString = (toChange == $phylum[mer-kin] ? "merkin" : toChange.to_string());
@@ -951,27 +957,33 @@ boolean auto_changeSnapperPhylum(phylum toChange) {
 	return true;
 }
 
-boolean auto_snapperPreAdventure(location loc) {
-	if (my_familiar() != $familiar[Red-Nosed Snapper]) {
+boolean auto_snapperPreAdventure(location loc)
+{
+	if (my_familiar() != $familiar[Red-Nosed Snapper])
+	{
 		return false;
 	}
 	
 	string desiredPhylum = get_property("auto_snapperPhylum");
-	if (desiredPhylum != "merkin" && desiredPhylum != "" && desiredPhylum.to_phylum() == $phylum[none]) {
+	if (desiredPhylum != "merkin" && desiredPhylum != "" && desiredPhylum.to_phylum() == $phylum[none])
+	{
 		auto_log_warning(`auto_snapperPhylum was set to bad value: {desiredPhylum}. Should be a valid phylum.`, "red");
 		remove_property("auto_snapperPhylum");
 		return false;
 	}
 
-	if (get_property("redSnapperPhylum") == desiredPhylum) {
+	if (get_property("redSnapperPhylum") == desiredPhylum)
+	{
 		auto_log_debug(`Red-Nosed Snapper is already guiding you towards {desiredPhylum}`);
 		return false;
 	}
 
 	// this is mainly in case autoChooseFamiliar switches to the Snapper due to no "better" +item familiars being available
 	// It is preferred that you do not rely on this to change phylum in a quest, call changeSnapperPhylum in the quest handling code instead.
-	if (desiredPhylum == "" && get_property("redSnapperProgress").to_int() == 0) {
-		switch (loc) {
+	if (desiredPhylum == "" && get_property("redSnapperProgress").to_int() == 0)
+	{
+		switch (loc)
+		{
 			case $location[The Penultimate Fantasy Airship]:
 			case $location[The Hidden Park]:
 			case $location[The Hidden Hospital]:

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -72,7 +72,7 @@ boolean L10_airship()
 	}
 
 	if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-		changeSnapperPhylum($phylum[dude]);
+		auto_changeSnapperPhylum($phylum[dude]);
 	}
 	autoAdv($location[The Penultimate Fantasy Airship]);
 	return true;
@@ -177,7 +177,7 @@ boolean L10_basement()
 				{
 					auto_log_warning("Backfarming an Amulet of Extreme Plot Significance, sigh :(", "blue");
 					if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-						changeSnapperPhylum($phylum[dude]);
+						auto_changeSnapperPhylum($phylum[dude]);
 					}
 					autoAdv(1, $location[The Penultimate Fantasy Airship]);
 				}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -71,6 +71,9 @@ boolean L10_airship()
 		visit_url("place.php?whichplace=beanstalk");	
 	}
 
+	if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+		changeSnapperPhylum($phylum[dude]);
+	}
 	autoAdv($location[The Penultimate Fantasy Airship]);
 	return true;
 }
@@ -173,6 +176,9 @@ boolean L10_basement()
 				else
 				{
 					auto_log_warning("Backfarming an Amulet of Extreme Plot Significance, sigh :(", "blue");
+					if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+						changeSnapperPhylum($phylum[dude]);
+					}
 					autoAdv(1, $location[The Penultimate Fantasy Airship]);
 				}
 				return true;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1246,6 +1246,10 @@ boolean L11_hiddenCity()
 			}
 		}
 
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
+		}
+
 		if(!elevatorAction)
 		{
 			auto_log_info("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");
@@ -1285,6 +1289,10 @@ boolean L11_hiddenCity()
 			auto_forceNextNoncombat();
 		}
 
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
+		}
+
 		auto_log_info("Hidden Office Progress: " + get_property("hiddenOfficeProgress"), "blue");
 		return autoAdv($location[The Hidden Office Building]);
 	}
@@ -1305,6 +1313,10 @@ boolean L11_hiddenCity()
 			}
 		}
 
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
+		}
+
 		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 		auto_log_info("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
 		return autoAdv($location[The Hidden Bowling Alley]);
@@ -1315,6 +1327,9 @@ boolean L11_hiddenCity()
 		if(item_amount($item[Dripping Stone Sphere]) > 0)
 		{
 			return true;
+		}
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
 		}
 		auto_log_info("The idden osptial!! [sic]", "blue");
 
@@ -1395,6 +1410,9 @@ boolean L11_hiddenCityZones()
 	}
 
 	if (needMachete || needRelocate) {
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
+		}
 		return autoAdv($location[The Hidden Park]);
 	}
 
@@ -1740,6 +1758,10 @@ boolean L11_redZeppelin()
 		}
 	}
 
+	if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+		changeSnapperPhylum($phylum[dude]);
+	}
+
 	int lastProtest = get_property("zeppelinProtestors").to_int();
 	boolean retval = autoAdv($location[A Mob Of Zeppelin Protesters]);
 	if(!lastAdventureSpecialNC())
@@ -1873,6 +1895,10 @@ boolean L11_shenCopperhead()
 				}
 			}
 			set_property("choiceAdventure855", behindtheStacheOption);
+		}
+
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
 		}
 
 		addToMaximize("-10ml");
@@ -2163,7 +2189,10 @@ boolean L11_palindome()
 		}
 
 		autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
-		autoAdv(1, $location[Inside the Palindome]);
+		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+			changeSnapperPhylum($phylum[dude]);
+		}
+		autoAdv($location[Inside the Palindome]);
 		if(($location[Inside the Palindome].turns_spent > 30) && (auto_my_path() != "Pocket Familiars") && (auto_my_path() != "G-Lover") && !in_koe())
 		{
 			abort("It appears that we've spent too many turns in the Palindome. If you run me again, I'll try one more time but many I failed finishing the Palindome");

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1247,7 +1247,7 @@ boolean L11_hiddenCity()
 		}
 
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 
 		if(!elevatorAction)
@@ -1290,7 +1290,7 @@ boolean L11_hiddenCity()
 		}
 
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 
 		auto_log_info("Hidden Office Progress: " + get_property("hiddenOfficeProgress"), "blue");
@@ -1314,7 +1314,7 @@ boolean L11_hiddenCity()
 		}
 
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 
 		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
@@ -1329,7 +1329,7 @@ boolean L11_hiddenCity()
 			return true;
 		}
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 		auto_log_info("The idden osptial!! [sic]", "blue");
 
@@ -1411,7 +1411,7 @@ boolean L11_hiddenCityZones()
 
 	if (needMachete || needRelocate) {
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 		return autoAdv($location[The Hidden Park]);
 	}
@@ -1759,7 +1759,7 @@ boolean L11_redZeppelin()
 	}
 
 	if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-		changeSnapperPhylum($phylum[dude]);
+		auto_changeSnapperPhylum($phylum[dude]);
 	}
 
 	int lastProtest = get_property("zeppelinProtestors").to_int();
@@ -1898,7 +1898,7 @@ boolean L11_shenCopperhead()
 		}
 
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 
 		addToMaximize("-10ml");
@@ -2190,7 +2190,7 @@ boolean L11_palindome()
 
 		autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
-			changeSnapperPhylum($phylum[dude]);
+			auto_changeSnapperPhylum($phylum[dude]);
 		}
 		autoAdv($location[Inside the Palindome]);
 		if(($location[Inside the Palindome].turns_spent > 30) && (auto_my_path() != "Pocket Familiars") && (auto_my_path() != "G-Lover") && !in_koe())


### PR DESCRIPTION
# Description

- add handling for changing the tracked phylum of the snapper.
- force swapping to the Red-Nosed Snapper in zones where we can farm human musk (Airship, some L11 quest zones, NEP when not powerlevelling).
- add human musk to banishers.
- add micronova to yellow rays.
- add some failover handling if the Snapper ends up as the best +item familiar to get some of the useful drops and/or increase odds of fighting the monster we want.

Fixes #212 

## How Has This Been Tested?

Used this in my last couple of LKS runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
