### PR TITLE
default maximizer pokefam cleanup

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -175,46 +175,45 @@ boolean tryAddItemToMaximize(slot s, item it)
 
 string defaultMaximizeStatement()
 {
-	string res = "5item,meat";
-
-	// combat is completely different in pokefam, so most stuff doesn't matter there
-	if(!in_pokefam())
+	if(in_pokefam())
 	{
-		res += ",0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble";
-		if(my_class() == $class[Vampyre])
+		return pokefam_defaultMaximizeStatement();
+	}
+	
+	string res = "5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble";
+	if(my_class() == $class[Vampyre])
+	{
+		res += ",0.8hp,3hp regen";
+	}
+	else
+	{
+		res += ",0.4hp,0.2mp 1000max";
+		res += isActuallyEd() ? ",6mp regen" : ",3mp regen";
+	}
+
+	if(!in_zelda())
+	{
+		if(my_primestat() == $stat[Mysticality])
 		{
-			res += ",0.8hp,3hp regen";
+			res += ",0.25spell damage,1.75spell damage percent";
 		}
 		else
 		{
-			res += ",0.4hp,0.2mp 1000max";
-			res += isActuallyEd() ? ",6mp regen" : ",3mp regen";
+			res += ",1.5weapon damage,0.75weapon damage percent,1.5elemental damage";
 		}
+	}
 
-		if(!in_zelda())
+	if(pathAllowsFamiliar())
+	{
+		res += ",2familiar weight";
+		if(my_familiar().familiar_weight() < 20)
 		{
-			if(my_primestat() == $stat[Mysticality])
-			{
-				res += ",0.25spell damage,1.75spell damage percent";
-			}
-			else
-			{
-				res += ",1.5weapon damage,0.75weapon damage percent,1.5elemental damage";
-			}
+			res += ",5familiar exp";
 		}
-
-		if(pathAllowsFamiliar())
-		{
-			res += ",2familiar weight";
-			if(my_familiar().familiar_weight() < 20)
-			{
-				res += ",5familiar exp";
-			}
-		}
-		if (in_zelda())
-		{
-			res += ",plumber,-ml";
-		}
+	}
+	if (in_zelda())
+	{
+		res += ",plumber,-ml";
 	}
 
 	if(!in_zelda() && ((my_level() < 13) || (get_property("auto_disregardInstantKarma").to_boolean())))

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -664,6 +664,7 @@ boolean picky_buyskills();
 boolean in_pokefam();
 void digimon_initializeDay(int day);
 void digimon_initializeSettings();
+string pokefam_defaultMaximizeStatement();
 boolean digimon_makeTeam();
 boolean LM_digimon();
 boolean digimon_autoAdv(int num, location loc, string option);

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -18,6 +18,16 @@ void digimon_initializeSettings()
 	}
 }
 
+string pokefam_defaultMaximizeStatement()
+{
+	// combat is completely different in pokefam, so most stuff doesn't matter there
+	string res = "5item,meat";
+	if(my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean())
+	{
+		res += ",10exp,5" + my_primestat() + " experience percent";
+	}
+	return res;
+}
 
 boolean digimon_makeTeam()
 {
@@ -88,7 +98,6 @@ boolean digimon_makeTeam()
 	}
 	return true;
 }
-
 
 boolean LM_digimon()
 {


### PR DESCRIPTION
* string pokefam_defaultMaximizeStatement() created and used
** instead of putting all the code to generate our default maximizer string inside a giant `if !pokefam` moved pokefam to its own function and cleaned up the main function to match

I suggest using "hide whitespace changes" when viewing file changes here

## How Has This Been Tested?

tested changes to default maximizer as seal clubber in class act to make sure I did not break it. pokefam testing is not really viable since pokefam autoscend support is very broken right now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
