### PR TITLE
Mapping the Monsters, Camel Spitting, a Cargo Pocket Use, Undead Slaying and more!

### DIFF
--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -37,7 +37,7 @@ Intergnat	item:BACON<150
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
 Grim Brother	prop:_grimFairyTaleDrops<5
-Pair of Stomping Boots	prop:_bootStomps<7
+Pair of Stomping Boots	!path:G-Lover;prop:_bootStomps<7
 Baby Sandworm	prop:_aguaDrops<5
 Bloovian Groose	prop:_grooseDrops<5
 Golden Monkey	prop:_powderedGoldDrops<5

--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -26,7 +26,7 @@ Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
 Cat Burglar	prop:_catBurglarCharge<30
 #
 # Melodramedary generating spit seems good
-#Melodramedary	prop:camelSpit<100 - Don't uncomment until we actally use it
+Melodramedary	prop:camelSpit<100
 #
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
 Intergnat	item:BACON<150

--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -46,7 +46,7 @@ Psychedelic Bear
 Piano Cat
 # Slightly special fairies
 Red-Nosed Snapper
-Pair of Stomping Boots
+Pair of Stomping Boots	!path:G-Lover
 Gelatinous Cubeling
 Steam-Powered Cheerleader
 Obtuse Angel

--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -1,4 +1,4 @@
-pygmy shaman	loc:The Hidden Apartment Building;sgeea:3;!effect:Thrice-Cursed
+pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
 Gurgle the Turgle
 Writing Desk	!prop:writingDesksDefeated=5
 Smoke Monster	item:Pack of Smokes>0

--- a/BUILD/monsters/yellowray.dat
+++ b/BUILD/monsters/yellowray.dat
@@ -1,5 +1,5 @@
 # Gotta get that wig
-Burly Sidekick	item:Mohawk Wig<1
+Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography
 # We also want an amulet, but not badly enough to yellow ray it unless we're backtracking to get it
 Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6
 # Dressing up as a harem girl because we have no shame
@@ -42,3 +42,6 @@ larval filthworm	!familiar:XO Skeleton;!class:Ed
 filthworm drone	!familiar:XO Skeleton;!class:Ed
 filthworm royal guard	!familiar:XO Skeleton;!class:Ed
 Knight (Snake)	class:Ed
+bearpig topiary animal	familiar:Melodramedary
+elephant (meatcar?) topiary animal	familiar:Melodramedary
+spider (duck?) topiary animal	familiar:Melodramedary

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -27,7 +27,7 @@ drop	0	Fist Turkey	prop:_turkeyBooze<5
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
 drop	1	Puck Man	item:Yellow Pixel<20
 drop	2	Ms. Puck Man	item:Yellow Pixel<20
-# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
 drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
 drop	4	Rockin' Robin	prop:rockinRobinProgress>=25
@@ -45,34 +45,34 @@ drop	9	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
 drop	10	Cat Burglar	prop:_catBurglarCharge<30
 #
 # Melodramedary generating spit seems good
-#Melodramedary	prop:camelSpit<100 - Don't uncomment until we actally use it
+drop	11	Melodramedary	prop:camelSpit<100
 #
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
-drop	11	Intergnat	item:BACON<150
+drop	12	Intergnat	item:BACON<150
 #
 # Below this lines drops are not needed more of for the run and are just grabbing for profit.
 # Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
 #
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
-drop	12	Grim Brother	prop:_grimFairyTaleDrops<5
-drop	13	Pair of Stomping Boots	prop:_bootStomps<7
-drop	14	Baby Sandworm	prop:_aguaDrops<5
-drop	15	Bloovian Groose	prop:_grooseDrops<5
-drop	16	Golden Monkey	prop:_powderedGoldDrops<5
-drop	17	Unconscious Collective	prop:_dreamJarDrops<5
+drop	13	Grim Brother	prop:_grimFairyTaleDrops<5
+drop	14	Pair of Stomping Boots	prop:_bootStomps<7
+drop	15	Baby Sandworm	prop:_aguaDrops<5
+drop	16	Bloovian Groose	prop:_grooseDrops<5
+drop	17	Golden Monkey	prop:_powderedGoldDrops<5
+drop	18	Unconscious Collective	prop:_dreamJarDrops<5
 # psychoanalytic jar 1 per day.
-drop	18	Angry Jung Man	prop:_jungDrops<1
+drop	19	Angry Jung Man	prop:_jungDrops<1
 # grimstone mask 1 per day
-drop	19	Grimstone Golem	prop:_grimstoneMaskDrops<1
+drop	20	Grimstone Golem	prop:_grimstoneMaskDrops<1
 # tales of spelunking 1 per day
-drop	20	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
+drop	21	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 # can drop 5 devilish folio a day
-drop	21	Blavious Kloop	prop:_kloopDrops<5
+drop	22	Blavious Kloop	prop:_kloopDrops<5
 # can drop 5 absinthe a day
-drop	22	Green Pixie	prop:_absintheDrops<5
+drop	23	Green Pixie	prop:_absintheDrops<5
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
-drop	23	Galloping Grill	prop:_hotAshesDrops<5
+drop	24	Galloping Grill	prop:_hotAshesDrops<5
 
 # We want to delevel, but don't want to deal damage
 gremlins	0	Nosy Nose

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -56,7 +56,7 @@ drop	12	Intergnat	item:BACON<150
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
 drop	13	Grim Brother	prop:_grimFairyTaleDrops<5
-drop	14	Pair of Stomping Boots	prop:_bootStomps<7
+drop	14	Pair of Stomping Boots	!path:G-Lover;prop:_bootStomps<7
 drop	15	Baby Sandworm	prop:_aguaDrops<5
 drop	16	Bloovian Groose	prop:_grooseDrops<5
 drop	17	Golden Monkey	prop:_powderedGoldDrops<5
@@ -135,7 +135,7 @@ item	27	Psychedelic Bear
 item	28	Piano Cat
 # Slightly special fairies
 item	29	Red-Nosed Snapper
-item	30	Pair of Stomping Boots
+item	30	Pair of Stomping Boots	!path:G-Lover
 item	31	Gelatinous Cubeling
 item	32	Steam-Powered Cheerleader
 item	33	Obtuse Angel

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -95,7 +95,7 @@ replace	37	Ancient Insane Monk	path:Community Service;loc:The Haiku Dungeon
 replace	38	Ferocious Bugbear	path:Community Service;loc:The Haiku Dungeon
 replace	39	Gelatinous Cube	path:Community Service;loc:The Haiku Dungeon
 
-sniff	0	pygmy shaman	loc:The Hidden Apartment Building;sgeea:3;!effect:Thrice-Cursed
+sniff	0	pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
 sniff	1	Gurgle the Turgle
 sniff	2	Writing Desk	!prop:writingDesksDefeated=5
 sniff	3	Smoke Monster	item:Pack of Smokes>0
@@ -127,7 +127,7 @@ sniff	28	Skinflute
 sniff	29	Red Butler
 
 # Gotta get that wig
-yellowray	0	Burly Sidekick	item:Mohawk Wig<1
+yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography
 # We also want an amulet, but not badly enough to yellow ray it unless we're backtracking to get it
 yellowray	1	Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6
 # Dressing up as a harem girl because we have no shame
@@ -170,4 +170,7 @@ yellowray	32	larval filthworm	!familiar:XO Skeleton;!class:Ed
 yellowray	33	filthworm drone	!familiar:XO Skeleton;!class:Ed
 yellowray	34	filthworm royal guard	!familiar:XO Skeleton;!class:Ed
 yellowray	35	Knight (Snake)	class:Ed
+yellowray	36	bearpig topiary animal	familiar:Melodramedary
+yellowray	37	elephant (meatcar?) topiary animal	familiar:Melodramedary
+yellowray	38	spider (duck?) topiary animal	familiar:Melodramedary
 

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -468,60 +468,16 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(2); // pick the mushroom.
 			break;
 		case 1427: // Hidden Junction (Cartography)
