### PR TITLE
add delaying for delay burning

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -184,6 +184,8 @@ void initializeSettings() {
 	remove_property("auto_shenZonesTurnsSpent");
 	remove_property("auto_lastShenTurn");
 	
+	set_property("auto_delayLastLevel", 0);
+
 	set_property("auto_sniffs", "");
 	set_property("auto_waitingArrowAlcove", "50");
 	set_property("auto_wandOfNagamar", true);
@@ -2824,6 +2826,14 @@ boolean doTasks()
 
 	if (L12_clearBattlefield())			return true;
 	if(LX_koeInvaderHandler())			return true;
+
+	// release the softblock on delay burning
+	if(allowSoftblockDelay())
+	{
+		auto_log_warning("I was trying to avoid delay zones, but I've run out of stuff to do. Releasing softblock.", "red");
+		set_property("auto_delayLastLevel", my_level());
+		return true;
+	}
 	
 	//release the softblock on quests that are waiting for shen quest
 	if(allowSoftblockShen())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4518,6 +4518,33 @@ location solveDelayZone()
 	return burnZone;
 }
 
+boolean allowSoftblockDelay()
+{
+	return get_property("auto_delayLastLevel").to_int() < my_level();
+}
+
+boolean canBurnDelay(location loc)
+{
+	// TODO: Add Digitize (Portscan?) & LOV Enamorang
+	if (!zone_delay(loc)._boolean || !allowSoftblockDelay())
+	{
+		return false;
+	}
+	if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 9)
+	{
+		return true;
+	}
+	else if (auto_haveVotingBooth() && (get_property("_voteFreeFights").to_int() < 3 || get_property("_voteMonster").to_monster() == $monster[angry ghost]))
+	{
+		return true;
+	}
+	else if (my_daycount() < 2 && (auto_haveVotingBooth() || auto_haveKramcoSausageOMatic()))
+	{
+		return true;
+	}
+	return false;
+}
+
 boolean auto_is_valid(item it)
 {
 	if(!glover_usable(it))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4534,7 +4534,7 @@ boolean canBurnDelay(location loc)
 	{
 		return true;
 	}
-	else if (auto_haveVotingBooth() && (get_property("_voteFreeFights").to_int() < 3 || get_property("_voteMonster").to_monster() == $monster[angry ghost]))
+	else if (auto_haveVotingBooth() && get_property("_voteFreeFights").to_int() < 3)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1360,6 +1360,8 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns);
 boolean auto_faceCheck(string face);
 location solveDelayZone();
+boolean allowSoftblockDelay();
+boolean canBurnDelay(location loc);
 boolean auto_is_valid(item it);
 boolean auto_is_valid(familiar fam);
 boolean auto_is_valid(skill sk);

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -303,17 +303,8 @@ boolean auto_saberDailyUpgrade(int day)
 	{
 		return auto_saberChoice("res");
 	}
-
-	if(day == 1)
-	{
-		return auto_saberChoice("ml");
-	}
-	else
-	{
-		return auto_saberChoice("res");
-	}
-
-	return false;
+	
+	return auto_saberChoice("fam");
 }
 
 monster auto_saberCurrentMonster()

--- a/RELEASE/scripts/autoscend/quests/level_02.ash
+++ b/RELEASE/scripts/autoscend/quests/level_02.ash
@@ -4,8 +4,11 @@ boolean L2_mosquito()
 	{
 		return false;
 	}
-	// Arboreal Respite choice adventure has a delay of 5 adventures.
-	// TODO: add a check for delay burning?
+	if (canBurnDelay($location[The Spooky Forest]))
+	{
+		// Arboreal Respite choice adventure has a delay of 5 adventures.
+		return false;
+	}
 	auto_log_info("Trying to find a mosquito.", "blue");
 	if (autoAdv($location[The Spooky Forest])) {
 		if (internalQuestStatus("questL02Larva") > 0 || item_amount($item[mosquito larva]) > 0)

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -18,6 +18,11 @@ boolean L5_getEncryptionKey()
 		return false;
 	}
 
