### PR TITLE
couple of issues reported in discord

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -928,7 +928,7 @@ boolean auto_post_adventure()
 		{
 			bjornify_familiar($familiar[el vibrato megadrone]);
 		}
-		if((my_bjorned_familiar() == $familiar[grim brother]) && (get_property("_grimFairyTaleDropsCrown").to_int() >= 1))
+		if((my_bjorned_familiar() == $familiar[grim brother]) && (get_property("_grimFairyTaleDropsCrown").to_int() >= 1) && have_familiar($familiar[El Vibrato Megadrone]))
 		{
 			bjornify_familiar($familiar[el vibrato megadrone]);
 		}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -335,10 +335,14 @@ boolean L10_holeInTheSkyUnlock()
 		set_property("auto_holeinthesky", false);
 		return false;
 	}
-	if (!needStarKey() && !isActuallyEd())
+	int day = get_property("shenInitiationDay").to_int();
+	int items_returned = shenItemsReturned();
+	boolean[location] shenLocs = shenSnakeLocations(day, items_returned);
+	if (!needStarKey() && !(shenLocs contains $location[The Hole in the Sky]))
 	{
 		// we force auto_holeinthesky to true in L11_shenCopperhead() as Ed if Shen sends us to the Hole in the Sky
 		// as otherwise the zone isn't required at all for Ed.
+		// Should also handle situations where the player manually got the star key before unlocking Shen.
 		set_property("auto_holeinthesky", false);
 		return false;
 	}


### PR DESCRIPTION
# Description

- only bjorn the El Vibrato Megadrone if you have one
- handle needing the HitS unlocked for Shen for all classes & paths not just Ed.

## How Has This Been Tested?

It runs fine but testing these issues requires either a specific account setup (Bjorn, Grim Brother, no El Vibrato Megadrone) or some manual intervention (have a Star Key without unlocking the HitS, I guess I could play a normal run and pull the chart and enough star key lime pies to make it?)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
