### PR TITLE
fix rare case of not using [solid shifting time weirdness]

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3166,7 +3166,7 @@ boolean doTasks()
 	if(my_familiar() == $familiar[Stooper])
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");
-		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[none]);
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
 		use_familiar(fam);
 	}
 	if(my_inebriety() > inebriety_limit())
@@ -3640,7 +3640,7 @@ void auto_begin()
 	if(my_familiar() == $familiar[Stooper])
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");
-		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[none]);
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
 		use_familiar(fam);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -522,7 +522,7 @@ void consumeStuff()
 		{
 			if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper])
 			{
-				use_familiar($familiar[none]);
+				use_familiar($familiar[Mosquito]);
 			}
 			boolean shouldDrink = true;
 			if (!hasSpookyravenLibraryKey() && my_inebriety() >= 10)

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -546,6 +546,8 @@ void equipRollover()
 		to_max += ",switch Trick-or-Treating Tot";
 	if(auto_have_familiar($familiar[Left-Hand Man]))
 		to_max += ",switch Left-Hand Man";
+	if(my_familiar() == $familiar[none] && auto_have_familiar($familiar[Mosquito]))
+		to_max += ",switch Mosquito";
 
 	backupSetting("logPreferenceChange", "false");
 	maximize(to_max, false);


### PR DESCRIPTION
when we are at 19/19 drunkness we auto equip stooper to make it 19/20 and then tell the user to overdrink and run autoscend again.

so i overdrink with stooper. then run it again... it then switches stooper to none, because we always switch stooper to none if it is current familiar to avoid stooper stupor. then after doing so it recognizes we are overdrunk so it stops main loop and goes to do bedtime.
in bedtime it will add switch for the 3 IOTM familiars that help bedtime beyond a normal familiar

but. a person without any of those iotm familiars who has solid shifting time weirdness would get +5 adv from rollover on any familiar... any familiar other than none that is. which is what it is set to. and as such would not use it

## How Has This Been Tested?

got an account overdrunk with stooper as current familiar and then ran autoscend

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
