### PR TITLE
fix aborting for lack of flyering targets

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2812,7 +2812,6 @@ boolean doTasks()
 	if(L12_farm())						return true;
 	if(L11_getBeehive())				return true;
 	if(L12_finalizeWar())				return true;
-	if(L12_lastDitchFlyer())			return true;
 
 	if(!inAftercore() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
 	{
@@ -2836,6 +2835,7 @@ boolean doTasks()
 	
 	if(LX_getDigitalKey()) 				return true;
 	if(LX_getStarKey()) 				return true;
+	if(L12_lastDitchFlyer())			return true;
 	if(L13_towerNSContests())			return true;
 	if(L13_towerNSHedge())				return true;
 	if(L13_sorceressDoor())				return true;


### PR DESCRIPTION
* fix aborting for lack of flyering targets when there are still quests remaining.
** I just moved the call on the function L12_lastDitchFlyer() to be called a few functions later. specifically after removing the shen softblock due to lack of things to do, and also after grabbing the digital and star key

## How Has This Been Tested?

Ran into this situation, this branch fixed it

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
