### PR TITLE
Replace expressions like 'a > b || a < b' with 'a != b

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -173,7 +173,7 @@ boolean L13_ed_councilWarehouse()
 	{
 		return false;
 	}
-	if (internalQuestStatus("questL13Warehouse") < 0 || internalQuestStatus("questL13Warehouse") > 0)
+	if (internalQuestStatus("questL13Warehouse") != 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -1,6 +1,6 @@
 boolean auto_tavern()
 {
-	if (internalQuestStatus("questL03Rat") < 1 || internalQuestStatus("questL03Rat") > 1)
+	if (internalQuestStatus("questL03Rat") != 1)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -32,7 +32,7 @@ boolean L5_getEncryptionKey()
 
 boolean L5_findKnob()
 {
-	if (internalQuestStatus("questL05Goblin") < 0 || internalQuestStatus("questL05Goblin") > 0)
+	if (internalQuestStatus("questL05Goblin") != 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -1,6 +1,6 @@
 boolean L7_crypt()
 {
-	if (internalQuestStatus("questL07Cyrptic") < 0 || internalQuestStatus("questL07Cyrptic") > 0)
+	if (internalQuestStatus("questL07Cyrptic") != 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -1,6 +1,6 @@
 boolean L8_trapperStart()
 {
-	if (internalQuestStatus("questL08Trapper") < 0 || internalQuestStatus("questL08Trapper") > 0)
+	if (internalQuestStatus("questL08Trapper") != 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -78,7 +78,7 @@ boolean L10_airship()
 
 boolean L10_basement()
 {
-	if (internalQuestStatus("questL10Garbage") < 7 || internalQuestStatus("questL10Garbage") > 7)
+	if (internalQuestStatus("questL10Garbage") != 7)
 	{
 		return false;
 	}
@@ -195,7 +195,7 @@ boolean L10_basement()
 
 boolean L10_ground()
 {
-	if (internalQuestStatus("questL10Garbage") < 8 || internalQuestStatus("questL10Garbage") > 8)
+	if (internalQuestStatus("questL10Garbage") != 8)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -643,7 +643,7 @@ boolean L11_forgedDocuments()
 
 boolean L11_mcmuffinDiary()
 {
-	if (internalQuestStatus("questL11MacGuffin") < 1 || internalQuestStatus("questL11MacGuffin") > 1 || internalQuestStatus("questL11Black") < 2)
+	if (internalQuestStatus("questL11MacGuffin") != 1 || internalQuestStatus("questL11Black") < 2)
 	{
 		return false;
 	}
@@ -2391,7 +2391,7 @@ boolean L11_unlockEd()
 
 boolean L11_defeatEd()
 {
-	if (internalQuestStatus("questL11Pyramid") < 3 || internalQuestStatus("questL11Pyramid") > 3 || !get_property("pyramidBombUsed").to_boolean())
+	if (internalQuestStatus("questL11Pyramid") != 3 || !get_property("pyramidBombUsed").to_boolean())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -767,7 +767,7 @@ boolean L12_startWar()
 
 boolean L12_filthworms()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestOrchardCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestOrchardCompleted") != "none")
 	{
 		return false;
 	}
@@ -918,7 +918,7 @@ boolean L12_orchardFinalize()
 
 boolean L12_gremlins()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestJunkyardCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestJunkyardCompleted") != "none")
 	{
 		return false;
 	}
@@ -1025,7 +1025,7 @@ boolean L12_gremlins()
 
 boolean L12_sonofaBeach()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestLighthouseCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestLighthouseCompleted") != "none")
 	{
 		return false;
 	}
@@ -1138,7 +1138,7 @@ boolean L12_sonofaPrefix()
 	// this appears to be a copy & paste of L12_sonofaBeach() with some small changes
 	// for Vote Monster/Macrometeor shenanigans. Refactor this so only the relevant code remains.
 
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestLighthouseCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestLighthouseCompleted") != "none")
 	{
 		return false;
 	}
@@ -1298,7 +1298,7 @@ boolean L12_sonofaPrefix()
 
 boolean L12_sonofaFinish()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestLighthouseCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestLighthouseCompleted") != "none")
 	{
 		return false;
 	}
@@ -1357,7 +1357,7 @@ boolean L12_lastDitchFlyer()
 	{
 		return false;
 	}
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestArenaCompleted") != "none" || get_property("flyeredML").to_int() >= 10000)
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestArenaCompleted") != "none" || get_property("flyeredML").to_int() >= 10000)
 	{
 		return false;
 	}
@@ -1441,7 +1441,7 @@ boolean LX_attemptFlyering()
 
 boolean L12_flyerFinish()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1)
+	if (internalQuestStatus("questL12War") != 1)
 	{
 		return false;
 	}
@@ -1481,7 +1481,7 @@ boolean L12_flyerFinish()
 
 boolean L12_themtharHills()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1 || get_property("sidequestNunsCompleted") != "none")
+	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestNunsCompleted") != "none")
 	{
 		return false;
 	}
@@ -1960,7 +1960,7 @@ boolean L12_clearBattlefield()
 
 boolean L12_finalizeWar()
 {
-	if (internalQuestStatus("questL12War") < 1 || internalQuestStatus("questL12War") > 1)
+	if (internalQuestStatus("questL12War") != 1)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -652,7 +652,7 @@ void maximize_hedge()
 
 boolean L13_towerNSHedge()
 {
-	if(internalQuestStatus("questL13Final") < 4 || internalQuestStatus("questL13Final") > 4)
+	if(internalQuestStatus("questL13Final") != 4)
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Makes some quest code a little easier to read by searching for all expressions matching the regex `(\S+) < (\S+) \|\| \1 > \2` and replacing them with `\1 != \2`.

## How Has This Been Tested?

proof by inspection

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
