### PR TITLE
Crown of Thrones/Buddy Bjorn familiar handling bugfix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -102,6 +102,7 @@ boolean canChangeToFamiliar(familiar target)
 	{
 		return false;
 	}
+	
 	// if this path doesn't allow this familiar, you can't change to it
 	if(!auto_is_valid(target))
 	{
@@ -113,9 +114,10 @@ boolean canChangeToFamiliar(familiar target)
 	{
 		return true;
 	}
+	
+	// check path limitations, as well as 100% runs for a different familiar than target
 	if(!canChangeFamiliar())
 	{
-		// checks path limitations, as well as 100% runs for a diferent familiar than target
 		return false;
 	}
 	
@@ -123,6 +125,12 @@ boolean canChangeToFamiliar(familiar target)
 	if(target == $familiar[none])	
 	{	
 		return false;	
+	}
+
+	// If target is in the Crown of Thrones or Buddy Bjorn, we can't switch to it either.
+	if (target == my_enthroned_familiar() || target == my_bjorned_familiar())
+	{
+		return false;
 	}
 
 	// if you reached this point, then auto_100familiar must not be set to anything, you are allowed to change familiar.


### PR DESCRIPTION
# Description

- you can't switch to a familiar if it's in the crown of thrones or buddy bjorn.

Issue reported (and debugged) in Discord.

## How Has This Been Tested?

It hasn't. I don't have either of those on my test account to test it so we're going to have to rely on users who do have them to let us know if this is terrible.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
