### PR TITLE
familiars passive damage and bad familiars

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3137,6 +3137,15 @@ void resetState() {
 	set_property("choiceAdventure1387", -1); // using the force non-combat
 	set_property("_auto_tunedElement", ""); // Flavour of Magic elemental alignment
 
+	if(isHinderingFamiliar100Run())		//some familiars are always bad
+	{
+		set_property("_auto_bad100Familiar", true);			//disable buffing familiar
+	}
+	else		//some familiars are only bad at certain locations
+	{
+		set_property("_auto_bad100Familiar", false); 		//reset to not bad. target location might set them as bad again
+	}
+
 	set_property("auto_januaryToteAcquireCalledThisTurn", false); // january tote item switching
 
 	horseDefault(); // horsery tracking

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3137,7 +3137,7 @@ void resetState() {
 	set_property("choiceAdventure1387", -1); // using the force non-combat
 	set_property("_auto_tunedElement", ""); // Flavour of Magic elemental alignment
 
-	if(isHinderingFamiliar100Run())		//some familiars are always bad
+	if(doNotBuffFamiliar100Run())		//some familiars are always bad
 	{
 		set_property("_auto_bad100Familiar", true);			//disable buffing familiar
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -11,9 +11,9 @@ boolean is100FamRun()
 	return true;
 }
 
-boolean isHinderingFamiliar100Run()
+boolean doNotBuffFamiliar100Run()
 {
-	//indicates that we are in a 100% familiar run with a familiar that hinders you. and thus should not be buffed
+	//indicates that we are in a 100% familiar run with a familiar that should not be buffed. Either because it hinders you or is useless.
 	if(!is100FamRun())
 	{
 		return false;
@@ -28,6 +28,12 @@ boolean isHinderingFamiliar100Run()
 	
 	//these familiars sometime attack the enemy
 	if($familiars[Fuzzy Dice, Stab Bat, Killer Bee, Scary Death Orb, RoboGoose] contains hundred_fam)
+	{
+		return true;
+	}
+	
+	//these familiars do nothing rather than actively hinder you. Still should not be buffed.
+	if($familiars[Pet Rock, Toothsome Rock, Bulky Buddy Box, Holiday Log, Homemade Robot, Software Bug, Bad Vibe] contains hundred_fam)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -11,6 +11,63 @@ boolean is100FamRun()
 	return true;
 }
 
+boolean isHinderingFamiliar100Run()
+{
+	//indicates that we are in a 100% familiar run with a familiar that hinders you. and thus should not be buffed
+	if(!is100FamRun())
+	{
+		return false;
+	}
+	familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
+	
+	//these familiars are only harmful
+	if($familiars[black cat, O.A.F.] contains hundred_fam)
+	{
+		return true;
+	}
+	
+	//these familiars sometime attack the enemy
+	if($familiars[Fuzzy Dice, Stab Bat, Killer Bee, Scary Death Orb, RoboGoose] contains hundred_fam)
+	{
+		return true;
+	}
+	
+	return false;
+}
+
+boolean isAttackFamiliar(familiar fam)
+{
+	//is the familiar called fam able to deal damage to the enemy
+	if(fam.physical_damage || fam.elemental_damage)
+	{
+		return true;
+	}
+	
+	//these familiars vary by configuration. TODO actually check their configuration
+	if($familiars[Mini-Crimbot,
+	El Vibrato Megadrone,
+	Reagnimated Gnome,
+	Mini-Adventurer,
+	Reanimated Reanimator,
+	Comma Chameleon,
+	Mad Hatrack,
+	Fancypants Scarecrow
+	] contains fam)
+	{
+		return true;
+	}
+	
+	if($familiars[Adventurous Spelunker,		//mafia bug. https://kolmafia.us/showthread.php?25467
+	Doppelshifter,								//random familiar every fight. can be an attack familiar
+	Dandy Lion									//attacks if you equip a whip.
+	] contains fam)
+	{
+		return true;
+	}
+	
+	return false;
+}
+
 boolean pathAllowsFamiliar()
 {
 	if($classes[

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -455,7 +455,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 15, 1, 10);
 		// Only maintain skills in path with familiars
-		if(pathAllowsFamiliar())
+		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
 		{
 			buffMaintain($effect[Leash of Linguini], 20, 1, 10);
 			if(regen > 10.0)
@@ -516,7 +516,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 20, 1, 10);
 		// Only Maintain skills in path with familiars
-		if(pathAllowsFamiliar())
+		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
 		{
 			buffMaintain($effect[Leash of Linguini], 30, 1, 10);
 			if(regen > 10.0)
@@ -583,7 +583,7 @@ boolean auto_post_adventure()
 			buffMaintain(whatStatSmile(), 40, 1, 10);
 		}
 		// Only maintain in path with familiars
-		if(pathAllowsFamiliar())
+		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
 		{
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);
 			if(regen > 4.0)
@@ -693,7 +693,7 @@ boolean auto_post_adventure()
 		}
 
 		// Only maintain in path with familiars
-		if(pathAllowsFamiliar())
+		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
 		{
 			buffMaintain($effect[Empathy], 50, 1, 10);
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);
@@ -783,9 +783,9 @@ boolean auto_post_adventure()
 		}
 
 		// Only maintain in path with familiars
-		if(pathAllowsFamiliar())
+		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
 		{
-			buffMaintain($effect[Jingle Jangle Jingle], 120, 1, 2);
+			buffMaintain($effect[Jingle Jangle Jingle], 120, 1, 2);		//familiar acts more often
 		}
 		buffMaintain($effect[A Few Extra Pounds], 200, 1, 2);
 		buffMaintain($effect[Boon of the War Snapper], 200, 1, 5);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4496,11 +4496,10 @@ boolean auto_is_valid(item it)
 
 boolean auto_is_valid(familiar fam)
 {
-	familiar hundo = to_familiar(get_property("auto_100familiar"));
-	if(hundo != $familiar[none] && hundo != fam){
-		auto_log_warning(fam + " isnt valid, player is in a 100% familiar run with " + hundo);
+	if(is100FamRun()){
+		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
-	return bees_hate_usable(fam.to_string()) && glover_usable(fam.to_string()) && is_unrestricted(fam) && (hundo == $familiar[none] || hundo == fam);
+	return bees_hate_usable(fam.to_string()) && glover_usable(fam.to_string()) && is_unrestricted(fam);
 }
 
 boolean auto_is_valid(skill sk)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -814,6 +814,7 @@ boolean L12_preOutfit();
 boolean L12_startWar();
 boolean L12_filthworms();
 boolean L12_orchardFinalize();
+void gremlinsFamiliar();
 boolean L12_gremlins();
 boolean L12_sonofaBeach();
 boolean L12_sonofaPrefix();
@@ -977,6 +978,8 @@ void equipRollover();
 ########################################################################################################
 //Defined in autoscend/auto_familiar.ash
 boolean is100FamRun();
+boolean isHinderingFamiliar100Run();
+boolean isAttackFamiliar(familiar fam);
 boolean pathAllowsFamiliar();
 boolean auto_have_familiar(familiar fam);
 boolean canChangeFamiliar();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -978,7 +978,7 @@ void equipRollover();
 ########################################################################################################
 //Defined in autoscend/auto_familiar.ash
 boolean is100FamRun();
-boolean isHinderingFamiliar100Run();
+boolean doNotBuffFamiliar100Run();
 boolean isAttackFamiliar(familiar fam);
 boolean pathAllowsFamiliar();
 boolean auto_have_familiar(familiar fam);

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -7,7 +7,6 @@ void digimon_initializeSettings()
 {
 	if(auto_my_path() == "Pocket Familiars")
 	{
-		set_property("auto_getBoningKnife", false);
 		set_property("auto_hippyInstead", true);
 		set_property("auto_ignoreFlyer", true);
 		set_property("auto_wandOfNagamar", false);

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -920,6 +920,36 @@ boolean L12_orchardFinalize()
 	return true;
 }
 
+void gremlinsFamiliar()
+{
+	//when fighting gremlins we want to minimize the familiar ability to cause damage.
+	//maximizer will try to force an equip into familiar slot. So disable maximizer switching of familiar equipment
+	addToMaximize("-familiar");
+	
+	familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
+	boolean strip_familiar = true;
+	if(hundred_fam != $familiar[none] && isAttackFamiliar(hundred_fam))		//in 100% familiar run with an attack familiar
+	{
+		set_property("_auto_bad100Familiar", true);			//do not buff bad familiar
+		
+		if(get_property("questS01OldGuy") == "unstarted" && !get_property("_auto_seaQuestStartedToday").to_boolean())
+		{
+			//easier to track if we tried today than to track if it is allowed in current path
+			set_property("_auto_seaQuestStartedToday", true);
+			visit_url("place.php?whichplace=sea_oldman&action=oldman_oldman");	//get bathysphere by starting the sea quest
+		}
+		if(possessEquipment($item[little bitty bathysphere]))
+		{
+			equip($slot[familiar], $item[little bitty bathysphere]);
+			strip_familiar = false;
+		}
+	}
+	if(strip_familiar)
+	{
+		equip($slot[familiar], $item[none]);	//strip familiar equipment if not in 100% run to avoid passive dmg
+	}
+}
+
 boolean L12_gremlins()
 {
 	if (internalQuestStatus("questL12War") != 1 || get_property("sidequestJunkyardCompleted") != "none")
@@ -987,9 +1017,8 @@ boolean L12_gremlins()
 		abort("Do gremlins manually, sorry. Or set sidequestJunkyardCompleted=fratboy and we will just skip them");
 	}
 
-	// Go into the fight with No Familiar Equips since maximizer wants to force an equip
-	// this keeps us from accidentally killing gremlins
-	addToMaximize("-familiar");
+	// Avoid killing the tool gremlins using familiar damage.
+	gremlinsFamiliar();
 
 	auto_log_info("Doing them gremlins", "blue");
 	addToMaximize("20dr,1da 1000max,3hp,-3ml");


### PR DESCRIPTION
familiars passive damage and bad familiars
*no need to log every single time we look to see if a familiar is valid and find it is not because we are in a 100% familiar run. It just adds pages long list of all the familiars which are not valid because we are in 100% run
*boolean isAttackFamiliar(familiar fam) created. lets us know if familiar deals damage to enemy.
*void gremlinsFamiliar() created and used. will prepare our familiar for the gremlins fight.
*pokefam removed redundant initialize for auto_getBoningKnife
*refactored the wall of bones fight.
**improving familiar handling. use gremlins familiar chart (delevel and no attacks) when possible instead of always none
**only buffing for towerkill if we actually try to towerkill
**always want boning knife in 100familiar run with attack familiar. save 1 adv which would have been spent on failing once.
*property _auto_bad100Familiar is used to indicate that our familiar is bad for us but cannot be changed because of 100% run
**disable using the buffs Jingle Jangle Jingle, Empathy, Leash of Linguini
**when fighting gremlins use use itty bitty bathysphere for -20 lbs
**support for familiar either being always bad, or situationally bad.
***Situationally bad currently used to indicate attack familiars (100% runs) when fighting gremlins
***boolean doNotBuffFamiliar100Run() created and used to indicate permanently bad familiars that should not be buffed. either because it is hindering us or because it is useless.

## How Has This Been Tested?

Gremlins tested with 100fam mayo wasp.
Wall of bones tested with 100fam mayo wasp.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
