### PR TITLE
bitchin meatcar meatreserve should be my_turncount() > 50 not <. fixup for PR #551

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5789,9 +5789,9 @@ int meatReserve()
 	
 	if(my_level() < 10)		//meat income is pretty low and the quests that need the reserve far away. Use restores freely
 	{
-		if(!isDesertAvailable() && inKnollSign() && my_level() > 5 && my_turncount() < 50)
-		{
-			return 500;		//reserve some meat for the bitchin' meatcar
+		if(!isDesertAvailable() && inKnollSign() && my_level() > 5 && my_turncount() > 50)
+		{		//reason for both level and turncount being checked is that many iotms could level us on turn 1.
+			return 500;		//reserve some meat for the bitchin' meatcar.
 		}
 		return 0;	
 	}


### PR DESCRIPTION
*bitchin meatcar meatreserve should be my_turncount() > 50 not <. fixup for PR #551

## How Has This Been Tested?

todo

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
