### PR TITLE
fixed beanscreen for awol

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1011,12 +1011,6 @@ string auto_combatHandler(int round, monster enemy, string text)
 		if(banishAction != "")
 		{
 			auto_log_info("Looking at banishAction: " + banishAction, "green");
-			#abort("Banisher considered here. Weee");
-			#wait(10);
-			#banishAction = "";
-		}
-		if(banishAction != "")
-		{
 			set_property("auto_combatHandler", combatState + "(banisher)");
 			if(index_of(banishAction, "skill") == 0)
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -2029,7 +2029,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			costMinor = mp_cost($skill[Cowcall]);
 		}
 
-		if(canUse($skill[Beanscreen], false) && canSurvive(2.0))
+		if(canUse($skill[Beanscreen], false) && !canSurvive(5.0))
 		{
 			stunner = useSkill($skill[Beanscreen], false);
 			costStunner = mp_cost($skill[Beanscreen]);

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -2023,9 +2023,9 @@ string auto_combatHandler(int round, monster enemy, string text)
 			costMinor = mp_cost($skill[Cowcall]);
 		}
 
-		if(canUse($skill[Beanscreen], false) && !canSurvive(5.0))
+		if(canUse($skill[Beanscreen]) && !canSurvive(5.0))
 		{
-			stunner = useSkill($skill[Beanscreen], false);
+			stunner = useSkill($skill[Beanscreen]);
 			costStunner = mp_cost($skill[Beanscreen]);
 		}
 


### PR DESCRIPTION
logic for it was missing a ! for canSurvive and the figure was too low.
also it can only be used once per round

## How it was tested

used it on HC beanslinger. it started using beanscreen appropriately.
although I think there might be an unrelated issue of failing to find a banisher causing it to fail to use a stunner. but that would be for a followup PR

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
