### PR TITLE
fix quest softblock not releasing when level 13+

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2162,16 +2162,16 @@ boolean isAboutToPowerlevel() {
 
 boolean LX_attemptPowerLevel()
 {
+	if (!isAboutToPowerlevel())		//determined that the softblock on quests waiting for optimal conditions is still on
+	{
+		auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
+		set_property("auto_powerLevelLastLevel", my_level());		//release softblock until you level up
+		set_property("auto_powerLevelAdvCount", 0);
+		return true;		//restart the main loop to give those quests a chance to run now that the softblock is released.
+	}
+	
 	if (my_level() > 12) {
 		return false;
-	}
-
-	if (!isAboutToPowerlevel()) {
-		//release the softblock on various quests that await optimal conditions.
-		auto_log_warning("Hmmm, we need to stop being so feisty about quests...", "red");
-		set_property("auto_powerLevelLastLevel", my_level());
-		set_property("auto_powerLevelAdvCount", 0);
-		return true;
 	}
 
 	auto_log_warning("I've run out of stuff to do. Time to powerlevel, I suppose.", "red");


### PR DESCRIPTION
the softblock release on quests that await optimal conditions is done after the return false if over level 12. this means that if you are level 13+ autoscend will never release the softblock. all those quests will continue waiting... thus it reaches the last line and quits saying it has nothing to do

I just flipped the order in which those two ifs were being done.

## How Has This Been Tested?

was stuck as level 14 sealclubber HC standard with several quests waiting for optimal conditions and not being done, it was saying there is nothing left to do.
With this change it now works

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
