### PR TITLE
ci: automatically fetch correct mafia artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       with:
         java-version: 1.8
 
-    - name: Prepare KoLmafia
+    - name: Determine KoLmafia version
+      id: mafia
       run: |
         set -o pipefail
         export MAFIA_VERSION=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
@@ -32,9 +33,22 @@ jobs:
           echo "Couldn't determine Jenkins build number!"
           exit 1
         fi
-        JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar"
-        echo "$JENKINS_URL"
-        curl "$JENKINS_URL" --output .github/kolmafia.jar
+        export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar"
+        echo "::set-output name=jenkins::$JENKINS_URL"
+        echo "::set-output name=build::$MAFIA_BUILD"
+        echo "::set-output name=version::$MAFIA_VERSION"
+
+    - name: Cache KoLmafia
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: .github/kolmafia.jar
+        key: kolmafia-${{steps.mafia.outputs.build}}-${{steps.mafia.outputs.version}}
+
+    - name: Download KoLmafia
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        curl "${{steps.mafia.outputs.jenkins}}" --output .github/kolmafia.jar
 
     - name: Install and verify
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 
 name: CI
 env:
-  MAFIA_BUILD: "1938"
-  MAFIA_VERSION: "20430"
   SCRIPT_NAMES: "autoscend.ash auto_pre_adv.ash auto_post_adv.ash auto_choice_adv.ash relay_autoscend.ash autoscend_settings_extra.ash"
 
 on: [push, pull_request]
@@ -17,16 +15,27 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: 1.8
 
     - name: Prepare KoLmafia
       run: |
-        if [[ ! -f ".github/kolmafia.jar" ]]; then
-          curl "https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar" --output .github/kolmafia.jar
+        set -o pipefail
+        export MAFIA_VERSION=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
+        if [[ -z "$MAFIA_VERSION" ]]; then
+          echo "Couldn't determine required mafia version!"
+          exit 1
         fi
-    
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=builds[number,artifacts[relativePath]]' | jq '[.builds[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
+        if [[ -z "$MAFIA_BUILD" ]]; then
+          echo "Couldn't determine Jenkins build number!"
+          exit 1
+        fi
+        JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar"
+        echo "$JENKINS_URL"
+        curl "$JENKINS_URL" --output .github/kolmafia.jar
+
     - name: Install and verify
       run: |
         cd RELEASE

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.bak
 *.sh
+.github/kolmafia.jar

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20430;	//min mafia revision needed to run this script. Last update: Cargo Shorts support complete
+since r20494;	//min mafia revision needed to run this script. Last update: Cargo Shorts support complete
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here


### PR DESCRIPTION
## Description

This pull requests automatically fetches the correct version of the kolmafia artifact from Jenkins. It grabs the necessary SVN revision from `RELEASE/scripts/autoscend.ash`, then uses the Jenkins API to find the build number corresponding to the SVN revision.

This ensures that:

* the version autoscend needs always exists on the kolmafia build server
* continuous integration and the script itself are never mismatched

## How Has This Been Tested?

Save the script as script.sh in the git root, and ensure that you have jq installed (which github does on its ubuntu runners)

Then run `bash script.sh` and watch as `.github/kolmafia.jar` is downloaded.

```bash
set -o pipefail
export MAFIA_VERSION=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
if [[ -z "$MAFIA_VERSION" ]]; then
    echo "Couldn't determine required mafia version!"
    exit 1
fi
export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=builds[number,artifacts[relativePath]]' | jq '[.builds[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number')
if [[ -z "$MAFIA_BUILD" ]]; then
    echo "Couldn't determine Jenkins build number!"
    exit 1
fi
JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar"
echo "$JENKINS_URL"
curl "$JENKINS_URL" --output .github/kolmafia.jar
```

You can set different values for MAFIA_VERSION, but since kolmafia recently changed build servers only 20493 and 20494 work for now.

```console
% bash script.sh  # MAFIA_VERSION=20494
https://ci.kolmafia.us/job/Kolmafia/8/artifact/dist/KoLmafia-20494.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.8M  100 15.8M    0     0  2710k      0  0:00:05  0:00:05 --:--:-- 3491k
 autoscend ⎇ update-ci  .  !

% bash script.sh # MAFIA_VERSION=20493
https://ci.kolmafia.us/job/Kolmafia/7/artifact/dist/KoLmafia-20493.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.8M  100 15.8M    0     0  2755k      0  0:00:05  0:00:05 --:--:-- 3735k

% bash script.sh # MAFIA_VERSION=20492
Couldn't determine Jenkins build number!

% echo $?
1
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
