### PR TITLE
sealclubber should consider northern explosion

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -467,7 +467,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(1); // fight the screambat.
 			break;
 		case 1428: // Choice 1428 is Your Neck of the Woods (Cartography)
-			run_choice(1); // advance neck quest
+			run_choice(2); // advance neck quest
 			break;
 		case 1429: // Choice 1429 is No Nook Unknown (Cartography)
 			run_choice(1); // acquire 2 evil eyes

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1717,12 +1717,25 @@ string auto_combatHandler(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Saucestorm]);
 		}
 
-		if(enemy.physical_resistance > 80 && canUse($skill[Saucestorm], false))
+		if(enemy.physical_resistance > 80)
 		{
-			attackMinor = useSkill($skill[Saucestorm], false);
-			attackMajor = useSkill($skill[Saucestorm], false);
-			costMinor = mp_cost($skill[Saucestorm]);
-			costMajor = mp_cost($skill[Saucestorm]);
+			boolean success = false;
+			foreach sk in $skills[Saucestorm, Saucegeyser, Northern Explosion]
+			{
+				if(canUse(sk, false))
+				{
+					attackMinor = useSkill(sk, false);
+					attackMajor = useSkill(sk, false);
+					costMinor = mp_cost(sk);
+					costMajor = mp_cost(sk);
+					success = true;
+					break;
+				}
+			}
+			if(!success)
+			{
+				abort("I am fighting a physically immune monster and I do not know how to kill it");
+			}
 		}
 
 		break;


### PR DESCRIPTION
* sealclubber should consider northern explosion against physically immune enemies. We require sauce storm but sauce storm is not available in all paths. for example in class act we lose access to sauce storm so falling back to northern explosion is necessary
* The Dark Neck of the Woods cartography NC. instead of 1k meat prefer to skip a NC and finish this quest quicker

## How Has This Been Tested?

I was dying to ancient protector specter because I was just trying to hit it with regular weapon. Then with this patch it used northern explosion and killed it in one hit

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
