### PR TITLE
L5 quest cleanup and fixes:

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2715,6 +2715,7 @@ boolean doTasks()
 	if(LX_artistQuest())				return true;
 	if(LX_galaktikSubQuest())			return true;
 	if(L9_leafletQuest())				return true;
+	if(L5_findKnob())					return true;		//use encryption key to unlock possible delay zone if you have it
 	if(L12_sonofaPrefix())				return true;
 	if(LX_burnDelay())					return true;
 	if (LM_edTheUndying())				return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2715,7 +2715,6 @@ boolean doTasks()
 	if(LX_artistQuest())				return true;
 	if(LX_galaktikSubQuest())			return true;
 	if(L9_leafletQuest())				return true;
-	if(L5_findKnob())					return true;
 	if(L12_sonofaPrefix())				return true;
 	if(LX_burnDelay())					return true;
 	if (LM_edTheUndying())				return true;
@@ -2734,7 +2733,6 @@ boolean doTasks()
 		if(LX_bitchinMeatcar())			return true;		//buy the meatcar before switching signs with the rune spoon
 	}
 	if(LX_unlockDesert())				return true;
-	if(L5_getEncryptionKey())			return true;
 	if(LX_unlockPirateRealm())			return true;
 	if(handleRainDoh())				return true;
 	if(routineRainManHandler())			return true;
@@ -2750,10 +2748,9 @@ boolean doTasks()
 	if(L2_mosquito())					return true;
 	if(LX_unlockHiddenTemple())	return true;
 	if(L6_dakotaFanning())				return true;
-	if(L5_haremOutfit())				return true;
 	if(LX_lockPicking())					return true;
 	if(LX_fatLootToken())				return true;
-	if(L5_goblinKing())					return true;
+	if(L5_slayTheGoblinKing())			return true;
 	if(LX_islandAccess())				return true;
 
 	if(in_hardcore() && isGuildClass())

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -727,7 +727,7 @@ boolean L4_batCave();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_05.ash
-boolean L5_waitForSemirare();
+boolean shouldWaitForSemirareL5();
 boolean L5_getEncryptionKey();
 boolean L5_findKnob();
 boolean L5_haremOutfit();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -727,6 +727,7 @@ boolean L4_batCave();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_05.ash
+boolean L5_waitForSemirare();
 boolean L5_getEncryptionKey();
 boolean L5_findKnob();
 boolean L5_haremOutfit();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -727,7 +727,6 @@ boolean L4_batCave();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_05.ash
-boolean shouldWaitForSemirareL5();
 boolean L5_getEncryptionKey();
 boolean L5_findKnob();
 boolean L5_haremOutfit();

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -4,25 +4,6 @@
 //step1 == used [Cobb's Knob map] with [Knob Goblin encryption key] to unlock internal zones.
 //finished == killed the king. you still need to visit council afterwards to get rewarded.
 
