### PR TITLE
Use tot properly in a-boo peak

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -557,15 +557,15 @@ boolean L9_aBooPeak()
 				}
 				set_property("auto_aboopending", my_turncount());
 			}
-			if(auto_have_familiar($familiar[Trick-or-Treating Tot]))
+			if(canChangeToFamiliar($familiar[Trick-or-Treating Tot]))
 			{
 				handleFamiliar($familiar[Trick-or-Treating Tot]);
 			}
-			else if(auto_have_familiar($familiar[Mu]))
+			else if(canChangeToFamiliar($familiar[Mu]))
 			{
 				handleFamiliar($familiar[Mu]);
 			}
-			else if(auto_have_familiar($familiar[Exotic Parrot]))
+			else if(canChangeToFamiliar($familiar[Exotic Parrot]))
 			{
 				handleFamiliar($familiar[Exotic Parrot]);
 			}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -557,7 +557,11 @@ boolean L9_aBooPeak()
 				}
 				set_property("auto_aboopending", my_turncount());
 			}
-			if(auto_have_familiar($familiar[Mu]))
+			if(auto_have_familiar($familiar[Trick-or-Treating Tot]))
+			{
+				handleFamiliar($familiar[Trick-or-Treating Tot]);
+			}
+			else if(auto_have_familiar($familiar[Mu]))
 			{
 				handleFamiliar($familiar[Mu]);
 			}


### PR DESCRIPTION
# Description

Changes Level 9 A-Boo peak handling to switch to Trick-or-Treating Tot via HandleFamiliar rather than only through maximizer, to avoid weird buffing/flip-flopping.

Fixes # (issue)

## How Has This Been Tested?

Was unable to test, due to lacking a tot, have handed off to player to this end.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [NA] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
