### PR TITLE
Add Cosplay Saber to Wall of Skin.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3341,6 +3341,7 @@ boolean[skill] ATSongList()
 		The Sonata of Sneakiness,
 		Fat Leon\'s Phat Loot Lyric,
 		The Polka of Plenty,
+		The Psalm of Pointiness,
 		Aloysius\' Antiphon of Aptitude,
 		Paul\'s Passionate Pop Song,
 		Donho\'s Bubbly Ballad,
@@ -3349,7 +3350,6 @@ boolean[skill] ATSongList()
 		Benetton\'s Medley of Diversity,
 		Dirge of Dreadfulness,
 		Stevedave\'s Shanty of Superiority,
-		The Psalm of Pointiness,
 		Brawnee\'s Anthem of Absorption,
 		Jackasses\' Symphony of Destruction,
 		The Power Ballad of the Arrowsmith,
@@ -4020,6 +4020,8 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}																						break;
 	case $effect[Pill Party!]:					useItem = $item[Pill Cup];						break;
 	case $effect[Pisces in the Skyces]:			useItem = $item[tobiko marble soda];			break;
+	case $effect[Psalm of Pointiness]:			shrugAT($effect[Psalm of Pointiness]);
+												useSkill = $skill[The Psalm of Pointiness];		break;
 	case $effect[Prayer of Seshat]:				useSkill = $skill[Prayer of Seshat];			break;
 	case $effect[Pride of the Puffin]:			useSkill = $skill[Pride of the Puffin];			break;
 	case $effect[Polar Express]:				useItem = $item[Cloaca Cola Polar];				break;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -918,6 +918,10 @@ boolean L13_towerNSTower()
 		{
 			sources = 6;
 		}
+		else if(autoEquip($item[Fourth of May Cosplay Saber]))
+		{
+			sources = 6;
+		}
 		else
 		{
 			foreach damage in $strings[Cold Damage, Hot Damage, Sleaze Damage, Spooky Damage, Stench Damage]
@@ -932,7 +936,12 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if(canChangeToFamiliar($familiar[warbear drone]))
+		if(canChangeToFamiliar($familiar[Mu]))
+		{
+			handleFamiliar($familiar[Mu]);
+			sources = sources + 5;
+		}
+		else if(canChangeToFamiliar($familiar[warbear drone]))
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -989,6 +998,11 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 			buffMaintain($effect[Jalape&ntilde;o Saucesphere], 0, 1, 1);
+		}
+		if(have_skill($skill[The Psalm of Pointiness]))
+		{
+			buffMaintain($effect[Psalm of Pointiness], 0, 1, 1);
+			sources = sources + 1;
 		}
 		handleBjornify($familiar[Hobo Monkey]);
 		autoEquip($slot[acc2], $item[world\'s best adventurer sash]);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -936,10 +936,10 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if(canChangeToFamiliar($familiar[Mu]))
+		if(canChangeToFamiliar($familiar[Imitation Crab]))
 		{
-			handleFamiliar($familiar[Mu]);
-			sources = sources + 5;
+			handleFamiliar($familiar[Imitation Crab]);
+			sources = sources + 4;
 		}
 		else if(canChangeToFamiliar($familiar[warbear drone]))
 		{
@@ -961,11 +961,6 @@ boolean L13_towerNSTower()
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;
-		}
-		else if(canChangeToFamiliar($familiar[Imitation Crab]))
-		{
-			handleFamiliar($familiar[Imitation Crab]);
-			sources = sources + 2;
 		}
 		if(autoEquip($slot[acc1], $item[hippy protest button]))
 		{


### PR DESCRIPTION
# Description

Auto failed to towerkill the wall of skin during one of my runs and was leaving many sources of damage on the table. I've updated it to include a couple extra, but I haven't found the original bug as to why it failed the first time. I expect that failure is due to the deeper problem where the towerkilling code doesn't distinguish between passive sources of damage and stinging sources.

## How Has This Been Tested?

Tested on a casual run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
