### PR TITLE
KOLHS support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -57,6 +57,7 @@ import <autoscend/paths/gelatinous_noob.ash>
 import <autoscend/paths/grey_goo.ash>
 import <autoscend/paths/heavy_rains.ash>
 import <autoscend/paths/kingdom_of_exploathing.ash>
+import <autoscend/paths/kolhs.ash>
 import <autoscend/paths/license_to_adventure.ash>
 import <autoscend/paths/live_ascend_repeat.ash>
 import <autoscend/paths/nuclear_autumn.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2192,17 +2192,37 @@ boolean councilMaintenance()
 
 boolean adventureFailureHandler()
 {
+	location place = my_location();
 	if(my_location().turns_spent > 52)
 	{
-		boolean tooManyAdventures = false;
-		if (($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Deep Dark Jungle, The Neverending Party, Noob Cave, Pirates of the Garbage Barges, The Secret Government Laboratory, Sloppy Seconds Diner, The SMOOCH Army HQ, Super Villain\'s Lair, Uncle Gator\'s Country Fun-Time Liquid Waste Sluice, VYKEA, The X-32-F Combat Training Snowman, The Exploaded Battlefield, The Arrrboretum] contains my_location()) == false)
+		boolean tooManyAdventures = true;
+		
+		//general override function
+		if ($locations[
+		//Many places do not have a proper ID which makes them indistinguishable from noob cave
+		Noob Cave,
+		
+		//quest locations where you spend lots of adventures and can not over adventure either
+		The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform),
+		
+		//kingdom of exploathing specific location for the hippy-frat war
+		The Exploaded Battlefield,
+		
+		//IOTM zones only used to powerlevel
+		The Deep Dark Jungle, The Neverending Party, Pirates of the Garbage Barges, The Secret Government Laboratory, Sloppy Seconds Diner, The SMOOCH Army HQ, Super Villain\'s Lair, Uncle Gator\'s Country Fun-Time Liquid Waste Sluice, VYKEA, The X-32-F Combat Training Snowman,
+		
+		//in KOLHS path you must spend 40 adv per day split between those locations. zones only exist in kolhs
+		The Hallowed Halls, Art Class, Chemistry Class, Shop Class,
+		
+		//holiday event. must spend 100 turns there to complete the holiday.
+		The Arrrboretum] contains place)
 		{
-			tooManyAdventures = true;
+			tooManyAdventures = false;
 		}
 
 		if(tooManyAdventures && (my_path() == "The Source"))
 		{
-			if($locations[The Haunted Ballroom, The Haunted Bathroom, The Haunted Bedroom, The Haunted Gallery] contains my_location())
+			if($locations[The Haunted Ballroom, The Haunted Bathroom, The Haunted Bedroom, The Haunted Gallery] contains place)
 			{
 				tooManyAdventures = false;
 			}
@@ -2210,7 +2230,7 @@ boolean adventureFailureHandler()
 
 		if(tooManyAdventures && isActuallyEd())
 		{
-			if ($location[Hippy Camp] == my_location())
+			if ($location[Hippy Camp] == place)
 			{
 				tooManyAdventures = false;
 			}
@@ -2218,7 +2238,7 @@ boolean adventureFailureHandler()
 		
 		if(tooManyAdventures && in_bhy())
 		{
-			if($locations[A-Boo Peak, Twin Peak] contains my_location())
+			if($locations[A-Boo Peak, Twin Peak] contains place)
 			{
 				//bees prevent doing these quickly
 				tooManyAdventures = false;
@@ -2227,13 +2247,13 @@ boolean adventureFailureHandler()
 
 		if (tooManyAdventures && auto_my_path() == "G-Lover")
 		{
-			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp, The Hidden Temple] contains my_location())
+			if ($locations[The Penultimate Fantasy Airship, The Smut Orc Logging Camp, The Hidden Temple] contains place)
 			{
 				tooManyAdventures = false;
 			}
 		}
 
-		if ($locations[The Haunted Gallery] contains my_location() && my_location().turns_spent < 100)
+		if ($locations[The Haunted Gallery] contains place && place.turns_spent < 100)
 		{
 			tooManyAdventures = false;
 		}
@@ -2243,12 +2263,12 @@ boolean adventureFailureHandler()
 			if(get_property("auto_newbieOverride").to_boolean())
 			{
 				set_property("auto_newbieOverride", false);
-				auto_log_warning("We have spent " + my_location().turns_spent + " turns at '" + my_location() + "' and that is bad... override accepted.", "red");
+				auto_log_warning("We have spent " + place.turns_spent + " turns at '" + place + "' and that is bad... override accepted.", "red");
 			}
 			else
 			{
 				auto_log_critical("You can set auto_newbieOverride = true to bypass this once.", "blue");
-				abort("We have spent " + my_location().turns_spent + " turns at '" + my_location() + "' and that is bad... aborting.");
+				abort("We have spent " + place.turns_spent + " turns at '" + place + "' and that is bad... aborting.");
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -214,6 +214,7 @@ void initializeSettings() {
 	glover_initializeSettings();
 	bat_initializeSettings();
 	koe_initializeSettings();
+	kolhs_initializeSettings();
 	zelda_initializeSettings();
 	lowkey_initializeSettings();
 	bhy_initializeSettings();
@@ -2587,6 +2588,7 @@ boolean doTasks()
 	if(LM_batpath()) 					return true;
 	if(doHRSkills())					return true;
 	if(LM_canInteract()) 			return true;
+	if(LM_kolhs()) 						return true;
 
 	if(auto_my_path() != "Community Service")
 	{

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -166,6 +166,10 @@ boolean auto_run_choice(int choice, string page)
 		case 693: // It's Almost Certainly a Trap (Daily Dungeon)
 			dailyDungeonChoiceHandler(choice, options);
 			break;
+		case 700: // Delirium in the Cafeterium (KOLHS 22nd adventure every day)
+		case 772: // Saved by the Bell (KOLHS after school)
+			kolhsChoiceHandler(choice);
+			break;
 		case 780: // Action Elevator (The Hidden Apartment Building)
 			if (in_pokefam() && get_property("relocatePygmyLawyer").to_int() != my_ascensions()) {
 				run_choice(3); // relocate lawyers to park

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -395,9 +395,9 @@ boolean canDrink(item toDrink, boolean checkValidity)
 	{
 		return false;
 	}
-	if(auto_my_path() == "KOLHS")
+	if(in_kolhs())
 	{
-		if(!($items[Bottle of Fruity &quot;Wine&quot;, Can of the Cheapest Beer, Single Swig of Vodka, Steel Margarita] contains toDrink))
+		if(!($items[Can of the Cheapest Beer, Bottle of Fruity &quot;Wine&quot;, Single Swig of Vodka, fountain \'soda\', stepmom\'s booze, Steel Margarita] contains toDrink))
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -526,6 +526,11 @@ void consumeStuff()
 		cs_eat_spleen();
 		return;
 	}
+	if(in_kolhs())
+	{
+		kolhs_consume();
+		return;
+	}
 
 	// fills up spleen for Ed.
 	if (ed_eatStuff())

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -177,6 +177,17 @@ boolean canChangeToFamiliar(familiar target)
 		return true;
 	}
 	
+	//kolhs specific check that needs to go here specifically. can not take familiars >10 lbs base weight into school zone.
+	if(kolhs_mandatorySchool() || 				//we are in kolhs and are adventuring in a school zone
+	get_property("_NC772_directive") != "")		//we are in kolhs and doing saved by the bell NC
+	{
+		if(target != $familiar[Steam-Powered Cheerleader] &&	//sole exception to the rule
+		familiar_weight(target) > 10)
+		{
+			return false;
+		}
+	}
+	
 	// check path limitations, as well as 100% runs for a different familiar than target
 	if(!canChangeFamiliar())
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -232,6 +232,13 @@ boolean auto_pre_adventure()
 		use_familiar(get_property("auto_100familiar").to_familiar());
 		auto_log_debug("Re-equipped your " + get_property("auto_100familiar") + " as something had unequipped it. This is bad and should be investigated.");
 	}
+	
+	if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains place)		//KOLHS path specific zones
+	{
+		//hats are forbidden. will fail to adventure if not removed
+		addToMaximize("-hat");
+		equip($slot[hat], $item[none]);
+	}
 
 	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))
 	{
@@ -264,6 +271,19 @@ boolean auto_pre_adventure()
 			if(equipped_amount($item[Unstable Fulminate]) == 0)
 			{
 				abort("Correction failed, please report this. Manually get the [wine bomb] then run me again");
+			}
+		}
+	}
+	
+	if(place == get_property("_yearbookCameraTargetLocation").to_location() && in_kolhs())
+	{
+		if(equipped_amount($item[Yearbook Club Camera]) == 0)
+		{
+			auto_log_warning("Tried to adventure in [" +place+ "] to do the yearbook camera quest without a [Yearbook Club Camera] equipped... correcting", "red");
+			autoForceEquip($slot[acc2], $item[Yearbook Club Camera]);
+			if(equipped_amount($item[Yearbook Club Camera]) == 0)
+			{
+				abort("Correction failed, please report this. Manually photograph a [" +get_property("yearbookCameraTarget")+ "] then run me again");
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -223,6 +223,7 @@ boolean auto_pre_adventure()
 	}
 
 	equipOverrides();
+	kolhs_preadv(place);
 
 	if (is100FamRun() && my_familiar() == $familiar[none])
 	{
@@ -231,13 +232,6 @@ boolean auto_pre_adventure()
 		// and L12_themtharHills()...
 		use_familiar(get_property("auto_100familiar").to_familiar());
 		auto_log_debug("Re-equipped your " + get_property("auto_100familiar") + " as something had unequipped it. This is bad and should be investigated.");
-	}
-	
-	if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains place)		//KOLHS path specific zones
-	{
-		//hats are forbidden. will fail to adventure if not removed
-		addToMaximize("-hat");
-		equip($slot[hat], $item[none]);
 	}
 
 	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))
@@ -275,19 +269,6 @@ boolean auto_pre_adventure()
 		}
 	}
 	
-	if(place == get_property("_yearbookCameraTargetLocation").to_location() && in_kolhs())
-	{
-		if(equipped_amount($item[Yearbook Club Camera]) == 0)
-		{
-			auto_log_warning("Tried to adventure in [" +place+ "] to do the yearbook camera quest without a [Yearbook Club Camera] equipped... correcting", "red");
-			autoForceEquip($slot[acc2], $item[Yearbook Club Camera]);
-			if(equipped_amount($item[Yearbook Club Camera]) == 0)
-			{
-				abort("Correction failed, please report this. Manually photograph a [" +get_property("yearbookCameraTarget")+ "] then run me again");
-			}
-		}
-	}
-
 	if(place == $location[The Black Forest])
 	{
 		autoEquip($slot[acc3], $item[Blackberry Galoshes]);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5773,14 +5773,19 @@ float npcStoreDiscountMulti()
 int meatReserve()
 {
 	//the amount of meat we want to reserve for quest usage when performing a restore
+	int reserve_extra = 0;		//extra reserved for various reasons
+	if(in_kolhs())
+	{
+		reserve_extra += 100;
+	}
 	
 	if(my_level() < 10)		//meat income is pretty low and the quests that need the reserve far away. Use restores freely
 	{
 		if(!isDesertAvailable() && inKnollSign() && my_level() > 5 && my_turncount() > 50)
 		{		//reason for both level and turncount being checked is that many iotms could level us on turn 1.
-			return 500;		//reserve some meat for the bitchin' meatcar.
+			return 500 + reserve_extra;		//reserve some meat for the bitchin' meatcar.
 		}
-		return 0;	
+		return reserve_extra;	
 	}
 	
 	int reserve_gnasir = 0;		//used to track how much we need to reserve for black paint for gnasir
@@ -5818,5 +5823,5 @@ int meatReserve()
 		}
 	}
 	
-	return reserve_gnasir + reserve_diary + reserve_island;
+	return reserve_gnasir + reserve_diary + reserve_island + reserve_extra;
 }

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -686,6 +686,15 @@ generic_t zone_delay(location loc)
 			value = 5 - (loc.turns_spent - get_property("auto_lastShenTurn").to_int());
 		}
 		break;
+	case $location[The Hallowed Halls]:
+	case $location[Art Class]:
+	case $location[Chemistry Class]:
+	case $location[Shop Class]:
+		if(kolhs_mandatorySchool())		//KOLHS path specific delay locations
+		{
+			value = 40 - get_property("_kolhsAdventures").to_int();		//shared counter of 40 adv between all 4 zones
+		}
+		break;
 	default:
 		retval._error = true;
 		break;
@@ -702,6 +711,15 @@ generic_t zone_delay(location loc)
 boolean zone_available(location loc)
 {
 	boolean retval = false;
+	
+	if(kolhs_mandatorySchool())		//kolhs path specifically blocks non school zones until school is done.
+	{
+		if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains loc)
+		{
+			retval = true;
+		}
+		return retval;
+	}
 
 	switch(loc)
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -589,6 +589,10 @@ boolean koe_initializeSettings();
 boolean LX_koeInvaderHandler();
 
 ########################################################################################################
+//Defined in autoscend/paths/kolhs.ash
+boolean in_kolhs();
+
+########################################################################################################
 //Defined in autoscend/paths/license_to_adventure.ash
 void bond_initializeSettings();
 boolean bond_initializeDay(int day);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -591,6 +591,15 @@ boolean LX_koeInvaderHandler();
 ########################################################################################################
 //Defined in autoscend/paths/kolhs.ash
 boolean in_kolhs();
+boolean kolhs_mandatorySchool();
+void kolhs_initializeSettings();
+void kolhs_closetDrink();
+void kolhs_consume();
+boolean LX_kolhs_yearbookCameraGet();
+boolean LX_kolhs_yearbookCameraQuest();
+boolean LX_kolhs_school();
+void kolhsChoiceHandler(int choice);
+boolean LM_kolhs();
 
 ########################################################################################################
 //Defined in autoscend/paths/license_to_adventure.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -595,6 +595,8 @@ boolean kolhs_mandatorySchool();
 void kolhs_initializeSettings();
 void kolhs_closetDrink();
 void kolhs_consume();
+void kolhs_preadv(location place);
+boolean LX_kolhs_visitYearbookClub();
 boolean LX_kolhs_yearbookCameraGet();
 boolean LX_kolhs_yearbookCameraQuest();
 boolean LX_kolhs_school();

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -267,6 +267,13 @@ boolean LM_kolhs()
 		return false;
 	}
 	
