### PR TITLE
buyUpTo

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3548,6 +3548,10 @@ boolean buyUpTo(int num, item it)
 
 boolean buyUpTo(int num, item it, int maxprice)
 {
+	if(item_amount(it) >= num)
+	{
+		return true;	//we already have the target amount
+	}
 	if(($items[Ben-Gal&trade; Balm, Hair Spray] contains it) && !isGeneralStoreAvailable())
 	{
 		return false;
@@ -3557,17 +3561,21 @@ boolean buyUpTo(int num, item it, int maxprice)
 		return false;
 	}
 
-	int orig = num;
-	num = num - item_amount(it);
-	if(num > 0)
+	int missing = num - item_amount(it);
+	if(can_interact() && shop_amount(it) > 0 && mall_price(it) < maxprice)	//prefer to buy from yourself
 	{
-		buy(num, it, maxprice);
-		if(item_amount(it) < orig)
+		take_shop(min(missing, shop_amount(it)), it);
+		missing = num - item_amount(it);
+	}
+	if(missing > 0)
+	{
+		buy(missing, it, maxprice);
+		if(item_amount(it) < num)
 		{
-			auto_log_warning("Could not buyUpTo(" + orig + ") of " + it + ". Maxprice: " + maxprice, "red");
+			auto_log_warning("Could not buyUpTo(" + num + ") of " + it + ". Maxprice: " + maxprice, "red");
 		}
 	}
-	return (item_amount(it) >= orig);
+	return (item_amount(it) >= num);
 }
 
 boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns, boolean speculative)


### PR DESCRIPTION
* buyUpTo returns true if you already have target amount. fixed this not applying to some unbuyable items
* prefer buying from yourself
* clearer code. instead of creating a new variable called orig to store original value and then modifying num to indicate missing. leave num fixed and create a new variable called missing

## How Has This Been Tested?

ash calls. see below

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
