### PR TITLE
non myst classes want dmg%

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -199,7 +199,7 @@ string defaultMaximizeStatement()
 			}
 			else
 			{
-				res += ",1.5weapon damage,-0.75weapon damage percent,1.5elemental damage";
+				res += ",1.5weapon damage,0.75weapon damage percent,1.5elemental damage";
 			}
 		}
 


### PR DESCRIPTION
there was a sign error on default maximizer string for non mys classes. it said we want flat dmg bonus, want elemental dmg bonus, and do NOT want % dmg bonuses. this is erroneous and was fixed

## How Has This Been Tested?

```
> ash import autoscend.ash; defaultMaximizeStatement();

Returned: 5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble,0.4hp,0.2mp 1000max,3mp regen,1.5weapon damage,0.75weapon damage percent,1.5elemental damage,2familiar weight,5familiar exp,10exp,5Muscle experience percent
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
