### PR TITLE
verify companion scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,7 @@ name: CI
 env:
   MAFIA_BUILD: "1938"
   MAFIA_VERSION: "20430"
-  SCRIPT_NAME1: "autoscend.ash"
-  SCRIPT_NAME2: "auto_pre_adv.ash"
-  SCRIPT_NAME3: "auto_post_adv.ash"
-  SCRIPT_NAME4: "auto_choice_adv.ash"
+  SCRIPT_NAMES: "autoscend.ash auto_pre_adv.ash auto_post_adv.ash auto_choice_adv.ash relay_autoscend.ash autoscend_quests.ash"
 
 on: [push, pull_request]
 
@@ -46,47 +43,19 @@ jobs:
           java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_dependencies
         fi
 
-        # Verify autoscend.ash
-        echo "Verifying autoscend.ash..."
-        echo "try { cli_execute('verify ${SCRIPT_NAME1}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
-        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output != *"Script verification complete." ]]; then echo $output
-          exit 1
-        else
-          echo "autoscend.ash verified!"      
-        fi
+        errors=0
+        for ashfile in ${SCRIPT_NAMES}; do
+            # Run the verification
+            echo "Verifying ${ashfile}..."
 
-        # Verify auto_pre_adv.ash
-        echo "Verifying auto_pre_adv.ash..."
-        echo "try { cli_execute('verify ${SCRIPT_NAME2}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
-        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output != *"Script verification complete." ]]; then
-          echo $output
-          exit 1
-        else
-          echo "auto_pre_adv.ash verified!"      
-        fi
+            echo "try { cli_execute('verify ${ashfile}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+            output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
+            if [[ $output == *"Script verification complete." ]]; then
+                echo "Verified ${ashfile}!"
+            else
+                echo $output
+                errors=$((errors+1))
+            fi
+        done
 
-        # Verify auto_post_adv.ash
-        echo "Verifying auto_post_adv.ash..."
-        echo "try { cli_execute('verify ${SCRIPT_NAME3}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
-        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output != *"Script verification complete." ]]; then
-          echo $output
-          exit 1
-        else
-          echo "auto_post_adv.ash verified!"      
-        fi
-
-        # Verify auto_choice_adv.ash
-        echo "Verifying auto_choice_adv.ash..."
-        echo "try { cli_execute('verify ${SCRIPT_NAME4}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
-        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output != *"Script verification complete." ]]; then
-          echo $output
-          exit 1
-        else
-          echo "auto_choice_adv.ash verified!"      
-        fi
-
-        exit 0
+        exit ${errors}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         else
           echo "autoscend.ash verified!"      
         fi
-		
+
         # Verify auto_pre_adv.ash
         echo "Verifying auto_pre_adv.ash..."
         echo "try { cli_execute('verify ${"auto_pre_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
@@ -63,7 +63,7 @@ jobs:
         else
           echo "auto_pre_adv.ash verified!"      
         fi
-		
+
         # Verify auto_post_adv.ash
         echo "Verifying auto_post_adv.ash..."
         echo "try { cli_execute('verify ${"auto_post_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
@@ -74,5 +74,5 @@ jobs:
         else
           echo "auto_post_adv.ash verified!"      
         fi
-		
+
         exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ env:
   SCRIPT_NAME1: "autoscend.ash"
   SCRIPT_NAME2: "auto_pre_adv.ash"
   SCRIPT_NAME3: "auto_post_adv.ash"
+  SCRIPT_NAME4: "auto_choice_adv.ash"
 
 on: [push, pull_request]
 
@@ -75,6 +76,17 @@ jobs:
           exit 1
         else
           echo "auto_post_adv.ash verified!"      
+        fi
+
+        # Verify auto_choice_adv.ash
+        echo "Verifying auto_choice_adv.ash..."
+        echo "try { cli_execute('verify ${SCRIPT_NAME4}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
+        if [[ $output != *"Script verification complete." ]]; then
+          echo $output
+          exit 1
+        else
+          echo "auto_choice_adv.ash verified!"      
         fi
 
         exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,33 +47,32 @@ jobs:
         echo "Verifying autoscend.ash..."
         echo "try { cli_execute('verify ${SCRIPT_NAME}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output != *"Script verification complete." ]]; then
-		  echo $output
+        if [[ $output != *"Script verification complete." ]]; then echo $output
           exit 1
         else
           echo "autoscend.ash verified!"      
         fi
 		
