### PR TITLE
misc minor fixes

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -1,7 +1,7 @@
 # "Item" is used when we want a familiar that boosts the chance of a monster dropping an item
 # We expect that familiars that drop items directly a limited amount of times per day will be used first elsewhere. So do not account for those.
 #
-# exempt from 10 lbs restriction in KOHLS path
+# exempt from 10 lbs restriction in KOLHS path
 Steam-Powered Cheerleader	path:KOLHS
 # Fairies with a multiplier
 # 1.4x multiplier fairy

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -90,7 +90,7 @@ init	3	Happy Medium
 # "Item" is used when we want a familiar that boosts the chance of a monster dropping an item
 # We expect that familiars that drop items directly a limited amount of times per day will be used first elsewhere. So do not account for those.
 #
-# exempt from 10 lbs restriction in KOHLS path
+# exempt from 10 lbs restriction in KOLHS path
 item	0	Steam-Powered Cheerleader	path:KOLHS
 # Fairies with a multiplier
 # 1.4x multiplier fairy

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1138,11 +1138,6 @@ void initializeDay(int day)
 				auto_sourceTerminalRequest("enquiry protect.enq");
 			}
 
-			//big rock is what mafia returns when you have no dwelling.
-			if(item_amount($item[Newbiesport&trade; tent]) > 0 && auto_is_valid($item[Newbiesport&trade; tent]) && get_dwelling() == $item[big rock])
-			{
-				use(1, $item[Newbiesport&trade; tent]);
-			}
 			kgbSetup();
 			if(item_amount($item[transmission from planet Xi]) > 0)
 			{
@@ -2559,6 +2554,7 @@ boolean doTasks()
 	oldPeoplePlantStuff();
 	use_barrels();
 	auto_latteRefill();
+	houseUpgrade();
 
 	//This just closets stuff so G-Lover does not mess with us.
 	if(LM_glover())						return true;

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -448,6 +448,8 @@ boolean auto_post_adventure()
 
 	# This is the list of castables that all MP sequences will use.
 	boolean [skill] toCast = $skills[Prevent Scurvy and Sobriety, Acquire Rhinestones, Advanced Cocktailcrafting, Advanced Saucecrafting, Communism!, Grab a Cold One, Lunch Break, Pastamastery, Perfect Freeze, Request Sandwich, Spaghetti Breakfast, Summon Alice\'s Army Cards, Summon Carrot, Summon Confiscated Things, Summon Crimbo Candy, Summon Geeky Gifts, Summon Hilarious Objects, Summon Holiday Fun!, Summon Kokomo Resort Pass, Summon Tasteful Items];
+	
+	boolean buff_familiar = pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean();
 
 	if(my_maxmp() < 50)
 	{
@@ -455,7 +457,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 15, 1, 10);
 		// Only maintain skills in path with familiars
-		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
+		if(buff_familiar)
 		{
 			buffMaintain($effect[Leash of Linguini], 20, 1, 10);
 			if(regen > 10.0)
@@ -516,7 +518,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Power Ballad of the Arrowsmith], 7, 1, 5);
 		buffMaintain(whatStatSmile(), 20, 1, 10);
 		// Only Maintain skills in path with familiars
-		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
+		if(buff_familiar)
 		{
 			buffMaintain($effect[Leash of Linguini], 30, 1, 10);
 			if(regen > 10.0)
@@ -583,7 +585,7 @@ boolean auto_post_adventure()
 			buffMaintain(whatStatSmile(), 40, 1, 10);
 		}
 		// Only maintain in path with familiars
-		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
+		if(buff_familiar)
 		{
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);
 			if(regen > 4.0)
@@ -693,7 +695,7 @@ boolean auto_post_adventure()
 		}
 
 		// Only maintain in path with familiars
-		if(pathAllowsFamiliar() && !get_property("_auto_bad100Familiar").to_boolean())
+		if(buff_familiar)
 		{
 			buffMaintain($effect[Empathy], 50, 1, 10);
 			buffMaintain($effect[Leash of Linguini], 35, 1, 10);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -909,6 +909,7 @@ boolean LX_unlockBelowdecks();
 boolean LX_pirateQuest();
 boolean LX_acquireEpicWeapon();
 boolean LX_NemesisQuest();
+void houseUpgrade();
 
 ########################################################################################################
 //Defined in autoscend/auto_adventure.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1873,7 +1873,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Stream of Sauce]);
 		}
 
-		if(my_soulsauce() >= 5)
+		if(canUse($skill[Soul Bubble], false) && my_soulsauce() >= 5)
 		{
 			stunner = useSkill($skill[Soul Bubble]);
 			costStunner = mp_cost($skill[Soul Bubble]);

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -45,7 +45,7 @@ boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 	if(casingsOwned == 0)
 		return false;
 		
-	//it is actually possible to have a casing but not have the kramko grinder
+	//it is actually possible to have a casing but not have the kramco grinder
 	if(!possessEquipment($item[Kramco Sausage-o-Matic&trade;]))
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/level_06.ash
+++ b/RELEASE/scripts/autoscend/quests/level_06.ash
@@ -39,35 +39,35 @@ boolean L6_friarsGetParts()
 		}
 	}
 
