### PR TITLE
if we decide to not do aboo peak then we should not equipBaseline() but resetState() instead

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -597,7 +597,7 @@ boolean L9_aBooPeak()
 		}
 
 		auto_log_info("Nevermind, that peak is too scary!", "green");
-		equipBaseline();
+		resetState();
 		handleBjornify(priorBjorn);
 	}
 	else


### PR DESCRIPTION
*if we decide to not do aboo peak then we should not equipBaseline() but resetState() instead before returning false
the former actually changes our outfit which can cause us to lose HP from switching the outfit back and forth and waste a lot of meat. the latter does not do that and instead resets our maximizer as well as a few other things to as if we just started a new loop.

## How Has This Been Tested?

ran it on my account that was just at the right spot for this to be an issue. and it solved the problem

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
