### PR TITLE
auto_king.ash refactored

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -4,7 +4,6 @@ auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we ha
 auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
 auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
 auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
-auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
 auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
 auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -7,7 +7,6 @@ auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liber
 auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
 auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
-auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
 auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
 auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
 auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -27,7 +27,7 @@ drop	0	Fist Turkey	prop:_turkeyBooze<5
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
 drop	1	Puck Man	item:Yellow Pixel<20
 drop	2	Ms. Puck Man	item:Yellow Pixel<20
-# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
 drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
 drop	4	Rockin' Robin	prop:rockinRobinProgress>=25

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -12,50 +12,49 @@ any	2	auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until
 any	3	auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
 any	4	auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
 any	5	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when liberating the King? This assumes that you are going to bother to ascend again the same day.
-any	6	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
-any	7	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
-any	8	auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
-any	9	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
-any	10	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
-any	11	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	12	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	13	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	14	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	15	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
-any	16	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	17	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	18	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	19	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	20	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	21	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	22	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	46	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	47	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
-any	48	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	49	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	6	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
+any	7	auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
+any	8	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
+any	9	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
+any	10	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	11	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	12	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	13	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	14	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
+any	15	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	16	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
+any	17	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	18	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	19	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	20	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+any	21	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	22	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	23	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	24	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	25	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	26	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	27	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	28	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	29	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	30	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	31	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	32	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	33	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	34	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	37	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	38	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	45	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	46	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	47	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	48	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -15,48 +15,47 @@ any	5	auto_borrowedTimeOnLiberation	boolean	Automatically use Borrowed Time when
 any	6	auto_clearCombatScripts	boolean	Clear out the postAdventure, preAdventure and kingLiberated settings upon kingLiberation. These will return upon running the script in a new ascension.
 any	7	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
 any	8	auto_powerLevelTimer	integer	Sets the delay before each adv spent powerleveling, default is 10 sec. lowest valid value is 1.
