### PR TITLE
G-Lover fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2925,6 +2925,12 @@ boolean adventureFailureHandler()
 			}
 		}
 
+		if (tooManyAdventures && auto_my_path() == "G-Lover") {
+			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp] contains my_location()) {
+				tooManyAdventures = false;
+			}
+		}
+
 		if ($locations[The Haunted Gallery] contains my_location() && my_location().turns_spent < 100)
 		{
 			tooManyAdventures = false;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2926,7 +2926,7 @@ boolean adventureFailureHandler()
 		}
 
 		if (tooManyAdventures && auto_my_path() == "G-Lover") {
-			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp] contains my_location()) {
+			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp, The Hidden Temple] contains my_location()) {
 				tooManyAdventures = false;
 			}
 		}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2925,8 +2925,10 @@ boolean adventureFailureHandler()
 			}
 		}
 
-		if (tooManyAdventures && auto_my_path() == "G-Lover") {
-			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp, The Hidden Temple] contains my_location()) {
+		if (tooManyAdventures && auto_my_path() == "G-Lover")
+		{
+			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp, The Hidden Temple] contains my_location())
+			{
 				tooManyAdventures = false;
 			}
 		}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1506,7 +1506,7 @@ boolean doBedtime()
 
 	while(LX_freeCombats());
 
-	if((my_class() == $class[Seal Clubber]) && guild_store_available() && (auto_my_path() != "G-Lover"))
+	if((my_class() == $class[Seal Clubber]) && guild_store_available())
 	{
 		handleFamiliar("stat");
 		int oldSeals = get_property("_sealsSummoned").to_int();

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -312,7 +312,14 @@ void finalizeMaximize()
 	}
 	if(!in_zelda() && get_property(getMaximizeSlotPref($slot[weapon])) == "" && !maximizeContains("-weapon") && my_primestat() != $stat[Mysticality])
 	{
-		addToMaximize("effective");
+		if (my_class() == $class[Seal Clubber] && auto_my_path() == "G-Lover")
+		{
+			addToMaximize("club");
+		}
+		else
+		{
+			addToMaximize("effective");
+		}
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3823,7 +3823,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Eldritch Alignment]:			useItem = $item[Eldritch Alignment Spray];		break;
 	case $effect[Elemental Saucesphere]:		useSkill = $skill[Elemental Saucesphere];		break;
 	case $effect[Empathy]:
-		if(have_familiar($familiar[Mosquito]) && acquireTotem())
+		if(pathAllowsFamiliars() && acquireTotem())
 		{
 			useSkill = $skill[Empathy of the Newt];
 		}																						break;
@@ -3948,7 +3948,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Juiced and Jacked]:			useItem = $item[Pumpkin Juice];					break;
 	case $effect[Juiced and Loose]:				useSkill = $skill[Steroid Bladder];				break;
 	case $effect[Leash of Linguini]:
-		if(have_familiar($familiar[Mosquito]))
+		if(pathAllowsFamiliars())
 		{
 			useSkill = $skill[Leash of Linguini];
 		}																						break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1342,11 +1342,11 @@ boolean adjustForYellowRayIfPossible()
 
 string replaceMonsterCombatString(monster target, boolean inCombat)
 {
-	if (auto_macrometeoritesAvailable() > 0)
+	if (auto_macrometeoritesAvailable() > 0 && auto_is_valid($skill[Macrometeorite]))
 	{
 		return "skill " + $skill[Macrometeorite];
 	}
-	if (auto_powerfulGloveReplacesAvailable(inCombat) > 0)
+	if (auto_powerfulGloveReplacesAvailable(inCombat) > 0 && auto_is_valid($skill[CHEAT CODE: Replace Enemy]))
 	{
 		return "skill " + $skill[CHEAT CODE: Replace Enemy];
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3823,7 +3823,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Eldritch Alignment]:			useItem = $item[Eldritch Alignment Spray];		break;
 	case $effect[Elemental Saucesphere]:		useSkill = $skill[Elemental Saucesphere];		break;
 	case $effect[Empathy]:
-		if(pathAllowsFamiliars() && acquireTotem())
+		if(pathAllowsFamiliar() && acquireTotem())
 		{
 			useSkill = $skill[Empathy of the Newt];
 		}																						break;
@@ -3948,7 +3948,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Juiced and Jacked]:			useItem = $item[Pumpkin Juice];					break;
 	case $effect[Juiced and Loose]:				useSkill = $skill[Steroid Bladder];				break;
 	case $effect[Leash of Linguini]:
