### PR TITLE
Cargo shorts redux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@
 
 name: CI
 env:
-  MAFIA_BUILD: "1902"
-  MAFIA_VERSION: "20394"
+  MAFIA_BUILD: "1938"
+  MAFIA_VERSION: "20430"
   SCRIPT_NAME: "autoscend.ash"
 
 on: [push, pull_request]

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20417;	//min mafia revision needed to run this script. Last update: Adventurous Spelunker familiar can deal damage
+since r20430;	//min mafia revision needed to run this script. Last update: Cargo Shorts support complete
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -392,10 +392,14 @@ boolean auto_cargoShortsCanOpenPocket(int pocket);
 boolean auto_cargoShortsCanOpenPocket(item i);
 boolean auto_cargoShortsCanOpenPocket(monster m);
 boolean auto_cargoShortsCanOpenPocket(effect e);
+boolean auto_cargoShortsCanOpenPocket(stat s);
+boolean auto_cargoShortsCanOpenPocket(string s);
 boolean auto_cargoShortsOpenPocket(int pocket);
 boolean auto_cargoShortsOpenPocket(item i);
 boolean auto_cargoShortsOpenPocket(monster m);
 boolean auto_cargoShortsOpenPocket(effect e);
+boolean auto_cargoShortsOpenPocket(stat e);
+boolean auto_cargoShortsOpenPocket(string s);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -348,99 +348,6 @@ boolean auto_hasCargoShorts()
 		auto_is_valid($item[Bagged Cargo Cultist Shorts]);
 }
 