-boolean shouldWaitForSemirareL5()
-{
-	//Defer if we can line up with the first semi-rare window to get a lunchbox.
-	if(my_turncount() > 70)
-	{
-		return false;
-	}
-	if(!contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie"))
-	{
-		return false;		//Only wait if we don't have an exact fortune cookie counter
-	}
-	if($location[The Outskirts of Cobb's Knob].turns_spent > 9)
-	{
-		return false;		//already done with the zone
-	}
-	
-	return true;
-}
-
 boolean L5_getEncryptionKey()
 {
 	if (internalQuestStatus("questL05Goblin") != 0 || item_amount($item[Knob Goblin Encryption Key]) > 0)
@@ -34,7 +15,10 @@ boolean L5_getEncryptionKey()
 		visit_url("guild.php?place=challenge");
 		return true;
 	}
-	if(shouldWaitForSemirareL5())
+
+	// Defer if we can line up with the first semi-rare window to get a lunchbox
+	// Only if we don't have a fortune cookie counter
+	if (my_turncount() < 70 && !contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie") && $location[The Outskirts of Cobb's Knob].turns_spent < 10)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -1,19 +1,40 @@
-boolean L5_getEncryptionKey()
+//L5 quest progress notes:
+//unstarted
+//started == acquired [Cobb's Knob map] from council
+//step1 == used [Cobb's Knob map] with [Knob Goblin encryption key] to unlock internal zones.
+//finished == killed the king. you still need to visit council afterwards to get rewarded.
+
+boolean L5_waitForSemirare()
 {
-	if (internalQuestStatus("questL05Goblin") > 0 || item_amount($item[Knob Goblin Encryption Key]) > 0)
+	//Defer if we can line up with the first semi-rare window to get a lunchbox.
+	if(my_turncount() > 70)
 	{
 		return false;
 	}
+	if(!contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie"))
+	{
+		return false;		//Only wait if we don't have an exact fortune cookie counter
+	}
+	if($location[The Outskirts of Cobb's Knob].turns_spent > 9)
+	{
+		return false;		//already done with the zone
+	}
+	
+	return true;
+}
 
+boolean L5_getEncryptionKey()
+{
+	if (internalQuestStatus("questL05Goblin") != 0 || item_amount($item[Knob Goblin Encryption Key]) > 0)
+	{
+		return false;
+	}
 	if(item_amount($item[11-inch knob sausage]) == 1)
 	{
 		visit_url("guild.php?place=challenge");
 		return true;
 	}
-
-	// Defer if we can line up with the first semi-rare window to get a lunchbox
-	// Only if we don't have a fortune cookie counter
-	if (my_turncount() < 70 && !contains_text(get_counters("Fortune Cookie", 0, 80 - my_turncount()), "Fortune Cookie") && $location[The Outskirts of Cobb's Knob].turns_spent < 10)
+	if(L5_waitForSemirare())
 	{
 		return false;
 	}
@@ -50,7 +71,7 @@ boolean L5_findKnob()
 
 boolean L5_haremOutfit()
 {
-	if (internalQuestStatus("questL05Goblin") < 0 || internalQuestStatus("questL05Goblin") > 1)
+	if(internalQuestStatus("questL05Goblin") != 1)
 	{
 		return false;
 	}
@@ -82,7 +103,7 @@ boolean L5_haremOutfit()
 
 boolean L5_goblinKing()
 {
-	if (internalQuestStatus("questL05Goblin") < 0 || internalQuestStatus("questL05Goblin") > 1)
+	if(internalQuestStatus("questL05Goblin") != 1)
 	{
 		return false;
 	}
@@ -147,7 +168,8 @@ boolean L5_goblinKing()
 	return advSpent;
 }
 
-boolean L5_slayTheGoblinKing() {
+boolean L5_slayTheGoblinKing()
+{
 	if (L5_getEncryptionKey() || L5_findKnob() || L5_haremOutfit() || L5_goblinKing()) {  return true; }
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -4,7 +4,7 @@
 //step1 == used [Cobb's Knob map] with [Knob Goblin encryption key] to unlock internal zones.
 //finished == killed the king. you still need to visit council afterwards to get rewarded.
 
-boolean L5_waitForSemirare()
+boolean shouldWaitForSemirareL5()
 {
 	//Defer if we can line up with the first semi-rare window to get a lunchbox.
 	if(my_turncount() > 70)
@@ -34,7 +34,7 @@ boolean L5_getEncryptionKey()
 		visit_url("guild.php?place=challenge");
 		return true;
 	}
-	if(L5_waitForSemirare())
+	if(shouldWaitForSemirareL5())
 	{
 		return false;
 	}


### PR DESCRIPTION
L5 quest cleanup and fixes:
* fixed trying to adventure inside cob knob before unlocking it. specifically the function for killing the king and for finding the harem outfit should only be run on step1 and not on step0
* added info about quest progress status and tightened when different functions are allowed to run (to make sure they are only run when they quest is at the correct step)
* switched default pathing in autoscend.ash from calling each individual components of L5 quest to instead calling a function that does the entire quest (function already existed but was unused)

## How Has This Been Tested?

I was running into errors when trying to kill the goblin king before unlocking it and then I switched to this branch and it finished the quest correctly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