-any	9	auto_pullPVPJunk	boolean	Pull various PVP junk when liberating the King? Mostly avatar potions but other stuff might get added.
-any	10	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
-any	11	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
-any	12	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	13	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	14	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	15	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	16	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
-any	17	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	18	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	19	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	20	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	21	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	22	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	23	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	24	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	25	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	26	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	27	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	28	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	29	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	30	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	31	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	32	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	33	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	34	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	35	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	36	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	37	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	38	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	39	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	40	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	41	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	42	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	43	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	44	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	45	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	46	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	47	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	48	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
-any	49	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	50	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	9	auto_kingLiberation	boolean	Use the CHEDDAH kingLiberation script?
+any	10	auto_allowSharingData	boolean	Allow the script to send information about the ascension to a sad, abused database in hopes of great spades? Specifics will appear (at the bottom) once set to true.
+any	11	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	12	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	13	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	14	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	15	auto_xiblaxianChoice	string	When using Xiblaxian Stuff, do we make a Xiblaxian Ultraburrito or Xiblaxian Space-Whiskey
+any	16	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	17	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
+any	18	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	19	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	20	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	21	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+any	22	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	23	auto_consumeKeyLimePies	boolean	When true, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	24	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	25	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	26	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	27	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	28	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	29	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	30	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	31	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	32	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	46	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	47	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	48	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	49	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -124,7 +124,6 @@ void initializeSettings() {
 
 	set_property("auto_abooclover", true);
 	set_property("auto_aboopending", 0);
-	set_property("auto_aftercore", false);
 	set_property("auto_banishes", "");
 	set_property("auto_batoomerangDay", 0);
 	set_property("auto_beatenUpCount", 0);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -180,7 +180,6 @@ void initializeSettings() {
 	// Last level during which we ran out of stuff to do without pre-completing some Shen quests.
 	set_property("auto_shenSkipLastLevel", 0); 
 
-	set_property("auto_snapshot", "");
 	set_property("auto_sniffs", "");
 	set_property("auto_waitingArrowAlcove", "50");
 	set_property("auto_wandOfNagamar", true);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3604,7 +3604,11 @@ void auto_begin()
 	backupSetting("dontStopForCounters", true);
 	backupSetting("maximizerCombinationLimit", "100000");
 
-	backupSetting("kingLiberatedScript", "scripts/autoscend/auto_king.ash");
+	if(get_property("auto_kingLiberation").to_boolean())
+	{
+		backupSetting("kingLiberatedScript", "scripts/autoscend/auto_king.ash");
+	}
+	
 	backupSetting("afterAdventureScript", "scripts/autoscend/auto_post_adv.ash");
 	backupSetting("choiceAdventureScript", "scripts/autoscend/auto_choice_adv.ash");
 	backupSetting("betweenBattleScript", "scripts/autoscend/auto_pre_adv.ash");

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -286,6 +286,7 @@ boolean settingFixer()
 	remove_property("auto_twinpeakprogress");
 	remove_property("auto_war");
 	remove_property("auto_winebomb");
+	remove_property("auto_clearCombatScripts");
 
 	if (property_exists("auto_legacyConsumeStuff"))
 	{

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -170,6 +170,7 @@ boolean settingFixer()
 
 	remove_property("auto_cubeItems");
 	remove_property("auto_useCubeling");
+	remove_property("auto_pullPVPJunk");
 
 	if(get_property("auto_xiblaxianChoice") == "")
 	{

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -159,14 +159,6 @@ boolean settingFixer()
 	{
 		set_property("auto_abooclover", false);
 	}
-	if(get_property("auto_aftercore") == "")
-	{
-		set_property("auto_aftercore", false);
-	}
-	if(get_property("auto_aftercore") == "done")
-	{
-		set_property("auto_aftercore", true);
-	}
 
 	remove_property("auto_cubeItems");
 	remove_property("auto_useCubeling");

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -67,8 +67,11 @@ void handleKingLiberation()
 	
 	displayOnKingLiberation();
 
-	//if you just finished a standard run mafia thinks icehouse is empty
+	//workaround for mafia thinking icehouse is empty when you finish a standard run
 	visit_url("museum.php?action=icehouse", false);
+	
+	//workaround for telegraphOfficeAvailable not updating when you finish a standard run. also grab your boots
+	visit_url("place.php?whichplace=town_right");
 
 	visit_url("campground.php?action=workshed");
 

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -25,7 +25,19 @@ void displayOnKingLiberation()
 		Thwaitgold Termite Statuette,				//2015 Community Service
 		Thwaitgold Scorpion Statuette,				//2016 Avatar of West of Loathing
 		Thwaitgold Moth Statuette,					//2016 The Source
-		Thwaitgold Cockroach Statuette				//2016 Nuclear Autumn
+		Thwaitgold Cockroach Statuette,				//2016 Nuclear Autumn
+		Thwaitgold amoeba statuette,				//2017 Gelatinous Noob
+		Thwaitgold bug statuette,					//2017 License to Adventure
+		Thwaitgold time fly statuette,				//2017 Live. Ascend. Repeat.
+		Thwaitgold metabug statuette,				//2018 Pocket Familiars
+		Thwaitgold chigger statuette,				//2018 G-Lover
+		Thwaitgold masked hunter statuette,			//2018 Disguises Delimit
+		Thwaitgold mosquito statuette,				//2019 Dark Gyffte
+		Thwaitgold nymph statuette,					//2019 Two Crazy Random Summer
+		Thwaitgold bombardier beetle statuette,		//2019 Kingdom of Exploathing
+		Thwaitgold buzzy beetle statuette,			//2020 Path of the Plumber
+		Thwaitgold keyhole spider statuette,		//2020 Low Key Summer
+		Thwaitgold slug statuette,					//2020 Grey Goo
 		];
 		
 		foreach it in toDisplay

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -1,24 +1,33 @@
 import <autoscend.ash>
 
-void handleKingLiberation()
+void displayOnKingLiberation()
 {
-	restoreAllSettings();
-	if(!inAftercore())
-	{
-		auto_log_info("can't run king liberated script. I am not actually in aftercore.");
-		return;
-	}
-
-	auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
-
-	if(my_familiar() != $familiar[Black Cat])
-	{
-		set_property("auto_100familiar", "");
-	}
-
 	if(have_display())
 	{
-		boolean[item] toDisplay = $items[Instant Karma, Thwaitgold Ant Statuette, Thwaitgold Bee Statuette, Thwaitgold Bookworm Statuette, Thwaitgold Butterfly Statuette, Thwaitgold Caterpillar Statuette, Thwaitgold Cockroach Statuette, Thwaitgold Dragonfly Statuette, Thwaitgold Firefly Statuette, Thwaitgold Goliath Beetle Statuette, Thwaitgold Grasshopper Statuette, Thwaitgold Maggot Statuette, Thwaitgold Moth Statuette, Thwaitgold Nit Statuette, Thwaitgold Praying Mantis Statuette, Thwaitgold Scarab Beetle Statuette, Thwaitgold Scorpion Statuette, Thwaitgold Spider Statuette, Thwaitgold Stag Beetle Statuette, Thwaitgold Termite Statuette, Thwaitgold Wheel Bug Statuette, Thwaitgold Woollybear Statuette];
+		boolean[item] toDisplay = $items[
+		Thwaitgold Bee Statuette,					//2011 Bees Hate You
+		Thwaitgold Grasshopper Statuette,			//2011 Way of the Surprising Fist
+		Thwaitgold Butterfly Statuette,				//2011 Trendy
+		Thwaitgold Stag Beetle Statuette,			//2012 Avatar of Boris
+		Thwaitgold Woollybear Statuette,			//2012 Bugbear Invasion
+		Thwaitgold Maggot Statuette,				//2012 Zombie Slayer
+		Thwaitgold Praying Mantis Statuette,		//2012 Class Act
+		Thwaitgold Firefly Statuette,				//2013 Avatar of Jarlsberg
+		Thwaitgold Goliath Beetle Statuette,		//2013 BIG!
+		Thwaitgold Bookworm Statuette,				//2013 KOLHS
+		Thwaitgold Ant Statuette,					//2013 Class Act II: A Class For Pigs
+		Thwaitgold Dragonfly Statuette,				//2014 Avatar of Sneaky Pete
+		Thwaitgold Wheel Bug Statuette,				//2014 Slow and Steady
+		Thwaitgold Spider Statuette,				//2014 Heavy Rains
+		Thwaitgold Nit Statuette,					//2014 Picky
+		Thwaitgold Scarab Beetle Statuette,			//2015 Actually Ed the Undying
+		Thwaitgold Caterpillar Statuette,			//2015 One Crazy Random Summer
+		Thwaitgold Termite Statuette,				//2015 Community Service
+		Thwaitgold Scorpion Statuette,				//2016 Avatar of West of Loathing
+		Thwaitgold Moth Statuette,					//2016 The Source
+		Thwaitgold Cockroach Statuette				//2016 Nuclear Autumn
+		];
+		
 		foreach it in toDisplay
 		{
 			if(item_amount(it) > 0)
@@ -28,12 +37,23 @@ void handleKingLiberation()
 			put_display(item_amount(it), it);
 		}
 	}
-	
-	if(get_property("lastEmptiedStorage").to_int() != my_ascensions())
+}
+
+void handleKingLiberation()
+{
+	if(!inAftercore())
 	{
-		cli_execute("pull all");
+		auto_log_info("can't run king liberated script. I am not actually in aftercore.");
+		return;
 	}
+	restoreAllSettings();
+	auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
+		
+	cli_execute("pull all");
+	visit_url("place.php?whichplace=sea_oldman&action=oldman_oldman");		//start sea quest so breakfast can collect [sea jelly]
 	cli_execute("breakfast");
+	
+	displayOnKingLiberation();
 
 	//if you just finished a standard run mafia thinks icehouse is empty
 	visit_url("museum.php?action=icehouse", false);

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -88,7 +88,7 @@ void handleKingLiberation()
 		set_property("auto_snapshot", my_ascensions());
 	}
 
-	if(inAftercore() && !get_property("auto_aftercore").to_boolean())
+	if(!get_property("auto_aftercore").to_boolean())
 	{
 //		buy_item($item[4-d camera], 1, 10000);
 //		buy_item($item[mojo filter], 2, 3500);
@@ -111,9 +111,9 @@ void handleKingLiberation()
 
 		if(get_property("auto_dickstab").to_boolean())
 		{
-			while(item_amount($item[Shore Inc. Ship Trip Scrip]) < 3)
+			while(item_amount($item[Shore Inc. Ship Trip Scrip]) < 4)
 			{
-				adventure(1, $location[The Shore\, Inc. Travel Agency]);
+				if(!LX_doVacation()) break;		//tries to vacation and if fails it will break the loop
 			}
 		}
 

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -88,7 +88,7 @@ void handleKingLiberation()
 		set_property("auto_snapshot", my_ascensions());
 	}
 
-	if(!get_property("auto_aftercore").to_boolean())
+	if(get_property("auto_aftercore").to_int() != my_ascensions())
 	{
 //		buy_item($item[4-d camera], 1, 10000);
 //		buy_item($item[mojo filter], 2, 3500);
@@ -117,7 +117,7 @@ void handleKingLiberation()
 			}
 		}
 
-		set_property("auto_aftercore", true);
+		set_property("auto_aftercore", my_ascensions());
 	}
 
 	auto_log_info("King Liberation Complete. Thank you for playing", "blue");

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -87,6 +87,18 @@ void handleKingLiberation()
 		}
 		set_property("auto_snapshot", my_ascensions());
 	}