-			run_choice(1); // fight the screambat.
-			break;
 		case 1428: // Choice 1428 is Your Neck of the Woods (Cartography)
-			run_choice(2); // advance neck quest
-			break;
 		case 1429: // Choice 1429 is No Nook Unknown (Cartography)
-			run_choice(1); // acquire 2 evil eyes
-			break;
 		case 1430: // Choice 1430 is Ghostly Memories (Cartography)
-			run_choice(1); // If we are adventuring in the peak we are trying to clear the peak, go to the horror
-			break;
 		case 1431: // Choice 1431 is Here There Be Giants (Cartography)
-			run_choice(1); // go to steampunk giant to complete the quest
-			break;
 		case 1432: // Choice 1432 is Mob Maptality (Cartography)
-			float fire_protestors = item_amount($item[Flamin\' Whatshisname]) > 0 ? 10 : 3;
-			float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");
-			float sleaze_protestors = square_root(sleaze_amount);
-			float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
-			foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
-				{
-					if (equipped_amount(it) > 0) {
-						lynyrd_protestors += 5;
-					}
-				}
-			float best_protestors = max(fire_protestors, max(sleaze_protestors, lynyrd_protestors));
-			if(best_protestors == lynyrd_protestors)
-			{
-				run_choice(2);
-			}
-			else if(best_protestors == sleaze_protestors)
-			{
-				run_choice(1);
-			}
-			else if (best_protestors == fire_protestors)
-			{
-				run_choice(3);
-			}
-			break;
 		case 1433: // Choice 1433 is Hippy camp verge of war Sneaky Sneaky (Cartography)
-			run_choice(3); // start the war
-			break;
 		case 1434: // Choice 1434 is frat camp verge of war Sneaky Sneaky (Cartography)
-			run_choice(2); // start the war
-			break;
+		case 1435: // Leading Yourself Right to Them (Map the Monsters)
 		case 1436: // Choice 1436 is Billiards Room Options (Cartography)
-			if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
-			{
-				run_choice(2);		//try to win the key. on failure still gain 1 pool skill
-			}
-			else
-			{
-				run_choice(1);		//acquire the pool cue
-			}
+			cartographyChoiceHandler(choice);
 			break;
 		default:
 			break;

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -567,7 +567,8 @@ void equipRollover()
 boolean auto_forceEquipSword() {
 	item swordToEquip = $item[none];
 	// use the ebony epee if we have it
-	if (possessEquipment($item[ebony epee])) {
+	if (possessEquipment($item[ebony epee]))
+	{
 		swordToEquip = $item[ebony epee];
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -595,5 +595,5 @@ boolean equipSword() {
 		}
 	}
 
-	return autoForceEquip(swordToEquip, $slot[weapon]);
+	return autoForceEquip($slot[weapon], swordToEquip);
 }

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -563,3 +563,37 @@ void equipRollover()
 		auto_log_info("Done putting on jammies, if you pulled anything with a rollover effect you might want to make sure it's equipped before you log out.", "red");
 	}
 }
+
+boolean equipSword() {
+	item swordToEquip = $item[none];
+	// use the ebony epee if we have it
+	if (possessEquipment($item[ebony epee])) {
+		swordToEquip = $item[ebony epee];
+	}
+
+	if (swordToEquip == $item[none])
+	{
+		// check for some swords that we might have acquired in run already. Yes machetes are actually swords.
+		foreach it in $items[antique machete, black sword, broken sword, cardboard katana, cardboard wakizashi,
+		drowsy sword, knob goblin deluxe scimitar, knob goblin scimitar, lupine sword, muculent machete,
+		ridiculously huge sword, serpentine sword, vorpal blade, white sword, sweet ninja sword]
+		{
+			if (possessEquipment(it) && can_equip(it))
+			{
+				swordToEquip = it;
+				break;
+			}
+		}
+	}
+
+	if (swordToEquip == $item[none])
+	{
+		// if we still don't have a sword available, buy one for a trivial amount of meat.
+		if (retrieve_item(1, $item[sweet ninja sword])) // costs 50 meat from the armorer and leggerer
+		{
+			swordToEquip = $item[sweet ninja sword];
+		}
+	}
+
+	return autoEquip(swordToEquip);
+}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -564,7 +564,7 @@ void equipRollover()
 	}
 }
 
-boolean equipSword() {
+boolean auto_forceEquipSword() {
 	item swordToEquip = $item[none];
 	// use the ebony epee if we have it
 	if (possessEquipment($item[ebony epee])) {

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -595,5 +595,5 @@ boolean equipSword() {
 		}
 	}
 
-	return autoEquip(swordToEquip);
+	return autoForceEquip(swordToEquip, $slot[weapon]);
 }

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -131,7 +131,7 @@ boolean auto_pre_adventure()
 			adjustForReplaceIfPossible(mon);
 		}
 
-		if(auto_wantToSniff(mon, place) && !burningDelay)
+		if (auto_wantToSniff(mon, place) && !burningDelay)
 		{
 			adjustForSniffingIfPossible(mon);
 		}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -130,6 +130,11 @@ boolean auto_pre_adventure()
 		{
 			adjustForReplaceIfPossible(mon);
 		}
+
+		if(auto_wantToSniff(mon, place) && !burningDelay)
+		{
+			adjustForSniffingIfPossible(mon);
+		}
 	}
 
 	if (in_koe() && possessEquipment($item[low-pressure oxygen tank]))

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -357,9 +357,6 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 		}
 		delta = simValue("Initiative") - numeric_modifier("Initiative");
 		auto_log_debug("With gear we can get to " + result());
-
-		if(!speculative)
-			handleFamiliar("init");
 	}
 
 	boolean pass()
@@ -369,6 +366,13 @@ float provideInitiative(int amt, boolean doEquips, boolean speculative)
 
 	if(pass())
 		return result();
