### PR TITLE
Catch if we fail to cast a powerful glove skill and update battery if needed.

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -119,6 +119,18 @@ boolean auto_powerfulGloveNoncombatSkill(skill sk)
 	{
 		handleTracker(sk, "auto_powerfulglove");
 	}
+	else
+	{
+		// if we fail to cast a skill, odds are something has gone wrong with
+		// mafia's tracking. Let's check to make sure, then make sure we stop
+		// attempting to use more cheats in vain if so.
+		string page = visit_url("desc_item.php?whichitem=991142661");
+		if(page.contains_text("The Glove's battery is fully depleted."))
+		{
+			auto_log_error("Mafia's Powerful Glove battery tracking was wrong, correcting.");
+			set_property("_powerfulGloveBatteryPowerUsed", 100);
+		}
+	}
 
 	return ret;
 }


### PR DESCRIPTION
# Description

I was caught in an infinite loop of attempting to cast triple size at bed time. Mafia thought I had used 90% of the battery, when I had actually used 100%.

## How Has This Been Tested?

I reran autoscend after making this change, saw the log message I added, and did not encounter the same infinite loop again.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
