### PR TITLE
stop retrocape being reconfigured by maximizer when we want a specific config

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20494;	//min mafia revision needed to run this script. Last update: Cargo Shorts support complete
+since r20555;	//min mafia revision needed to run this script. Last update: Support retrocape in the Maximizer.
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -2467,6 +2467,7 @@ void resetState() {
 		set_property("_auto_bad100Familiar", false); 		//reset to not bad. target location might set them as bad again
 	}
 
+	set_property("auto_retrocapeSettings", ""); // retrocape config
 	set_property("auto_januaryToteAcquireCalledThisTurn", false); // january tote item switching
 
 	horseDefault(); // horsery tracking

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -442,6 +442,7 @@ boolean auto_pre_adventure()
 
 	// EQUIP MAXIMIZED GEAR
 	equipMaximizedGear();
+	auto_handleRetrocape(); // has to be done after equipMaximizedGear otherwise the maximizer reconfigures it
 	cli_execute("checkpoint clear");
 
 	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1338,7 +1338,6 @@ boolean adjustForYellowRay(string combat_string)
 	if(combat_string == ("skill " + $skill[Unleash the Devil's Kiss]))
 	{
 		auto_configureRetrocape("heck", "kiss");
-		return autoEquip($slot[back], $item[unwrapped knock-off retro superhero cape]);
 	}
 	return true;
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -408,6 +408,7 @@ boolean auto_mapTheMonsters();
 void cartographyChoiceHandler(int choice);
 boolean auto_hasRetrocape();
 boolean auto_configureRetrocape(string hero, string tag);
+boolean auto_handleRetrocape();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -681,6 +681,38 @@ boolean auto_configureRetrocape(string hero, string tag)
 	{
 		return false;
 	}
+
+	// store the requested settings in a property so we can handle them later
+	string settings = hero + "," + tag;
+	set_property("auto_retrocapeSettings", settings);
+
+	// cut down potential server hits by telling the maximizer to not consider it.
+	addToMaximize("-equip unwrapped knock-off retro superhero cape");
+	return true;
+}
+
+boolean auto_handleRetrocape()
+{
+	if (!auto_hasRetrocape())
+	{
+		return false;
+	}
+
+	string settingsProperty = get_property("auto_retrocapeSettings");
+	if (settingsProperty == "")
+	{
+		return false;
+	}
+
+	string[int] settings = split_string(settingsProperty, ",");
+	if (count(settings) != 2)
+	{
+		return false;
+	}
+
+	string hero = settings[0];
+	string tag = settings[1];
+
 	if (hero != "muscle" &&
 			hero != "mysticality" &&
 			hero != "moxie" &&
@@ -715,7 +747,11 @@ boolean auto_configureRetrocape(string hero, string tag)
 	if (get_property("retroCapeSuperhero") != tempHero || get_property("retroCapeWashingInstructions") != tag)
 	{
 		// retrocape [muscle | mysticality | moxie | vampire | heck | robot] [hold | thrill | kiss | kill]
-		cli_execute(`retrocape {tempHero} {tag}`);
+		cli_execute(`retrocape {tempHero} {tag}`); // configures and equips
 	}
-	return get_property("retroCapeSuperhero") == tempHero && get_property("retroCapeWashingInstructions") == tag;
+	else
+	{
+		equip($item[unwrapped knock-off retro superhero cape]); // already configured, just equip
+	}
+	return get_property("retroCapeSuperhero") == tempHero && get_property("retroCapeWashingInstructions") == tag && have_equipped($item[unwrapped knock-off retro superhero cape]);
 }

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -42,7 +42,6 @@ boolean L7_crypt()
 	{
 		if (auto_configureRetrocape("vampire", "kill"))
 		{
-			autoEquip($item[unwrapped knock-off retro superhero cape]);
 			auto_forceEquipSword();
 		}
 	}


### PR DESCRIPTION
# Description

r20555 and later of mafia made the maximizer fold the retrocape which broke our handling of it for Yellow Rays and Slay the Undead. This fixes it so when we want a specific configuration, we exclude it from the maximizer and manually equip it after configuring it.

## How Has This Been Tested?

Ran day 1 of HC Standard. It's using the YR and cast Slay the Undead in every single Cyrpt combat again now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