+	if (canBurnDelay($location[The Outskirts of Cobb's Knob]))
+	{
+		return false;
+	}
+
 	if(in_gnoob() && auto_have_familiar($familiar[Robortender]))
 	{
 		if(!have_skill($skill[Retractable Toes]) && (item_amount($item[Cocktail Mushroom]) == 0))

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -212,6 +212,11 @@ boolean L10_ground()
 		return false;
 	}
 
+	if (canBurnDelay($location[The Castle in the Clouds in the Sky (Ground Floor)]))
+	{
+		return false;
+	}
+
 	auto_log_info("Castle Ground Floor, boring!", "blue");
 	set_property("choiceAdventure672", 3); // There's No Ability Like Possibility: Skip
 	set_property("choiceAdventure673", 1); // Putting Off Is Off-Putting: Very Overdue Library Book then Skip
@@ -363,4 +368,13 @@ boolean L10_holeInTheSkyUnlock()
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 
 	return true;
+}
+
+boolean L10_rainOnThePlains()
+{
+	if (L10_plantThatBean() || L10_airship() || L10_basement() || L10_ground() || L10_topFloor() || L10_holeInTheSkyUnlock())
+	{
+		return true;
+	}
+	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -179,14 +179,26 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 	{
 		// Assume we're going to start Shen today, tomorrow, or two days from now.
 		boolean[location] zones_to_avoid;
-
-		for (int d=0; d<3; d++)
+		if (my_level() < 11)
 		{
-			foreach z, _ in shenSnakeLocations(d+my_daycount(), 0)
+
+			for (int day=0; day<3; day++)
+			{
+				foreach z, _ in shenSnakeLocations(day+my_daycount(), 0)
+				{
+					zones_to_avoid[z] = true;
+				}
+
+			}
+		}
+		else
+		{
+			// if we're already level 11, well either be starting ASAP
+			// or leaving it until day 2 if we're on day 1
+			foreach z, _ in shenSnakeLocations(max(2, my_daycount()), 0)
 			{
 				zones_to_avoid[z] = true;
 			}
-
 		}
 		return zones_to_avoid;
 	}
@@ -227,8 +239,11 @@ boolean LX_unlockHiddenTemple() {
 	if (item_amount($item[Spooky Sapling]) == 0 && my_meat() < 100) {
 		return false;
 	}
-	// Arboreal Respite choice adventure has a delay of 5 adventures.
-	// TODO: add a check for delay burning
+	if (canBurnDelay($location[The Spooky Forest]))
+	{
+		// Arboreal Respite choice adventure has a delay of 5 adventures.
+		return false;
+	}
 	auto_log_info("Attempting to make the Hidden Temple less hidden.", "blue");
 	pullXWhenHaveY($item[Spooky-Gro Fertilizer], 1, 0);
 	if (autoAdv($location[The Spooky Forest])) {
@@ -505,7 +520,12 @@ boolean LX_getLadySpookyravensDancingShoes() {
 		return false;
 	}
 
-	// Louvre It or Leave It choice adventure has a delay of 5 adventures.
+	if (canBurnDelay($location[The Haunted Gallery]))
+	{
+		// Louvre It or Leave It choice adventure has a delay of 5 adventures.
+		return false;
+	}
+
 	backupSetting("louvreDesiredGoal", "7"); // lets just let mafia automate this for us.
 	auto_log_info("Spookyraven: Gallery", "blue");
 
@@ -525,7 +545,13 @@ boolean LX_getLadySpookyravensPowderPuff() {
 	if (item_amount($item[Lady Spookyraven\'s Powder Puff]) > 0) {
 		return false;
 	}
-	// Never Gonna Make You Up choice adventure has a delay of 5 adventures.
+
+	if (canBurnDelay($location[The Haunted Bathroom]))
+	{
+		// Never Gonna Make You Up choice adventure has a delay of 5 adventures.
+		return false;
+	}
+
 	auto_log_info("Spookyraven: Bathroom", "blue");
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
@@ -1500,6 +1526,12 @@ boolean L11_mauriceSpookyraven()
 			return false;
 		}
 
+		if (canBurnDelay($location[The Haunted Ballroom]))
+		{
+			// We'll All Be Flat choice adventure has a delay of 5 adventures.
+			return false;
+		}
+
 		return autoAdv($location[The Haunted Ballroom]);
 	}
 	if(item_amount($item[recipe: mortar-dissolving solution]) == 0)
@@ -2010,6 +2042,12 @@ boolean L11_shenCopperhead()
 			else if (goal == $location[The Smut Orc Logging Camp] && (L9_ed_chasmStart() || L9_chasmBuild()))
 			{
 				return true;
+			}
+
+			if (canBurnDelay(goal))
+			{
+				// Snakes have variable delay of 3-5 adventures but we can burn at least 3 of that.
+				return false;
 			}
 
 			return autoAdv(goal);

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -452,6 +452,11 @@ boolean LX_guildUnlock()
 			return false;
 		}
 
+		if (canBurnDelay(loc)) {
+			// All guild unlock choice adventures have a delay of 5 adventures.
+			return false;
+		}
+
 		autoAdv(1, loc);
 		if (internalQuestStatus(pref) == 1)
 		{


### PR DESCRIPTION
# Description

I've been adding more and more delay zones to `zone_delay()` so we now attempt to burn delay in all the places it helps. However some of those places can be optimised to wait until we have burned the delay before doing whatever we want to do there. This does that.

## How Has This Been Tested?

I've been running this stuff for literally months. Like since before LKS stopped being the current challenge path. I have more on top of this to use non-free Voter ghosts but that requires a lot more effort to be useful (like our war handling not being terrible so you can actually make twice-haunted screwdrivers from all the ghostly ectoplasm you end up with).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