+
+	if (!speculative && doEquips)
+	{
+		handleFamiliar("init");
+		if(pass())
+			return result();
+	}
 
 	void handleEffect(effect eff)
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -347,7 +347,7 @@ boolean organsFull()
 boolean backupSetting(string setting, string newValue)
 {
 	string[string,string] defaults;
-	file_to_map("defaults.txt", defaults);
+	file_to_map("data/defaults.txt", defaults);
 
 	int found = 0;
 	string oldValue = "";
@@ -386,7 +386,7 @@ boolean backupSetting(string setting, string newValue)
 boolean restoreAllSettings()
 {
 	string[string,string] defaults;
-	file_to_map("defaults.txt", defaults);
+	file_to_map("data/defaults.txt", defaults);
 
 	boolean retval = false;
 	foreach domain, name, value in defaults

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1337,11 +1337,7 @@ boolean adjustForYellowRay(string combat_string)
 	}
 	if(combat_string == ("skill " + $skill[Unleash the Devil's Kiss]))
 	{
-		// avoid uselessly reconfiguring the cape
-		if (get_property("retroCapeSuperhero") != "heck" && get_property("retroCapeWashingInstructions") != "kiss")
-		{
-			cli_execute("retrocape mysticality kiss");
-		}
+		auto_configureRetrocape("heck", "kiss");
 		return autoEquip($slot[back], $item[unwrapped knock-off retro superhero cape]);
 	}
 	return true;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1447,7 +1447,8 @@ boolean adjustForSniffingIfPossible(monster target)
 		auto_log_info("Uneffecting On the trail to have Transcendent Olfaction available for " + target, "blue");
 		monster old_olfact = get_property("olfactedMonster").to_monster();
 		string output = cli_execute_output("uneffect On the trail");
-		if (output.contains_text("On the Trail removed.")) {
+		if (output.contains_text("On the Trail removed."))
+		{
 			handleTracker($item[soft green echo eyedrop antidote], old_olfact, "auto_otherstuff");
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -920,7 +920,7 @@ boolean canYellowRay(monster target)
 	}
 	# Pulled Yellow Taffy	- How do we handle the underwater check?
 	# He-Boulder?			- How do we do this?
-	return yellowRayCombatString(target) != "";
+	return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal] contains target) != "";
 }
 
 boolean canYellowRay()
@@ -1241,7 +1241,7 @@ boolean adjustForBanishIfPossible(monster enemy, location loc)
 	return false;
 }
 
-string yellowRayCombatString(monster target, boolean inCombat)
+string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDrop)
 {
 	if(have_effect($effect[Everything Looks Yellow]) <= 0)
 	{
@@ -1298,13 +1298,18 @@ string yellowRayCombatString(monster target, boolean inCombat)
 	if((inCombat ? have_equipped($item[Fourth of May cosplay saber]) : possessEquipment($item[Fourth of May cosplay saber])) && (auto_saberChargesAvailable() > 0))
 	{
 		// can't use the force on uncopyable monsters
-		if(target == $monster[none] || target.copyable)
+		if(target == $monster[none] || target.copyable || noForceDrop)
 		{
 			return auto_combatSaberYR();
 		}
 	}
 
 	return "";
+}
+
+string yellowRayCombatString(monster target, boolean inCombat)
+{
+	return yellowRayCombatString(target, inCombat, false);
 }
 
 string yellowRayCombatString(monster target)
@@ -1346,7 +1351,7 @@ boolean adjustForYellowRayIfPossible(monster target)
 {
 	if(canYellowRay(target))
 	{
-		string yr_string = yellowRayCombatString(target);
+		string yr_string = yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal] contains target);
 		auto_log_info("Adjusting to have YR available for " + target + ": " + yr_string, "blue");
 		return adjustForYellowRay(yr_string);
 	}
@@ -1421,6 +1426,46 @@ boolean adjustForReplaceIfPossible(monster target)
 boolean adjustForReplaceIfPossible()
 {
 	return adjustForReplaceIfPossible($monster[none]);
+}
+
+boolean canSniff(monster enemy, location loc)
+{
+	if (have_skill($skill[Transcendent Olfaction]) &&
+	auto_is_valid($skill[Transcendent Olfaction]) &&
+	get_property("olfactedMonster").to_monster() != enemy &&
+	(have_effect($effect[On The Trail]) == 0 || item_amount($item[soft green echo eyedrop antidote]) > 0))
+	{
+		return auto_wantToSniff(enemy, loc);
+	}
+	return false;
+}
+
+boolean adjustForSniffingIfPossible(monster target)
+{
+	if(have_skill($skill[Transcendent Olfaction]) &&
+	auto_is_valid($skill[Transcendent Olfaction]) &&
+	get_property("olfactedMonster").to_monster() != target &&
+	have_effect($effect[On the trail]) > 0 &&
+	item_amount($item[soft green echo eyedrop antidote]) > 0)
+	{
+		auto_log_info("Uneffecting On the trail to have Transcendent Olfaction available for " + target, "blue");
+		monster old_olfact = get_property("olfactedMonster").to_monster();
+		string output = cli_execute_output("uneffect On the trail");
+		if (output.contains_text("On the Trail removed.")) {
+			handleTracker($item[soft green echo eyedrop antidote], old_olfact, "auto_otherstuff");
+			return true;
+		}
+		else
+		{
+			auto_log_info("Failed to Uneffect On the trail for some reason?", "blue");
+		}
+	}
+	return false;
+}
+
+boolean adjustForSniffingIfPossible()
+{
+	return adjustForSniffingIfPossible($monster[none]);
 }
 
 string statCard()

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -517,6 +517,11 @@ generic_t zone_combatMod(location loc)
 	case $location[Cobb's Knob Treasury]:
 		value = 15;
 		break;
+	case $location[The VERY Unquiet Garves]:
+		if (item_amount($item[Wand of Nagamar]) == 0 && internalQuestStatus("questL13Final") == 12 && !in_koe()) {
+			value = -100;
+		}
+		break;
 	case $location[Super Villain\'s Lair]:
 		if(!get_property("_villainLairColorChoiceUsed").to_boolean() || !get_property("_villainLairDoorChoiceUsed").to_boolean() || !get_property("_villainLairSymbologyChoiceUsed").to_boolean())
 		{
@@ -681,7 +686,7 @@ generic_t zone_delay(location loc)
 		}
 		break;
 	case $location[The Copperhead Club]:
-		if (internalQuestStatus("questL11Shen") > 0 && internalQuestStatus("questL11Shen") % 2 == 0)
+		if (internalQuestStatus("questL11Shen") > 0 && internalQuestStatus("questL11Shen") < 8)
 		{
 			value = 5 - (loc.turns_spent - get_property("auto_lastShenTurn").to_int());
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1018,6 +1018,7 @@ boolean possessOutfit(string outfit);
 void equipBaseline();
 void ensureSealClubs();
 void equipRollover();
+boolean auto_forceEquipSword();
 
 ########################################################################################################
 //Defined in autoscend/auto_familiar.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -132,6 +132,7 @@ int amountTurkeyBooze();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2015.ash
+boolean auto_haveLovebugs();
 boolean mayo_acquireMayo(item it);
 boolean auto_barrelPrayers();
 boolean auto_mayoItems();
@@ -382,6 +383,7 @@ boolean auto_canTendMushroomGarden();
 int auto_piranhaPlantFightsRemaining();
 boolean auto_mushroomGardenHandler();
 boolean auto_getGuzzlrCocktailSet();
+boolean auto_canCamelSpit();
 boolean auto_latheHardwood(item toLathe);
 boolean auto_latheAppropriateWeapon();
 boolean auto_hasCargoShorts();
@@ -401,6 +403,9 @@ boolean auto_cargoShortsOpenPocket(monster m);
 boolean auto_cargoShortsOpenPocket(effect e);
 boolean auto_cargoShortsOpenPocket(stat e);
 boolean auto_cargoShortsOpenPocket(string s);
+boolean auto_canMapTheMonsters();
+boolean auto_mapTheMonsters();
+void cartographyChoiceHandler(int choice);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
@@ -772,6 +777,7 @@ boolean L10_basement();
 boolean L10_ground();
 boolean L10_topFloor();
 boolean L10_holeInTheSkyUnlock();
+boolean L10_rainOnThePlains();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_11.ash
@@ -881,6 +887,7 @@ boolean L13_sorceressDoor();
 boolean L13_towerNSTower();
 boolean L13_towerNSFinal();
 boolean L13_towerNSNagamar();
+boolean L13_towerAscent();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_any.ash
@@ -1228,6 +1235,7 @@ string banisherCombatString(monster enemy, location loc);
 boolean canBanish(monster enemy, location loc);
 boolean adjustForBanish(string combat_string);
 boolean adjustForBanishIfPossible(monster enemy, location loc);
+string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDrop);
 string yellowRayCombatString(monster target, boolean inCombat);
 string yellowRayCombatString(monster target);
 string yellowRayCombatString();
@@ -1242,6 +1250,9 @@ boolean canReplace();
 boolean adjustForReplace(string combat_string);
 boolean adjustForReplaceIfPossible(monster target);
 boolean adjustForReplaceIfPossible();
+boolean canSniff(monster enemy, location loc);
+boolean adjustForSniffingIfPossible(monster target);
+boolean adjustForSniffingIfPossible();
 string statCard();
 boolean hasTorso();
 boolean isGuildClass();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -406,6 +406,8 @@ boolean auto_cargoShortsOpenPocket(string s);
 boolean auto_canMapTheMonsters();
 boolean auto_mapTheMonsters();
 void cartographyChoiceHandler(int choice);
+boolean auto_hasRetrocape();
+boolean auto_configureRetrocape(string hero, string tag);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -399,7 +399,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
-
+	if ($monsters[pygmy bowler, bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, red butler] contains enemy && canUse($skill[%fn\, spit on them!]))
+	{
+		handleTracker($skill[%fn\, spit on them!], enemy, "auto_otherstuff");
+		return useSkill($skill[%fn\, spit on them!], true);
+	}
 
 	if(have_effect($effect[Temporary Amnesia]) > 0)
 	{
@@ -1396,6 +1400,10 @@ string auto_combatHandler(int round, monster enemy, string text)
 			{
 				return useSkill($skill[Become a Cloud of Mist]);
 			}
+		}
+
+		if (enemy == $monster[dirty thieving brigand] && canUse($skill[Become a Wolf]) && get_property("_vampyreCloakeFormUses").to_int() < 10) {
+			return useSkill($skill[Become a Wolf]);
 		}
 
 		if(canUse($skill[Air Dirty Laundry]))

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1408,7 +1408,8 @@ string auto_combatHandler(int round, monster enemy, string text)
 			}
 		}
 
