### PR TITLE
*finish giant trash quest questL10Garbage before doing L10_holeInTheSkyUnlock()

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -315,8 +315,9 @@ boolean L10_topFloor()
 
 boolean L10_holeInTheSkyUnlock()
 {
-	if (internalQuestStatus("questL10Garbage") < 9)
+	if (internalQuestStatus("questL10Garbage") < 11)
 	{
+		//top floor opens at step9. but we want to finish the giant trash quest first before we do hole in the sky.
 		return false;
 	}
 	if(!get_property("auto_holeinthesky").to_boolean())


### PR DESCRIPTION
*finish giant trash quest questL10Garbage before doing L10_holeInTheSkyUnlock()

## How Has This Been Tested?

In a run where it broke, tried the fixed version and it solved the problem

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
