### PR TITLE
gremlins. no suicide and use beanscreen

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -69,6 +69,11 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	{
 		return useSkill($skill[Summon Love Gnats]);
 	}
+	
+	if(canUse($skill[Beanscreen]))
+	{
+		return useSkill($skill[Beanscreen]);
+	}
 
 	if(canUse($skill[Bad Medicine]))
 	{
@@ -117,6 +122,11 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		{
 			return findBanisher(round, enemy, text);
 		}
+	}
+	
+	if(!canSurvive(1.5))
+	{
+		abort("I am too weak to safely stasis this gremlin");
 	}
 
 	foreach it in $items[Seal Tooth, Spectre Scepter, Doc Galaktik\'s Pungent Unguent]


### PR DESCRIPTION
*do not commit suicide against tool gremlin using seal tooth
*avatar of west of loathing use beanscreen to get 3 extra turns of survival against tool gremlin

## How Has This Been Tested?

Fought gremlins with it as a beanslinger

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