-		if (enemy == $monster[dirty thieving brigand] && canUse($skill[Become a Wolf]) && get_property("_vampyreCloakeFormUses").to_int() < 10) {
+		if (enemy == $monster[dirty thieving brigand] && canUse($skill[Become a Wolf]) && get_property("_vampyreCloakeFormUses").to_int() < 10)
+		{
 			return useSkill($skill[Become a Wolf]);
 		}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1249,6 +1249,12 @@ string auto_combatHandler(int round, monster enemy, string text)
 		}
 	}
 
+	if (canUse($skill[Slay the Dead]) && enemy.phylum == $phylum[undead])
+	{
+		// instakills Undead and reduces evilness in Cyrpt zones.
+		return useSkill($skill[Slay the Dead]);
+	}
+
 	if(canUse($skill[Bad Medicine]) && (my_mp() >= (3 * mp_cost($skill[Bad Medicine]))))
 	{
 		return useSkill($skill[Bad Medicine]);

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -2,6 +2,11 @@
 #	Handling: shrine to the Barrel God, Chateau Mantegna Room Key, Deck of Every Card
 #
 
+boolean auto_haveLovebugs()
+{
+	return get_property("lovebugsUnlocked").to_boolean() && auto_is_valid($skill[Summon Love Stinkbug]);
+}
+
 boolean mayo_acquireMayo(item it)
 {
 	if(!is_unrestricted($item[Portable Mayo Clinic]))

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1356,7 +1356,7 @@ boolean rethinkingCandy(effect acquire)
 
 boolean rethinkingCandy(effect acquire, boolean simulate)
 {
-	if(!have_skill($skill[Sweet Synthesis]) && !simulate)
+	if((!have_skill($skill[Sweet Synthesis]) || !auto_is_valid($skill[Sweet Synthesis])) && !simulate)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -97,7 +97,7 @@ int auto_powerfulGloveCharges()
 
 boolean auto_powerfulGloveNoncombatSkill(skill sk)
 {
-	if (!auto_hasPowerfulGlove()) return false;
+	if (!auto_hasPowerfulGlove() || !auto_is_valid(sk)) return false;
 
 	if (auto_powerfulGloveCharges() < 5) return false;
 

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -685,14 +685,23 @@ boolean auto_configureRetrocape(string hero, string tag)
 	{
 		return false;
 	}
-	if (!($strings["muscle", "mysticality", "moxie", "vampire", "heck", "robot"] contains hero))
+	if (hero != "muscle"
+	    && hero != "mysticality"
+	    && hero != "moxie"
+	    && hero != "vampire"
+	    && hero != "heck"
+			&& hero != "robot")
 	{
 		return false;
 	}
-	if (!($strings["hold", "thrill", "kiss", "kill"] contains tag))
+	if (tag != "hold"
+	    && tag != "thrill"
+	    && tag != "kiss"
+			&& tag != "kill")
 	{
 		return false;
 	}
+
 	// avoid uselessly reconfiguring the cape
 	if (get_property("retroCapeSuperhero") != hero && get_property("retroCapeWashingInstructions") != tag)
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -501,7 +501,7 @@ boolean auto_canMapTheMonsters()
 
 boolean auto_mapTheMonsters()
 {
-	if(get_property("mappingMonsters").to_boolean())
+	if (get_property("mappingMonsters").to_boolean())
 	{
 		auto_log_warning("Trying to cast map the monsters but we already have an unused cast pending, skipping.", "red");
 		return true;
@@ -612,17 +612,18 @@ void cartographyChoiceHandler(int choice)
 		float sleaze_protestors = square_root(sleaze_amount);
 		float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
 		foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
+		{
+			if (equipped_amount(it) > 0)
 			{
-				if (equipped_amount(it) > 0) {
-					lynyrd_protestors += 5;
-				}
+				lynyrd_protestors += 5;
 			}
+		}
 		float best_protestors = max(fire_protestors, max(sleaze_protestors, lynyrd_protestors));
-		if(best_protestors == lynyrd_protestors)
+		if (best_protestors == lynyrd_protestors)
 		{
 			run_choice(2);
 		}
-		else if(best_protestors == sleaze_protestors)
+		else if (best_protestors == sleaze_protestors)
 		{
 			run_choice(1);
 		}
@@ -654,7 +655,7 @@ void cartographyChoiceHandler(int choice)
 	}
 	else if (choice == 1436) // Billiards Room Options (The Haunted Billiards Room)
 	{
-		if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
+		if (poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
 		{
 			run_choice(2);		//try to win the key. on failure still gain 1 pool skill
 		}
@@ -680,19 +681,19 @@ boolean auto_configureRetrocape(string hero, string tag)
 	{
 		return false;
 	}
-	if (hero != "muscle"
-	    && hero != "mysticality"
-	    && hero != "moxie"
-	    && hero != "vampire"
-	    && hero != "heck"
-			&& hero != "robot")
+	if (hero != "muscle" &&
+			hero != "mysticality" &&
+			hero != "moxie" &&
+			hero != "vampire" &&
+			hero != "heck" &&
+			hero != "robot")
 	{
 		return false;
 	}
-	if (tag != "hold"
-	    && tag != "thrill"
-	    && tag != "kiss"
-			&& tag != "kill")
+	if (tag != "hold" &&
+			tag != "thrill" &&
+			tag != "kiss" &&
+			tag != "kill")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -276,6 +276,11 @@ boolean auto_getGuzzlrCocktailSet() {
 	return false;
 }
 
+boolean auto_canCamelSpit()
+{
+	return canChangeToFamiliar($familiar[Melodramedary]) && get_property("camelSpit").to_int() == 100;
+}
+
 boolean auto_latheHardwood(item toLathe)
 {
 	// can't lathe if lathe is out of standard (or otherwise unusable)
@@ -483,4 +488,188 @@ boolean auto_cargoShortsOpenPocket(string s)
 		return auto_cargoShortsOpenPocket(s.to_stat());
 
 	return false;
+}
+
+boolean auto_canMapTheMonsters()
+{
+	if (have_skill($skill[Map the Monsters]) && auto_is_valid($skill[Map the Monsters]))
+	{
+		return get_property("_monstersMapped").to_int() < 3;
+	}
+	return false;
+}
+
+boolean auto_mapTheMonsters()
+{
+	if(get_property("auto_mappingMonsters").to_boolean())
+	{
+		auto_log_warning("Trying to cast map the monsters but we already have an unused cast pending, skipping.", "red");
+		return true;
+	}
+	if (auto_canMapTheMonsters())
+	{
+		if (use_skill(1, $skill[Map the Monsters]))
+		{
+			set_property("auto_mappingMonsters", true);
+		}
+		return true;
+	}
+	return false;
+}
+
+monster auto_monsterToMap(location loc)
+{
+	monster enemy = $monster[none];
+	switch (loc)
+	{
+		case $location[8-Bit Realm]:
+			enemy = $monster[Blooper];
+			break;
+		case $location[The Haunted Library]:
+			enemy = $monster[writing desk];
+			break;
+		case $location[The Defiled Niche]:
+			enemy = $monster[dirty old lihc];
+			break;
+		case $location[The Goatlet]:
+			enemy = $monster[dairy goat];
+			break;
+		case $location[Twin Peak]:
+			enemy = $monster[bearpig topiary animal];
+			break;
+		case $location[A Mob of Zeppelin Protesters]:
+			enemy = $monster[blue oyster cultist];
+			break;
+		case $location[The Red Zeppelin]:
+			enemy = $monster[red butler];
+			break;
+		case $location[Inside the Palindome]:
+			enemy = $monster[Bob Racecar];
+			break;
+		case $location[The Hidden Bowling Alley]:
+			enemy = $monster[Pygmy Bowler];
+			break;
+		case $location[The Hidden Hospital]:
+			enemy = $monster[Pygmy Witch Surgeon];
+			break;
+		case $location[The Haunted Laundry Room]:
+			enemy = $monster[cabinet of dr. limpieza];
+			break;
+		case $location[The Haunted Wine Cellar]:
+			enemy = $monster[possessed wine rack];
+			break;
+		case $location[The Middle Chamber]:
+			enemy = $monster[tomb rat];
+			break;
+		case $location[Sonofa Beach]:
+			enemy = $monster[lobsterfrogman]; // not implemented yet (will be used to saber copy in 2021)
+			break;
+	}
+	return enemy;
+}
+
+void cartographyChoiceHandler(int choice)
+{
+	auto_log_info("cartographyChoiceHandler Running choice " + choice, "blue");
+	if (choice == 1427) // Hidden Junction (Guano Junction)
+	{
+		run_choice(1); // fight the screambat.
+	}
+	else if (choice == 1428) // Your Neck of the Woods (The Dark Neck of the Woods)
+	{
+		run_choice(2); // skip first 2 quest non-combats
+	}
+	else if (choice == 1429) // No Nook Unknown (The Defiled Nook)
+	{
+			run_choice(1); // acquire 2 evil eyes
+	}
+	else if (choice == 1430) // Ghostly Memories (A-boo Peak)
+	{
+		run_choice(1); // If we are adventuring in the peak we are trying to clear the peak, go to the horror
+	}
+	else if (choice == 1431) // Choice 1431 is Here There Be Giants (Cartography)
+	{
+		if (internalQuestStatus("questL10Garbage") == 9)
+		{
+			if (item_amount($item[model airship]) > 0)
+			{
+				run_choice(1); // go to steampunk choice to complete the quest
+			}
+			else if (have_equipped($item[mohawk wig]))
+			{
+				run_choice(4); // go to the punk rock choice to complete the quest
+			}
+			else
+			{
+				run_choice(3); // go to the raver choice to get the record?
+			}
+		}
+		else
+		{
+			run_choice(1); // go to steampunk choice to open the hole in the sky.
+		}
+	}
+	else if (choice == 1432) // Mob Maptality (A Mob of Zeppelin Protesters)
+	{
+		float fire_protestors = item_amount($item[Flamin\' Whatshisname]) > 0 ? 10 : 3;
+		float sleaze_amount = numeric_modifier("sleaze damage") + numeric_modifier("sleaze spell damage");
+		float sleaze_protestors = square_root(sleaze_amount);
+		float lynyrd_protestors = have_effect($effect[Musky]) > 0 ? 6 : 3;
+		foreach it in $items[lynyrdskin cap, lynyrdskin tunic, lynyrdskin breeches]
+			{
+				if (equipped_amount(it) > 0) {
+					lynyrd_protestors += 5;
+				}
+			}
+		float best_protestors = max(fire_protestors, max(sleaze_protestors, lynyrd_protestors));
+		if(best_protestors == lynyrd_protestors)
+		{
+			run_choice(2);
+		}
+		else if(best_protestors == sleaze_protestors)
+		{
+			run_choice(1);
+		}
+		else if (best_protestors == fire_protestors)
+		{
+			run_choice(3);
+		}
+	}
+	else if (choice == 1433) // Sneaky Sneaky (The Hippy Camp (Verge of War))
+	{
+		run_choice(3); // start the war
+	}
+	else if (choice == 1434) // Sneaky Sneaky (Orcish Frat House (Verge of War))
+	{
+		run_choice(2); // start the war
+	}
+	else if (choice == 1435) // Leading Yourself Right to Them (Map the Monsters)
+	{
+		monster enemy = auto_monsterToMap(my_location());
+		if (enemy != $monster[none])
+		{
+			handleTracker($skill[Map the Monsters], enemy, "auto_otherstuff");
+			set_property("auto_mappingMonsters", false);
+			run_choice(1, `heyscriptswhatsupwinkwink={enemy.to_int()}`);
+		}
+		else
+		{
+			abort("trying to map a monster but don't know which monster to map!");
+		}
+	}
+	else if (choice == 1436) // Billiards Room Options (The Haunted Billiards Room)
+	{
+		if(poolSkillPracticeGains() == 1 || currentPoolSkill() > 15)
+		{
+			run_choice(2);		//try to win the key. on failure still gain 1 pool skill
+		}
+		else
+		{
+			run_choice(1);		//acquire the pool cue
+		}
+	}
+	else
+	{
+		abort("unhandled choice in cartographyChoiceHandler");
+	}
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -673,3 +673,31 @@ void cartographyChoiceHandler(int choice)
 		abort("unhandled choice in cartographyChoiceHandler");
 	}
 }
+
+boolean auto_hasRetrocape()
+{
+	return possessEquipment($item[unwrapped knock-off retro superhero cape]) && auto_is_valid($item[unwrapped knock-off retro superhero cape]);
+}
+
+boolean auto_configureRetrocape(string hero, string tag)
+{
+	if (!auto_hasRetrocape())
+	{
+		return false;
+	}
+	if (!($strings["muscle", "mysticality", "moxie", "vampire", "heck", "robot"] contains hero))
+	{
+		return false;
+	}
+	if (!($strings["hold", "thrill", "kiss", "kill"] contains tag))
+	{
+		return false;
+	}
+	// avoid uselessly reconfiguring the cape
+	if (get_property("retroCapeSuperhero") != hero && get_property("retroCapeWashingInstructions") != tag)
+	{
+		// retrocape [muscle | mysticality | moxie | vampire | heck | robot] [hold | thrill | kiss | kill]
+		cli_execute(`retrocape {hero} {tag}`);
+	}
+	return get_property("retroCapeSuperhero") == hero && get_property("retroCapeWashingInstructions") == tag;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -716,7 +716,7 @@ boolean auto_configureRetrocape(string hero, string tag)
 	}
 
 	// avoid uselessly reconfiguring the cape
-	if (get_property("retroCapeSuperhero") != tempHero && get_property("retroCapeWashingInstructions") != tag)
+	if (get_property("retroCapeSuperhero") != tempHero || get_property("retroCapeWashingInstructions") != tag)
 	{
 		// retrocape [muscle | mysticality | moxie | vampire | heck | robot] [hold | thrill | kiss | kill]
 		cli_execute(`retrocape {tempHero} {tag}`);

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -701,12 +701,25 @@ boolean auto_configureRetrocape(string hero, string tag)
 	{
 		return false;
 	}
+	string tempHero = hero;
+	if (hero == "muscle")
+	{
+		temphero = "vampire";
+	}
+	if (hero == "mysticality")
+	{
+		temphero = "heck";
+	}
+	if (hero == "moxie")
+	{
+		temphero = "robot";
+	}
 
 	// avoid uselessly reconfiguring the cape
-	if (get_property("retroCapeSuperhero") != hero && get_property("retroCapeWashingInstructions") != tag)
+	if (get_property("retroCapeSuperhero") != tempHero && get_property("retroCapeWashingInstructions") != tag)
 	{
 		// retrocape [muscle | mysticality | moxie | vampire | heck | robot] [hold | thrill | kiss | kill]
-		cli_execute(`retrocape {hero} {tag}`);
+		cli_execute(`retrocape {tempHero} {tag}`);
 	}
-	return get_property("retroCapeSuperhero") == hero && get_property("retroCapeWashingInstructions") == tag;
+	return get_property("retroCapeSuperhero") == tempHero && get_property("retroCapeWashingInstructions") == tag;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -501,18 +501,14 @@ boolean auto_canMapTheMonsters()
 
 boolean auto_mapTheMonsters()
 {
-	if(get_property("auto_mappingMonsters").to_boolean())
+	if(get_property("mappingMonsters").to_boolean())
 	{
 		auto_log_warning("Trying to cast map the monsters but we already have an unused cast pending, skipping.", "red");
 		return true;
 	}
 	if (auto_canMapTheMonsters())
 	{
-		if (use_skill(1, $skill[Map the Monsters]))
-		{
-			set_property("auto_mappingMonsters", true);
-		}
-		return true;
+		return use_skill(1, $skill[Map the Monsters]);
 	}
 	return false;
 }
@@ -649,7 +645,6 @@ void cartographyChoiceHandler(int choice)
 		if (enemy != $monster[none])
 		{
 			handleTracker($skill[Map the Monsters], enemy, "auto_otherstuff");
-			set_property("auto_mappingMonsters", false);
 			run_choice(1, `heyscriptswhatsupwinkwink={enemy.to_int()}`);
 		}
 		else

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -13,7 +13,7 @@ boolean L5_getEncryptionKey()
 
 	// Defer if we can line up with the first semi-rare window to get a lunchbox
 	// Only if we don't have a fortune cookie counter
-	if (my_turncount() < 70 && !contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie"))
+	if (my_turncount() < 70 && !contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie") && $location[The Outskirts of Cobb's Knob].turns_spent < 10)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -114,6 +114,10 @@ boolean L7_crypt()
 		}
 
 		auto_log_info("The Niche!", "blue");
+		if (canSniff($monster[Dirty Old Lihc], $location[The Defiled Niche]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Dirty Old Lihc.");
+		}
 		return autoAdv(1, $location[The Defiled Niche]);
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -42,7 +42,7 @@ boolean L7_crypt()
 	{
 		if (auto_configureRetrocape("vampire", "kill")) {
 			autoEquip($item[unwrapped knock-off retro superhero cape]);
-			equipSword();
+			auto_forceEquipSword();
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -40,7 +40,8 @@ boolean L7_crypt()
 
 	void knockOffCapePrep()
 	{
-		if (auto_configureRetrocape("vampire", "kill")) {
+		if (auto_configureRetrocape("vampire", "kill"))
+		{
 			autoEquip($item[unwrapped knock-off retro superhero cape]);
 			auto_forceEquipSword();
 		}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -38,6 +38,15 @@ boolean L7_crypt()
 		}
 	}
 
+	void knockOffCapePrep()
+	{
+		if (auto_hasRetrocape()) {
+			auto_configureRetrocape("vampire", "kill");
+			autoEquip($item[unwrapped knock-off retro superhero cape]);
+			equipSword();
+		}
+	}
+
 	// make sure quest status is correct before we attempt to adventure.
 	visit_url("crypt.php");
 	use(1, $item[Evilometer]);
@@ -53,7 +62,7 @@ boolean L7_crypt()
 		provideInitiative(850, true);
 
 		autoEquip($item[Gravy Boat]);
-
+		knockOffCapePrep();
 		addToMaximize("100initiative 850max");
 
 		if(get_property("cyrptAlcoveEvilness").to_int() >= 28)
@@ -62,7 +71,7 @@ boolean L7_crypt()
 		}
 
 		auto_log_info("The Alcove! (" + initiative_modifier() + ")", "blue");
-		return autoAdv(1, $location[The Defiled Alcove]);
+		return autoAdv($location[The Defiled Alcove]);
 	}
 
 	// In KoE, skeleton astronauts are random encounters that drop Evil Eyes.
@@ -80,6 +89,7 @@ boolean L7_crypt()
 		auto_log_info("The Nook!", "blue");
 		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
 		autoEquip($item[Gravy Boat]);
+		knockOffCapePrep();
 
 		bat_formBats();
 
@@ -87,8 +97,8 @@ boolean L7_crypt()
 			januaryToteAcquire($item[broken champagne bottle]);
 		}
 
-		autoAdv(1, $location[The Defiled Nook]);
-		return true;
+		
+		return autoAdv($location[The Defiled Nook]);
 	}
 	else if(skip_in_koe)
 	{
@@ -102,6 +112,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Artistic Goth Kid]);
 		}
 		autoEquip($item[Gravy Boat]);
+		knockOffCapePrep();
 
 		if(auto_have_familiar($familiar[Space Jellyfish]) && (get_property("_spaceJellyfishDrops").to_int() < 3))
 		{
@@ -118,7 +129,7 @@ boolean L7_crypt()
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Dirty Old Lihc.");
 		}
-		return autoAdv(1, $location[The Defiled Niche]);
+		return autoAdv($location[The Defiled Niche]);
 	}
 
 	if(get_property("cyrptCrannyEvilness").to_int() > 0)
@@ -132,6 +143,7 @@ boolean L7_crypt()
 		}
 
 		autoEquip($item[Gravy Boat]);
+		knockOffCapePrep();
 
 		spacegateVaccine($effect[Emotional Vaccine]);
 
@@ -164,8 +176,7 @@ boolean L7_crypt()
 		auto_MaxMLToCap(auto_convertDesiredML(149), true);
 
 		addToMaximize("200ml " + auto_convertDesiredML(149) + "max");
-		autoAdv(1, $location[The Defiled Cranny]);
-		return true;
+		return autoAdv($location[The Defiled Cranny]);
 	}
 
 	if(get_property("cyrptTotalEvilness").to_int() <= 0)

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -40,8 +40,7 @@ boolean L7_crypt()
 
 	void knockOffCapePrep()
 	{
-		if (auto_hasRetrocape()) {
-			auto_configureRetrocape("vampire", "kill");
+		if (auto_configureRetrocape("vampire", "kill")) {
 			autoEquip($item[unwrapped knock-off retro superhero cape]);
 			equipSword();
 		}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -96,7 +96,6 @@ boolean L7_crypt()
 			januaryToteAcquire($item[broken champagne bottle]);
 		}
 
-		
 		return autoAdv($location[The Defiled Nook]);
 	}
 	else if(skip_in_koe)

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -226,6 +226,10 @@ boolean L8_getGoatCheese()
 	{
 		auto_sourceTerminalEducate($skill[Extract], $skill[Duplicate]);
 	}
+	if (canSniff($monster[Dairy Goat], $location[The Goatlet]) && auto_mapTheMonsters())
+	{
+		auto_log_info("Attemping to use Map the Monsters to olfact a Dairy Goat.");
+	}
 	boolean retval = autoAdv($location[The Goatlet]);
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 	return retval;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -153,11 +153,9 @@ boolean L9_chasmBuild()
 
 
 	auto_log_info("Chasm time", "blue");
-
-	if(item_amount($item[fancy oil painting]) > 0)
-	{
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-	}
+	
+	// make sure our progress count is correct before we do anything.
+	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 
 	// -Combat is useless here since NC is triggered by killing Orcs...So we kill orcs better!
 	// -ML helps us deal more cold damage and trigger the NC faster.
@@ -768,6 +766,21 @@ boolean L9_twinPeak()
 		}
 	}
 
+	if (auto_canCamelSpit() && auto_canMapTheMonsters())
+	{
+		if (adjustForYellowRayIfPossible($monster[bearpig topiary animal]))
+		{
+			if (auto_mapTheMonsters())
+			{
+				handleFamiliar($familiar[Melodramedary]);
+				auto_log_info("Attemping to use Map the Monsters to Yellow Ray a Camel Spitted bearpig topiary animal. Yes that is a mouthful but lets hope it works and we get 4 rusty hedge trimmers!");
+			}
+		}
+		else
+		{
+			return false;
+		}
+	}
 	return autoAdv($location[Twin Peak]);
 }
 
@@ -899,9 +912,9 @@ boolean L9_highLandlord()
 		return true;
 	}
 
