### PR TITLE
your shadow: red pixel potion support & improve funksling & fix rain-doh indigo cup

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -233,38 +233,52 @@ string auto_combatHandler(int round, monster enemy, string text)
 			}
 			abort("Oh no, I don't have any super deluxe mushrooms to deal with this shadow plumber :(");
 		}
-		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
+		boolean ambi = auto_have_skill($skill[Ambidextrous Funkslinging]);
+		item hand_1 = $item[none];
+		item hand_2 = $item[none];
+		item icup = $item[Rain-Doh Indigo Cup];		//restore 20% of max HP. only once per combat
+		if(canUse(icup))
 		{
-			if(item_amount($item[Gauze Garter]) >= 2)
+			if(my_maxhp() > 500 && hand_1 == $item[none])
 			{
-				return "item " + $item[Gauze Garter] + ", " + $item[Gauze Garter];
+				markAsUsed(icup);
+				hand_1 = icup;
 			}
-			if(item_amount($item[Filthy Poultice]) >= 2)
+			else if(ambi && my_maxhp() > 250 && hand_1 == $item[none])
 			{
-				return "item " + $item[filthy Poultice] + ", " + $item[Filthy Poultice];
+				markAsUsed(icup);
+				hand_1 = icup;
 			}
-			if((item_amount($item[Gauze Garter]) > 0) && (item_amount($item[Filthy Poultice]) > 0))
+		}
+		//items which can be used multiple times per combat
+		foreach it in $items[Gauze Garter, filthy Poultice, red pixel potion]
+		{
+			if(hand_1 == $item[none] && item_amount(it) > 0)
 			{
-				return "item " + $item[Gauze Garter] + ", " + $item[Filthy Poultice];
+				hand_1 = it;
+			}
+			if(hand_2 == $item[none])
+			{
+				if(item_amount(it) > 1)
+				{
+					hand_2 = it;
+				}
+				else if(item_amount(it) > 0 && hand_1 != it)
+				{
+					hand_2 = it;
+				}
 			}
 		}
-		if(item_amount($item[Gauze Garter]) > 0)
+		
+		if(ambi && hand_1 != $item[none] && hand_2 != $item[none])
 		{
-			return "item " + $item[Gauze Garter];
+			return "item " +hand_1+ ", " +hand_2;
 		}
-		if(item_amount($item[Filthy Poultice]) > 0)
+		if(hand_1 != $item[none])
 		{
-			return "item " + $item[Filthy Poultice];
+			return "item " +hand_1;
 		}
-		if(item_amount($item[red pixel potion]) > 0)
-		{
-			return "item " + $item[red pixel potion];
-		}
-		if(item_amount($item[Rain-Doh Indigo Cup]) > 0)
-		{
-			return "item " + $item[Rain-Doh Indigo Cup];
-		}
-		abort("Uh oh, I ran out of gauze garters and filthy poultices");
+		abort("Uh oh, I ran out of healing items to use against your shadow");
 	}
 
 	if(enemy == $monster[Wall Of Meat])

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -256,6 +256,10 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			return "item " + $item[Filthy Poultice];
 		}
+		if(item_amount($item[red pixel potion]) > 0)
+		{
+			return "item " + $item[red pixel potion];
+		}
 		if(item_amount($item[Rain-Doh Indigo Cup]) > 0)
 		{
 			return "item " + $item[Rain-Doh Indigo Cup];

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1175,7 +1175,7 @@ boolean L13_towerNSTower()
 		cli_execute("scripts/autoscend/auto_post_adv.ash");
 		acquireHP();
 
-		int n_healing_items = item_amount($item[gauze garter]) + item_amount($item[filthy poultice]);
+		int n_healing_items = item_amount($item[gauze garter]) + item_amount($item[filthy poultice]) + item_amount($item[red pixel potion]);
 		if(in_zelda())
 		{
 			n_healing_items = item_amount($item[super deluxe mushroom]);
@@ -1187,7 +1187,16 @@ boolean L13_towerNSTower()
 		}
 		if(n_healing_items < 5)
 		{
-			abort("We only have " + n_healing_items + " healing items, I'm not sure we can do the shadow.");
+			int create_target = min(creatable_amount($item[red pixel potion]), 5 - n_healing_items);
+			if(create_target > 0)
+			{
+				if(create(create_target, $item[red pixel potion]))
+				{
+					return true;
+				}
+				abort("I tried to create [red pixel potions] for the shadow and mysteriously failed");
+			}
+			return autoAdv($location[8-bit Realm]);
 		}
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);
 		return true;


### PR DESCRIPTION
* When facing [your shadow] without enough healing items, grab red pixel potions. also use them in combat against it.
* improve funkslinging code against your shadow to better mix and match items as needed
* fix rain-doh indigo cup against Your Shadow. its code was never actually used against shadow. added code to use it when it is worthwhile to do so

## How Has This Been Tested?

Seal clubber run. I had only 2 poultices, immediately crafted 2 red pixel potions, then farmed enough pixels for a 3rd one, crafted it, and fought the shadow
standard sauceror run. tested the new ambidexterous funkslinging code

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
