### PR TITLE
Restore

### DIFF
--- a/RELEASE/data/autoscend_restoration.txt
+++ b/RELEASE/data/autoscend_restoration.txt
@@ -16,7 +16,7 @@
 15	forest tears	item	7	0	0	0	Beaten Up	none
 16	Doc Galaktik's Pungent Unguent	item	4	0	0	0	none	none
 17	palm-frond fan	item	40	40	0	0	none	none
-18	pixel orb	item	ALL	ALL	0	0	none	none
+18	Cloaca-Cola	item	0	12	0	0	none	none
 19	scroll of drastic healing	item	ALL	0	0	0	none	none
 20	warm El Vibrato drone	item	ALL	0	0	0	none	Well-preserved
 21	Camp Scout pup tent	item	1000	0	0	0	none	none
@@ -103,11 +103,10 @@
 106	generic mana potion	item	0	scaling	0	0	none	none
 107	A Relaxing Hot Tub	clan	ALL	0	5	2	All Negative	none
 108	Psychokinetic Energy Blob	item	0	25	0	0	none	none
-109	Cloaca-Cola	item	0	12	0	0	none	none
 ## Actually Ed the Undying restores
-110	Holy Spring Water	item	0	50	0	0	none	Spiritually Awake
-111	Spirit Beer	item	0	90	0	0	none	Spiritually Aware
-112	Sacramental Wine	item	0	180	0	0	none	Spiritually Awash
-113	linen bandages	item	30	0	0	0	none	none
-114	cotton bandages	item	60	0	0	0	none	none
-115	silk bandages	item	120	0	0	0	none	none
+109	Holy Spring Water	item	0	50	0	0	none	Spiritually Awake
+110	Spirit Beer	item	0	90	0	0	none	Spiritually Aware
+111	Sacramental Wine	item	0	180	0	0	none	Spiritually Awash
+112	linen bandages	item	30	0	0	0	none	none
+113	cotton bandages	item	60	0	0	0	none	none
+114	silk bandages	item	120	0	0	0	none	none

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -396,17 +396,17 @@ boolean auto_post_adventure()
 
 	if((monster_level_adjustment() > 120) && ((my_hp() * 10) < (my_maxhp() * 8)) && (my_mp() >= 20))
 	{
-		useCocoon();
+		acquireHP();
 	}
 
 	if((my_maxhp() > 200) && (my_hp() < 80) && (my_mp() > 25))
 	{
-		useCocoon();
+		acquireHP();
 	}
 
 	if((my_maxhp() > 200) && (my_hp() < 140) && (my_mp() > 100))
 	{
-		useCocoon();
+		acquireHP();
 	}
 
 
