### PR TITLE
workaround for mafia bug in adv1

### DIFF
--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -28,7 +28,27 @@ boolean autoAdv(int num, location loc, string option)
 		return digimon_autoAdv(num, loc, option);
 	}
 
-	return adv1(loc, -1, option);
+	// adv1 can erroneously return false for "choiceless" non-combats
+	// see https://kolmafia.us/showthread.php?25370-adv1-returns-false-for-quot-choiceless-quot-choice-adventures
+	// undo all this when (if?) that ever gets fixed
+	string previousEncounter = get_property("lastEncounter");
+	int turncount = my_turncount();
+	boolean advReturn = adv1(loc, -1, option);
+	if (!advReturn)
+	{
+		auto_log_debug("adv1 returned false for some reason. Did we actually adventure though?", "blue");
+		if (get_property("lastEncounter") != previousEncounter)
+		{
+			auto_log_debug(`Looks like we may have adventured, lastEncounter was {previousEncounter}, now {get_property("lastEncounter")}`, "blue");
+			advReturn = true;
+		}
+		if (my_turncount() > turncount)
+		{
+			auto_log_debug(`Looks like we may have adventured, turncount was {turncount}, now {my_turncount()}`, "blue");
+			advReturn = true;
+		}
+	}
+	return advReturn;
 }
 
 boolean autoAdv(int num, location loc)


### PR DESCRIPTION
# Description

KoLmafia sometimes returns false even though we successfully adventured (see https://kolmafia.us/showthread.php?25370-adv1-returns-false-for-quot-choiceless-quot-choice-adventures)
This causes issues as the script then carries on in the doTasks() loop from that point without resetting things like the maximizer statement.

## How Has This Been Tested?

I've been running this for quite a while according to my logs. At least a few Normal LKS runs and 6 Normal Standard runs (1 of each class). I've been meaning to report it on the mafia forum for a while but was prompted by @taltamir running into this issue in Ed runs while building extremity to ascend the peak.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