+	
+	if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
+	{
+		if(get_property("_clipartSummons").to_int() < 3)
+		{
+			cli_execute("make borrowed time");
+		}
+		if((item_amount($item[Borrowed Time]) > 0) && (my_daycount() > 1))
+		{
+			use(1, $item[borrowed time]);
+		}
+	}
 
 	if(get_property("auto_aftercore").to_int() != my_ascensions())
 	{

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -3,93 +3,86 @@ import <autoscend.ash>
 void handleKingLiberation()
 {
 	restoreAllSettings();
-	if(inAftercore() && (get_property("auto_snapshot") == ""))
+	if(!inAftercore())
 	{
-		auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
-		if(!get_property("auto_kingLiberation").to_boolean())
-		{
-			set_property("auto_snapshot", "aborted");
-			return;
-		}
+		auto_log_info("can't run king liberated script. I am not actually in aftercore.");
+		return;
+	}
 
-		if(my_familiar() != $familiar[Black Cat])
-		{
-			set_property("auto_100familiar", $familiar[none]);
-		}
+	auto_log_info("Yay! The King is saved. I suppose you should do stuff.");
 
-		// Some items don\'t get pulled, notably, Stench Wad but some others as well (fat loot token, holiday fun, box of sunshine).
-		// This might fix it...
-		cli_execute("refresh all");
+	if(my_familiar() != $familiar[Black Cat])
+	{
+		set_property("auto_100familiar", "");
+	}
 
-		if(have_display())
+	if(have_display())
+	{
+		boolean[item] toDisplay = $items[Instant Karma, Thwaitgold Ant Statuette, Thwaitgold Bee Statuette, Thwaitgold Bookworm Statuette, Thwaitgold Butterfly Statuette, Thwaitgold Caterpillar Statuette, Thwaitgold Cockroach Statuette, Thwaitgold Dragonfly Statuette, Thwaitgold Firefly Statuette, Thwaitgold Goliath Beetle Statuette, Thwaitgold Grasshopper Statuette, Thwaitgold Maggot Statuette, Thwaitgold Moth Statuette, Thwaitgold Nit Statuette, Thwaitgold Praying Mantis Statuette, Thwaitgold Scarab Beetle Statuette, Thwaitgold Scorpion Statuette, Thwaitgold Spider Statuette, Thwaitgold Stag Beetle Statuette, Thwaitgold Termite Statuette, Thwaitgold Wheel Bug Statuette, Thwaitgold Woollybear Statuette];
+		foreach it in toDisplay
 		{
-			boolean[item] toDisplay = $items[Instant Karma, Thwaitgold Ant Statuette, Thwaitgold Bee Statuette, Thwaitgold Bookworm Statuette, Thwaitgold Butterfly Statuette, Thwaitgold Caterpillar Statuette, Thwaitgold Cockroach Statuette, Thwaitgold Dragonfly Statuette, Thwaitgold Firefly Statuette, Thwaitgold Goliath Beetle Statuette, Thwaitgold Grasshopper Statuette, Thwaitgold Maggot Statuette, Thwaitgold Moth Statuette, Thwaitgold Nit Statuette, Thwaitgold Praying Mantis Statuette, Thwaitgold Scarab Beetle Statuette, Thwaitgold Scorpion Statuette, Thwaitgold Spider Statuette, Thwaitgold Stag Beetle Statuette, Thwaitgold Termite Statuette, Thwaitgold Wheel Bug Statuette, Thwaitgold Woollybear Statuette];
-			foreach it in toDisplay
+			if(item_amount(it) > 0)
 			{
-				if(item_amount(it) > 0)
-				{
-					auto_log_info("Displaying " + item_amount(it) + " " + it, "green");
-				}
-				put_display(item_amount(it), it);
+				auto_log_info("Displaying " + item_amount(it) + " " + it, "green");
 			}
+			put_display(item_amount(it), it);
 		}
+	}
+	
+	if(get_property("lastEmptiedStorage").to_int() != my_ascensions())
+	{
+		cli_execute("pull all");
+	}
 
-		if(get_property("lastEmptiedStorage").to_int() != my_ascensions())
+	visit_url("museum.php?action=icehouse", false);
+	visit_url("place.php?whichplace=desertbeach&action=db_nukehouse");
+	if((get_property("sidequestOrchardCompleted") != "none") && !get_property("_hippyMeatCollected").to_boolean())
+	{
+		visit_url("shop.php?whichshop=hippy");
+	}
+	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
+	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
+	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
+	visit_url("clan_rumpus.php?action=click&spot=1&furni=4");
+	visit_url("clan_rumpus.php?action=click&spot=4&furni=2");
+	visit_url("clan_rumpus.php?action=click&spot=9&furni=3");
+
+	if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
+	{
+		if(get_property("_clipartSummons").to_int() < 3)
 		{
-			cli_execute("pull all");
+			cli_execute("make borrowed time");
 		}
-
-//		visit_url("lair2.php?preaction=key&whichkey=436");
-		visit_url("museum.php?action=icehouse", false);
-		visit_url("place.php?whichplace=desertbeach&action=db_nukehouse");
-		if((get_property("sidequestOrchardCompleted") != "none") && !get_property("_hippyMeatCollected").to_boolean())
+		if((item_amount($item[Borrowed Time]) > 0) && (my_daycount() > 1))
 		{
-			visit_url("shop.php?whichshop=hippy");
+			use(1, $item[borrowed time]);
 		}
-		visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-		visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-		visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-		visit_url("clan_rumpus.php?action=click&spot=1&furni=4");
-		visit_url("clan_rumpus.php?action=click&spot=4&furni=2");
-		visit_url("clan_rumpus.php?action=click&spot=9&furni=3");
+	}
 
-		if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
+	visit_url("campground.php?action=workshed");
+
+	if(get_property("auto_snapshot") == "")
+	{
+		if(svn_info("bumcheekascend-snapshot").last_changed_rev > 0)
 		{
-			if(get_property("_clipartSummons").to_int() < 3)
-			{
-				cli_execute("make borrowed time");
-			}
-			if((item_amount($item[Borrowed Time]) > 0) && (my_daycount() > 1))
-			{
-				use(1, $item[borrowed time]);
-			}
+			cli_execute("snapshot");
 		}
-
-		visit_url("campground.php?action=workshed");
-
-		if(get_property("auto_snapshot") == "")
+		if(svn_info("ccascend-snapshot").last_changed_rev > 0)
 		{
-			if(svn_info("bumcheekascend-snapshot").last_changed_rev > 0)
-			{
-				cli_execute("snapshot");
-			}
-			if(svn_info("ccascend-snapshot").last_changed_rev > 0)
-			{
-				cli_execute("cc_snapshot");
-			}
-			set_property("auto_snapshot", "done");
+			cli_execute("cc_snapshot");
 		}
+		set_property("auto_snapshot", "done");
+	}
 
-		visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");
+	visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");
 
-		if((item_amount($item[Game Grid Token]) > 0) || (item_amount($item[Game Grid Ticket]) > 0))
+	if((item_amount($item[Game Grid Token]) > 0) || (item_amount($item[Game Grid Ticket]) > 0))
+	{
+		int oldToken = item_amount($item[Defective Game Grid Token]);
+		visit_url("place.php?whichplace=arcade&action=arcade_plumber", false);
+		if(item_amount($item[Defective Game Grid Token]) > oldToken)
 		{
-			int oldToken = item_amount($item[Defective Game Grid Token]);
-			visit_url("place.php?whichplace=arcade&action=arcade_plumber", false);
-			if(item_amount($item[Defective Game Grid Token]) > oldToken)
-			{
-				auto_log_info("Woohoo!!! You got a game grid tokON!!", "green");
-			}
+			auto_log_info("Woohoo!!! You got a game grid tokON!!", "green");
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -70,18 +70,6 @@ void handleKingLiberation()
 	//if you just finished a standard run mafia thinks icehouse is empty
 	visit_url("museum.php?action=icehouse", false);
 
-	if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
-	{
-		if(get_property("_clipartSummons").to_int() < 3)
-		{
-			cli_execute("make borrowed time");
-		}
-		if((item_amount($item[Borrowed Time]) > 0) && (my_daycount() > 1))
-		{
-			use(1, $item[borrowed time]);
-		}
-	}
-
 	visit_url("campground.php?action=workshed");
 
 	if(get_property("auto_snapshot") == "")

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -86,16 +86,6 @@ void handleKingLiberation()
 
 	visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");
 
-	if((item_amount($item[Game Grid Token]) > 0) || (item_amount($item[Game Grid Ticket]) > 0))
-	{
-		int oldToken = item_amount($item[Defective Game Grid Token]);
-		visit_url("place.php?whichplace=arcade&action=arcade_plumber", false);
-		if(item_amount($item[Defective Game Grid Token]) > oldToken)
-		{
-			auto_log_info("Woohoo!!! You got a game grid tokON!!", "green");
-		}
-	}
-
 	if(inAftercore() && !get_property("auto_aftercore").to_boolean())
 	{
 //		buy_item($item[4-d camera], 1, 10000);

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -118,13 +118,6 @@ void handleKingLiberation()
 		set_property("auto_aftercore", true);
 	}
 
-	if(get_property("auto_clearCombatScripts").to_boolean())
-	{
-		restoreSetting("kingLiberatedScript");
-		restoreSetting("afterAdventureScript");
-		restoreSetting("betweenBattleScript");
-		restoreSetting("counterScript");
-	}
 	auto_log_info("King Liberation Complete. Thank you for playing", "blue");
 }
 

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -90,10 +90,7 @@ void handleKingLiberation()
 	
 	if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
 	{
-		if(get_property("_clipartSummons").to_int() < 3)
-		{
-			cli_execute("make borrowed time");
-		}
+		retrieve_item(1, $item[borrowed time]);
 		if((item_amount($item[Borrowed Time]) > 0) && (my_daycount() > 1))
 		{
 			use(1, $item[borrowed time]);

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -72,17 +72,13 @@ void handleKingLiberation()
 
 	visit_url("campground.php?action=workshed");
 
-	if(get_property("auto_snapshot") == "")
+	if(get_property("auto_snapshot").to_int() != my_ascensions())
 	{
-		if(svn_info("bumcheekascend-snapshot").last_changed_rev > 0)
-		{
-			cli_execute("snapshot");
-		}
 		if(svn_info("ccascend-snapshot").last_changed_rev > 0)
 		{
-			cli_execute("cc_snapshot");
+			cli_execute("cc_snapshot.ash");
 		}
-		set_property("auto_snapshot", "done");
+		set_property("auto_snapshot", my_ascensions());
 	}
 
 	visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -11,8 +11,6 @@ void handleKingLiberation()
 			set_property("auto_snapshot", "aborted");
 			return;
 		}
-		visit_url("storage.php?action=takemeat&pwd&amt=" + my_storage_meat());
-		visit_url("storage.php?pwd&");
 
 		if(my_familiar() != $familiar[Black Cat])
 		{
@@ -36,27 +34,10 @@ void handleKingLiberation()
 			}
 		}
 
-		boolean[item] toPull = $items[30669 scroll, 33398 scroll, 334 scroll, 5-hour acrimony, 64067 scroll, 668 scroll, 7-foot dwarven mattock, aerogel accordion, angst burger, anti-earplugs, antique accordion, antique tacklebox, Asdon Martin Keyfob, ass-stompers of violence, backwoods banjo, bacon, bag o\' tricks, bag of park garbage, ball-in-a-cup, baneful bandolier, Basaltamander Buckler, Bastille Battalion control rig, beach buck, bellhop\'s hat, belt of loathing, blue LavaCo Lamp&trade;, Boris\'s Helm, Boris\'s Helm (askew), box of sunshine, Brand of Violence, Bricko Eye Brick, Bricko Brick, Buddy Bjorn, buffalo dime, Camp Scout Backpack, can of rain-doh, carrot juice, carrot nose, caustic slime nodule, chamoisole, cheap sunglasses, cheer extractor, chibibuddy&trade; (on), chibibuddy&trade; (off), chroner, circle drum, clara\'s bell, claw of the infernal seal, cloak of dire shadows, coinspiracy, cold stone of hatred, cold wad, confusing led clock, cop dollar, corroded breeches, corrosive cowl, cow poker, Crayon Shavings, The Crown of Ed the Undying, crown of thrones, crumpled felt fedora, Crystalline Cheer, csa fire-starting kit, Daily Affirmation: Keep Free Hate In Your Heart, Dallas Dynasty Falcon Crest Shield, das boot, Deck of Every Card, deck of tropical cards, defective game grid token, diabolical crossbow, Dinsey\'s Brain, Dinsey\'s Glove, Dinsey\'s Oculus, Dinsey\'s Pants, Dinsey\'s Pizza Cutter, Dinsey\'s Radar Dish, dreadful fedora, dreadful glove, dreadful sweater, drunkula\'s wineglass, electronic dulcimer pants, eleven-foot pole, eternal car battery, Everfull Glass, Experimental Carbon Fiber Pasta Additive, Fake Washboard, FantasyRealm Key, Fat Loot Token, Fiberglass Fedora, Fiberglass Fetish, Filthy Lucre, First Post Shirt - Cir Senam, Fishy Pipe, Flaskfull of Hollow, Fossilized Necklace, Freddy Kruegerand, Frying Brainpan, Fudgecycle, Funfunds&trade;, fuzzy slippers of hatred, game grid ticket, game grid token, garbage sticker, gabardine gunnysack, genie bottle, giant yellow hat, girdle of hatred, glass eye, glass of goat\'s milk, Glenn\'s Golden Dice, goggles of loathing, Golden Mr. Accessory, grandfather watch, Gravyskin Belt of the Sauceblob, Great Wolf\'s Headband, Greatest American Pants, green face paint, green LavaCo Lamp&trade;, Grisly Shield, Hairpiece on Fire, Half A Purse, Handmade Hobby Horse, Hardened Slime Belt, Hardened Slime Hat, Hardened Slime Pants, High-Temperature mining drill, HOA regulation book, Hobo Nickel, Holiday Fun!, hot wad, how to avoid scams, instant karma, Incredibly Dense Meat Gem, ittah bittah hookah, Jackass Plumber Home Game, January\'s Garbage Tote, jarlsberg\'s pan, jarlsberg\'s pan (Cosmic Portal Mode), jeans of loathing, Jewel-Eyed Wizard Hat, jodhpurs of violence, The Jokester\'s gun, juju mojo mask, Jumping Horseradish, KoL Con 13 Snowglobe, Kremlin\'s Greatest Briefcase, LARP Membership Card, leathery bat skin, the legendary beat, lens of hatred, lens of violence, Liar\'s Pants, Li\'l Unicorn Costume, License To Chill, Lime, Little Geneticist DNA-Splicing Lab, Little Red Book, little wooden mannequin, llama lama gong, Loathing Legion Helicopter, Loathing Legion Jackhammer, Loathing Legion Knife, Lucky Crimbo Tiki Necklace, LyleCo Premium Magnifying Glass, LyleCo Premium Monocle, LyleCo Premium Pickaxe, LyleCo Premium Rope, Mace of the Tortoise, Mafia Middle Finger Ring, Mafia Pinky Ring, Mafia Thumb Ring, Map to Kokomo, Malevolent Medallion, mayor ghost\'s scissors, mayfly bait necklace, mer-kin digpick, mer-kin gladiator mask, mer-kin gladiator tailpiece, Mercenary Pistol, Mesmereyes&trade; Contact Lenses, milk of magnesium, Mime Army Shotglass, mime pocket probe, miner\'s helmet, miner\'s pants, Mr. Accessory, Mr. Accessory Jr., Mr. Cheeng\'s Spectacles, Mr. Eh?, Mr. Screege\'s Spectacles, mon tiki, Moveable Feast, Mumming Trunk, nasty-smelling moss, nasty rat mask, ninjammies, novelty belt buckle of violence, The Nuge\'s Favorite Crossbow, numberwang, octolus-skin cloak, odd silver coin, operation patriot shield, opium grenade, order of the silver wossname, ornamental sextant, Oscus\'s dumpster waders, Oscus\'s Neverending Soda, Oscus\'s Pelt, outrageous sombrero, over-the-shoulder folder holder, packet of beer seeds, packet of dragon\'s teeth, packet of tall grass seeds, packet of thanksgarden seeds, packet of winter seeds, pantaloons of hatred, pantsgiving, PARTY HARD T-Shirt, Pecos Dave\'s sixgun, peppermint parasol, pernicious cudgel, Pick-O-Matic lockpicks, pigsticker of violence, pine cone necklace, plastic vampire fangs, Platinum Yendorian Express Card, pocket square of loathing, poppy, portable cassette player, portable mayo clinic, Portable Pantogram, possessed sugar cube, Protonic Accelerator Pack, Primitive Alien Totem, psychoanalytic jar, puppet strings, quake of arrows, Ratskin Pajama Pants, red and green rain stick, red face paint, red LavaCo Lamp&trade;, reflection of a map, replica bat-oomerang, Ring of Detect Boring Doors, Ring Of The Skeleton Lord, Robin\'s Egg, Royal Scepter, rubber spider, Rubee&trade;, Sacramento Wine, sand dollar, sasq&trade; watch, scepter of loathing, School of Hard Knocks Diploma, sea lasso, sea cowbell, sewing kit, set of jacks, shirt kit, Shore Inc. Ship Trip Scrip, silver cow creamer, Sister Accessory, sleaze wad, slime-covered club, slime-covered compass, slime-covered greaves, slime-covered helmet, slime-covered lantern, slime-covered necklace, slime-covered shovel, slime-covered speargun, slime-covered staff, smooth velvet bra, smooth velvet hanky, smooth velvet hat, smooth velvet pants, smooth velvet pocket square, smooth velvet shirt, smooth velvet socks, Sneaky Pete\'s Leather Jacket, Sneaky Pete\'s Leather Jacket (Collar Popped), snow suit, soft green echo eyedrop antidote, solid shifting time weirdness, Source essence, Source shades, Spacegate Research, Space Trip Safety Headphones, Special Seasoning, Spelunker\'s Fedora, Spelunker\'s Khakis, spinning wheel, spooky putty monster, spooky putty sheet, spooky wad, sprinkles, staff of kitchen royalty, staff of the scummy sink, staff of simmering hatred, stench wad, stinky cheese diaper, stinky cheese eye, stinky cheese sword, stinky cheese wheel, Stephen\'s Lab Coat, stick-knife of loathing, stinky fannypack, STYX Deodorant Body Spray, Tales of Spelunking, Talisman of Baio, Talking Spade, Tenderizing Hammer, Thor\'s Pliers, Ticksilver Ring, Tiki Lighter, Time Bandit Time Towel, Time Bandit Badge of Courage, Time Lord Badge of Honor, Time Shuriken, time sword, Time-Spinner, Time-twitching Toolbelt, tiny costume wardrobe, Toggle Switch (Bartend), tropical paperweight, toy accordion, Travoltan Trousers, Transmission from Planet Xi, Treads of Loathing, twinkly wad, unbearable light, Uncle Buck, Uncle Crimbo\'s Hat, unconscious collective dream jar, V for Vivala Mask, villainous scythe, volcoino, Wal-Mart gift certificate, Wand of Oscus, water wings for babies, Western-Style Skinning Knife, Work is a Four Letter Sword, woven baling wire bracelets, Xiblaxian 5D Printer, Xiblaxian Alloy, Xiblaxian Circuitry, Xiblaxian Holo-Wrist-Puter, Xiblaxian Polymer, Xiblaxian Stealth Cowl, Xiblaxian Stealth Trousers, Xiblaxian Stealth Vest, Zombo\'s Empty Eye];
-		foreach it in toPull
+		if(get_property("lastEmptiedStorage").to_int() != my_ascensions())
 		{
-			if(storage_amount(it) > 0)
-			{
-				auto_log_info("Pulling " + storage_amount(it) + " " + it, "green");
-			}
-			pullAll(it);
+			cli_execute("pull all");
 		}
-
-		toPull = $items[Bittycar meatcar, burrowgrub hive, Can of Rain-Doh, Cheap Toaster, chester\'s bag of candy, chroner cross, chroner trigger, the cocktail shaker, Creepy Voodoo Doll, festive warbear bank, glass gnoll eye, infinite BACON machine, picky tweezers, taco dan\'s taco stand flier, Trivial Avocations Board Game, warbear breakfast machine, warbear soda machine];
-		foreach it in toPull
-		{
-			if(storage_amount(it) > 0)
-			{
-				auto_log_info("Pulling/Using " + storage_amount(it) + " " + it, "green");
-			}
-			pullAndUse(it, 1);
-		}
-
-		pullPVPJunk();
 
 //		visit_url("lair2.php?preaction=key&whichkey=436");
 		visit_url("museum.php?action=icehouse", false);
@@ -152,27 +133,6 @@ void handleKingLiberation()
 		restoreSetting("counterScript");
 	}
 	auto_log_info("King Liberation Complete. Thank you for playing", "blue");
-}
-
-
-boolean pullPVPJunk()
-{
-	if(!get_property("auto_pullPVPJunk").to_boolean())
-	{
-		return false;
-	}
-	boolean[item] toPull = $items[artisanal hand-squeezed wheatgrass juice, ascii fu manchu, bangyomaman battle juice, black friar\'s tonsure, black magic powder, blob of acid, blue oyster badge, booby trap, brigand brittle, bubblin\' chemistry solution, bull blubber, button rouge, cheap clip-on ninja tie, clove-flavored lip balm, compressed air canister, cube of ectoplasm, dancing fan, ectoplasm <i>au jus</i>, eldritch dough, electric copperhead potion, enchanted flyswatter, enchanted muesli, enchanted plunger, filthy armor, fireclutch, fitspiration&trade; poster, flask of rainwater, flayed mind, frog lip-print, fu manchu wax, gearhead goo, giant neckbeard, giant tube of black lipstick, gilt perfume bottle, glass of gnat milk, glass of warm milk, gnollish crossdress, gold toothbrush, handyman &quot;hand soap&quot;, holistic headache remedy, iiti kitty gumdrop, illuminati earpiece, janglin\' bones, jazzy cigarette holder, knob goblin mutagen, kobold kibble, leather glove, leonard\'s glasses, lucky cat\'s paw, lynyrd skinner toothblack, missing eye simulation device, muscle oil, ninja eyeblack, ninja fear powder, oil-filled donut, page of the necrohobocon, perpendicular guano, pirate cream pie, plastic jefferson wings, punk patch, pygmy adder oil, pygmy dart, pygmy papers, pygmy witchhazel, ravenous eye, red army camouflage kit, redeye&trade; eyedrops, salt water taffy, scrunchie tourniquet, secret mummy herbs and spices, Shivering Ch&egrave;vre, short deposition, skelelton spine, skeletal banana, skullery maid\'s knee, smart bone dust, smut orc sunglasses, space marine flash grenade, spooky gravy fairy warlock hat, steampunk potion, stone golem pebbles, tears of the quiet healer, temporary tribal tattoo, tiny canopic jar, una poca de gracia, unholy water, vial of swamp vapors, voodoo glowskull, white chocolate golem seeds, zombie hollandaise];
-	foreach it in toPull
-	{
-		pullAll(it);
-	}
-
-	toPull = $items[all-purpose cleaner, awful poetry journal, batgut];
-	foreach it in toPull
-	{
-		pullAll(it);
-	}
-	return true;
 }
 
 void main()

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -33,19 +33,10 @@ void handleKingLiberation()
 	{
 		cli_execute("pull all");
 	}
+	cli_execute("breakfast");
 
+	//if you just finished a standard run mafia thinks icehouse is empty
 	visit_url("museum.php?action=icehouse", false);
-	visit_url("place.php?whichplace=desertbeach&action=db_nukehouse");
-	if((get_property("sidequestOrchardCompleted") != "none") && !get_property("_hippyMeatCollected").to_boolean())
-	{
-		visit_url("shop.php?whichshop=hippy");
-	}
-	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-	visit_url("clan_rumpus.php?action=click&spot=3&furni=3");
-	visit_url("clan_rumpus.php?action=click&spot=1&furni=4");
-	visit_url("clan_rumpus.php?action=click&spot=4&furni=2");
-	visit_url("clan_rumpus.php?action=click&spot=9&furni=3");
 
 	if(get_property("auto_borrowedTimeOnLiberation").to_boolean() && (get_property("_borrowedTimeUsed") == "false"))
 	{

--- a/RELEASE/scripts/autoscend/auto_king.ash
+++ b/RELEASE/scripts/autoscend/auto_king.ash
@@ -73,7 +73,11 @@ void handleKingLiberation()
 	//workaround for telegraphOfficeAvailable not updating when you finish a standard run. also grab your boots
 	visit_url("place.php?whichplace=town_right");
 
+	//probably a workaround for going into a standard run with an out of standard item resulting in mafia thinking you have no item in workshed.
+	//is this fix still needed?
 	visit_url("campground.php?action=workshed");
+	
+	visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");
 
 	if(get_property("auto_snapshot").to_int() != my_ascensions())
 	{
@@ -83,8 +87,6 @@ void handleKingLiberation()
 		}
 		set_property("auto_snapshot", my_ascensions());
 	}
-
-	visit_url("place.php?whichplace=town_wrong&action=townwrong_precinct");
 
 	if(inAftercore() && !get_property("auto_aftercore").to_boolean())
 	{

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -1318,32 +1318,7 @@ boolean LA_cs_communityService()
 	case 0:
 		{
 			auto_log_info("Service Complete, finishing finish...", "blue");
-			try
-			{
-				if(do_cs_quest(30))
-				{
-					cli_execute("call auto_king");
-					return true;
-				}
-				else
-				{
-					abort("Could not complete run.");
-				}
-			}
-			finally
-			{
-				auto_log_warning("Waiting a few seconds, please hold.", "red");
-				wait(5);
-				if(inAftercore())
-				{
-					cli_execute("call auto_king");
-					return true;
-				}
-				else
-				{
-					abort("kingLiberation not set correctly but run is probably complete. Beep boop. Try running again to handle resetting options");
-				}
-			}
+			do_cs_quest(30);
 		}
 		break;
 


### PR DESCRIPTION
*replace king liberated script's many many individual pulls with a single "pull all" command
*fixes the king liberated script crashing with a failure to find the function `pullPVPJunk()`
*allow kingliberated to do stuff regardless of snapshot state or setting. actual calling of snapshot scripts already had its own check for its own setting.
*do breakfast as part of kingliberated. remove the individual visit url calls that were obsoleted by it
*property auto_kingLiberation used to determine if we switch from the user defined king liberated script to autoscend's king liberated script. old behavior was to always switch to our script but then have it do nothing if set to false
*removed auto_pullPVPJunk setting
*start sea quest so we can grab sea jelly as part of breakfast. move displaying to its own function. removed instant karma from being auto displayed so now we only display thwaitgold. changed whitespace to make it more readable. added comments on which is what and sorted them by path instead of alphabetically
*added thwaitgold for 2017 to 2020 paths
*remove bumcheek snapshot. only cc_snapshot will be used.
*auto_snapshot setting only used in auto_king.ash and will now be set to the last ascension in which it ran.
*workaround for telegraphOfficeAvailable not updating when you finish a standard run. also grab boots
*removed Defective Game Grid Token handling. mafia does that now.
*removed setting auto_clearCombatScripts we already always restore all settings
*url visits (mostly for correcting mafia tracking after standard) should all be done before snapshot
*fix vacationing in aftercore (only used for dickstab)
*no need to force king liberated script to run after community service anymore. it was fixed in mafia
*auto_aftercore localized to auto_king.ash and uses my_ascensions() to track if it was ran this ascension yet.
*borrowed time will use retrieve_item instead of cli make. it will prefer to make it yourself, but if you don not have the tome or tome uses left it will mallbuy it instead.

## How Has This Been Tested?

ran it directly

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
