### PR TITLE
util: support retrocape yellow ray

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1284,6 +1284,10 @@ string yellowRayCombatString(monster target, boolean inCombat)
 		{
 			return "skill " + $skill[Open a Big Yellow Present];
 		}
+		if(inCombat ? have_skill($skill[Unleash the Devil's Kiss]) : possessEquipment($item[unwrapped knock-off retro superhero cape]))
+		{
+			return "skill " + $skill[Unleash the Devil's Kiss];
+		}
 	}
 
 	if(asdonCanMissile())
@@ -1325,6 +1329,15 @@ boolean adjustForYellowRay(string combat_string)
 	if(combat_string == ("skill " + $skill[Use the Force]))
 	{
 		return autoEquip($slot[weapon], $item[Fourth of May cosplay saber]);
+	}
+	if(combat_string == ("skill " + $skill[Unleash the Devil's Kiss]))
+	{
+		// avoid uselessly reconfiguring the cape
+		if (get_property("retroCapeSuperhero") != "heck" && get_property("retroCapeWashingInstructions") != "kiss")
+		{
+			cli_execute("retrocape mysticality kiss");
+		}
+		return autoEquip($slot[back], $item[unwrapped knock-off retro superhero cape]);
 	}
 	return true;
 }


### PR DESCRIPTION
## Description

Adds checks to utils to properly use retrocape yellow rays. This needs mafia r20494.

## How Has This Been Tested?

Ran it while waiting for yellow ray debuff to wear off, then checked that mafia equipped the retrocape and set it to the proper configuration. Then watched as it disintegrated an enemy.

```
[INFO] - Starting preadventure script...
[INFO] - Trying to provide 25 negative combat rate, with equipment
Maximizer: 5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble,0.4hp,0.2mp 1000max,3mp regen,1.5weapon damage,-0.75weapon damage percent,1.5elemental damage,2familiar weight,10exp,5Moxie experience percent,-200combat 25max,effective
Maximizing...
32 combinations checked, best score 2,800.95
[INFO] - I think we're good to go to apply The Sonata of Sneakiness
[INFO] - Adjusting to have YR available for Burly Sidekick: skill Unleash the Devil's Kiss
Reconfiguring retro cape
Encounter: Setup your knock-off retro superhero cape
[INFO] - Equipping unwrapped knock-off retro superhero cape to slot back
Maximizer: 5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble,0.4hp,0.2mp 1000max,3mp regen,1.5weapon damage,-0.75weapon damage percent,1.5elemental damage,2familiar weight,10exp,5Moxie experience percent,-200combat 25max,50item 1000.0max,+equip unwrapped knock-off retro superhero cape,effective
Maximizing...
32 combinations checked, best score 13,314.48
Maximizer: 5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble,0.4hp,0.2mp 1000max,3mp regen,1.5weapon damage,-0.75weapon damage percent,1.5elemental damage,2familiar weight,10exp,5Moxie experience percent,-200combat 25max,50item 1000.0max,ml 1max,+equip unwrapped knock-off retro superhero cape,effective
Maximizing...
32 combinations checked, best score 13,315.46
Checkpoints cleared.
[INFO] - Pre Adventure at The Penultimate Fantasy Airship done, beep.
Resetting mind control device...
Mind control device reset.
[INFO] - HP: 148/148, MP: 89/206 Meat: 10544
[INFO] - Familiar: Baby Gravy Fairy @ 20 + 20lbs.
[INFO] - ML: 30 Encounter: -5.0 Init: 27.0
[INFO] - Exp Bonus: 7.651785714285714 Meat Drop: 0.0 Item Drop: 133.9041575982343
[INFO] - Resists: 1.0/3.0/1.0/1.0/1.0

[snip]

Visit to Beanstalk: The Penultimate Fantasy Airship in progress...

[525] The Penultimate Fantasy Airship
Encounter: Burly Sidekick
Round 0: jonchang wins initiative!
[INFO] - auto_combatHandler: 0
Round 1: jonchang tries to steal an item!
You acquire an item: tiny house
Round 2: jonchang casts UNLEASH THE DEVIL'S KISS!
You acquire an effect: Everything Looks Yellow (99)
Round 3: jonchang wins the fight!
You gain 135 Meat
After Battle: Trog does a little fairy dance.
You acquire an item: Mohawk wig
You acquire an item: cocoa eggshell fragment
You acquire an item: armgun
After Battle: You gain 6 Beefiness
After Battle: You gain 9 Mysteriousness
After Battle: You gain 24 Cheek
```




## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