+	familiar familiar_target_100 = get_property("auto_100familiar").to_familiar();
+	if(familiar_target_100 != $familiar[none] && familiar_target_100 != $familiar[Steam-Powered Cheerleader])
+	{
+		set_property("auto_100familiar", $familiar[none]);
+		abort("Detected an attempted 100% familiar run with [" +familiar_target_100+ "] in KOLHS. [Steam Powered Cheerleader] is the only valid 100% familiar run in KOLHS. 100% familiar run disabled. You can run autoscend again to continue");
+	}
+	
 	kolhs_closetDrink();								//in postronin closet extra combat drop drinks to prevent issues
 	
 	if(LX_kolhs_school()) return true;					//mandatory for first 40 adv to be spent in school

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -1,0 +1,4 @@
+boolean in_kolhs()
+{
+	return auto_my_path() == "KOLHS";
+}

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -115,6 +115,29 @@ void kolhs_consume()
 	}
 }
 
+void kolhs_preadv(location place)
+{
+	if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains place)		//KOLHS path specific zones
+	{
+		//hats are forbidden. will fail to adventure if not removed
+		addToMaximize("-hat");
+		equip($slot[hat], $item[none]);
+	}
+	
+	if(place == get_property("_yearbookCameraTargetLocation").to_location() && in_kolhs())
+	{
+		if(equipped_amount($item[Yearbook Club Camera]) == 0)
+		{
+			auto_log_warning("Tried to adventure in [" +place+ "] to do the yearbook camera quest without a [Yearbook Club Camera] equipped... correcting", "red");
+			autoForceEquip($slot[acc2], $item[Yearbook Club Camera]);
+			if(equipped_amount($item[Yearbook Club Camera]) == 0)
+			{
+				abort("Correction failed, please report this. Manually photograph a [" +get_property("yearbookCameraTarget")+ "] then run me again");
+			}
+		}
+	}
+}
+
 boolean LX_kolhs_visitYearbookClub()
 {
 	//visit to yearbook club. You start the quest on one day and complete it the next day so no point in multiple visits in one day.

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -117,14 +117,20 @@ void kolhs_consume()
 
 void kolhs_preadv(location place)
 {
-	if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains place)		//KOLHS path specific zones
+	if(!in_kolhs())
 	{
-		//hats are forbidden. will fail to adventure if not removed
+		return;
+	}
+	
+	//KOLHS path specific zones where hats are forbidden. wearing one fails to adv and causes infinite loop
+	if($locations[The Hallowed Halls, Art Class, Chemistry Class, Shop Class] contains place)
+	{
 		addToMaximize("-hat");
 		equip($slot[hat], $item[none]);
 	}
 	
-	if(place == get_property("_yearbookCameraTargetLocation").to_location() && in_kolhs())
+	//prepare yearbook camera
+	if(place == get_property("_yearbookCameraTargetLocation").to_location() && !get_property("yearbookCameraPending").to_boolean())
 	{
 		if(equipped_amount($item[Yearbook Club Camera]) == 0)
 		{

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -2,3 +2,282 @@ boolean in_kolhs()
 {
 	return auto_my_path() == "KOLHS";
 }
+
+boolean kolhs_mandatorySchool()
+{
+	//true means it is mandatory for you to attend school right now. All non school zones are unavailable. Summoning fights works though
+	if(!in_kolhs())
+	{
+		return false;	//not in the path so we are not required to attend school
+	}
+	return get_property("_kolhsAdventures").to_int() < 40;
+}
+
+void kolhs_initializeSettings()
+{
+	if(!in_kolhs())
+	{
+		return;
+	}
+	
+	set_property("kolhs_closetDrink", false);
+}
+
+void kolhs_closetDrink()
+{
+	//prevent kolhs issues in postronin (or drop to casual) caused by special drinks by closetting excess amount.
+	//this function and related variables are needed because mafia does not track which is the last dropped kolhs combat drink.
+	//we can pull leftovers/purchases. and we might have leveled since last combat when it dropped.
+	if(!in_kolhs())
+	{
+		return;
+	}
+	if(!can_interact())
+	{
+		return;		//we are not in postronin/casual
+	}
+	if(get_property("kolhs_closetDrink").to_boolean())
+	{
+		return;		//already done this ascension
+	}
+	set_property("kolhs_closetDrink", true);
+	
+	//drink one first if needed so they continue to drop.
+	item target = $item[can of the cheapest beer];
+	if(my_level() > 8)
+	{
+		target = $item[single swig of vodka];
+	}
+	else if(my_level() > 4)
+	{
+		target = $item[bottle of fruity &quot;wine&quot;];
+	}
+	if(my_inebriety() < 10 && item_amount(target) > 0)
+	{
+		autoDrink(1, target);
+	}
+	
+	//closet all the others
+	foreach it in $items[single swig of vodka, bottle of fruity &quot;wine&quot;, can of the cheapest beer]
+	{
+		int amt = item_amount(it);
+		if(amt > 0)
+		{
+			put_closet(amt, it);
+		}
+	}
+}
+
+void kolhs_consume()
+{
+	//handles consumption for KOLHS which has special drinking mechanics
+	if(!in_kolhs())
+	{
+		return;
+	}
+	
+	//KOLHS drinking mechanics is not tracked by mafia and is believed to work as per:
+	//3 combat drinks drop at the end of combat, automatically costing 100 meat. not encountered in the school itself.
+	//only encountered if you drank the last one that dropped today. and only if inebrity under 10.
+	//this means we need to drink them as soon as they drop to allow the next one to drop. Or we end up with empty liver and out of adventures
+	//[single swig of vodka] = level 9+. size 2. 2.75 adv/size
+	//[bottle of fruity &quot;wine&quot;] = level 5-8. size 2. 2.5 adv/size
+	//[can of the cheapest beer] = level 1-4. size 1. 2 adv/size
+	
+	if(my_inebriety() < 10)		//phase 1. drink these as soon as they drop. no return here because we want to eat too.
+	{
+		foreach it in $items[single swig of vodka, bottle of fruity &quot;wine&quot;, can of the cheapest beer]
+		{
+			if(item_amount(it) > 0)
+			{
+				autoDrink(1, it);
+			}
+		}
+	}
+	
+	if(stomach_left() > 0)		//phase 2. fill up on food before we finish off liver
+	{
+		if(my_adventures() < 10)
+		{
+			auto_autoConsumeOne("eat", false);
+			return;
+		}
+		else
+		{
+			return;		//if we fail to fill up stomach then do not auto consume booze in kolhs
+		}
+	}
+	if(my_adventures() < 10)	//phase 3. final drinking now that our stomach is full
+	{
+		//TODO replace it with specific manual handling. autoConsumeOne says it cannot find anything to consume.
+		auto_autoConsumeOne("drink", false);
+		return;
+	}
+}
+
+boolean LX_kolhs_visitYearbookClub()
+{
+	//visit to yearbook club. You start the quest on one day and complete it the next day so no point in multiple visits in one day.
+	//if you did not finish the quest then it changes. so you need to revisit every day regardless of completion status.
+	//on first visit per ascension you acquire the camera. if you already maxed out camera no point in visiting again
+	if(get_property("_yearbookClubVisitedToday").to_boolean())
+	{
+		return false;		//already visited today
+	}
+	if(get_property("_kolhsSavedByTheBell").to_int() > 2)
+	{
+		return false;		//we ran out of saved by the bell NC visits. so we cannot reach it today.
+	}
+	auto_log_info("Visiting the yearbook club", "blue");
+	set_property("_NC772_directive", 3);				//NC772 [saved by the bell] should visit yearbook club
+	return autoAdv($location[The Hallowed Halls]);		//goto NC772
+}
+
+boolean LX_kolhs_yearbookCameraGet()
+{
+	//grab the yearbook camera if you have not already done so.
+	if(possessEquipment($item[Yearbook Club Camera]))
+	{
+		return false;	//already have the camera
+	}
+	if(kolhs_mandatorySchool())
+	{
+		return false;	//we have not yet unlocked [saved by the bell] today
+	}
+	return LX_kolhs_visitYearbookClub();	//grab the camera if you did not get it yet this ascension
+}
+
+boolean LX_kolhs_yearbookCameraQuest()
+{
+	//grab a yearbook camera. do sidequest to acquire permanent between ascensions upgrades for it
+	if(kolhs_mandatorySchool())
+	{
+		return false;	//we have not yet unlocked [saved by the bell] today
+	}
+	
+	if(LX_kolhs_yearbookCameraGet()) return true;	//grab the yearbook camera if you have not already done so.
+	
+	//do we actually need to do the quest?
+	if(get_property("yearbookCameraAscensions").to_int() > 20)
+	{
+		return false;	//already maxed out permanent upgrades
+	}
+	if(my_ascensions() == get_property("lastYearbookCameraAscension").to_int())
+	{
+		return false;	//already upgraded once this ascension. only one upgrade per ascension can become permanent.
+	}
+	if(LX_kolhs_visitYearbookClub()) return true;		//start, restart, or finish quest.
+	
+	if(get_property("yearbookCameraPending").to_boolean())
+	{
+		return false;	 //we finished the quest today but must wait until tomorrow to turn it in
+	}
+	
+	//try to get a photograph
+	monster target = get_property("yearbookCameraTarget").to_monster();
+	location adv_target;
+	foreach loc in monster_to_location(target)
+	{
+		if(zone_isAvailable(loc, true))
+		{
+			adv_target = loc;
+			break;
+		}
+	}
+	set_property("_yearbookCameraTargetLocation", adv_target);		//used by pre_adv to verify camera is actually equipped
+	if(adv_target == $location[none])
+	{
+		return false;		//just in case. should not be possible since it picks from reachable locations
+	}
+
+	autoEquip($item[Yearbook Club Camera]);
+	return autoAdv(adv_target);
+	
+	return false;
+}
+
+boolean LX_kolhs_school()
+{
+	//adventure in school. mandatory for first 40 adv to be spent there.
+	if(!kolhs_mandatorySchool())
+	{
+		return false;	//done for today
+	}
+	
+	return autoAdv($location[The Hallowed Halls]);
+	//TODO specific classes https://kol.coldfront.net/thekolwiki/index.php/KoL_High_School
+	//TODO sniff wastoid in hallowed halls
+}
+
+void kolhsChoiceHandler(int choice)
+{
+	auto_log_debug("Running kolhsChoiceHandler");
+	switch (choice)
+	{
+		case 700: // Delirium in the Cafeterium (KOLHS 22nd adventure every day)
+			if(have_effect($effect[Jamming with the Jocks]) > 0)
+			{
+				run_choice(1); // get XP
+			}
+			else if(have_effect($effect[Nerd is the Word]) > 0)
+			{
+				run_choice(2); // get XP
+			}
+			else if(have_effect($effect[Greaser Lightnin\']) > 0)
+			{
+				run_choice(3); // get XP
+			}
+			else
+			{
+				auto_log_warning("I do not have the necessary intrinsic to gain xp in [Delirium in the Cafeterium]", "red");
+				run_choice(3); // lose HP
+			}
+			break;
+		case 772: // Saved by the Bell (KOLHS after school)
+			//we use directive property. it both tells us what to do, and helps pre-adv do stuff. for example ensure we are not wearing a familiar that is blocking us
+			int target = get_property("_NC772_directive").to_int();
+			remove_property("_NC772_directive");		//remove it now in case we abort
+			if(target == 0)
+			{
+				abort("We are in [saved by the bell] and do not know what to do because _NC772_directive is not valid or set. Leaving will waste this NC so do something manually");
+			}
+			if(available_choice_options() contains target)
+			{
+				if(target == 3)		//yearbook club should only be visited once daily
+				{
+					set_property("_yearbookClubVisitedToday", true);
+				}
+				run_choice(target);
+			}
+			else
+			{
+				abort("We are in [saved by the bell] and do not know what to do. Wanted to press button number " +target+ " but it mysteriously does not exist. Leaving will waste this NC so do something manually");
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+boolean LM_kolhs()
+{
+	//this function is called early once every loop of doTasks() in autoscend.ash to do things when we are in kolhs
+	if(!in_kolhs())
+	{
+		return false;
+	}
+	
+	kolhs_closetDrink();								//in postronin closet extra combat drop drinks to prevent issues
+	
+	if(LX_kolhs_school()) return true;					//mandatory for first 40 adv to be spent in school
+	if(LX_kolhs_yearbookCameraGet()) return true;		//grab the yearbook camera if you have not already done so.
+	if(my_level() < 9)									//important to rush level 9 for the superior drink drops
+	{
+		if(LX_freeCombats(true)) return true;
+	}
+	if(LX_kolhs_yearbookCameraQuest()) return true;		//gain permanent upgrades to yearbook camera
+	
+	//TODO other saved by the bell adventures as needed?
+	
+	return false;
+}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -4,7 +4,10 @@ boolean LX_loggingHatchet()
 	{
 		return false;
 	}
-
+	if(kolhs_mandatorySchool())
+	{
+		return false;	//avoid infinite loop in kolhs. we can not get the hatchet until we finish mandatory school for the day
+	}
 	if (available_amount($item[logging hatchet]) > 0)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -369,8 +369,9 @@ boolean LX_steelOrgan()
 		}
 		boolean wontBeOverdrunk = inebriety_left() >= $item[Steel Margarita].inebriety - 5;
 		boolean notOverdrunk = my_inebriety() <= inebriety_limit();
-		boolean notSavingForBilliards = hasSpookyravenLibraryKey() || get_property("lastSecondFloorUnlock").to_int() == my_ascensions();
-		if((item_amount($item[Steel Margarita]) > 0) && wontBeOverdrunk && notOverdrunk && (notSavingForBilliards || my_inebriety() + $item[Steel Margarita].inebriety <= 10 || my_inebriety() >= 12))
+		boolean notSavingForBilliards = hasSpookyravenLibraryKey() || get_property("lastSecondFloorUnlock").to_int() == my_ascensions() || my_inebriety() + $item[Steel Margarita].inebriety <= 10 || my_inebriety() >= 12;
+		boolean notWaitingKOLHS = !in_kolhs() || my_inebriety() > 9;
+		if(item_amount($item[Steel Margarita]) > 0 && wontBeOverdrunk && notOverdrunk && notSavingForBilliards && notWaitingKOLHS)
 		{
 			autoDrink(1, $item[Steel Margarita]);
 		}


### PR DESCRIPTION
* kolhs initial support
* special diet support
** try to rush to level 9 early via free combats for the better combat drink drops
* handling for choice adv 700 [Delirium in the Cafeterium]. KOLHS 22nd adventure every day
* basic adventuring in school
* yearbook camera sidequest
* boolean kolhs_mandatorySchool() created and used
** fixed trying to get logging hatchet on turn 1 of the run and getting stuck in infinite loop
* hats are forbidden in high school
* fix canDrink not identifying stepmom's booze and fountain 'soda'
* changes to generic_t zone_delay(location loc) for the purpose of recognizing the kolhs zones as delay zones
* fix steel margarita drinking for kolhs
* do not abort for too many adventures spent in school
* small cleanup of convoluted code for adventureFailureHandler(). also comments
* only steam powered cheerleader is valid for 100% fam run in kolhs
* kolhs can not take familiar >10 lbs base weight into school

Fixes #72
Fixes #73

## How Has This Been Tested?

account with no IOTMs: 2 complete run
account with many IOTMs: 4 complete softcore runs, 2 complete HC runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