-	if(L9_twinPeak())			return true;
 	if(L9_aBooPeak())			return true;
 	if(L9_oilPeak())			return true;
+	if(L9_twinPeak())			return true;
 
 	if (internalQuestStatus("questL09Topping") == 3)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -125,7 +125,10 @@ boolean L10_basement()
 		set_property("choiceAdventure669", "1"); // The Fast and the Furry-ous: Open Ground floor (with Umbrella) or Neckbeard Choice
 	}
 
-	auto_forceNextNoncombat();
+	if (possessEquipment($item[Amulet of Extreme Plot Significance]))
+	{
+		auto_forceNextNoncombat();
+	}
 
 	if(in_gnoob() && auto_have_familiar($familiar[Robortender]))
 	{
@@ -135,7 +138,7 @@ boolean L10_basement()
 		}
 	}
 
-	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
+	autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
 	resetMaximize();
 	
 
@@ -232,8 +235,7 @@ boolean L10_ground()
 		}
 	}
 
-	autoAdv(1, $location[The Castle in the Clouds in the Sky (Ground Floor)]);
-	return true;
+	return autoAdv($location[The Castle in the Clouds in the Sky (Ground Floor)]);
 }
 
 boolean L10_topFloor()

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1634,7 +1634,7 @@ boolean L11_mauriceSpookyraven()
 		}
 		if (canSniff($monster[Possessed Wine Rack], $location[The Haunted Wine Cellar]) && auto_mapTheMonsters())
 		{
-			auto_log_info("Attemping to use Map the Monsters to olfact a Cabinet of Dr. Limpieza.");
+			auto_log_info("Attemping to use Map the Monsters to olfact a Possessed Wine Rack.");
 		}
 		return autoAdv($location[The Haunted Wine Cellar]);
 	}