-	boolean delayHeart = (get_property("auto_dakotaFanning").to_boolean() && internalQuestStatus("questM16Temple") < 0);
-	// if we have to do the "Dakota" Fanning quest to unlock the Hidden Temple,
-	// delay adventuring in The Dark Heart of the Woods until the quest is started.
-
-	if(item_amount($item[box of birthday candles]) == 0 && !delayHeart)
-	{
-		auto_log_info("Getting Box of Birthday Candles", "blue");
-		auto_forceNextNoncombat();
-		return autoAdv($location[The Dark Heart of the Woods]);
-	}
-
 	if(item_amount($item[dodecagram]) == 0)
 	{
 		auto_log_info("Getting Dodecagram", "blue");
 		auto_forceNextNoncombat();
 		return autoAdv($location[The Dark Neck of the Woods]);
 	}
-
 	if(item_amount($item[eldritch butterknife]) == 0)
 	{
 		auto_log_info("Getting Eldritch Butterknife", "blue");
 		auto_forceNextNoncombat();
 		return autoAdv($location[The Dark Elbow of the Woods]);
 	}
+	if(item_amount($item[box of birthday candles]) == 0)
+	{
+		if(get_property("auto_dakotaFanning").to_boolean() && internalQuestStatus("questM16Temple") < 0)
+		{
+			// if we have to do the "Dakota" Fanning quest to unlock the Hidden Temple,
+			// delay adventuring in The Dark Heart of the Woods until the quest is started.
+			return false;
+		}
+		auto_log_info("Getting Box of Birthday Candles", "blue");
+		auto_forceNextNoncombat();
+		return autoAdv($location[The Dark Heart of the Woods]);
+	}
 
 	auto_log_info("Finishing friars", "blue");
 	visit_url("friars.php?action=ritual&pwd");
 	council();
-	return true;
+	return internalQuestStatus("questL06Friar") > 2;
 }
 
 boolean L6_dakotaFanning()

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -63,12 +63,6 @@ boolean L9_leafletQuest()
 		cli_execute("leaflet nomagic");		//no substat gains
 	}
 	
-	//upgrade dwelling. big rock is what mafia returns when you have no dwelling.
-	if(get_dwelling() == $item[big rock] || get_dwelling() == $item[Newbiesport&trade; tent])
-	{
-		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
-	}
-	
 	return get_property("leafletCompleted").to_boolean();
 }
 

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1002,7 +1002,7 @@ boolean LX_NemesisQuest()
 void houseUpgrade()
 {
 	//function for upgrading your dwelling.
-	if(isActuallyEd() || my_class() == $class[Vampyre])
+	if(isActuallyEd() || my_class() == $class[Vampyre] || auto_my_path() == "Nuclear Autumn")
 	{
 		return;		//paths where dwelling is locked
 	}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -998,3 +998,22 @@ boolean LX_NemesisQuest()
 	if (LX_guildUnlock() || LX_acquireEpicWeapon()) { return true; }
 	return false;
 }
+
+void houseUpgrade()
+{
+	//function for upgrading your dwelling.
+	if(isActuallyEd() || my_class() == $class[Vampyre])
+	{
+		return;		//paths where dwelling is locked
+	}
+	
+	//if you have no dwelling get_dwelling() returns $item[big rock]
+	if(item_amount($item[Newbiesport&trade; tent]) > 0 && auto_is_valid($item[Newbiesport&trade; tent]) && get_dwelling() == $item[big rock])
+	{
+		use(1, $item[Newbiesport&trade; tent]);
+	}
+	if(get_dwelling() == $item[big rock] || get_dwelling() == $item[Newbiesport&trade; tent])
+	{
+		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
+	}
+}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1012,7 +1012,9 @@ void houseUpgrade()
 	{
 		use(1, $item[Newbiesport&trade; tent]);
 	}
-	if(get_dwelling() == $item[big rock] || get_dwelling() == $item[Newbiesport&trade; tent])
+	if((get_dwelling() == $item[big rock] || get_dwelling() == $item[Newbiesport&trade; tent]) &&
+	item_amount($item[Frobozz Real-Estate Company Instant House (TM)]) > 0 &&
+	auto_is_valid($item[Frobozz Real-Estate Company Instant House (TM)]))
 	{
 		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
 	}


### PR DESCRIPTION
* slightly reworked familiar buffing check
* misc spelling fixes
* void houseUpgrade() created and used
** fixes #19
* do not assume that any sauceror with 5 soulsauce can use soul bubble. verify it via the `canUse` function. which checks for limiting factors. For example, the fact that you are in a g-lover run and cannot use soul bubble because it has no g in the name will be caught by canUse.
* fix inf loop at L6_friarsGetParts() when delaying [The Dark Heart of the Woods] for the purpose of doing dakota fanning

## How Has This Been Tested?

ash calls.
did a few combats in g-lover to test the soul bubble fix
L6 inf loop tested by encountering it in pathless softcore

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
