### PR TITLE
remove hardcoded fist turkey familiar from doTasks()

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3356,11 +3356,6 @@ boolean doTasks()
 	dna_sorceressTest();
 	dna_generic();
 
-	if((my_daycount() == 1) && ($familiar[Fist Turkey].drops_today < 5) && auto_have_familiar($familiar[Fist Turkey]))
-	{
-		handleFamiliar($familiar[Fist Turkey]);
-	}
-
 	if(((my_hp() * 5) < my_maxhp()) && (my_mp() > 100))
 	{
 		acquireHP();


### PR DESCRIPTION
it is already handled in our familiar code. in fact the very first line option in "drop" dat file is the same as what I removed.

## How Has This Been Tested?

validates. all it really needs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
