### PR TITLE
remove outdated workaround. fixed upstream mafia r20417

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20321; // Log daycount when first got Shen Copperhead, Nightclub Owner.  Thanks to fredg1
+since r20417;	//min mafia revision needed to run this script. Last update: Adventurous Spelunker familiar can deal damage
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -63,8 +63,7 @@ boolean isAttackFamiliar(familiar fam)
 		return true;
 	}
 	
-	if($familiars[Adventurous Spelunker,		//mafia bug. https://kolmafia.us/showthread.php?25467
-	Doppelshifter,								//random familiar every fight. can be an attack familiar
+	if($familiars[Doppelshifter,				//random familiar every fight. can be an attack familiar
 	Dandy Lion									//attacks if you equip a whip.
 	] contains fam)
 	{


### PR DESCRIPTION
remove outdated workaround for Adventurous Spelunker familiar. fixed upstream mafia r20417

## How Has This Been Tested?

I do not own that IOTM, but it is simple enough to not need testing beyond verifying

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
