### PR TITLE
Don't check if chez snootee/microbrewery stuff is valid

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -373,13 +373,13 @@ boolean consumeMilkOfMagnesiumIfUnused()
 	return use(1, $item[Milk of Magnesium]);
 }
 
-boolean canDrink(item toDrink)
+boolean canDrink(item toDrink, boolean checkValidity)
 {
 	if(!can_drink())
 	{
 		return false;
 	}
-	if(!auto_is_valid(toDrink))
+	if(!auto_is_valid(toDrink) && checkValidity)
 	{
 		return false;
 	}
@@ -432,13 +432,18 @@ boolean canDrink(item toDrink)
 	return true;
 }
 
-boolean canEat(item toEat)
+boolean canDrink(item toDrink)
+{
+	return canDrink(toDrink, true);
+}
+
+boolean canEat(item toEat, boolean checkValidity)
 {
 	if(!can_eat())
 	{
 		return false;
 	}
-	if(!auto_is_valid(toEat))
+	if(!auto_is_valid(toEat) && checkValidity)
 	{
 		return false;
 	}
@@ -476,6 +481,12 @@ boolean canEat(item toEat)
 
 	return true;
 }
+
+boolean canEat(item toEat)
+{
+	return canEat(toEat, true);
+}
+
 
 boolean canChew(item toChew)
 {
@@ -787,9 +798,14 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	else if (_type == "drink") type = SL_ORGAN_LIVER;
 	else return false;
 
+	boolean canConsume(item it, boolean checkValidity)
+	{
+		return type == SL_ORGAN_STOMACH ? canEat(it, checkValidity) : canDrink(it, checkValidity);
+	}
+
 	boolean canConsume(item it)
 	{
-		return type == SL_ORGAN_STOMACH ? canEat(it) : canDrink(it);
+		return canConsume(it, true);
 	}
 
 	int organLeft()
@@ -989,7 +1005,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	if(type == SL_ORGAN_STOMACH && !canadia_available()) return false;
 
 	// Add daily special
-	if (daily_special() != $item[none] && canConsume(daily_special()))
+	if (daily_special() != $item[none] && canConsume(daily_special(), false)) // specials are always consumable even if they would be restricted as regular consumables.
 	{
 		int daily_special_limit = 1 + min(my_meat()/get_property("_dailySpecialPrice").to_int(), organLeft()/organCost(daily_special()));
 		for (int i=0; i < daily_special_limit; i++)


### PR DESCRIPTION
# Description

daily specials in Chez Snootee and the Gnomish Microbrewery were being checked for path validity. This is not required as they're never blocked from being consumed by path restrictions (e.g. in Standard you can eat or drink stuff that is out of Standard, in G-Lover you can eat or drink stuff that lacks G's).

Reported in Discord.

## How Has This Been Tested?

Ran a few HC Standard runs with Canadia moon signs with this but nothing worth consuming has come up yet in Chez Snootee so it hasn't broken anything but verifying it works as expected requires either a G-Lover run or waiting for something good to appear which could take forever.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