@@ -666,23 +666,23 @@ boolean auto_post_adventure()
 
 		if((my_mp() > 150) && (my_maxhp() > 300) && (my_hp() < 140))
 		{
-			useCocoon();
+			acquireHP();
 		}
 		if((my_mp() > 100) && (my_maxhp() > 500) && (my_hp() < 250))
 		{
-			useCocoon();
+			acquireHP();
 		}
 		if((my_mp() > 75) && (my_maxhp() > 500) && (my_hp() < 200))
 		{
-			useCocoon();
+			acquireHP();
 		}
 		if((my_mp() > 75) && (my_maxhp() > 700) && (my_hp() < 300))
 		{
-			useCocoon();
+			acquireHP();
 		}
 		if((my_mp() > 75) && ((my_hp() == 0) || ((my_maxhp()/my_hp()) > 3)))
 		{
-			useCocoon();
+			acquireHP();
 		}
 
 		buffMaintain($effect[Fat Leon\'s Phat Loot Lyric], 250, 1, 10);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -123,11 +123,6 @@ boolean auto_pre_adventure()
 		acquireCombatMods(combatModifier._int, true);
 	}
 
-	if(monster_level_adjustment() > 120)
-	{
-		acquireHP(80.0);
-	}
-
 	foreach i,mon in get_monsters(place)
 	{
 		if(auto_wantToYellowRay(mon, place) && !burningDelay)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -516,8 +516,11 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if (metadata.type == "item")
 		{
 			item i = to_item(metadata.name);
-			if(can_interact())			//we have unlimited mall access = casual, aftercore, or postronin
+			if(can_interact() || my_meat() > 20000)
 			{
+				//we have unlimited mall access = casual, aftercore, or postronin. or we are just rich with over 20k meat.
+				//In either case we want to conserve rare items and consider an item's mall value rather than conserving our current meat stocks.
+				//ex: scroll of drastic healing will be considered to be worth its mall price here.
 				int price = 999999;		//do not use items that cannot be bought
 				if(is_tradeable(i))		//is possible to trade in the mall
 				{
@@ -529,9 +532,11 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 				}
 				return price;
 			}
-			else		//mall access is limited. this means pulls are limited too.
+			else
 			{
-				return npc_price(i);	//note that this sets items that cannot be purchased to free
+				//mall access is limited, this means pulls are limited too. also meat < 20k so we want to spend items to preserve meat
+				//ex: scroll of drastic healing will be considered free. since we spent no meat for it to drop.
+				return npc_price(i);	//this will set items that cannot be purchased from an NPC store to free.
 			}
 		}
 		else if (metadata.type == "skill")

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1979,7 +1979,7 @@ boolean uneffect(effect toRemove)
 	}
 	if(($effects[Driving Intimidatingly, Driving Obnoxiously, Driving Observantly, Driving Quickly, Driving Recklessly, Driving Safely, Driving Stealthily, Driving Wastefully, Driving Waterproofly] contains toRemove) && (auto_get_campground() contains $item[Asdon Martin Keyfob]))
 	{
-		string temp = visit_url("campground.php?pwd=&preaction=undrive");
+		visit_url("campground.php?pwd=&preaction=undrive");
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -516,12 +516,23 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if (metadata.type == "item")
 		{
 			item i = to_item(metadata.name);
-			int price = npc_price(i);
-			if (can_interact())
+			if(can_interact())			//we have unlimited mall access = casual, aftercore, or postronin
 			{
-				price = min(price, auto_mall_price(i));
+				int price = 999999;		//do not use items that cannot be bought
+				if(is_tradeable(i))		//is possible to trade in the mall
+				{
+					price = min(price, auto_mall_price(i));
+				}
+				if(npc_price(i) > 0)	//is possible to buy from an NPC store
+				{
+					price = min(price, npc_price(i));
+				}
+				return price;
 			}
-			return price;
+			else		//mall access is limited. this means pulls are limited too.
+			{
+				return npc_price(i);	//note that this sets items that cannot be purchased to free
+			}
 		}
 		else if (metadata.type == "skill")
 		{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1614,23 +1614,23 @@ void invalidateRestoreOptionCache()
 
 
 /**
- * Try to acquire your max mp (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
+ * Try to acquire your max mp (useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
  *
  * returns true if my_mp() >= my_maxmp() after attempting to restore.
  */
-boolean acquireMP(){
+boolean acquireMP()
+{
 	return acquireMP(my_maxmp());
 }
 
 /**
- * Try to acquire up to the mp goal (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
+ * Try to acquire up to the mp goal (useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
  *
  * returns true if my_mp() >= goal after attempting to restore.
  */
 boolean acquireMP(int goal)
 {
-  int meat_reserve = can_interact() ? 0 : my_meat();
-	return acquireMP(goal, meat_reserve);
+	return acquireMP(goal, meatReserve());
 }
 
 /**
@@ -1638,7 +1638,8 @@ boolean acquireMP(int goal)
  *
  * returns true if my_mp() >= goal after attempting to restore.
  */
-boolean acquireMP(int goal, int meat_reserve){
+boolean acquireMP(int goal, int meat_reserve)
+{
 	return acquireMP(goal, meat_reserve, true);
 }
 
@@ -1683,13 +1684,13 @@ boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 }
 
 /**
- * Try to acquire up to the mp goal expressed as a percentage (out of either 1.0 or 100.0) (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
+ * Try to acquire up to the mp goal expressed as a percentage (out of either 1.0 or 100.0) (useFreeRests: true). Will also cure poisoned and beaten up before restoring any mp.
  *
  * returns true if my_mp() >= goalPercent after attempting to restore.
  */
-boolean acquireMP(float goalPercent){
-  int meat_reserve = can_interact() ? 0 : my_meat();
-	return acquireMP(goalPercent, meat_reserve);
+boolean acquireMP(float goalPercent)
+{
+	return acquireMP(goalPercent, meatReserve());
 }
 
 /**
@@ -1697,7 +1698,8 @@ boolean acquireMP(float goalPercent){
  *
  * returns true if my_mp() >= goalPercent after attempting to restore.
  */
-boolean acquireMP(float goalPercent, int meat_reserve){
+boolean acquireMP(float goalPercent, int meat_reserve)
+{
 	return acquireMP(goalPercent, meat_reserve, true);
 }
 
@@ -1706,7 +1708,8 @@ boolean acquireMP(float goalPercent, int meat_reserve){
  *
  * returns true if my_mp() >= goalPercent after attempting to restore.
  */
-boolean acquireMP(float goalPercent, int meat_reserve, boolean useFreeRests){
+boolean acquireMP(float goalPercent, int meat_reserve, boolean useFreeRests)
+{
 	int goal = my_maxmp();
 	if(goalPercent > 1.0){
 		goal = ceil((goalPercent/100.0) * my_maxmp());
@@ -1717,22 +1720,23 @@ boolean acquireMP(float goalPercent, int meat_reserve, boolean useFreeRests){
 }
 
 /**
- * Try to acquire your max hp (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
+ * Try to acquire your max hp (useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
  *
  * returns true if my_hp() >= my_maxhp() after attempting to restore.
  */
-boolean acquireHP(){
+boolean acquireHP()
+{
 	return acquireHP(my_maxhp());
 }
 
 /**
- * Try to acquire up to the hp goal (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
+ * Try to acquire up to the hp goal (useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
  *
  * returns true if my_hp() >= goal after attempting to restore.
  */
-boolean acquireHP(int goal){
-  int meat_reserve = can_interact() ? 0 : my_meat();
-	return acquireHP(goal, meat_reserve);
+boolean acquireHP(int goal)
+{
+	return acquireHP(goal, meatReserve());
 }
 
 /**
@@ -1740,7 +1744,8 @@ boolean acquireHP(int goal){
  *
  * returns true if my_hp() >= goal after attempting to restore.
  */
-boolean acquireHP(int goal, int meat_reserve){
+boolean acquireHP(int goal, int meat_reserve)
+{
 	return acquireHP(goal, meat_reserve, true);
 }
 
@@ -1822,13 +1827,13 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 }
 
 /**
- * Try to acquire up to the hp goal expressed as a percentage (out of either 1.0 or 100.0) (meat_reserve: 0 if out of ronin otherwise my_meat (wont spend meat), useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
+ * Try to acquire up to the hp goal expressed as a percentage (out of either 1.0 or 100.0) (useFreeRests: true). Will also cure poisoned and beaten up before restoring any hp.
  *
  * returns true if my_hp() >= goalPercent after attempting to restore.
  */
-boolean acquireHP(float goalPercent){
-  int meat_reserve = can_interact() ? 0 : my_meat();
-	return acquireHP(goalPercent, meat_reserve);
+boolean acquireHP(float goalPercent)
+{
+	return acquireHP(goalPercent, meatReserve());
 }
 
 /**
@@ -1836,7 +1841,8 @@ boolean acquireHP(float goalPercent){
  *
  * returns true if my_hp() >= goalPercent after attempting to restore.
  */
-boolean acquireHP(float goalPercent, int meat_reserve){
+boolean acquireHP(float goalPercent, int meat_reserve)
+{
 	return acquireHP(goalPercent, meat_reserve, true);
 }
 
@@ -1845,7 +1851,8 @@ boolean acquireHP(float goalPercent, int meat_reserve){
  *
  * returns true if my_hp() >= goalPercent after attempting to restore.
  */
-boolean acquireHP(float goalPercent, int meat_reserve, boolean useFreeRests){
+boolean acquireHP(float goalPercent, int meat_reserve, boolean useFreeRests)
+{
 	int goal = my_maxhp();
 	if(goalPercent > 1.0){
 		goal = ceil((goalPercent/100.0) * my_maxhp());

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2004,12 +2004,6 @@ boolean uneffect(effect toRemove)
 	return false;
 }
 
-// Deprecated, please use acquireHP()
-boolean useCocoon()
-{
-  return acquireHP();
-}
-
 /**
  * we could in theory set this as our restore script, but autoscend is not currently designed to heal this way and changing this now would probably break assumptions people have anticipated in their code, causing undefined behavior. I assume this is why we have the warning about autoscend not playing well with restore scripts and disabling them when it starts.
  *

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5782,3 +5782,50 @@ float npcStoreDiscountMulti()
 	
 	return retval;
 }
+
+int meatReserve()
+{
+	//the amount of meat we want to reserve for quest usage when performing a restore
+	
+	if(my_level() < 10)		//meat income is pretty low and the quests that need the reserve far away. Use restores freely
+	{
+		return 0;	
+	}
+	
+	int reserve_gnasir = 0;		//used to track how much we need to reserve for black paint for gnasir
+	int reserve_diary = 0;		//used to track how much we need to reserve to acquire [your father's MacGuffin diary] at L11 quest
+	int reserve_island = 0;		//used to track how much we need to reserve to unlock the mysterious island
+	
+	//how much do we reserve for gnasir?
+	if(internalQuestStatus("questL11Desert") < 1 &&				//bitwise. desert exploration not yet finished
+	(get_property("gnasirProgress").to_int() & 2) != 2)			//gnasir has not been given black paint yet
+	{
+		reserve_gnasir += 1000;
+	}
+	
+	//how much do we reserve for [your father's MacGuffin diary]?
+	if(item_amount($item[your father\'s MacGuffin diary]) == 0 &&		//you do not yet have diary
+	!in_koe() &&														//diary is given by council for free in kingdom of exploathing
+	my_path() != "Way of the Surprising Fist")							//costs 5 meat total in way of the surprising fist. no need to track that
+	{
+		reserve_diary += 500;		//1 vacation. no need to count script. we don't pull it or get it prematurely.
+		
+		//cannot just use npc_price() for [forged identification documents] because they are not always available. it would return 0.
+		if(item_amount($item[forged identification documents]) == 0)
+		{
+			reserve_diary += 5000 * npcStoreDiscountMulti();
+		}
+	}
+	
+	//how much do we reserve for unlocking mysterious island?
+	if(get_property("lastIslandUnlock").to_int() < my_ascensions())		//need to unlock island
+	{
+		reserve_island += 1500;		//3 vacations. no need to count script. we don't pull it or get it prematurely.
+		if(item_amount($item[dingy planks]) == 0)
+		{
+			reserve_island += 400 * npcStoreDiscountMulti();
+		}
+	}
+	
+	return reserve_gnasir + reserve_diary + reserve_island;
+}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5789,6 +5789,10 @@ int meatReserve()
 	
 	if(my_level() < 10)		//meat income is pretty low and the quests that need the reserve far away. Use restores freely
 	{
+		if(!isDesertAvailable() && inKnollSign() && my_level() > 5 && my_turncount() < 50)
+		{
+			return 500;		//reserve some meat for the bitchin' meatcar
+		}
 		return 0;	
 	}
 	

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5764,3 +5764,21 @@ int poolSkillPracticeGains()
 	return count;
 }
 
+float npcStoreDiscountMulti()
+{
+	//calculates a multiplier to be applied to store prices for our current discount for NPC stores.
+	//does not bother with sleaze jelly or Post-holiday sale coupon
+	
+	float retval = 1.0;
+	
+	if(auto_have_skill($skill[Five Finger Discount]))
+	{
+		retval -= 0.05;
+	}
+	if(possessEquipment($item[Travoltan trousers]) && auto_is_valid($item[Travoltan trousers]))
+	{
+		retval -= 0.05;
+	}
+	
+	return retval;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1342,3 +1342,4 @@ boolean hasTTBlessing();
 void effectAblativeArmor(boolean passive_dmg_allowed);
 int currentPoolSkill();
 int poolSkillPracticeGains();
+float npcStoreDiscountMulti();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -477,7 +477,6 @@ int get_cs_questNum(string input);
 void set_cs_questListFast(int[int] fast);
 boolean cs_preTurnStuff(int curQuest);
 boolean cs_healthMaintain();
-boolean cs_healthMaintain(int target);
 boolean cs_mpMaintain();
 boolean cs_mpMaintain(int target);
 boolean canTrySaberTrickMeteorShower();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1098,7 +1098,6 @@ boolean doFreeRest();
 boolean haveFreeRestAvailable();
 int freeRestsRemaining();
 boolean uneffect(effect toRemove);
-boolean useCocoon();
 
 ########################################################################################################
 //Defined in autoscend/autoscend_migration.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1343,3 +1343,4 @@ void effectAblativeArmor(boolean passive_dmg_allowed);
 int currentPoolSkill();
 int poolSkillPracticeGains();
 float npcStoreDiscountMulti();
+int meatReserve();

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1022,7 +1022,7 @@ boolean LX_ghostBusting()
 			return false;
 		}
 
-		useCocoon();
+		acquireHP();
 		auto_log_info("Ghost busting time! At: " + get_property("ghostLocation"), "blue");
 		boolean newbieFail = false;
 		if(goal == $location[The Skeleton Store])

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -4212,11 +4212,7 @@ boolean cs_healthMaintain(){
 	if(my_maxhp() < 50){
 		target = floor(my_maxhp() * .8);
 	}
-	return cs_healthMaintain(target);
-}
-
-boolean cs_healthMaintain(int target){
-	return acquireHP(target, 2500, true);
+	return acquireHP(target, 2500);
 }
 
 boolean cs_mpMaintain(){
@@ -4226,11 +4222,11 @@ boolean cs_mpMaintain(){
 	} else if(my_maxmp() >= 120){
 		target = 120;
 	}
-	return cs_mpMaintain(target);
+	return acquireMP(target, 1500);
 }
 
 boolean cs_mpMaintain(int target){
-	return acquireMP(target, 1500, true);
+	return acquireMP(target, 1500);
 }
 
 boolean canTrySaberTrickMeteorShower(){


### PR DESCRIPTION
*remove depreciated useCocoon(). it was only serving as a wrapper for acquireHP() with a note saying it is depreciated and not to use it.
*string temp = visit_url is only needed when using "ash" command. when running a script it works like ashq command. q stands for quiet and does not print to CLI the entire page result of visit url
*fix postronin/casual/aftercore wasting all your expensive healing items. issue #218 subissue 11
**it tried to use cheaper between mall and NPC price, but did it wrong resulting in all items not sold by NPC store being considered to be free
**hypothetically if an NPC store sold you an item that is not mall tradeable, it would have been considered free as well and that was preemptively fixed as well.
*also if we have over 20k meat in ronin/hardcore then consider the item's mallprice and try to preserve untradeable items. (normally we try to preserve meat instead by considering items in inventory free)
**the removed redundant code checked if monster level over 120 and if so restored us to 80% HP... which is wholly redundant because in preadventure after changing equipment we always automatically restore our HP to 100% if it is currently under 75%. in fact it hurts us because it means we go into combat with high ML monsters with 80% HP instead of 100% HP like we do against weak monsters
*community service restore fixes
**removed redundant boolean cs_healthMaintain(int target) which was just acting as a wrapper for acquireHP. at least cs_healthMaintain() actually does something.
**slightly altered cs_mpMaintain() and cs_mpMaintain(int target) to remove redundant portions.
*created float npcStoreDiscountMulti()
**calculates a multiplier to use for npc storeprice for the 2 unlimited discounts available (skill + travoltan trousers)
*created int meatReserve()
**This calculates the amount to reserve instead of just setting it to current meat (which assumed we never want to use any meat to restore)
*remove pixel orb from restores.
**it is an old rare collectors item that is worth over half a million meat in the mall each. there is no reason for us to even consider it.

## How Has This Been Tested?

ran it for a few days on multiple accounts

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
