### PR TITLE
Initial Grey Goo support :)

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -53,6 +53,7 @@ import <autoscend/paths/dark_gyffte.ash>
 import <autoscend/paths/disguises_delimit.ash>
 import <autoscend/paths/g_lover.ash>
 import <autoscend/paths/gelatinous_noob.ash>
+import <autoscend/paths/grey_goo.ash>
 import <autoscend/paths/heavy_rains.ash>
 import <autoscend/paths/kingdom_of_exploathing.ash>
 import <autoscend/paths/license_to_adventure.ash>
@@ -217,6 +218,7 @@ void initializeSettings() {
 	zelda_initializeSettings();
 	lowkey_initializeSettings();
 	bhy_initializeSettings();
+	grey_goo_initializeSettings();
 
 	set_property("auto_doneInitialize", my_ascensions());
 }
@@ -1114,6 +1116,7 @@ void initializeDay(int day)
 	majora_initializeDay(day);
 	glover_initializeDay(day);
 	bat_initializeDay(day);
+	grey_goo_initializeDay(day);
 
 	if(day == 1)
 	{
@@ -3326,6 +3329,15 @@ boolean doTasks()
 	if(auto_my_path() == "Community Service")
 	{
 		abort("Should not have gotten here, aborted LA_cs_communityService method allowed return to caller. Uh oh.");
+	}
+
+	if(LA_grey_goo_tasks())
+	{
+		return true;
+	}
+	if(auto_my_path() == "Grey Goo")
+	{
+		abort("Should not have gotten here, aborted LA_grey_goo_tasks method allowed return to caller. Uh oh.");
 	}
 
 	auto_voteSetup(0,0,0);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1169,6 +1169,10 @@ boolean canGroundhog(location loc);							//Defined in autoscend/auto_groundhog.
 boolean groundhogAbort(location loc);						//Defined in autoscend/auto_groundhog.ash
 boolean LM_groundhog();										//Defined in autoscend/auto_groundhog.ash
 
+void grey_goo_initializeSettings();							//Defined in autoscend/grey_goo.ash
+void grey_goo_initializeDay(int day);						//Defined in autoscend/grey_goo.ash
+boolean LA_grey_goo_tasks();								//Defined in autoscend/grey_goo.ash
+
 void bat_startAscension(); // Defined in autoscend/auto_batpath.ash
 void bat_initializeSession(); // Defined in autoscend/auto_batpath.ash
 void bat_terminateSession(); // Defined in autoscend/auto_batpath.ash

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -23,7 +23,7 @@ boolean LA_grey_goo_tasks()
 		return false;
 	}
 
-    print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!")
+    print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
 
     if (my_daycount() >= 3)
     {

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -1,0 +1,35 @@
+script "grey_goo.ash"
+
+void grey_goo_initializeSettings()
+{
+	if (my_path() != "Grey Goo")
+	{
+		return;
+	}
+}
+
+void grey_goo_initializeDay(int day)
+{
+	if (my_path() != "Grey Goo")
+	{
+		return;
+	}
+}
+
+boolean LA_grey_goo_tasks()
+{
+	if (my_path() != "Grey Goo")
+	{
+		return false;
+	}
+
+    print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!")
+
+    if (my_daycount() >= 3)
+    {
+        abort("You made it beyond the dawn of the third day and can now ascend. Congratulations!");
+    }
+	
+	abort("Please come back in " + (3 - my_daycount()) + " days.");
+    return true;
+}

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -23,13 +23,13 @@ boolean LA_grey_goo_tasks()
 		return false;
 	}
 
-    print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
+	print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
 
-    if (my_daycount() >= 3)
-    {
-        abort("You made it beyond the dawn of the third day and can now ascend. Congratulations!");
-    }
+	if (my_daycount() >= 3)
+	{
+		abort("You made it beyond the dawn of the third day and can now ascend. Congratulations!");
+	}
 	
 	abort("Please come back in " + (3 - my_daycount()) + " days.");
-    return true;
+	return true;
 }


### PR DESCRIPTION
# Description

Grey goo is certainly a path in the online video game Kingdom of Loathing.

## How Has This Been Tested?

```Adventuring in Grey Goo is not currently supported, or necessary. Have fun!
Please     come back in 2 days.
Stack trace:
  at LA_grey_goo_tasks     (grey_goo.ash:33)
  at doTasks (autoscend.ash:3334)
  at     auto_begin (autoscend.ash:3656)
  at safe_preference_reset_wrapper     (autoscend.ash:3691)
  at safe_preference_reset_wrapper     (autoscend.ash:3698)
  at safe_preference_reset_wrapper     (autoscend.ash:3698)
  at safe_preference_reset_wrapper     (autoscend.ash:3698)
  at main (autoscend.ash:3726)```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
