### PR TITLE
Guano Junction do not suicide with clover & do not assume success

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -111,6 +111,24 @@ boolean L4_batCave()
 
 	if (cloversAvailable() > 0 && batStatus <= 1 && !in_bhy())
 	{
+		if(my_hp() < 6)	//we will be taking 5 damage from this
+		{
+			if(my_maxhp() < 6)
+			{
+				auto_log_warning("How did I end up in [Guano Junction] with less than 6 max HP? skipping until maxHP > 5", "blue");
+				return false;
+			}
+			if(isActuallyEd())
+			{
+				auto_log_warning("Ed wanted to clover [Guano Junction] but does not have enough HP. skipping until HP > 5", "blue");
+				return false;
+			}
+			if(!acquireHP(6))	//try to restore HP to avoid beaten up
+			{
+				auto_log_warning("Tried to restore HP to 6 to clover [Guano Junction] but failed to do so. skipping until HP > 5", "blue");
+				return false;
+			}
+		}
 		cloverUsageInit();
 		autoAdvBypass(31, $location[Guano Junction]);
 		cloverUsageFinish();
@@ -118,6 +136,5 @@ boolean L4_batCave()
 	}
 
 	bat_formBats();
-	autoAdv($location[Guano Junction]);
-	return true;
+	return autoAdv($location[Guano Junction]);
 }


### PR DESCRIPTION
*[Guano Junction] do not suicide with clover, with any class.
*[Guano Junction] do not assume success when adventuring there

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
