### PR TITLE
restore

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -904,17 +904,6 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 				return true;
 			}
 		}
-		if(get_value("total_uses_available") < get_value("total_uses_needed"))
-		{
-			if(get_value("total_meat_used") > 0.0 && get_value("total_meat_used") <= get_value("meat_available_to_spend"))
-			{
-				return true;
-			}
-			if(get_value("total_coinmaster_tokens_used") > 0.0 && get_value("total_coinmaster_tokens_used") < to_item(metadata.name).seller.available_tokens)
-			{
-				return true;
-			}
-		}
 		return get_value("total_uses_available") > 0.0 && get_value("total_uses_available") >= get_value("total_uses_needed");
 	}
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -609,8 +609,10 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 
 		float price_per = 0.0;
 		float currency_available = 0.0;
+		item it = to_item(metadata.name);
 
-		if(get_value("meat_per_use") > 0.0)
+		boolean mall_buyable = can_interact() && is_tradeable(it);
+		if(mall_buyable || npc_price(it) > 0)
 		{
 			price_per = get_value("meat_per_use");
 			currency_available = max(0.0, my_meat() - meat_reserve);
@@ -618,7 +620,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		else if(get_value("tokens_per_use") > 0.0)
 		{
 			price_per = get_value("tokens_per_use");
-			currency_available = to_item(metadata.name).seller.available_tokens;
+			currency_available = it.seller.available_tokens;
 		}
 
 		if(currency_available == 0)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -628,7 +628,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			return 0.0;
 		}
 
-		return floor(price_per / currency_available);
+		return floor(currency_available / price_per);
 	}
 
 	float total_uses_available()

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -874,10 +874,12 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if(metadata.type == "item")
 		{
 			item i = to_item(metadata.name);
-			boolean npc_buyable = npc_price(i) > 0 || (i.seller != $coinmaster[none] && is_accessible(i.seller) && get_property("autoSatisfyWithCoinmasters").to_boolean());
 			boolean mall_buyable = can_interact() && auto_mall_price(i) > 0;
-			boolean can_buy = meat_reserve < my_meat() && (npc_buyable || mall_buyable);
-			return (available_amount(i) > 0 || can_buy);
+			boolean npc_meat_buyable = npc_price(i) > 0;
+			boolean coinmaster_buyable = i.seller != $coinmaster[none] && is_accessible(i.seller) && get_property("autoSatisfyWithCoinmasters").to_boolean();
+			
+			boolean can_buy = meat_reserve < my_meat() && (npc_meat_buyable || mall_buyable);
+			return (available_amount(i) > 0 || can_buy || coinmaster_buyable);
 		}
 		if(metadata.type == "skill")
 		{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -405,6 +405,11 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		{
 			optimization_parameters.vars[name] = value;
 		}
+		else
+		{
+			//we must have [name] defined in one of the above keys or it will not be stored/retrieved.
+			abort("void set_value(string name, float value) was asked to store the undefined key = " + name);
+		}
 	}
 
 	void set_value(string name, boolean value)
@@ -412,6 +417,11 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if(__CONSTRAINT_KEYS contains name)
 		{
 			optimization_parameters.constraints[name] = value;
+		}
+		else
+		{
+			//we must have [name] defined in one of the above keys or it will not be stored/retrieved.
+			abort("void set_value(string name, boolean value) was asked to store the undefined key = " + name);
 		}
 	}
 
@@ -425,6 +435,8 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		{
 			return optimization_parameters.vars[name];
 		}
+		//we must have [name] defined in one of the above keys or it will not be stored/retrieved.
+		abort("float get_value(string name) was asked to return the undefined key = " + name);
 		return 0.0;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -325,6 +325,9 @@ boolean[string] __VARS_KEYS = {
 	"amount_creatable": true,
 	"amount_buyable": true,
 	"meat_per_use": true,
+	"tokens_per_use": true,
+	"total_creatable": true,
+	"total_buyable": true,
 	"reserve_limit_hard": true,
 	"total_uses_remaining": true, // candidate for removal
 	"soft_reserve_limit": true,

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -896,6 +896,9 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 
 	boolean have_required_resources()
 	{
+		//this is used to quickly remove unavailable restorers from consideration before we even do any optimization.
+		
+		//for skills, the value of total_uses_available assumes we will not restore_mp to cast. so we overrule it in this function by comparing to our maxmp instead.
 		if(metadata.type == "skill")
 		{
 			skill s = to_skill(metadata.name);
@@ -904,7 +907,9 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 				return true;
 			}
 		}
-		return get_value("total_uses_available") > 0.0 && get_value("total_uses_available") >= get_value("total_uses_needed");
+		
+		//for everything that is not a skill we trust total_uses_available.
+		return get_value("total_uses_available") > 0.0;
 	}
 
 	boolean restores_needed_resources()


### PR DESCRIPTION
*do not use `meat_per_use() > 0` as a way to determine if the item is currently buyable for meat (that is, sold by NPC store for meat or we are in casual/postronin).
**if we are sufficiently wealthy (over 20k) then instead of assuming any item currently in the inventory is free aka `meat_per_use() == 0` , we want to consider its mall value when calculating relative prices. As it might be better off if we spend 200 meat on galaktik restorers instead of spending an item in inventory worth 2000 meat in the mall.
*the function `boolean have_required_resources()` will no longer override the calculation of item availability, as it had very threadbare calculation method.
**it is already calling on a different function that calculated this already `float total_uses_available()` which itself calls on various sub functions and has checks and verifications which do a better job than the overly simplistic code in `boolean have_required_resources()`
**that overruling, while subpar, was actually previously necessary as a workaround for the _KEY issue (see below) causing the results from functions lower down the chain to be lost
**added documentation to `boolean have_required_resources()`. it is used to quick eliminate things which are not available at all before doing optimizations.
**adjusted it to do its function better. it incorrectly required we have enough copies of an item to fully restore using that item alone or else it would early eliminate it before any optimizations were done. We do not even (yet) possess the ability to multi-use items so that was pointless. even when we add multiusing later it will still not do to early eliminate an item from consideration just because it performs a partial restore. it might be the best restorer we have.
*`is_currently_useable()` do not return false for coinmaster restorers if `meat_reserve < my_meat()`
**coinmaster restorers do not actually use meat to buy. they use some other form of currency. as such they do not care about meat reserve
*total_buyable() = floor(money / price_per)
**it was set backwards to floor(price_per / money)
*abort with informative message when we try to store or retrieve data for a key that has not been defined.
**float get_value(string name)
**void set_value(string name, float value)
**void set_value(string name, boolean value)
**such undefined keys do not get anything stored into them either, and thus always returned 0.0 causing our calculations to be lost.
**now we will immediately identify when we broke restore code by trying to use an undefined key
*boolean[string] __VARS_KEYS defined missing keys. see above. The newly defined keys are:
**tokens_per_use
**total_creatable
**total_buyable

## How Has This Been Tested?

`ash import autoscend.ash; acquireMP(1+my_mp());`
also a bunch of temporary `print(information);` in various places in the file to help track down the issues
ran it a couple of days on various accounts in various paths

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
