### PR TITLE
exclude kramco if mapping monsters

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -300,9 +300,10 @@ void addBonusToMaximize(item it, int amt)
 
 void finalizeMaximize()
 {
-	if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 8 && solveDelayZone() != $location[none])
+	if (auto_haveKramcoSausageOMatic() && ((auto_sausageFightsToday() < 8 && solveDelayZone() != $location[none]) || get_property("mappingMonsters").to_boolean()))
 	{
 		// Save the first 8 sausage goblins for delay burning
+		// also don't equip Kramco when using Map the Monsters as sausage goblins override the NC
 		addToMaximize("-equip " + $item[Kramco Sausage-o-Matic&trade;].to_string());
 	}
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]


### PR DESCRIPTION
# Description

Reported in Discord. Sausage Goblins override the Map the Monsters non-combat which can then cause the charge to be used in the wrong zone (which then causes an abort if it's a zone we don't handle mapping monsters in).

## How Has This Been Tested?

Hasn't yet but it's a one line change. Not exactly easy to set up the conditions to test it though either.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
