### PR TITLE
Initial support for cargo shorts

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -383,6 +383,19 @@ boolean auto_mushroomGardenHandler();
 boolean auto_getGuzzlrCocktailSet();
 boolean auto_latheHardwood(item toLathe);
 boolean auto_latheAppropriateWeapon();
+boolean auto_hasCargoShorts();
+int auto_cargoShortsGetPocket(item i);
+int auto_cargoShortsGetPocket(monster m);
+int auto_cargoShortsGetPocket(effect e);
+boolean auto_cargoShortsCanOpenPocket();
+boolean auto_cargoShortsCanOpenPocket(int pocket);
+boolean auto_cargoShortsCanOpenPocket(item i);
+boolean auto_cargoShortsCanOpenPocket(monster m);
+boolean auto_cargoShortsCanOpenPocket(effect e);
+boolean auto_cargoShortsOpenPocket(int pocket);
+boolean auto_cargoShortsOpenPocket(item i);
+boolean auto_cargoShortsOpenPocket(monster m);
+boolean auto_cargoShortsOpenPocket(effect e);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -342,3 +342,169 @@ boolean auto_latheAppropriateWeapon()
 	return auto_latheHardwood(toLathe);
 }
 
+boolean auto_hasCargoShorts()
+{
+	return possessEquipment($item[Cargo Cultist Shorts]) && 
+		auto_is_valid($item[Bagged Cargo Cultist Shorts]);
+}
+
+int auto_cargoShortsGetPocket(item i)
+{
+	// Until mafia tracks these
+	switch (i)
+	{
+		case $item[Yeg's Motel mouthwash]: return 26;
+		case $item[Yeg's Motel shower cap]: return 84;
+		case $item[Yeg's Motel alarm clock]: return 121;
+		case $item[Yeg's Motel stationery]: return 130;
+		case $item[Yeg's Motel slippers]: return 132;
+		case $item[Yeg's Motel hand soap]: return 177;
+		case $item[Yeg's Motel bathrobe]: return 218;
+		case $item[Yeg's Motel toothbrush]: return 284;
+		case $item[Yeg's Motel disposable razor]: return 322;
+		case $item[flask of moonshine]: return 324;
+		case $item[Yeg's Motel ashtray]: return 409;
+		case $item[Yeg's Motel pillow mint]: return 439;
+		case $item[sizzling desk bell]: return 517;
+		case $item[greasy desk bell]: return 533;
+		case $item[frost-rimed desk bell]: return 587;
+		case $item[uncanny desk bell]: return 590;
+		case $item[Yeg's Motel Sewing Kit]: return 642;
+		case $item[nasty desk bell]: return 653;
+		case $item[Yeg's Motel minibar key]: return 660;
+
+		// Chess
+		case $item[alabaster pawn]: return 46;
+		case $item[onyx pawn]: return 105;
+		case $item[alabaster rook]: return 111;
+		case $item[onyx rook]: return 197;
+		case $item[alabaster knight]: return 275;
+		case $item[onyx knight]: return 4;
+		case $item[alabaster king]: return 523;
+		case $item[onyx king]: return 88;
+		case $item[alabaster bishop]: return 567;
+		case $item[onyx bishop]: return 537;
+		case $item[alabaster queen]: return 651;
+		case $item[onyx queen]: return 506;
+
+		// Other
+		case $item[cursed piece of thirteen]: return 600;
+	}
+	return -1;
+}
+
+int auto_cargoShortsGetPocket(monster m)
+{
+	// Until mafia tracks these
+	switch (m)
+	{
+		case $monster[bookbat]: return 30;
+		case $monster[dairy goat]: return 47;
+		case $monster[Knob Goblin Elite Guardsman]: return 136;
+		case $monster[dirty old lihc]: return 143;
+		case $monster[batrat]: return 191;
+		case $monster[Lobsterfrogman]: return 220;
+		case $monster[modern zmobie]: return 235;
+		case $monster[blooper]: return 250;
+		case $monster[creepy clown]: return 267;
+		case $monster[Knob Goblin Harem Girl]: return 299;
+		case $monster[big creepy spider]: return 306;
+		case $monster[camel's toe]: return 317;
+		case $monster[Pufferfish]: return 363;
+		case $monster[skinflute]: return 383;
+		case $monster[fruit golem]: return 402;
+		case $monster[eXtreme Orcish snowboarder]: return 425;
+		case $monster[Mob Penguin Thug]: return 428;
+		case $monster[War Hippy (space) cadet]: return 443;
+		case $monster[completely different spider]: return 448;
+		case $monster[pygmy shaman]: return 452;
+		case $monster[booze giant]: return 490;
+		case $monster[mountain man]: return 565;
+		case $monster[War Pledge]: return 568;
+		case $monster[Green Ops Soldier]: return 589;
+		case $monster[1335 HaXx0r]: return 646;
+		case $monster[smut orc pervert]: return 666;
+	}
+	return -1;
+}
+
+int auto_cargoShortsGetPocket(effect e)
+{
+	// Until mafia tracks these
+	switch (e)
+	{
+		case $effect[Ode to Booze]: return 242;
+		case $effect[Night Vision]: return 339;
+		case $effect[Filthworm Drone Stench]: return 343;
+		case $effect[Medieval Mage Mayhem]: return 617;
+	}
+	return -1;
+}
+
+boolean auto_cargoShortsCanOpenPocket()
+{
+	if (!auto_hasCargoShorts())
+		return false;
+	
+	return !get_property("_cargoPocketEmptied").to_boolean();
+}
+
+boolean auto_cargoShortsCanOpenPocket(int pocket)
+{
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+	
+	if (pocket <= 0 || pocket > 666)
+		return false;
+
+	foreach key,value in get_property("cargoPocketsEmptied").split_string(",")
+	{
+		if (value.to_int() == pocket)
+			return false;
+	}
+	
+	return true;
+}
+
+boolean auto_cargoShortsCanOpenPocket(item i)
+{
+	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(i));
+}
+
+boolean auto_cargoShortsCanOpenPocket(monster m)
+{
+	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(m));
+}
+
+boolean auto_cargoShortsCanOpenPocket(effect e)
+{
+	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(e));
+}
+
+boolean auto_cargoShortsOpenPocket(int pocket)
+{
+	if (!auto_cargoShortsCanOpenPocket(pocket))
+		return false;
+	
+	cli_execute("try; cargo " + pocket);
+	if (get_property("_cargoPocketEmptied").to_boolean())
+	{
+		return true;
+	}
+	return false;
+}
+
+boolean auto_cargoShortsOpenPocket(item i)
+{
+	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(i));
+}
+
+boolean auto_cargoShortsOpenPocket(monster m)
+{
+	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(m));
+}
+
+boolean auto_cargoShortsOpenPocket(effect e)
+{
+	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(e));
+}


### PR DESCRIPTION
# Description

Support opening cargo shorts pockets. Currently unused. I leave this as an exercise for someone who is actively ascending.
Doesn't support all pockets, I just added (most of) the interesting ones from the spreadsheet.

## How Has This Been Tested?

Manually tested:
```
> ash import autoscend; auto_cargoShortsOpenPocket($item[alabaster knight])

Inspecting Cargo Cultist Shorts
picking pocket 275
You acquire an item: alabaster knight
Returned: true

> ash import autoscend; auto_cargoShortsOpenPocket($item[alabaster knight])

Returned: false
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
