### PR TITLE
Live. Ascend. Repeat. fix inf loop in NC163 and 178

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -51,9 +51,16 @@ boolean auto_run_choice(int choice, string page)
 		case 163: // Melvil Dewey Would Be Ashamed (The Haunted Library)
 			if(auto_my_path() == "Live. Ascend. Repeat.")
 			{
-				set_property("_LAR_skipNC163", my_turncount());	//In LAR path NC163 is forced to reoccur if we skip it. Go do something else.
+				set_property("_LAR_skipNC163", my_turncount());	//NC in LAR path forced to reoccur if we skip it. Go do something else.
 			}
 			run_choice(4); // skip
+			break;
+		case 178: // Hammering the Armory
+			if(auto_my_path() == "Live. Ascend. Repeat.")
+			{
+				set_property("_LAR_skipNC178", my_turncount());	//NC in LAR path forced to reoccur if we skip it. Go do something else.
+			}
+			run_choice(2); // skip
 			break;
 		case 184: // That Explains All The Eyepatches (Barrrney's Barrr)
 		case 185: // Yes, You're a Rock Starrr (Barrrney's Barrr)

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -49,6 +49,10 @@ boolean auto_run_choice(int choice, string page)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
 		case 163: // Melvil Dewey Would Be Ashamed (The Haunted Library)
+			if(auto_my_path() == "Live. Ascend. Repeat.")
+			{
+				set_property("_LAR_skipNC163", my_turncount());	//In LAR path NC163 is forced to reoccur if we skip it. Go do something else.
+			}
 			run_choice(4); // skip
 			break;
 		case 184: // That Explains All The Eyepatches (Barrrney's Barrr)

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -33,13 +33,17 @@ boolean L10_airship()
 	{
 		return false;
 	}
+	if(my_turncount() == get_property("_LAR_skipNC178").to_int())
+	{
+		auto_log_info("In LAR path NC178 is forced to reoccur if we skip it. Go do something else.");
+		return false;
+	}
 
 	auto_log_info("Fantasy Airship Fly Fly time", "blue");
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
 		handleBjornify($familiar[Grimstone Golem]);
 	}
-	set_property("choiceAdventure178", "2"); // Hammering the Armory: Skip
 
 	if(item_amount($item[Model Airship]) == 0)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -414,11 +414,18 @@ boolean LX_unlockManorSecondFloor() {
 		return false;
 	}
 
+	//finish quest
 	if (item_amount($item[Lady Spookyraven\'s Necklace]) > 0) {
 		auto_log_info("Giving Lady Spookyraven her necklace.", "blue");
 		visit_url("place.php?whichplace=manor1&action=manor1_ladys");
 		visit_url("place.php?whichplace=manor2&action=manor2_ladys");
 		return true;
+	}
+	
+	if(my_turncount() == get_property("_LAR_skipNC163").to_int())
+	{
+		auto_log_info("In LAR path NC163 is forced to reoccur if we skip it. Go do something else.");
+		return false;
 	}
 
 	auto_log_info("Well, we need writing desks", "blue");


### PR DESCRIPTION
* In Live Ascend Repeat can get in inf loop at an NC that can be skipped for no adv cost. as this NC will always reoccur (only to be skipped again) unless we spend an adv somewhere else.
** Fixed for NC163 = https://kol.coldfront.net/thekolwiki/index.php/Melvil_Dewey_Would_Be_Ashamed
** fixed for NC178 = https://kol.coldfront.net/thekolwiki/index.php/Hammering_the_Armory

## How Has This Been Tested?

encountered and successfully passed those infinite loop triggering NCs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
