### PR TITLE
boolean[location] monster_to_location(monster target) created

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1746,6 +1746,29 @@ boolean is_ghost_in_zone(location loc)
 	return false;
 }
 
+location[int] monster_to_location(monster target)
+{
+	location[int] retval;
+	int key = 0;
+	foreach loc in $locations[]		//check all locations in the game
+	{
+		boolean mon_in_loc = false;
+		foreach idx, mon in get_monsters(loc)
+		{
+			if(target == mon)
+			{
+				mon_in_loc = true;
+			}
+		}
+		if(mon_in_loc)
+		{
+			retval[key] = loc;
+			key++;
+		}
+	}
+	return retval;
+}
+
 
 /*
 	case $location[The Oasis]:

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1752,18 +1752,10 @@ location[int] monster_to_location(monster target)
 	int key = 0;
 	foreach loc in $locations[]		//check all locations in the game
 	{
-		boolean mon_in_loc = false;
-		foreach idx, mon in get_monsters(loc)
+		foreach idx, mon in get_monsters(loc) if (target == mon)
 		{
-			if(target == mon)
-			{
-				mon_in_loc = true;
-			}
-		}
-		if(mon_in_loc)
-		{
-			retval[key] = loc;
-			key++;
+			retval[key++] = loc;
+			break;
 		}
 	}
 	return retval;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1746,15 +1746,14 @@ boolean is_ghost_in_zone(location loc)
 	return false;
 }
 
-location[int] monster_to_location(monster target)
+boolean[location] monster_to_location(monster target)
 {
-	location[int] retval;
-	int key = 0;
+	boolean[location] retval;
 	foreach loc in $locations[]		//check all locations in the game
 	{
 		foreach idx, mon in get_monsters(loc) if (target == mon)
 		{
-			retval[key++] = loc;
+			retval[loc] = true;
 			break;
 		}
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1160,7 +1160,7 @@ monster[int] mobs_available();
 item[int] drops_available();
 item[int] hugpocket_available();
 boolean is_ghost_in_zone(location loc);
-location[int] monster_to_location(monster target);
+boolean[location] monster_to_location(monster target);
 
 ########################################################################################################
 //Defined in autoscend/auto_util.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1160,6 +1160,7 @@ monster[int] mobs_available();
 item[int] drops_available();
 item[int] hugpocket_available();
 boolean is_ghost_in_zone(location loc);
+location[int] monster_to_location(monster target);
 
 ########################################################################################################
 //Defined in autoscend/auto_util.ash


### PR DESCRIPTION
* provides all the locations in which this monster can be found. note that they are not filtered by accessibility

## Testing
```
> ash import autoscend.ash; monster_to_location($monster[bar])

Returned: aggregate boolean [location]
The Spooky Forest => true

> ash import autoscend.ash; monster_to_location($monster[A.M.C. gremlin])

Returned: aggregate boolean [location]
Near an Abandoned Refrigerator => true
Next to that Barrel with Something Burning in it => true
Out by that Rusted-Out Car => true
Over Where the Old Tires Are => true
Post-War Junkyard => true
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
