### PR TITLE
Fix standard check for Voting Booth

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -1164,7 +1164,8 @@ boolean auto_latteRefill()
 }
 
 boolean auto_haveVotingBooth() {
-	return ((get_property("_voteToday").to_boolean() || get_property("voteAlways").to_boolean()) && auto_is_valid($item[voter registration form]));
+	// is_unrestricted instead of auto_is_valid as the enchatments are usable in g lover.
+	return ((get_property("_voteToday").to_boolean() || get_property("voteAlways").to_boolean()) && is_unrestricted($item[voter registration form]));
 }
 
 boolean auto_voteSetup()
@@ -1195,7 +1196,7 @@ boolean auto_voteSetup(int candidate, int first, int second)
 	{
 		return false;
 	}
-	if(!get_property("_voteToday").to_boolean() && !get_property("voteAlways").to_boolean())
+	if(!auto_haveVotingBooth())
 	{
 		return false;
 	}
@@ -1270,7 +1271,7 @@ boolean auto_voteMonster(boolean freeMon, location loc, string option)
 	{
 		return false;
 	}
-	if(!possessEquipment($item[&quot;I voted!&quot; sticker]))
+	if(!possessEquipment($item[&quot;I voted!&quot; sticker]) || !auto_is_valid($item[&quot;I voted!&quot; sticker]))
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Actually check if the voting booth is unrestricted before setting enchantments.

Fixes #649

## How Has This Been Tested?

Started a standard ascension & ensured the voting booth is not used.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