@@ -1847,7 +1847,8 @@ boolean L11_ronCopperhead()
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Red Butler.");
 		}
-		if (auto_canCamelSpit()) {
+		if (auto_canCamelSpit())
+		{
 			auto_log_info("Bringing the Camel to spit on a Red Butler for glark cables.");
 			handleFamiliar($familiar[Melodramedary]);
 		}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -430,10 +430,11 @@ boolean LX_unlockManorSecondFloor() {
 
 	auto_log_info("Well, we need writing desks", "blue");
 	auto_log_info("Going to the library!", "blue");
-	if (autoAdv($location[The Haunted Library])) {
-		return true;
+	if (canSniff($monster[Writing Desk], $location[The Haunted Library]) && auto_mapTheMonsters())
+	{
+		auto_log_info("Attemping to use Map the Monsters to olfact a writing desk.");
 	}
-	return false;
+	return autoAdv($location[The Haunted Library]);
 }
 
 boolean LX_spookyravenManorFirstFloor() {
@@ -1071,7 +1072,7 @@ boolean L11_aridDesert()
 		int need = 100 - get_property("desertExploration").to_int();
 		auto_log_info("Getting some ultrahydrated, I suppose. Desert left: " + need, "blue");
 
-		if((need > (5 * progress)) && (cloversAvailable() > 2) && !get_property("lovebugsUnlocked").to_boolean())
+		if((need > (5 * progress)) && cloversAvailable() > 2 && !auto_haveLovebugs())
 		{
 			auto_log_info("Gonna clover this, yeah, it only saves 2 adventures. So?", "green");
 			cloverUsageInit();
@@ -1239,39 +1240,9 @@ boolean L11_hiddenCity()
 	if (internalQuestStatus("questL11Curses") > 1 || item_amount($item[Moss-Covered Stone Sphere]) > 0)
 	{
 		uneffect($effect[Thrice-Cursed]);
-		if((have_effect($effect[On The Trail]) > 0) && (get_property("olfactedMonster") == $monster[Pygmy Shaman]))
-		{
-			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
-			{
-				auto_log_info("They stink so much!", "blue");
-				uneffect($effect[On The Trail]);
-			}
-		}
 	}
 
-	if (internalQuestStatus("questL11Business") > 1 || item_amount($item[Crackling Stone Sphere]) > 0)
-	{
-		if((have_effect($effect[On The Trail]) > 0) && (get_property("olfactedMonster") == $monster[Pygmy Witch Accountant]))
-		{
-			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
-			{
-				auto_log_info("No more accountants to hunt!", "blue");
-				uneffect($effect[On The Trail]);
-			}
-		}
-	}
 
-	if (internalQuestStatus("questL11Spare") > 1 || item_amount($item[Scorched Stone Sphere]) > 0)
-	{
-		if((have_effect($effect[On The Trail]) > 0) && (get_property("olfactedMonster") == $monster[Pygmy Bowler]))
-		{
-			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
-			{
-				auto_log_info("No more stinky bowling shoes to worry about!", "blue");
-				uneffect($effect[On The Trail]);
-			}
-		}
-	}
 
 	if (item_amount($item[Moss-Covered Stone Sphere]) == 0 && internalQuestStatus("questL11Business") < 1)
 	{
@@ -1365,6 +1336,15 @@ boolean L11_hiddenCity()
 
 		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 		auto_log_info("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
+		if (canSniff($monster[Pygmy Bowler], $location[The Hidden Bowling Alley]) && auto_mapTheMonsters() && item_amount($item[bowling ball]) < 1)
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Pygmy Bowler.");
+		}
+		if (auto_canCamelSpit() && get_property("hiddenBowlingAlleyProgress").to_int() < 2)
+		{
+			auto_log_info("Bringing the Camel to spit on a Pygmy Bowler for bowling balls.");
+			handleFamiliar($familiar[Melodramedary]);
+		}
 		return autoAdv($location[The Hidden Bowling Alley]);
 	}
 
@@ -1652,6 +1632,10 @@ boolean L11_mauriceSpookyraven()
 		{
 			bat_formBats();
 		}
+		if (canSniff($monster[Possessed Wine Rack], $location[The Haunted Wine Cellar]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Cabinet of Dr. Limpieza.");
+		}
 		return autoAdv($location[The Haunted Wine Cellar]);
 	}
 	if (item_amount($item[blasting soda]) == 0 && !possessEquipment($item[Unstable Fulminate]) && internalQuestStatus("questL11Manor") < 3)
@@ -1660,6 +1644,10 @@ boolean L11_mauriceSpookyraven()
 		if(!bat_wantHowl($location[The Haunted Wine Cellar]))
 		{
 			bat_formBats();
+		}
+		if (canSniff($monster[Cabinet of Dr. Limpieza], $location[The Haunted Laundry Room]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Cabinet of Dr. Limpieza.");
 		}
 		return autoAdv($location[The Haunted Laundry Room]);
 	}
@@ -1806,6 +1794,10 @@ boolean L11_redZeppelin()
 	}
 
 	int lastProtest = get_property("zeppelinProtestors").to_int();
+	if (canSniff($monster[Blue Oyster Cultist], $location[A Mob Of Zeppelin Protesters]) && auto_mapTheMonsters())
+	{
+		auto_log_info("Attemping to use Map the Monsters to olfact a Blue Oyster Cultist.");
+	}
 	boolean retval = autoAdv($location[A Mob Of Zeppelin Protesters]);
 	if(!lastAdventureSpecialNC())
 	{
@@ -1851,6 +1843,14 @@ boolean L11_ronCopperhead()
 		}
 		// For Glark Cables. OPTIMAL!
 		bat_formBats();
+		if (canSniff($monster[Red Butler], $location[The Red Zeppelin]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Red Butler.");
+		}
+		if (auto_canCamelSpit()) {
+			auto_log_info("Bringing the Camel to spit on a Red Butler for glark cables.");
+			handleFamiliar($familiar[Melodramedary]);
+		}
 		boolean retval = autoAdv($location[The Red Zeppelin]);
 		// open red boxes when we get them (not sure if this is the place for this but it'll do for now)
 		if (item_amount($item[red box]) > 0)
@@ -1884,6 +1884,7 @@ boolean L11_shenStartQuest()
 		return false;
 	}
 	backupSetting("choiceAdventure1074", 1);
+	auto_log_info("Going to see the World's Biggest Jerk about some snakes and stones and stuff.", "blue");
 	if (autoAdv($location[The Copperhead Club]))
 	{
 		if (internalQuestStatus("questL11Shen") == 1)
@@ -2235,26 +2236,26 @@ boolean L11_palindome()
 			}
 		}
 
-		if((have_effect($effect[On The Trail]) > 0) && !($monsters[Bob Racecar, Racecar Bob] contains get_property("olfactedMonster").to_monster()) && internalQuestStatus("questL11Palindome") < 2)
-		{
-			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
-			{
-				auto_log_info("Gotta hunt down them Naskar boys.", "blue");
-				uneffect($effect[On The Trail]);
-			}
-		}
-
 		autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
-		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
+		if (handleFamiliar($familiar[Red-Nosed Snapper]))
+		{
 			auto_changeSnapperPhylum($phylum[dude]);
 		}
-		autoAdv($location[Inside the Palindome]);
+		if (canSniff($monster[Bob Racecar], $location[Inside the Palindome]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Bob Racecar.");
+		}
+		boolean advSpent = autoAdv($location[Inside the Palindome]);
 		if(($location[Inside the Palindome].turns_spent > 30) && !in_pokefam() && (auto_my_path() != "G-Lover") && !in_koe())
 		{
 			abort("It appears that we've spent too many turns in the Palindome. If you run me again, I'll try one more time but many I failed finishing the Palindome");
 		}
+		else
+		{
+			return advSpent;
+		}
 	}
-	return true;
+	return false;
 }
 
 boolean L11_unlockPyramid()
@@ -2355,6 +2356,11 @@ boolean L11_unlockEd()
 
 	if((total >= 10) && (my_adventures() >= 4) && get_property("controlRoomUnlock").to_boolean())
 	{
+		if (get_counters("Fortune Cookie", 0, 3) == "Fortune Cookie")
+		{
+			return false;
+		}
+
 		visit_url("place.php?whichplace=pyramid&action=pyramid_control");
 		int x = 0;
 		while(x < 10)
@@ -2401,13 +2407,6 @@ boolean L11_unlockEd()
 			cli_execute("make sugar fairy");
 			buffMaintain($effect[Dance of the Sugar Fairy], 0, 1, 1);
 		}
-		if((have_effect($effect[On The Trail]) > 0) && (get_property("olfactedMonster") != $monster[Tomb Rat]))
-		{
-			if(item_amount($item[soft green echo eyedrop antidote]) > 0)
-			{
-				uneffect($effect[On The Trail]);
-			}
-		}
 		if(have_effect($effect[items.enh]) == 0)
 		{
 			auto_sourceTerminalEnhance("items");
@@ -2423,6 +2422,10 @@ boolean L11_unlockEd()
 		}
 	}
 
