### PR TITLE
heavy rains familiar equip fix & copying

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -642,7 +642,10 @@ void preAdvUpdateFamiliar(location place)
 	//familiar equipment overrides
 	if(my_path() == "Heavy Rains")
 	{
-		autoEquip($slot[familiar], $item[miniature life preserver]);
+		if(famChoice != $familiar[Left-Hand Man])
+		{
+			autoEquip($slot[familiar], $item[miniature life preserver]);
+		}
 	}
 
 	if(my_familiar() == $familiar[Trick-Or-Treating Tot])

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -13,25 +13,16 @@ void print_footer() {
 
 boolean auto_pre_adventure()
 {
-	auto_log_debug("Running auto_pre_adv.ash");
-
 	location place = my_location();
-	if((equipped_item($slot[familiar]) == $item[none]) && (my_familiar() != $familiar[none]) && (auto_my_path() == "Heavy Rains"))
-	{
-		abort("Familiar has no equipment, WTF");
-	}
-
 	if(get_property("auto_disableAdventureHandling").to_boolean())
 	{
 		auto_log_info("Preadventure skipped by standard adventure handler.", "green");
 		return true;
 	}
-
 	auto_log_info("Starting preadventure script...", "green");
 	auto_log_debug("Adventuring at " + place.to_string(), "green");
-
+	
 	preAdvUpdateFamiliar(place);
-
 	ed_handleAdventureServant(place);
 
 	if(get_floundry_locations() contains place)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -579,8 +579,7 @@ boolean routineRainManHandler();
 void hr_initializeDay(int day);
 void hr_doBedtime();
 boolean doHRSkills();
-boolean rainManSummon(string monsterName, boolean copy, boolean wink, string option);
-boolean rainManSummon(string monsterName, boolean copy, boolean wink);
+boolean rainManSummon(monster target, boolean copy, boolean wink);
 boolean L13_towerFinalHeavyRains();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -748,19 +748,24 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if(canUse($skill[Wink At]) && (my_familiar() == $familiar[Reanimated Reanimator]))
+	skill wink_skill = $skill[none];
+	if(canUse($skill[Wink At]))
+	{
+		wink_skill = $skill[Wink At];
+	}
+	if(canUse($skill[Fire a badly romantic arrow]))
+	{
+		wink_skill = $skill[Fire a badly romantic arrow];
+	}
+	if(wink_skill != $skill[none])		//we can wink / romatic arrow
 	{
 		if($monsters[Lobsterfrogman, Modern Zmobie, Ninja Snowman Assassin] contains enemy)
 		{
-			if((get_property("_badlyRomanticArrows").to_int() == 1) && (round <= 1) && (get_property("romanticTarget") != enemy))
-			{
-				abort("Have animator out but can not arrow");
-			}
 			if(enemy == $monster[modern zmobie])
 			{
 				set_property("auto_waitingArrowAlcove", get_property("cyrptAlcoveEvilness").to_int() - 20);
 			}
-			return useSkill($skill[Wink At]);
+			return useSkill(wink_skill);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -480,7 +480,10 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 		}
 	}
 
-	if(get_property("_raindohCopiesMade").to_int() >= 5 || item_amount($item[Rain-doh box full of monster]) > 0)
+	
+	if(item_amount($item[Rain-Doh black box]) > 0 ||			//do we actually have a black box to copy with
+	get_property("_raindohCopiesMade").to_int() >= 5 ||			//ran out of uses today
+	item_amount($item[Rain-doh box full of monster]) > 0)		//must discharge the full box before we can use the empty box again
 	{
 		copy = false;
 	}

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -26,78 +26,62 @@ boolean routineRainManHandler()
 	{
 		return false;
 	}
-	
-	boolean want_to_rainman = false;
-	if((my_rain() > (92 - (7 * (my_daycount() - 1)))) && (have_effect($effect[ultrahydrated]) == 0))
+	if(my_rain() < 50)
 	{
-		want_to_rainman = true;
+		return false;	//not enough rain to use skill
 	}
-	//stomach and liver are full, and 1 adv is left before we are done for the day
-	if(my_adventures() <= (1 + auto_advToReserve()) && my_rain() >= 50 && my_fullness() == fullness_limit() && my_inebriety() == inebriety_limit())
+	if(my_rain() < 80 && my_adventures() > (1 + auto_advToReserve()) && inebriety_left() > 0 && stomach_left() > 0)
 	{
-		want_to_rainman = true;
+		return false;	//if we got plenty of adventures left then delay using rain man until rain meter reaches 80
 	}
 	
-	if(want_to_rainman)
+	if(my_daycount() == 2 && (!get_property("chateauAvailable").to_boolean() || get_property("chateauMonster") != "lobsterfrogman"))
 	{
-		if(my_daycount() == 2 && (!get_property("chateauAvailable").to_boolean() || get_property("chateauMonster") != "lobsterfrogman"))
+		return rainManSummon($monster[lobsterfrogman], true, true);
+	}
+	if(get_property("auto_mountainmen") == "")
+	{
+		set_property("auto_mountainmen", "1");
+		return rainManSummon($monster[mountain man], true, false);
+	}
+	if(internalQuestStatus("questL08Trapper") == 1 && needOre())
+	{
+		return rainManSummon($monster[mountain man], false, false);
+	}
+	if(get_property("auto_ninjasnowmanassassin") == "")
+	{
+		return rainManSummon($monster[ninja snowman assassin], true, false);
+	}
+	if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_orcishfratboyspy") == "") && !get_property("auto_hippyInstead").to_boolean())
+	{
+		return rainManSummon($monster[orcish frat boy spy], false, false);
+	}
+	if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_warhippyspy") == "") && get_property("auto_hippyInstead").to_boolean())
+	{
+		return rainManSummon($monster[war hippy spy], false, false);
+	}
+	if(needStarKey())
+	{
+		if(item_amount($item[star]) < 8 && item_amount($item[line]) < 7)
 		{
-			rainManSummon($monster[lobsterfrogman], true, true);
+			return rainManSummon($monster[skinflute], true, false);
 		}
-		
-		if(get_property("auto_mountainmen") == "")
+		else if((item_amount($item[star chart]) == 0))
 		{
-			set_property("auto_mountainmen", "1");
-			return rainManSummon($monster[mountain man], true, false);
-		}
-
-		if (internalQuestStatus("questL08Trapper") < 2)
-		{
-			return rainManSummon($monster[mountain man], false, false);
-		}
-
-		if(get_property("auto_ninjasnowmanassassin") == "")
-		{
-			return rainManSummon($monster[ninja snowman assassin], true, false);
-		}
-
-		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_orcishfratboyspy") == "") && !get_property("auto_hippyInstead").to_boolean())
-		{
-			return rainManSummon($monster[orcish frat boy spy], false, false);
-		}
-		
-		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_warhippyspy") == "") && get_property("auto_hippyInstead").to_boolean())
-		{
-			return rainManSummon($monster[war hippy spy], false, false);
-		}
-		
-		if(needStarKey())
-		{
-			if(item_amount($item[star]) < 8 && item_amount($item[line]) < 7)
-			{
-				return rainManSummon($monster[skinflute], true, false);
-			}
-			else if((item_amount($item[star chart]) == 0))
-			{
-				return rainManSummon($monster[astronomer], false, false);
-			}
-		}
-		if(needDigitalKey())
-		{
-			if (get_property("sidequestNunsCompleted") != "none" && my_rain() > 92)
-			{
-				if(whitePixelCount() < 30 && item_amount($item[digital key]) == 0)
-				{
-					return rainManSummon($monster[ghost], false, false);
-				}
-			}
-		}
-
-		if(my_daycount() < 3)
-		{
-			auto_log_info("I have nothing left to rain man, maybe we are getting ready for make it rain?");
+			return rainManSummon($monster[astronomer], false, false);
 		}
 	}
+	if(needDigitalKey())
+	{
+		if (get_property("sidequestNunsCompleted") != "none" && my_rain() > 92)
+		{
+			if(whitePixelCount() < 30 && item_amount($item[digital key]) == 0)
+			{
+				return rainManSummon($monster[ghost], false, false);
+			}
+		}
+	}
+
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -22,7 +22,7 @@ void hr_initializeSettings()
 
 boolean routineRainManHandler()
 {
-	if(!have_skill($skill[Rain Man]) || (auto_my_path() != "Heavy Rains"))
+	if(!have_skill($skill[Rain Man]))
 	{
 		return false;
 	}
@@ -295,11 +295,6 @@ boolean doHRSkills()
 
 boolean rainManSummon(string monsterName, boolean copy, boolean wink, string option)
 {
-	if(my_path() != "Heavy Rains")
-	{
-		return false;
-	}
-
 	if(!have_skill($skill[Rain Man]))
 	{
 		return false;
@@ -487,8 +482,6 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	{
 		copy = false;
 	}
-
-	set_property("choiceAdventure970", "0");
 
 	//prepare wink/arrow familiar
 	if(get_property("_badlyRomanticArrows") == "1")		//shared property for [Obtuse Angel] && [Reanimated Reanimator]

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -33,7 +33,7 @@ boolean routineRainManHandler()
 		want_to_rainman = true;
 	}
 	//stomach and liver are full, and 1 adv is left before we are done for the day
-	if(my_adventures() == (1 + auto_advToReserve()) && my_rain() >= 50 && my_fullness() == fullness_limit() && my_inebriety() == inebriety_limit())
+	if(my_adventures() <= (1 + auto_advToReserve()) && my_rain() >= 50 && my_fullness() == fullness_limit() && my_inebriety() == inebriety_limit())
 	{
 		want_to_rainman = true;
 	}

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -43,38 +43,38 @@ boolean routineRainManHandler()
 		if(get_property("auto_mountainmen") == "")
 		{
 			set_property("auto_mountainmen", "1");
-			return rainManSummon("mountain man", true, false);
+			return rainManSummon($monster[mountain man], true, false);
 		}
 
 		if (internalQuestStatus("questL08Trapper") < 2)
 		{
-			return rainManSummon("mountain man", false, false);
+			return rainManSummon($monster[mountain man], false, false);
 		}
 
 		if(get_property("auto_ninjasnowmanassassin") == "")
 		{
-			return rainManSummon("ninja snowman assassin", true, false);
+			return rainManSummon($monster[ninja snowman assassin], true, false);
 		}
 
 		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_orcishfratboyspy") == "") && !get_property("auto_hippyInstead").to_boolean())
 		{
-			return rainManSummon("orcish frat boy spy", false, false);
+			return rainManSummon($monster[orcish frat boy spy], false, false);
 		}
 		
 		if((have_effect($effect[Everything Looks Yellow]) == 0) && (get_property("auto_warhippyspy") == "") && get_property("auto_hippyInstead").to_boolean())
 		{
-			return rainManSummon("war hippy spy", false, false);
+			return rainManSummon($monster[war hippy spy], false, false);
 		}
 		
 		if(needStarKey())
 		{
 			if(item_amount($item[star]) < 8 && item_amount($item[line]) < 7)
 			{
-				return rainManSummon("skinflute", true, false);
+				return rainManSummon($monster[skinflute], true, false);
 			}
 			else if((item_amount($item[star chart]) == 0))
 			{
-				return rainManSummon("the astronomer", false, false);
+				return rainManSummon($monster[astronomer], false, false);
 			}
 		}
 		if(needDigitalKey())
@@ -83,7 +83,7 @@ boolean routineRainManHandler()
 			{
 				if(whitePixelCount() < 30 && item_amount($item[digital key]) == 0)
 				{
-					return rainManSummon("ghost", false, false);
+					return rainManSummon($monster[ghost], false, false);
 				}
 			}
 		}
@@ -146,7 +146,7 @@ void hr_initializeDay(int day)
 		{
 			if((get_property("chateauAvailable").to_boolean() == false) || (get_property("chateauMonster") != "lobsterfrogman"))
 			{
-				rainManSummon("lobsterfrogman", true, true);
+				rainManSummon($monster[lobsterfrogman], true, true);
 			}
 		}
 	}
@@ -293,7 +293,7 @@ boolean doHRSkills()
 	return false;
 }
 
-boolean rainManSummon(string monsterName, boolean copy, boolean wink, string option)
+boolean rainManSummon(monster target, boolean copy, boolean wink)
 {
 	if(!have_skill($skill[Rain Man]))
 	{
@@ -307,112 +307,41 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	{
 		return false;
 	}
-	string mId = 0;
-	if((monsterName == "astronomer") || (monsterName == "the astronomer"))
+
+	if(item_amount($item[richard\'s star key]) == 1 && target == $monster[skinflute])
 	{
-		mId = 184;
+		return false;		//already have the goal, don't summon
 	}
-	if(monsterName == "huge swarm of ghuol whelps")
+	if(target == $monster[astronomer])
 	{
-		mId = 1072;
-	}
-	if(monsterName == "trouser snake")
-	{
-		mId = 179;
-	}
-	if(monsterName == "family jewels")
-	{
-		mId = 180;
-	}
-	if(monsterName == "orcish frat boy spy")
-	{
-		mId = 409;
-	}
-	if(monsterName == "war hippy spy")
-	{
-		mId = 419;
-	}
-	if(monsterName == "morbid skull")
-	{
-		mId = 1269;
-	}
-	if(monsterName == "skinflute")
-	{
-		mId = 353;
-	}
-	if(monsterName == "writing desk")
-	{
-		mId = 405;
-	}
-	if(monsterName == "dirty thieving brigand")
-	{
-		mId = 475;
-	}
-	if(monsterName == "lobsterfrogman")
-	{
-		mId = 529;
-	}
-	if(monsterName == "ghost")
-	{
-		mId = 950;
-	}
-	if(monsterName == "mountain man")
-	{
-		mId = 1153;
-	}
-	if(monsterName == "ninja snowman assassin")
-	{
-		mId = 1185;
+		if(item_amount($item[richard\'s star key]) == 1 || item_amount($item[star chart]) > 0)
+		{
+			return false;		//already have the goal, don't summon
+		}
 	}
 
-	if(mId == 0)
-	{
-		return false;
-	}
-
-	if((item_amount($item[ghost of a necklace]) == 1) && (monsterName == "writing desk"))
-	{
-		#No more writing desks please.
-		return false;
-	}
-	if((item_amount($item[richard\'s star key]) == 1) && (monsterName == "skinflute"))
-	{
-		#already have the goal, don't summon
-		return false;
-	}
-	if((item_amount($item[richard\'s star key]) == 1) && (mId == 184))
-	{
-		#already have the goal, don't summon
-		return false;
-	}
-	if((item_amount($item[star chart]) > 0) && (mId == 184))
-	{
-		#already have the goal, don't summon
-		return false;
-	}
-
-	if((item_amount($item[star]) >= 8) && (item_amount($item[line]) >= 7) && (monsterName == "skinflute"))
+	if((item_amount($item[star]) >= 8) && (item_amount($item[line]) >= 7) && target == $monster[skinflute])
 	{
 		#already have the subgoal, don't summon
 		return false;
 	}
-	if((item_amount($item[digital key]) == 1) && (monsterName == "ghost"))
+	if((item_amount($item[digital key]) == 1) && target == $monster[ghost])
 	{
 		#already have the goal, don't summon
 		return false;
 	}
-	if(whitePixelCount() > 29 && monsterName == "ghost")
+	if(whitePixelCount() > 29 && target == $monster[ghost])
 	{
 		#already have the subgoal, don't summon
 		return false;
 	}
-	if ((get_property("sidequestLighthouseCompleted") != "none" || item_amount($item[barrel of gunpowder]) >= 5) && monsterName == "lobsterfrogman")
+	if ((get_property("sidequestLighthouseCompleted") != "none" || item_amount($item[barrel of gunpowder]) >= 5) && target == $monster[lobsterfrogman])
 	{
 		#already have the subgoal, don't summon
 		return false;
 	}
 	##Handle reject after we satisfy the lobsterfrogman
-	if(monsterName == "ninja snowman assassin")
+	if(target == $monster[ninja snowman assassin])
 	{
 		int count = min(item_amount($item[ninja rope]), 1);
 		count = count + min(item_amount($item[ninja crampons]), 1);
@@ -431,7 +360,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 		wink = false;
 	}
 
-	if(monsterName == "orcish frat boy spy")
+	if(target == $monster[orcish frat boy spy])
 	{
 		set_property("auto_orcishfratboyspy", "done");
 		if((item_amount($item[beer helmet]) > 0) || (item_amount($item[bejeweled pledge pin]) > 0) || (item_amount($item[distressed denim pants]) > 0))
@@ -444,7 +373,7 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 		}
 	}
 	
-	if(monsterName == "war hippy spy")
+	if(target == $monster[war hippy spy])
 	{
 		set_property("auto_warhippyspy", "done");
 		if((item_amount($item[reinforced beaded headband]) > 0) || (item_amount($item[round purple sunglasses]) > 0) || (item_amount($item[bullet-proof corduroys]) > 0))
@@ -457,19 +386,17 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 		}
 	}
 
-	if(monsterName == "skinflute")
+	if(target == $monster[skinflute])
 	{
 		if(item_amount($item[star]) >= 8)
 		{
-			monsterName = "trouser snake";
-			mId = 179;
+			target = $monster[trouser snake];
 			copy = false;
 			wink = false;
 		}
 		else if(item_amount($item[line]) >= 7)
 		{
-			monsterName = "family jewels";
-			mId = 180;
+			target = $monster[family jewels];
 			copy = false;
 			wink = false;
 		}
@@ -511,11 +438,11 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	}
 
 	//use the rainman to summon a monster
-	auto_log_info("Looking to summon: " + monsterName, "blue");
+	auto_log_info("Rain Man will summon: " +target, "blue");
 	string[int] pages;
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";
-	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" + mId + "&option=1&choice2=and+Fight%21";
-	autoAdvBypass(0, pages, $location[Noob Cave], option);
+	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" +target.to_int()+ "&option=1&choice2=and+Fight%21";
+	autoAdvBypass(0, pages, $location[Noob Cave], "");
 
 	if(copy && item_amount($item[Rain-doh box full of monster]) == 0)
 	{
@@ -523,12 +450,6 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 	}
 
 	return true;
-}
-
-
-boolean rainManSummon(string monsterName, boolean copy, boolean wink)
-{
-	return rainManSummon(monsterName, copy, wink, "");
 }
 
 boolean L13_towerFinalHeavyRains()

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -629,7 +629,7 @@ boolean L13_towerFinalHeavyRains()
 	//Fight!
 	//auto_disableAdventureHandling because we don't want maximize, switch familiar, change buffs, or anything else that might break our specific prepwork.
 	acquireHP();
-	acquireMP();
+	acquireMP(200);
 	set_property("auto_disableAdventureHandling", true);		
 	autoAdvBypass("place.php?whichplace=nstower&action=ns_10_sorcfight", $location[Noob Cave]);
 	set_property("auto_disableAdventureHandling", false);

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -480,53 +480,48 @@ boolean rainManSummon(string monsterName, boolean copy, boolean wink, string opt
 		}
 	}
 
-
-	if((get_property("_raindohCopiesMade").to_int() >= 5) || (item_amount($item[Rain-doh box full of monster]) > 0))
+	if(get_property("_raindohCopiesMade").to_int() >= 5 || item_amount($item[Rain-doh box full of monster]) > 0)
 	{
 		copy = false;
 	}
 
 	set_property("choiceAdventure970", "0");
 
-	if(!canChangeToFamiliar($familiar[Reanimated Reanimator]))
+	//prepare wink/arrow familiar
+	if(get_property("_badlyRomanticArrows") == "1")		//shared property for [Obtuse Angel] && [Reanimated Reanimator]
 	{
-		wink = false;
+		wink = false;		//we already used our only daily wink/arrow today
 	}
-	else
+	if(wink == true)
 	{
-		handleFamiliar("item");
-	}
-
-	if((wink == true) && have_familiar($familiar[Reanimated Reanimator]))
-	{
-		if(get_property("_badlyRomanticArrows") == "1")
+		if(canChangeToFamiliar($familiar[Reanimated Reanimator]))
 		{
-			abort("Trying to arrow/wink a monster but we've already done so today.");
+			handleFamiliar($familiar[Reanimated Reanimator]);
 		}
-#		use_familiar($familiar[Reanimated Reanimator]);
-		handleFamiliar($familiar[Reanimated Reanimator]);
+		else if(canChangeToFamiliar($familiar[Obtuse Angel]))
+		{
+			handleFamiliar($familiar[Obtuse Angel]);
+		}
+		else
+		{
+			wink = false;
+			handleFamiliar("item");
+		}
 	}
 
 	if(copy)
 	{
 		set_property("auto_doCombatCopy", "yes");
 	}
-	auto_log_info("Looking to summon: " + monsterName, "blue");
 
+	//use the rainman to summon a monster
+	auto_log_info("Looking to summon: " + monsterName, "blue");
 	string[int] pages;
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";
 	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" + mId + "&option=1&choice2=and+Fight%21";
 	autoAdvBypass(0, pages, $location[Noob Cave], option);
 
-#	visit_url("runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1", true);
-#	visit_url("choice.php?pwd&whichchoice=970&whichmonster=" + mId + "&option=1&choice2=and+Fight%21");
-#	autoAdv(1, $location[Noob Cave]);
-
-	if(wink == true)
-	{
-		handleFamiliar("item");
-	}
-	if(copy && (item_amount($item[Rain-doh box full of monster]) == 0))
+	if(copy && item_amount($item[Rain-doh box full of monster]) == 0)
 	{
 		abort("Tried to make a copy but failed");
 	}

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -40,6 +40,11 @@ boolean routineRainManHandler()
 	
 	if(want_to_rainman)
 	{
+		if(my_daycount() == 2 && (!get_property("chateauAvailable").to_boolean() || get_property("chateauMonster") != "lobsterfrogman"))
+		{
+			rainManSummon($monster[lobsterfrogman], true, true);
+		}
+		
 		if(get_property("auto_mountainmen") == "")
 		{
 			set_property("auto_mountainmen", "1");
@@ -141,13 +146,6 @@ void hr_initializeDay(int day)
 			}
 			set_property("auto_day1_skills", "finished");
 			visit_url("main.php");
-		}
-		else if((day == 2) && (my_rain() > 80))
-		{
-			if((get_property("chateauAvailable").to_boolean() == false) || (get_property("chateauMonster") != "lobsterfrogman"))
-			{
-				rainManSummon($monster[lobsterfrogman], true, true);
-			}
 		}
 	}
 }

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -292,7 +292,7 @@ boolean L8_getMineOres()
 		}
 		auto_log_info("Trying to summon a mountain man", "blue");
 		set_property("auto_mountainmen", "1");
-		return rainManSummon("mountain man", false, false);
+		return rainManSummon($monster[mountain man], false, false);
 	}
 	
 	//in softcore we want to pull the ores.


### PR DESCRIPTION
* cleared up some redundant notifications from pre_adv.
** redundant in that we were saying the same thing multiple times in a row
* pre_adv should not abort if it detects that heavy rains familiar has no gear equipped.
** this is already handled in preAdvUpdateFamiliar(place)
** the abort was done before the familiar handling, which meant it could not be fixed
* do not try to equip miniature life preserver on left-hand man
* heavy rains cleanup some obsolete code in rainManSummon
* heavy rains fix [wink at] not working properly
* cleanup combat code for [wink at].
* added combat support for [Fire a badly romantic arrow]
* hardcore heavy rains stop abort on failing to copy using raindoh blackbox when you do not have one. that IOTM is only accessible in softcore. And in heavy rains runs we just assumed we have a blackbox.
* cleanup. for rain man skill handling functions returning false if we do not have the skill OR if we are not in heavy rains is redundant. Since if we are not in heavy rains we cannot have the skill, and if we have the skill we must be in heavy rains.
* rainManSummon now uses $monster instead of string to denote enemy
* unnecessary manual translation of monster name to int replaced with target.to_int()
** tested it first and verified all the mIds are the same. they are.
** although the ghoul whelp swarm was fighting the smallest possible swarm instead of largest. and the name was misspelled.
*removed some writing desk copying code
* do not use rain man in daily initialization. moved it to routineRainManHandler
* fix not doing end of day rain man summon
* prevent unnecessary mountain man summons via rain man skill by using needOre()
* cleaner delaying of rain man

## How Has This Been Tested?

HC heavy rains run that was later dropped to softcore heavy rains

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
