### PR TITLE
fixup bedtime

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -14,6 +14,7 @@ import <autoscend/autoscend_migration.ash>
 import <canadv.ash>
 
 import <autoscend/auto_adventure.ash>
+import <autoscend/auto_bedtime.ash>
 import <autoscend/auto_consume.ash>
 import <autoscend/auto_deprecation.ash>
 import <autoscend/auto_equipment.ash>


### PR DESCRIPTION
#611 was missing an import in autoscend.ash for the bedtime file

## How Has This Been Tested?

ran autoscend.ash and saw it actually run bedtime

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
