### PR TITLE
Some Ed fixes

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1421,7 +1421,7 @@ boolean LM_edTheUndying()
 		return true;
 	}
 	// start the macguffin quest, conveniently the black forest is a 1.4 Ka zone.
-	if (L11_blackMarket() || L11_forgedDocuments() || L11_mcmuffinDiary())
+	if (L11_blackMarket() || L11_forgedDocuments() || L11_mcmuffinDiary() || L11_shenStartQuest())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -107,9 +107,9 @@ desert_buff_record desertBuffs()
 int shenItemsReturned()
 {
 	int progress = internalQuestStatus("questL11Shen");
-	if (progress < 1) return 0;
-	if (progress < 3) return 1;
-	else if (progress < 5) return 2;
+	if (progress < 3) return 0;
+	if (progress < 5) return 1;
+	else if (progress < 7) return 2;
 	else return 3;
 }
 


### PR DESCRIPTION
# Description

- fix off by one error in shenItemsReturned()
- Ed should use all available banishes not just Curse of Vacation and use the glove to replace.
- Start Shen Copperhead quest as soon as it is available as Ed.

## How Has This Been Tested?

Ran an Ed run. All works now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