-		# Verify auto_pre_adv.ash
-		echo "Verifying auto_pre_adv.ash..."
+        # Verify auto_pre_adv.ash
+        echo "Verifying auto_pre_adv.ash..."
         echo "try { cli_execute('verify ${"auto_pre_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
         if [[ $output != *"Script verification complete." ]]; then
-		  echo $output
+          echo $output
           exit 1
         else
           echo "auto_pre_adv.ash verified!"      
         fi
 		
-		# Verify auto_post_adv.ash
-		echo "Verifying auto_post_adv.ash..."
+        # Verify auto_post_adv.ash
+        echo "Verifying auto_post_adv.ash..."
         echo "try { cli_execute('verify ${"auto_post_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
         if [[ $output != *"Script verification complete." ]]; then
-		  echo $output
+          echo $output
           exit 1
         else
           echo "auto_post_adv.ash verified!"      
         fi
 		
-		exit 0
+        exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ name: CI
 env:
   MAFIA_BUILD: "1938"
   MAFIA_VERSION: "20430"
-  SCRIPT_NAME: "autoscend.ash"
+  SCRIPT_NAME1: "autoscend.ash"
+  SCRIPT_NAME2: "auto_pre_adv.ash"
+  SCRIPT_NAME3: "auto_post_adv.ash"
 
 on: [push, pull_request]
 
@@ -45,7 +47,7 @@ jobs:
 
         # Verify autoscend.ash
         echo "Verifying autoscend.ash..."
-        echo "try { cli_execute('verify ${SCRIPT_NAME}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        echo "try { cli_execute('verify ${SCRIPT_NAME1}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
         if [[ $output != *"Script verification complete." ]]; then echo $output
           exit 1
@@ -55,7 +57,7 @@ jobs:
 
         # Verify auto_pre_adv.ash
         echo "Verifying auto_pre_adv.ash..."
-        echo "try { cli_execute('verify ${"auto_pre_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        echo "try { cli_execute('verify ${SCRIPT_NAME2}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
         if [[ $output != *"Script verification complete." ]]; then
           echo $output
@@ -66,7 +68,7 @@ jobs:
 
         # Verify auto_post_adv.ash
         echo "Verifying auto_post_adv.ash..."
-        echo "try { cli_execute('verify ${"auto_post_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        echo "try { cli_execute('verify ${SCRIPT_NAME3}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
         if [[ $output != *"Script verification complete." ]]; then
           echo $output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,37 @@ jobs:
           java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_dependencies
         fi
 
-        # Run the verification
-        echo "Verifying..."
-
+        # Verify autoscend.ash
+        echo "Verifying autoscend.ash..."
         echo "try { cli_execute('verify ${SCRIPT_NAME}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
         output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
-        if [[ $output == *"Script verification complete." ]]; then
-          echo "Verified!"
-          exit 0
-        else
-          echo $output
+        if [[ $output != *"Script verification complete." ]]; then
+		  echo $output
           exit 1
+        else
+          echo "autoscend.ash verified!"      
         fi
+		
+		# Verify auto_pre_adv.ash
+		echo "Verifying auto_pre_adv.ash..."
+        echo "try { cli_execute('verify ${"auto_pre_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
+        if [[ $output != *"Script verification complete." ]]; then
+		  echo $output
+          exit 1
+        else
+          echo "auto_pre_adv.ash verified!"      
+        fi
+		
+		# Verify auto_post_adv.ash
+		echo "Verifying auto_post_adv.ash..."
+        echo "try { cli_execute('verify ${"auto_post_adv.ash"}'); } finally { cli_execute('exit'); }" > scripts/_ci_verify.ash
+        output=$(java -DuseCWDasROOT=true -jar ../.github/kolmafia.jar --CLI _ci_verify)
+        if [[ $output != *"Script verification complete." ]]; then
+		  echo $output
+          exit 1
+        else
+          echo "auto_post_adv.ash verified!"      
+        fi
+		
+		exit 0


### PR DESCRIPTION
github pull request automatic verification was missing a few files. Added the following files to verification:
* auto_pre_adv.ash
* auto_post_adv.ash
* auto_choice_adv.ash

## How Has This Been Tested?

looked at the checks tab above after each change and checked that it works
intentionally broke post_adv and made sure it caught it, then dropped the breaking commit

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
