### PR TITLE
fix infinite loops in restore

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1376,6 +1376,19 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		return -1;
 	}
 	
+	int max_resource()
+	{
+		if(resource_type == "hp")
+		{
+			return my_maxhp();
+		}
+		else if(resource_type == "mp")
+		{
+			return my_maxmp();
+		}
+		return -1;
+	}
+	
 	int hp_target()
 	{
 		if(resource_type == "hp")
@@ -1558,6 +1571,10 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 
 	while(current_resource() < goal)
 	{
+		if(goal > max_resource())	//prevent infinite loop in case maxHP or maxMP dropped below goal
+		{
+			goal = max_resource();
+		}
 		__RestorationOptimization[int] options = __maximize_restore_options(hp_target(), mp_target(), meat_reserve, useFreeRests);
 		if(count(options) == 0)
 		{
@@ -1628,7 +1645,7 @@ void invalidateRestoreOptionCache()
  */
 boolean acquireMP()
 {
-	return acquireMP(my_maxmp());
+	return acquireMP(min(0.95 * my_maxmp(),300));
 }
 
 /**
@@ -1685,7 +1702,8 @@ boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 	// TODO: move this to general effectiveness method
 	if(my_maxmp() - my_mp() > 300)
 	{
-		auto_sausageEatEmUp(1);
+		auto_sausageEatEmUp(1);		//this involve outfit changes which can lower our maxMP to below what goal was. which would cause infinite loop
+		goal = min(goal, my_maxmp());
 	}
 	__restore("mp", goal, meat_reserve, useFreeRests);
 	return (my_mp() >= goal);


### PR DESCRIPTION
* fix infinite loops in restore code
* more reasonable acquireMP() target.
** If someone wanted to get 100% MP they would use acquireMP(100.0).
** acquireMP() should be "get a reasonable amount of MP". so that is what it does now. It gets 300 MP or 95% of your maxMP, whichever is lower.
** Worth nothing that `acquoreMP()` without specifying a specific amount was only used once in all of autoscend... by me, incorrectly thinking it means "automatically get a reasonable amount of MP" instead of "get 100% of MP". which was fixed at #612 

## How Has This Been Tested?

I was at a position where I was regularly getting an infinite loop in restore every time I ran autoscend due to sausage slurping changing outfit. this fixed it by preventing a command to restore higher than maxmp

tested the code to prevent the inf loop when a command to restore above maxmp or maxhp is sent via ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