-		if(pathAllowsFamiliars())
+		if(pathAllowsFamiliar())
 		{
 			useSkill = $skill[Leash of Linguini];
 		}																						break;

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -510,7 +510,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if((my_familiar() == $familiar[Pair of Stomping Boots]) && (get_property("_bootStomps").to_int()) < 7 && instakillable(enemy) && get_property("bootsCharged").to_boolean())
 	{
-		if(!($monsters[Dairy Goat, Lobsterfrogman, Writing Desk] contains enemy) && !($locations[The Laugh Floor, Infernal Rackets Backstage] contains my_location())  )
+		if(!($monsters[Dairy Goat, Lobsterfrogman, Writing Desk] contains enemy) && !($locations[The Laugh Floor, Infernal Rackets Backstage] contains my_location()) && canUse($skill[Release the boots]))
 		{
 			return useSkill($skill[Release the boots]);
 		}
@@ -1354,7 +1354,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			}
 		}
 
-		if(my_location() == $location[The Haunted Kitchen] && equipped_amount($item[vampyric cloake]) > 0 && get_property("_vampyreCloakeFormUses").to_int() < 10)
+		if(my_location() == $location[The Haunted Kitchen] && canUse($skill[Become a Cloud of Mist]) && get_property("_vampyreCloakeFormUses").to_int() < 10)
 		{
 			int hot = to_int(numeric_modifier("Hot Resistance"));
 			int stench = to_int(numeric_modifier("Stench Resistance"));

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -275,7 +275,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
-	if((loveEffect == 2) && !have_familiar($familiar[Mosquito]))
+	if((loveEffect == 2) && !pathAllowsFamiliars())
 	{
 		loveEffect = 3;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -275,7 +275,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
-	if((loveEffect == 2) && !pathAllowsFamiliars())
+	if((loveEffect == 2) && !pathAllowsFamiliar())
 	{
 		loveEffect = 3;
 	}

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -53,6 +53,15 @@ boolean glover_usable(string it)
 	{
 		return true;
 	}
+	item checkItem = it.to_item();
+	if (checkItem != $item[none] && $items[Ninja Carabiner, Ninja Crampons, Ninja Rope, linoleum ore, chrome ore, asbestos ore, wet stew] contains checkItem) {
+		// these are not "used", they just need to exist in inventory for the quest they are used in.
+		return true;
+	} else if (to_slot(checkItem) != $slot[none]) {
+		// easy way to check if an item is equipment.
+		// all equipment is fine to use, you just don't get enchantments from stuff that lacks G's
+		return true;
+	}
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -56,9 +56,10 @@ boolean glover_usable(string it)
 	item checkItem = it.to_item();
 	if (checkItem != $item[none] && $items[ninja Carabiner, ninja Crampons, ninja Rope,
 	eXtreme scarf, snowboarder pants, eXtreme mittens, linoleum ore, chrome ore, asbestos ore,
-	amulet of extreme plot significance, titanium assault umbrella, antique machete, half-size scalpel,
-	head mirror, wet stew,  Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack,
-	filthy corduroys, beer helmet, distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem) {
+	amulet of extreme plot significance, titanium assault umbrella, antique machete,
+	half-size scalpel, head mirror, wet stew, Talisman o' Namsilat, Mega Gem, Orcish baseball cap,
+	Orcish frat-paddle, filthy knitted dread sack, filthy corduroys, beer helmet,
+	distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem) {
 		// these are all used for quest furthering porpoises so they still "work" even though they don't contain G's
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -70,7 +70,7 @@ boolean glover_usable(string it)
 																				head mirror,
 																				wet stew,
 																				Orcish baseball cap,
-																				homoerotic frat-paddle,
+																				Orcish frat-paddle,
 																				filthy knitted dread sack,
 																				filthy corduroys,
 																				beer helmet,

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -56,10 +56,11 @@ boolean glover_usable(string it)
 	item checkItem = it.to_item();
 	if (checkItem != $item[none] && $items[ninja Carabiner, ninja Crampons, ninja Rope,
 	eXtreme scarf, snowboarder pants, eXtreme mittens, linoleum ore, chrome ore, asbestos ore,
-	amulet of extreme plot significance, titanium assault umbrella, antique machete,
-	half-size scalpel, head mirror, wet stew, Talisman o' Namsilat, Mega Gem, Orcish baseball cap,
-	Orcish frat-paddle, filthy knitted dread sack, filthy corduroys, beer helmet,
-	distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem) {
+	loadstone, amulet of extreme plot significance, titanium assault umbrella, antique machete,
+	half-size scalpel, head mirror, wet stew, UV-resistant compass, Talisman o' Namsilat,
+	Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack, filthy corduroys,
+	beer helmet, distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem)
+	{
 		// these are all used for quest furthering porpoises so they still "work" even though they don't contain G's
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -54,12 +54,30 @@ boolean glover_usable(string it)
 		return true;
 	}
 	item checkItem = it.to_item();
-	if (checkItem != $item[none] && $items[Ninja Carabiner, Ninja Crampons, Ninja Rope, linoleum ore, chrome ore, asbestos ore, wet stew] contains checkItem) {
-		// these are not "used", they just need to exist in inventory for the quest they are used in.
-		return true;
-	} else if (to_slot(checkItem) != $slot[none]) {
-		// easy way to check if an item is equipment.
-		// all equipment is fine to use, you just don't get enchantments from stuff that lacks G's
+	if (checkItem != $item[none] && $items[ninja Carabiner,
+																				ninja Crampons,
+																				ninja Rope,
+																				eXtreme scarf,
+																				snowboarder pants,
+																				eXtreme mittens,
+																				linoleum ore,
+																				chrome ore,
+																				asbestos ore,
+																				amulet of extreme plot significance,
+																				titanium assault umbrella,
+																				antique machete,
+																				half-size scalpel,
+																				head mirror,
+																				wet stew,
+																				Orcish baseball cap,
+																				homoerotic frat-paddle,
+																				filthy knitted dread sack,
+																				filthy corduroys,
+																				beer helmet,
+																				distressed denim pants,
+																				reinforced beaded headband,
+																				bullet-proof corduroys] contains checkItem) {
+		// these are all used for quest furthering porpoises so they still "work" even though they don't contain G's
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -57,7 +57,7 @@ boolean glover_usable(string it)
 	if (checkItem != $item[none] && $items[ninja Carabiner, ninja Crampons, ninja Rope,
 	eXtreme scarf, snowboarder pants, eXtreme mittens, linoleum ore, chrome ore, asbestos ore,
 	loadstone, amulet of extreme plot significance, titanium assault umbrella, antique machete,
-	half-size scalpel, head mirror, wet stew, UV-resistant compass, Talisman o' Namsilat,
+	half-size scalpel, head mirror, wet stew, UV-resistant compass, Talisman o' Namsilat, Unstable Fulminate,
 	Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack, filthy corduroys,
 	beer helmet, distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem)
 	{

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -54,29 +54,11 @@ boolean glover_usable(string it)
 		return true;
 	}
 	item checkItem = it.to_item();
-	if (checkItem != $item[none] && $items[ninja Carabiner,
-																				ninja Crampons,
-																				ninja Rope,
-																				eXtreme scarf,
-																				snowboarder pants,
-																				eXtreme mittens,
-																				linoleum ore,
-																				chrome ore,
-																				asbestos ore,
-																				amulet of extreme plot significance,
-																				titanium assault umbrella,
-																				antique machete,
-																				half-size scalpel,
-																				head mirror,
-																				wet stew,
-																				Orcish baseball cap,
-																				Orcish frat-paddle,
-																				filthy knitted dread sack,
-																				filthy corduroys,
-																				beer helmet,
-																				distressed denim pants,
-																				reinforced beaded headband,
-																				bullet-proof corduroys] contains checkItem) {
+	if (checkItem != $item[none] && $items[ninja Carabiner, ninja Crampons, ninja Rope,
+	eXtreme scarf, snowboarder pants, eXtreme mittens, linoleum ore, chrome ore, asbestos ore,
+	amulet of extreme plot significance, titanium assault umbrella, antique machete, half-size scalpel,
+	head mirror, wet stew,  Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack,
+	filthy corduroys, beer helmet, distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem) {
 		// these are all used for quest furthering porpoises so they still "work" even though they don't contain G's
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_06.ash
+++ b/RELEASE/scripts/autoscend/quests/level_06.ash
@@ -39,7 +39,11 @@ boolean L6_friarsGetParts()
 		}
 	}
 
-	if(item_amount($item[box of birthday candles]) == 0)
+	boolean delayHeart = (get_property("auto_dakotaFanning").to_boolean() && internalQuestStatus("questM16Temple") < 0);
+	// if we have to do the "Dakota" Fanning quest to unlock the Hidden Temple,
+	// delay adventuring in The Dark Heart of the Woods until the quest is started.
+
+	if(item_amount($item[box of birthday candles]) == 0 && !delayHeart)
 	{
 		auto_log_info("Getting Box of Birthday Candles", "blue");
 		autoAdv(1, $location[The Dark Heart of the Woods]);

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -796,7 +796,7 @@ boolean L9_oilPeak()
 		{
 			if (auto_my_path() == "G-Lover")
 			{
-				if (item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 3)
+				if (item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 2)
 				{
 					buy($coinmaster[G-Mart], 1, $item[Crude Oil Congealer]);
 				}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -784,21 +784,33 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif")) {
+	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
+	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean needJar = ((oilProgress & 4) == 0) && item_amount($item[Jar Of Oil]) == 0;
-		if (!needJar) {
+		if (!needJar)
+		{
 			return false;
-		} else if (item_amount($item[Bubblin' Crude]) >= 12) {
-			if (auto_my_path() == "G-Lover") {
-				if (item_amount($item[Crude Oil Congealer]) < 1) {
+		}
+		else if (item_amount($item[Bubblin' Crude]) >= 12)
+		{
+			if (auto_my_path() == "G-Lover")
+			{
+				if (item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 3)
+				{
 					buy($coinmaster[G-Mart], 1, $item[Crude Oil Congealer]);
 				}
-				use(1, $item[Crude Oil Congealer]);
-			} else if (auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0) {
+				if (item_amount($item[Crude Oil Congealer]) > 0)
+				{
+					use(1, $item[Crude Oil Congealer]);
+				}
+			}
+			else if (auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0)
+			{
 				create(1, $item[Jar Of Oil]);
 			}
-			if (item_amount($item[Jar Of Oil]) > 0) {
+			if (item_amount($item[Jar Of Oil]) > 0)
+			{
 				return true;
 			}
 		}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -747,6 +747,7 @@ boolean L9_twinPeak()
 	int starting_trimmers = item_amount($item[Rusty Hedge Trimmers]);
 	if(starting_trimmers > 0)
 	{
+		equipMaximizedGear();
 		use(1, $item[rusty hedge trimmers]);
 		cli_execute("refresh inv");
 		if(item_amount($item[rusty hedge trimmers]) == starting_trimmers)
@@ -783,35 +784,23 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
-	{
-		if (!auto_is_valid($item[Bubblin\' Crude]))
-		{
-			return false;
-		}
+	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif")) {
 		int oilProgress = get_property("twinPeakProgress").to_int();
-		boolean needJar = ((oilProgress & 4) == 0);
-
-		if((item_amount($item[Bubblin\' Crude]) >= 12) && needJar)
-		{
-			if(auto_my_path() == "G-Lover")
-			{
-				if(item_amount($item[Crude Oil Congealer]) == 0)
-				{
-					cli_execute("make " + $item[Crude Oil Congealer]);
+		boolean needJar = ((oilProgress & 4) == 0) && item_amount($item[Jar Of Oil]) == 0;
+		if (!needJar) {
+			return false;
+		} else if (item_amount($item[Bubblin' Crude]) >= 12) {
+			if (auto_my_path() == "G-Lover") {
+				if (item_amount($item[Crude Oil Congealer]) < 1) {
+					buy($coinmaster[G-Mart], 1, $item[Crude Oil Congealer]);
 				}
 				use(1, $item[Crude Oil Congealer]);
+			} else if (auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0) {
+				create(1, $item[Jar Of Oil]);
 			}
-			else
-			{
-				cli_execute("make " + $item[Jar Of Oil]);
+			if (item_amount($item[Jar Of Oil]) > 0) {
+				return true;
 			}
-			return true;
-		}
-
-		if((item_amount($item[Jar Of Oil]) > 0) || !needJar)
-		{
-			return false;
 		}
 		auto_log_info("Oil Peak is finished but we need more crude!", "blue");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1714,7 +1714,7 @@ boolean L11_redZeppelin()
 		}
 	}
 
-	if(item_amount($item[lynyrd snare]) > 0 && get_property("_lynyrdSnareUses").to_int() < 3 && my_hp() > 150)
+	if(auto_is_valid($item[lynyrd snare]) && item_amount($item[lynyrd snare]) > 0 && get_property("_lynyrdSnareUses").to_int() < 3 && my_hp() > 150)
 	{
 		return autoAdvBypass("inv_use.php?pwd=&whichitem=7204&checked=1", $location[A Mob of Zeppelin Protesters]);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -269,7 +269,8 @@ WarPlan auto_bestWarPlan()
 		considerNuns = false;
 		considerOrchard = false;
 	}
-	if (auto_my_path() == "G-Lover") {
+	if (auto_my_path() == "G-Lover")
+	{
 		considerArena = false;
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -269,6 +269,9 @@ WarPlan auto_bestWarPlan()
 		considerNuns = false;
 		considerOrchard = false;
 	}
+	if (auto_my_path() == "G-Lover") {
+		considerArena = false;
+	}
 	
 	// Calculate the adventure cost of doing each sidequest.
 	int advCostArena = 0;		//Arena actual cost is 0 adventures... unless you mess it up. TODO: check if messed up.


### PR DESCRIPTION
# Description

Fixes for G-Lover so it runs without interruption. I have paid very little attention to speed issues (one exception being delaying adventuring in The Dark Heart of the Woods until we start the Dakota Fanning quest as it's trivial enough and not G-Lover specific).
My current run spent 82 adventures trying to unlock the Hidden City (can't use Stone Wool) and will waste a lot of adventures trying to get non-combats as without manual pulls it can't get any -combat.
It also breaks in combat as it runs out of MP if it casts Gallapagosian Mating Call since it keeps a relatively small amount of MP on hand (my test runs have been as Sauceror but since you can't cast Weaksauce (or Saucestorm) you get no extra MP). Otherwise combat seems fine spamming Saucegeyser. I probably should've been running Seal Clubber in retrospect.

I may look at increasing the amount of MP it adventures with as meat for restores is not an issue.
Also I may consider adding the things I pull at the start of the run to our handlePulls (blessed dragon scale, meteorite guard, ring of conflict & gravy boat)

Fixes #424 #425 

## How Has This Been Tested?

I've run 4 Normal Sauceror runs while successively fixing issues, currently awaiting the 5th run completing (it ran out of adventures on day 4 having broke ronin, clearing the battlefield & level 13).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