-int auto_cargoShortsGetPocket(item i)
-{
-	// Until mafia tracks these
-	switch (i)
-	{
-		case $item[Yeg's Motel mouthwash]: return 26;
-		case $item[Yeg's Motel shower cap]: return 84;
-		case $item[Yeg's Motel alarm clock]: return 121;
-		case $item[Yeg's Motel stationery]: return 130;
-		case $item[Yeg's Motel slippers]: return 132;
-		case $item[Yeg's Motel hand soap]: return 177;
-		case $item[Yeg's Motel bathrobe]: return 218;
-		case $item[Yeg's Motel toothbrush]: return 284;
-		case $item[Yeg's Motel disposable razor]: return 322;
-		case $item[flask of moonshine]: return 324;
-		case $item[Yeg's Motel ashtray]: return 409;
-		case $item[Yeg's Motel pillow mint]: return 439;
-		case $item[sizzling desk bell]: return 517;
-		case $item[greasy desk bell]: return 533;
-		case $item[frost-rimed desk bell]: return 587;
-		case $item[uncanny desk bell]: return 590;
-		case $item[Yeg's Motel Sewing Kit]: return 642;
-		case $item[nasty desk bell]: return 653;
-		case $item[Yeg's Motel minibar key]: return 660;
-
-		// Chess
-		case $item[alabaster pawn]: return 46;
-		case $item[onyx pawn]: return 105;
-		case $item[alabaster rook]: return 111;
-		case $item[onyx rook]: return 197;
-		case $item[alabaster knight]: return 275;
-		case $item[onyx knight]: return 4;
-		case $item[alabaster king]: return 523;
-		case $item[onyx king]: return 88;
-		case $item[alabaster bishop]: return 567;
-		case $item[onyx bishop]: return 537;
-		case $item[alabaster queen]: return 651;
-		case $item[onyx queen]: return 506;
-
-		// Other
-		case $item[cursed piece of thirteen]: return 600;
-	}
-	return -1;
-}
-
-int auto_cargoShortsGetPocket(monster m)
-{
-	// Until mafia tracks these
-	switch (m)
-	{
-		case $monster[bookbat]: return 30;
-		case $monster[dairy goat]: return 47;
-		case $monster[Knob Goblin Elite Guardsman]: return 136;
-		case $monster[dirty old lihc]: return 143;
-		case $monster[batrat]: return 191;
-		case $monster[Lobsterfrogman]: return 220;
-		case $monster[modern zmobie]: return 235;
-		case $monster[blooper]: return 250;
-		case $monster[creepy clown]: return 267;
-		case $monster[Knob Goblin Harem Girl]: return 299;
-		case $monster[big creepy spider]: return 306;
-		case $monster[camel's toe]: return 317;
-		case $monster[Pufferfish]: return 363;
-		case $monster[skinflute]: return 383;
-		case $monster[fruit golem]: return 402;
-		case $monster[eXtreme Orcish snowboarder]: return 425;
-		case $monster[Mob Penguin Thug]: return 428;
-		case $monster[War Hippy (space) cadet]: return 443;
-		case $monster[completely different spider]: return 448;
-		case $monster[pygmy shaman]: return 452;
-		case $monster[booze giant]: return 490;
-		case $monster[mountain man]: return 565;
-		case $monster[War Pledge]: return 568;
-		case $monster[Green Ops Soldier]: return 589;
-		case $monster[1335 HaXx0r]: return 646;
-		case $monster[smut orc pervert]: return 666;
-	}
-	return -1;
-}
-
-int auto_cargoShortsGetPocket(effect e)
-{
-	// Until mafia tracks these
-	switch (e)
-	{
-		case $effect[Ode to Booze]: return 242;
-		case $effect[Night Vision]: return 339;
-		case $effect[Filthworm Drone Stench]: return 343;
-		case $effect[Medieval Mage Mayhem]: return 617;
-	}
-	return -1;
-}
-
 boolean auto_cargoShortsCanOpenPocket()
 {
 	if (!auto_hasCargoShorts())
@@ -457,54 +364,143 @@ boolean auto_cargoShortsCanOpenPocket(int pocket)
 	if (pocket <= 0 || pocket > 666)
 		return false;
 
-	foreach key,value in get_property("cargoPocketsEmptied").split_string(",")
-	{
-		if (value.to_int() == pocket)
-			return false;
-	}
+	boolean[int] picked = picked_pockets();
+	if (picked[pocket])
+		return false;
 	
 	return true;
 }
 
 boolean auto_cargoShortsCanOpenPocket(item i)
 {
-	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(i));
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+
+	foreach index, pocket in potential_pockets(i)
+	{
+		if (auto_cargoShortsCanOpenPocket(pocket))
+			return true;
+	}
+
+	return false;
 }
 
 boolean auto_cargoShortsCanOpenPocket(monster m)
 {
-	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(m));
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+
+	foreach index, pocket in potential_pockets(m)
+	{
+		if (auto_cargoShortsCanOpenPocket(pocket))
+			return true;
+	}
+
+	return false;
 }
 
 boolean auto_cargoShortsCanOpenPocket(effect e)
 {
-	return auto_cargoShortsCanOpenPocket(auto_cargoShortsGetPocket(e));
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+
+	foreach index, pocket in potential_pockets(e)
+	{
+		if (auto_cargoShortsCanOpenPocket(pocket))
+			return true;
+	}
+
+	return false;
+}
+
+boolean auto_cargoShortsCanOpenPocket(stat s)
+{
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+
+	foreach index, pocket in potential_pockets(s)
+	{
+		if (auto_cargoShortsCanOpenPocket(pocket))
+			return true;
+	}
+
+	return false;
+}
+
+boolean auto_cargoShortsCanOpenPocket(string s)
+{
+	if (!auto_cargoShortsCanOpenPocket())
+		return false;
+
+	if (s.to_int() != 0)
+		return auto_cargoShortsCanOpenPocket(s.to_int());
+	else if (s.to_item() != $item[none])
+		return auto_cargoShortsCanOpenPocket(s.to_item());
+	else if (s.to_monster() != $monster[none])
+		return auto_cargoShortsCanOpenPocket(s.to_monster());
+	else if (s.to_effect() != $effect[none])
+		return auto_cargoShortsCanOpenPocket(s.to_effect());
+	else if (s.to_stat() != $stat[none])
+		return auto_cargoShortsCanOpenPocket(s.to_stat());
+
+	return false;
 }
 
 boolean auto_cargoShortsOpenPocket(int pocket)
 {
 	if (!auto_cargoShortsCanOpenPocket(pocket))
 		return false;
-	
-	cli_execute("try; cargo " + pocket);
-	if (get_property("_cargoPocketEmptied").to_boolean())
-	{
-		return true;
-	}
-	return false;
+
+	return pick_pocket(pocket);
 }
 
 boolean auto_cargoShortsOpenPocket(item i)
 {
-	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(i));
+	if (!auto_cargoShortsCanOpenPocket(i))
+		return false;
+
+	return pick_pocket(i);
 }
 
 boolean auto_cargoShortsOpenPocket(monster m)
 {
-	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(m));
+	if (!auto_cargoShortsCanOpenPocket(m))
+		return false;
+
+	return pick_pocket(m);
 }
 
 boolean auto_cargoShortsOpenPocket(effect e)
 {
-	return auto_cargoShortsOpenPocket(auto_cargoShortsGetPocket(e));
+	if (!auto_cargoShortsCanOpenPocket(e))
+		return false;
+
+	return pick_pocket(e);
+}
+
+boolean auto_cargoShortsOpenPocket(stat s)
+{
+	if (!auto_cargoShortsCanOpenPocket(s))
+		return false;
+
+	return pick_pocket(s);
+}
+
+boolean auto_cargoShortsOpenPocket(string s)
+{
+	if (!auto_cargoShortsCanOpenPocket(s))
+		return false;
+
+	if (s.to_int() != 0)
+		return pick_pocket(s.to_int());
+	else if (s.to_item() != $item[none])
+		return pick_pocket(s.to_item());
+	else if (s.to_monster() != $monster[none])
+		return pick_pocket(s.to_monster());
+	else if (s.to_effect() != $effect[none])
+		return pick_pocket(s.to_effect());
+	else if (s.to_stat() != $stat[none])
+		return pick_pocket(s.to_stat());
+
+	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -409,7 +409,7 @@ boolean auto_cargoShortsCanOpenPocket(string s)
 		return false;
 
 	// to_int errors if not an int, check with regex first
-	matcher m = create_matcher("^\d+$", cond);
+	matcher m = create_matcher("^\d+$", s);
 	if (m.find())
 		return auto_cargoShortsCanOpenPocket(s.to_int());
 	else if (s.to_item() != $item[none])
@@ -470,7 +470,7 @@ boolean auto_cargoShortsOpenPocket(string s)
 		return false;
 
 	// to_int errors if not an int, check with regex first
-	matcher m = create_matcher("^\d+$", cond);
+	matcher m = create_matcher("^\d+$", s);
 	if (m.find())
 		return auto_cargoShortsOpenPocket(s.to_int());
 	else if (s.to_item() != $item[none])

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -376,13 +376,7 @@ boolean auto_cargoShortsCanOpenPocket(item i)
 	if (!auto_cargoShortsCanOpenPocket())
 		return false;
 
-	foreach index, pocket in potential_pockets(i)
-	{
-		if (auto_cargoShortsCanOpenPocket(pocket))
-			return true;
-	}
-
-	return false;
+	return available_pocket(i) != 0;
 }
 
 boolean auto_cargoShortsCanOpenPocket(monster m)
@@ -390,27 +384,15 @@ boolean auto_cargoShortsCanOpenPocket(monster m)
 	if (!auto_cargoShortsCanOpenPocket())
 		return false;
 
-	foreach index, pocket in potential_pockets(m)
-	{
-		if (auto_cargoShortsCanOpenPocket(pocket))
-			return true;
-	}
-
-	return false;
+	return available_pocket(m) != 0;
 }
 
 boolean auto_cargoShortsCanOpenPocket(effect e)
 {
 	if (!auto_cargoShortsCanOpenPocket())
 		return false;
-
-	foreach index, pocket in potential_pockets(e)
-	{
-		if (auto_cargoShortsCanOpenPocket(pocket))
-			return true;
-	}
-
-	return false;
+	
+	return available_pocket(e) != 0;
 }
 
 boolean auto_cargoShortsCanOpenPocket(stat s)
@@ -418,13 +400,7 @@ boolean auto_cargoShortsCanOpenPocket(stat s)
 	if (!auto_cargoShortsCanOpenPocket())
 		return false;
 
-	foreach index, pocket in potential_pockets(s)
-	{
-		if (auto_cargoShortsCanOpenPocket(pocket))
-			return true;
-	}
-
-	return false;
+	return available_pocket(s) != 0;
 }
 
 boolean auto_cargoShortsCanOpenPocket(string s)
@@ -459,7 +435,7 @@ boolean auto_cargoShortsOpenPocket(item i)
 	if (!auto_cargoShortsCanOpenPocket(i))
 		return false;
 
-	return count(pick_pocket(i)) != 0;
+	return pick_pocket(available_pocket(i));
 }
 
 boolean auto_cargoShortsOpenPocket(monster m)
@@ -467,7 +443,7 @@ boolean auto_cargoShortsOpenPocket(monster m)
 	if (!auto_cargoShortsCanOpenPocket(m))
 		return false;
 
-	return pick_pocket(m);
+	return pick_pocket(available_pocket(m));
 }
 
 boolean auto_cargoShortsOpenPocket(effect e)
@@ -475,7 +451,7 @@ boolean auto_cargoShortsOpenPocket(effect e)
 	if (!auto_cargoShortsCanOpenPocket(e))
 		return false;
 
-	return count(pick_pocket(e)) != 0;
+	return pick_pocket(available_pocket(e));
 }
 
 boolean auto_cargoShortsOpenPocket(stat s)
@@ -483,7 +459,7 @@ boolean auto_cargoShortsOpenPocket(stat s)
 	if (!auto_cargoShortsCanOpenPocket(s))
 		return false;
 
-	return count(pick_pocket(s)) != 0;
+	return pick_pocket(available_pocket(s));
 }
 
 boolean auto_cargoShortsOpenPocket(string s)

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -408,7 +408,9 @@ boolean auto_cargoShortsCanOpenPocket(string s)
 	if (!auto_cargoShortsCanOpenPocket())
 		return false;
 
-	if (s.to_int() != 0)
+	// to_int errors if not an int, check with regex first
+	matcher m = create_matcher("^\d+$", cond);
+	if (m.find())
 		return auto_cargoShortsCanOpenPocket(s.to_int());
 	else if (s.to_item() != $item[none])
 		return auto_cargoShortsCanOpenPocket(s.to_item());
@@ -467,7 +469,9 @@ boolean auto_cargoShortsOpenPocket(string s)
 	if (!auto_cargoShortsCanOpenPocket(s))
 		return false;
 
-	if (s.to_int() != 0)
+	// to_int errors if not an int, check with regex first
+	matcher m = create_matcher("^\d+$", cond);
+	if (m.find())
 		return auto_cargoShortsOpenPocket(s.to_int());
 	else if (s.to_item() != $item[none])
 		return auto_cargoShortsOpenPocket(s.to_item());

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -459,7 +459,7 @@ boolean auto_cargoShortsOpenPocket(item i)
 	if (!auto_cargoShortsCanOpenPocket(i))
 		return false;
 
-	return pick_pocket(i);
+	return count(pick_pocket(i)) != 0;
 }
 
 boolean auto_cargoShortsOpenPocket(monster m)
@@ -475,7 +475,7 @@ boolean auto_cargoShortsOpenPocket(effect e)
 	if (!auto_cargoShortsCanOpenPocket(e))
 		return false;
 
-	return pick_pocket(e);
+	return count(pick_pocket(e)) != 0;
 }
 
 boolean auto_cargoShortsOpenPocket(stat s)
@@ -483,7 +483,7 @@ boolean auto_cargoShortsOpenPocket(stat s)
 	if (!auto_cargoShortsCanOpenPocket(s))
 		return false;
 
-	return pick_pocket(s);
+	return count(pick_pocket(s)) != 0;
 }
 
 boolean auto_cargoShortsOpenPocket(string s)
@@ -492,15 +492,15 @@ boolean auto_cargoShortsOpenPocket(string s)
 		return false;
 
 	if (s.to_int() != 0)
-		return pick_pocket(s.to_int());
+		return auto_cargoShortsOpenPocket(s.to_int());
 	else if (s.to_item() != $item[none])
-		return pick_pocket(s.to_item());
+		return auto_cargoShortsOpenPocket(s.to_item());
 	else if (s.to_monster() != $monster[none])
-		return pick_pocket(s.to_monster());
+		return auto_cargoShortsOpenPocket(s.to_monster());
 	else if (s.to_effect() != $effect[none])
-		return pick_pocket(s.to_effect());
+		return auto_cargoShortsOpenPocket(s.to_effect());
 	else if (s.to_stat() != $stat[none])
-		return pick_pocket(s.to_stat());
+		return auto_cargoShortsOpenPocket(s.to_stat());
 
 	return false;
 }


### PR DESCRIPTION
# Description

Update cargo shorts function to use builtin mafia functions, now that support is completed.

Fixes # N/A

## How Has This Been Tested?

```
> ash import autoscend; auto_cargoShortsOpenPocket("Yeg's Motel toothbrush")

Inspecting Cargo Cultist Shorts
picking pocket 284
You acquire an item: Yeg's Motel toothbrush
Returned: true

> ash import autoscend; auto_cargoShortsOpenPocket("Yeg's Motel toothbrush")

Returned: false
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