+	if (canSniff($monster[Tomb Rat], $location[The Middle Chamber]) && auto_mapTheMonsters())
+	{
+		auto_log_info("Attemping to use Map the Monsters to olfact a Tomb Rat.");
+	}
 	autoAdv(1, $location[The Middle Chamber]);
 	return true;
 }

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -654,7 +654,7 @@ boolean L12_preOutfit()
 		}
 	}
 
-	if(have_skill($skill[Calculate the Universe]) && (my_daycount() == 1))
+	if(have_skill($skill[Calculate the Universe]) && my_daycount() == 1 && get_property("_universeCalculated").to_int() < get_property("skillLevel144").to_int())
 	{
 		return false;
 	}
@@ -881,6 +881,11 @@ boolean L12_filthworms()
 				abort("Can not handle item drop amount for the Filthworms, deja vu!! Either get us to +400% and rerun or do it yourself.");
 			}
 		}
+	}
+
+	if (auto_cargoShortsOpenPocket(343)) // skip straight to the Royal Guard Chamber
+	{
+		handleTracker($item[Cargo Cultist Shorts], $effect[Filthworm Drone Stench], "auto_otherstuff");
 	}
 	
 	boolean retval = false;
@@ -1219,12 +1224,12 @@ boolean L12_sonofaPrefix()
 				{
 					set_property("auto_doCombatCopy", "yes");
 				}
