### PR TITLE
remove auto debug for gnoob on shadow workaround.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -468,11 +468,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 		return "runaway";
 	}
 
-	//TODO test plumber, geleatinous noob, and west of loathing paths to see if these workarounds are still needed.
-	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger, shadow gelatinous noob] contains enemy.to_string())
+	//TODO test west of loathing paths to see if the workaround of checking strings is still needed
+	if(enemy == $monster[Your Shadow] || $strings[shadow cow puncher, shadow snake oiler, shadow beanslinger] contains enemy.to_string())
 	{
 		//debug as you go
-		if($classes[Snake Oiler, Cow Puncher, Beanslinger, Gelatinous Noob] contains my_class())
+		if($classes[Snake Oiler, Cow Puncher, Beanslinger] contains my_class())
 		{
 			if(enemy == $monster[Your Shadow])
 			{


### PR DESCRIPTION
removed automatic debugging of whether or not an old workaround for detecting your shadow is still needed for gnoob.
I already confirmed it was an obsolete workaround for plumber and gnoob. Currently west of loathing testing remaining

## How Has This Been Tested?

validates. which is all it needs considering what is changed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
