### PR TITLE
tunnel of love zone availability

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1167,6 +1167,12 @@ generic_t zone_available(location loc)
 			retval._boolean = true;
 		}
 		break;
+	case $location[The Tunnel of L.O.V.E.]:
+		if(get_property("loveTunnelAvailable").to_boolean() && !get_property("_loveTunnelUsed").to_boolean())
+		{
+			retval._boolean = true;
+		}
+		break;
 	case $location[Fastest Adventurer Contest]:
 		if(get_property("nsContestants1").to_int() > 0)
 		{


### PR DESCRIPTION
*add tunnel of love to generic_t zone_available(location loc) so it will correctly identify its availability.

## How Has This Been Tested?

tested via ash calls.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