-				if (auto_voteMonster())
+				if (auto_voteMonster() && !auto_voteMonster(true))
 				{
 					auto_voteMonster(false, $location[Sonofa Beach], "");
 					return true;
 				}
-				else if (auto_sausageGoblin())
+				else if (auto_sausageGoblin() && !auto_haveVotingBooth())
 				{
 					auto_sausageGoblin($location[Sonofa Beach], "");
 					return true;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -4,7 +4,7 @@ boolean needStarKey()
 	{
 		return false;
 	}
-	if(item_amount($item[Richard\'s Star Key]) > 0)
+	if(item_amount($item[Richard\'s Star Key]) > 0 || creatable_amount($item[Richard\'s Star Key]) > 0)
 	{
 		return false;
 	}
@@ -165,7 +165,11 @@ boolean LX_getDigitalKey()
 		{
 			autoEquip($item[Fourth of May cosplay saber]);
 		}
-		adv_spent = autoAdv(1, $location[8-bit Realm]);
+		if (canSniff($monster[Blooper], $location[8-bit Realm]) && auto_mapTheMonsters())
+		{
+			auto_log_info("Attemping to use Map the Monsters to olfact a Blooper.");
+		}
+		adv_spent = autoAdv($location[8-bit Realm]);
 	}
 	return adv_spent;
 }
@@ -1434,6 +1438,15 @@ boolean L13_towerNSNagamar()
 		{
 			auto_log_warning("Clovering [The Castle in the Clouds in the Sky (Basement)] for wand parts failed for some reason", "red");
 		}
+	}
+	return false;
+}
+
+boolean L13_towerAscent()
+{
+	if (L13_towerNSContests() || L13_towerNSHedge()|| L13_sorceressDoor() || L13_towerNSTower() || L13_towerNSNagamar() || L13_towerNSFinal())
+	{
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
# Description

- Add using map the monsters and camel spit
- add using Cargo pocket for Filthworms to skip the first 2 chambers
- Add using the Slay the Undead skill in the Cyrpt
- add using SGEEA's to remove On the Trail if we're going somewhere we want to olfact a monster
- change provideInit to only switch familiar if we haven't hit the target from equips (saves switching familiars unnecessarily in some situations)
- use vampire cape Wolf skill for extra meat drop against brigands
- bunch of random bug fixes

Fixes #470 #606 #631 #633 #634 

## How Has This Been Tested?

Ran a couple of HC Standard so far. Last one was broken by mafia changes so I want to run one more before I'm happy this is good.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
