### PR TITLE
account for ed being undying when avoiding death by gremlin

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -126,7 +126,10 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	
 	if(!canSurvive(1.5))
 	{
-		abort("I am too weak to safely stasis this gremlin");
+		if(!isActuallyEd() || get_property("_edDefeats").to_int() >= 2)
+		{
+			abort("I am too weak to safely stasis this gremlin");
+		}
 	}
 
 	foreach it in $items[Seal Tooth, Spectre Scepter, Doc Galaktik\'s Pungent Unguent]


### PR DESCRIPTION
account for ed being undying when avoiding death by gremlin.
#556 prevents us from committing suicide against gremlins via poking them with a seal tooth when they are projected to kill us within 1.5 rounds (a little over 1 round to account for inaccuracies in canSurvive())
However as ed the undying this is not an issue since he can resurrect for free twice per fight. will now account for this. will only above if not ed OR if ed is out of free resurrections

## How Has This Been Tested?

validates. issue is not that easy to replicate

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
