### PR TITLE
ccs: use retrospecs and retrocape delevels

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1321,6 +1321,16 @@ string auto_combatHandler(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Curse Of Weaksauce]);
 		}
+				  
+		if(canUse($skill[Detect Weakness]))
+		{
+			return useSkill($skill[Detect Weakness]);
+		}
+
+		if(canUse($skill[Deploy Robo-Handcuffs]))
+		{
+			return useSkill($skill[Deploy Robo-Handcuffs]);
+		}
 
 		if(canUse($skill[Pocket Crumbs]))
 		{


### PR DESCRIPTION
## Description

These stagger and devel, and cost 0 mp, so there's no reason to not use these in combat when we can. Kolmafia r20494 supports robo-handcuffs.

## How Has This Been Tested?

I ran this for about 50 adventures at the peak. Example fight:

```
[478] Twin Peak
Encounter: the Big Wheelin' Twins
Round 0: jonchang wins initiative!
[INFO] - auto_combatHandler: 0
Round 1: jonchang tries to steal an item!
Round 2: jonchang casts DETECT WEAKNESS!
Round 3: Big Wheelin' Twins drops 12 attack power.
Round 3: Big Wheelin' Twins drops 11 defense.
Round 3: jonchang casts DEPLOY ROBO-HANDCUFFS!
Round 4: Big Wheelin' Twins drops 20 attack power.
Round 4: jonchang attacks!
Round 5: Big Wheelin' Twins takes 87 damage.
Round 5: jonchang attacks!
Round 6: Big Wheelin' Twins takes 90 damage.
Round 6: jonchang wins the fight!
You gain 58 Meat
After Battle: Trog does a little fairy dance.
After Battle: You gain 6 Muscleboundness
After Battle: You gain 9 Wizardliness
After Battle: You gain 18 Chutzpah
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
