### PR TITLE
Support maximizer bonus keyword

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -639,6 +639,11 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[etched hourglass], 1, 0);
 		}
 
+		if((storage_amount($item[mafia thumb ring]) > 0) && auto_is_valid($item[mafia thumb ring]))
+		{
+			pullXWhenHaveY($item[mafia thumb ring], 1, 0);
+		}
+
 		if((storage_amount($item[can of rain-doh]) > 0) && glover_usable($item[Can Of Rain-Doh]) && (pullXWhenHaveY($item[can of Rain-doh], 1, 0)))
 		{
 			if(item_amount($item[Can of Rain-doh]) > 0)
@@ -763,11 +768,6 @@ int handlePulls(int day)
 		if(auto_have_skill($skill[Summon Smithsness]))
 		{
 			pullXWhenHaveY($item[hand in glove], 1, 0);
-		}
-		else
-		{
-			//pullXWhenHaveY(<smithsWeapon>, 1, 0);
-			//Possibly pull other smiths gear?
 		}
 
 		if((auto_my_path() != "Heavy Rains") && (auto_my_path() != "License to Adventure") && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20555;	//min mafia revision needed to run this script. Last update: Support retrocape in the Maximizer.
+since r20568;	//min mafia revision needed to run this script. Last update: Maximizer bonus keyword
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -219,7 +219,6 @@ string defaultMaximizeStatement()
 	{
 		res += ",plumber,-ml";
 	}
-
 	else if((my_level() < 13) || (get_property("auto_disregardInstantKarma").to_boolean()))
 	{
 		res += ",10exp,5" + my_primestat() + " experience percent";

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -181,6 +181,10 @@ string defaultMaximizeStatement()
 	}
 	
 	string res = "5item,meat,0.5initiative,0.1da 1000max,dr,0.5all res,1.5mainstat,mox,-fumble";
+	if(my_primestat() != $stat[Moxie])
+		res += ",mox";
+
+
 	if(my_class() == $class[Vampyre])
 	{
 		res += ",0.8hp,3hp regen";
@@ -199,7 +203,7 @@ string defaultMaximizeStatement()
 		}
 		else
 		{
-			res += ",1.5weapon damage,0.75weapon damage percent,1.5elemental damage";
+			res += ",1.5weapon damage,-0.75weapon damage percent,1.5elemental damage";
 		}
 	}
 
@@ -216,7 +220,7 @@ string defaultMaximizeStatement()
 		res += ",plumber,-ml";
 	}
 
-	if(!in_zelda() && ((my_level() < 13) || (get_property("auto_disregardInstantKarma").to_boolean())))
+	else if((my_level() < 13) || (get_property("auto_disregardInstantKarma").to_boolean()))
 	{
 		res += ",10exp,5" + my_primestat() + " experience percent";
 	}
@@ -289,12 +293,14 @@ void resetMaximize()
 	}
 }
 
+void addBonusToMaximize(item it, int amt)
+{
+	if(possessEquipment(it) && auto_can_equip(it))
+		addToMaximize("+" + amt + "bonus " + it);
+}
+
 void finalizeMaximize()
 {
-	if(auto_wantToEquipPowerfulGlove())
-	{
-		auto_forceEquipPowerfulGlove();
-	}
 	if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 8 && solveDelayZone() != $location[none])
 	{
 		// Save the first 8 sausage goblins for delay burning
@@ -309,6 +315,17 @@ void finalizeMaximize()
 			removeFromMaximize("-equip " + toEquip);
 			addToMaximize("+equip " + toEquip);
 		}
+	}
+	if(auto_wantToEquipPowerfulGlove())
+	{
+		addBonusToMaximize($item[Powerful Glove], 1000); // pixels
+	}
+	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
+	addBonusToMaximize($item[Mr. Screege's spectacles], 100); // meat stuff
+	if(have_effect($effect[blood bubble]) == 0)
+	{
+		// blocks first hit, but doesn't stack with blood bubble
+		addBonusToMaximize($item[Eight Days a Week Pill Keeper], 100);
 	}
 	if(!in_zelda() && get_property(getMaximizeSlotPref($slot[weapon])) == "" && !maximizeContains("-weapon") && my_primestat() != $stat[Mysticality])
 	{


### PR DESCRIPTION
# Description

Adds autoscend support for the newly added maximizer bonus keyword. This way we can suggest certain items to the maximizer without forcing them.

Specific recommendations atm are:
- Powerful Glove (massive bonus if pixels still needed)
- Mafia thumb ring (moderate bonus for extra adventures, also now pulled if available)
- Mr. Screege's spectacles (small bonus, might as well get extra meat drops)
- Eight Days a Week Pill Keeper (small bonus if blood bubble isn't active, to dodge first hit in combat)

## How Has This Been Tested?

Ran across several ascensions while I just had the mafia changes locally but they hadn't been officially merged yet. Observed gear occasionally, mafia thumb ring was used often but not when we really needed something else. Also no longer forced powerful glove when we needed elemental resistance very badly, for example.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
