### PR TITLE
Box o' ghosts support and a handful of other bugfixes

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -45,6 +45,7 @@ Casagnova Gnome
 Psychedelic Bear
 Piano Cat
 # Slightly special fairies
+Ghost of Crimbo Carols
 Red-Nosed Snapper
 Pair of Stomping Boots	!path:G-Lover
 Gelatinous Cubeling

--- a/BUILD/familiars/meat.dat
+++ b/BUILD/familiars/meat.dat
@@ -49,6 +49,7 @@ Hand Turkey
 # Sorry, we don't use him for yellow rays but we can at least use him for meat I guess
 He-Boulder
 # Marginally special leprechauns
+Ghost of Crimbo Commerce
 Knob Goblin Organ Grinder
 #Mutant Cactus Bud	grimdark:2
 Urchin Urchin

--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -13,6 +13,7 @@ Elf Operative
 Optimistic Candle
 Rockin' Robin
 # Volleychauns
+Ghost of Crimbo Commerce
 Golden Monkey
 Bloovian Groose
 Unconscious Collective
@@ -29,6 +30,7 @@ Melodramedary
 # Might as well build up weight for free runs, even though I'm pretty sure we don't use them...
 Frumious Bandersnatch
 # Slightly special volleyballs
+Ghost of Crimbo Cheer
 Reanimated Reanimator
 God Lobster
 Party Mouse

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -134,33 +134,34 @@ item	26	Casagnova Gnome
 item	27	Psychedelic Bear
 item	28	Piano Cat
 # Slightly special fairies
-item	29	Red-Nosed Snapper
-item	30	Pair of Stomping Boots	!path:G-Lover
-item	31	Gelatinous Cubeling
-item	32	Steam-Powered Cheerleader
-item	33	Obtuse Angel
-item	34	Green Pixie
+item	29	Ghost of Crimbo Carols
+item	30	Red-Nosed Snapper
+item	31	Pair of Stomping Boots	!path:G-Lover
+item	32	Gelatinous Cubeling
+item	33	Steam-Powered Cheerleader
+item	34	Obtuse Angel
+item	35	Green Pixie
 # Elemental fairies
-item	35	Sleazy Gravy Fairy
-item	36	Stinky Gravy Fairy
-item	37	Flaming Gravy Fairy
-item	38	Frozen Gravy Fairy
-item	39	Spooky Gravy Fairy
+item	36	Sleazy Gravy Fairy
+item	37	Stinky Gravy Fairy
+item	38	Flaming Gravy Fairy
+item	39	Frozen Gravy Fairy
+item	40	Spooky Gravy Fairy
 # Physical damage fairy
-item	40	Bowlet
+item	41	Bowlet
 # Barely special fairies
-item	41	Mechanical Songbird
-item	42	Grouper Groupie
-item	43	Peppermint Rhino
+item	42	Mechanical Songbird
+item	43	Grouper Groupie
+item	44	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	44	Slimeling
+item	45	Slimeling
 # Turtles are cute
-item	45	Syncopated Turtle
+item	46	Syncopated Turtle
 # The original
-item	46	Baby Gravy Fairy
+item	47	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	47	Mutant Fire Ant
+item	48	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1
@@ -213,13 +214,14 @@ meat	34	Hand Turkey
 # Sorry, we don't use him for yellow rays but we can at least use him for meat I guess
 meat	35	He-Boulder
 # Marginally special leprechauns
-meat	36	Knob Goblin Organ Grinder
+meat	36	Ghost of Crimbo Commerce
+meat	37	Knob Goblin Organ Grinder
 #Mutant Cactus Bud	grimdark:2
-meat	37	Urchin Urchin
+meat	38	Urchin Urchin
 # Memes, doesn't actually give substats apparently
-meat	38	Cornbeefadon
+meat	39	Cornbeefadon
 # The original
-meat	39	Leprechaun
+meat	40	Leprechaun
 
 # Typical starfish are better than whelps
 # Whelps on average restore .375*(weight+5)
@@ -294,37 +296,39 @@ stat	5	Elf Operative
 stat	6	Optimistic Candle
 stat	7	Rockin' Robin
 # Volleychauns
-stat	8	Golden Monkey
-stat	9	Bloovian Groose
-stat	10	Unconscious Collective
-stat	11	Grim Brother
-stat	12	Dramatic Hedgehog
-stat	13	Chauvinist Pig
-stat	14	Uniclops
-stat	15	Hunchbacked Minion
-stat	16	Nervous Tick
-stat	17	Cymbal-Playing Monkey
-stat	18	Cheshire Bat
+stat	8	Ghost of Crimbo Commerce
+stat	9	Golden Monkey
+stat	10	Bloovian Groose
+stat	11	Unconscious Collective
+stat	12	Grim Brother
+stat	13	Dramatic Hedgehog
+stat	14	Chauvinist Pig
+stat	15	Uniclops
+stat	16	Hunchbacked Minion
+stat	17	Nervous Tick
+stat	18	Cymbal-Playing Monkey
+stat	19	Cheshire Bat
 # VolleyWhelps
-stat	19	Melodramedary
+stat	20	Melodramedary
 # Might as well build up weight for free runs, even though I'm pretty sure we don't use them...
-stat	20	Frumious Bandersnatch
+stat	21	Frumious Bandersnatch
 # Slightly special volleyballs
-stat	21	Reanimated Reanimator
-stat	22	God Lobster
-stat	23	Party Mouse
-stat	24	Lil' Barrel Mimic
-stat	25	Piranha Plant
-stat	26	Antique Nutcracker
+stat	22	Ghost of Crimbo Cheer
+stat	23	Reanimated Reanimator
+stat	24	God Lobster
+stat	25	Party Mouse
+stat	26	Lil' Barrel Mimic
+stat	27	Piranha Plant
+stat	28	Antique Nutcracker
 # Fancy
-stat	27	Miniature Sword &amp; Martini Guy
+stat	29	Miniature Sword &amp; Martini Guy
 #Baby Mutant Rattlesnake	grimdark:2
 # Turtles are cute
-stat	28	Grinning Turtle
+stat	30	Grinning Turtle
 # His winning smile
-stat	29	Smiling Rat
+stat	31	Smiling Rat
 # The original
-stat	30	Blood-Faced Volleyball
+stat	32	Blood-Faced Volleyball
 
 yellowray	0	Crimbo Shrub
 # Nanorhino and He-Boulder would require a bit of extra doing to make work

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20568;	//min mafia revision needed to run this script. Last update: Maximizer bonus keyword
+since r20623;	// min mafia revision needed to run this script. Last update: Rename crimbo20 cafe consumables & lower ranges, mark as Unspaded as wiki appears incorrect
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -202,6 +202,7 @@ void initializeSettings() {
 	set_property("auto_junkspritesencountered", 0);
 	set_property("auto_openedziggurat", false);
 	remove_property("auto_minedCells");
+	remove_property("auto_boughtCommerceGhostItem");
 	beehiveConsider();
 
 	eudora_initializeSettings();
@@ -2581,6 +2582,7 @@ boolean doTasks()
 	oldPeoplePlantStuff();
 	use_barrels();
 	auto_latteRefill();
+	auto_buyCrimboCommerceMallItem();
 	houseUpgrade();
 
 	//This just closets stuff so G-Lover does not mess with us.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -202,6 +202,7 @@ void initializeSettings() {
 	set_property("auto_junkspritesencountered", 0);
 	set_property("auto_openedziggurat", false);
 	remove_property("auto_minedCells");
+	remove_property("auto_shinningStarted");
 	remove_property("auto_boughtCommerceGhostItem");
 	beehiveConsider();
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -300,6 +300,13 @@ void addBonusToMaximize(item it, int amt)
 
 void finalizeMaximize()
 {
+	if (possessEquipment($item[miniature crystal ball]))
+	{
+		// until we add support for this, we shouldn't allow the maximizer to equip it
+		// I noticed it being worn in preference to the astral pet sweater which is a waste
+		addToMaximize(`-equip {$item[miniature crystal ball].to_string()}`);
+	}
+
 	if (auto_haveKramcoSausageOMatic() && ((auto_sausageFightsToday() < 8 && solveDelayZone() != $location[none]) || get_property("mappingMonsters").to_boolean()))
 	{
 		// Save the first 8 sausage goblins for delay burning

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1024,6 +1024,11 @@ boolean auto_post_adventure()
 		auto_log_info("Fought " + get_property("auto_modernzmobiecount") + " modern zmobies.", "blue");
 	}
 
+	if (get_property("lastEncounter") == "Welcome to the Great Overlook Lodge")
+	{
+		set_property("auto_shinningStarted", true);
+	}
+
 	if(have_effect($effect[Disavowed]) > 0)
 	{
 		if(get_property("_auto_bondBriefing") != "finished")

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -333,7 +333,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Inscrutable Gaze], 30, 1, 1);
 		buffMaintain($effect[Big], 50, 1, 1);
 
-		boolean [skill] toCast = $skills[Acquire Rhinestones, Advanced Cocktailcrafting, Advanced Saucecrafting, Communism!, Grab a Cold One, Lunch Break, Pastamastery, Perfect Freeze, Prevent Scurvy and Sobriety, Request Sandwich, Spaghetti Breakfast, Summon Alice\'s Army Cards, Summon Carrot, Summon Confiscated Things, Summon Crimbo Candy, Summon Geeky Gifts, Summon Hilarious Objects, Summon Holiday Fun!, Summon Kokomo Resort Pass, Summon Tasteful Items];
+		boolean [skill] toCast = $skills[Acquire Rhinestones, Advanced Cocktailcrafting, Advanced Saucecrafting, Bowl Full of Jelly, Chubby and Plump, Communism!, Eye and a Twist, Grab a Cold One, Lunch Break, Pastamastery, Perfect Freeze, Prevent Scurvy and Sobriety, Request Sandwich, Spaghetti Breakfast, Summon Alice\'s Army Cards, Summon Carrot, Summon Confiscated Things, Summon Crimbo Candy, Summon Geeky Gifts, Summon Hilarious Objects, Summon Holiday Fun!, Summon Kokomo Resort Pass, Summon Tasteful Items];
 
 		foreach sk in toCast
 		{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -564,22 +564,22 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			{
 				meat_per_mp = meat_per_mp * 0.95; // this isn't quite right for discounted Doc Galaktik but I don't care.
 			}
-		if (isMystGuildStoreAvailable())
-		{
-			int mmj_cost = auto_have_skill($skill[Five Finger Discount]) ? 95 : 100;
-			int mmj_mp_restored = my_level() * 1.5 + 5;
-			float mmj_meat_per_mp = mmj_cost / mmj_mp_restored;
-			meat_per_mp = min(meat_per_mp, mmj_meat_per_mp);
-			// at level 6 and above, MMJ is better than all but discounted doc galaktik
-			// and at level 8 and above it's better than everything
-		}
-		if (my_class() == $class[Sauceror])
-		{
-			// your MP cup runneth over
-			meat_per_mp = 0.1;
-		}
-		skill s = to_skill(metadata.name);
-		return (mp_cost(s) * meat_per_mp);
+			if (isMystGuildStoreAvailable())
+			{
+				int mmj_cost = auto_have_skill($skill[Five Finger Discount]) ? 95 : 100;
+				int mmj_mp_restored = my_level() * 1.5 + 5;
+				float mmj_meat_per_mp = mmj_cost / mmj_mp_restored;
+				meat_per_mp = min(meat_per_mp, mmj_meat_per_mp);
+				// at level 6 and above, MMJ is better than all but discounted doc galaktik
+				// and at level 8 and above it's better than everything
+			}
+			if (my_class() == $class[Sauceror] || can_interact())
+			{
+				// your MP cup runneth over
+				meat_per_mp = 0.1;
+			}
+			skill s = to_skill(metadata.name);
+			return (mp_cost(s) * meat_per_mp);
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1437,23 +1437,28 @@ boolean canSniff(monster enemy, location loc)
 
 boolean adjustForSniffingIfPossible(monster target)
 {
-	if(have_skill($skill[Transcendent Olfaction]) &&
-	auto_is_valid($skill[Transcendent Olfaction]) &&
-	get_property("olfactedMonster").to_monster() != target &&
-	have_effect($effect[On the trail]) > 0 &&
-	item_amount($item[soft green echo eyedrop antidote]) > 0)
+	if (have_skill($skill[Transcendent Olfaction]) && auto_is_valid($skill[Transcendent Olfaction]))
 	{
-		auto_log_info("Uneffecting On the trail to have Transcendent Olfaction available for " + target, "blue");
-		monster old_olfact = get_property("olfactedMonster").to_monster();
-		string output = cli_execute_output("uneffect On the trail");
-		if (output.contains_text("On the Trail removed."))
+		if (get_property("olfactedMonster").to_monster() != target &&
+				have_effect($effect[On the trail]) > 0 &&
+				item_amount($item[soft green echo eyedrop antidote]) > 0)
 		{
-			handleTracker($item[soft green echo eyedrop antidote], old_olfact, "auto_otherstuff");
-			return true;
+			auto_log_info("Uneffecting On the trail to have Transcendent Olfaction available for " + target, "blue");
+			monster old_olfact = get_property("olfactedMonster").to_monster();
+			string output = cli_execute_output("uneffect On the trail");
+			if (output.contains_text("On the Trail removed."))
+			{
+				handleTracker($item[soft green echo eyedrop antidote], old_olfact, "auto_otherstuff");
+				return true;
+			}
+			else
+			{
+				auto_log_info("Failed to Uneffect On the trail for some reason?", "blue");
+			}
 		}
-		else
+		if (my_mp() < mp_cost($skill[Transcendent Olfaction]))
 		{
-			auto_log_info("Failed to Uneffect On the trail for some reason?", "blue");
+			acquireMP(mp_cost($skill[Transcendent Olfaction]));
 		}
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -409,6 +409,7 @@ void cartographyChoiceHandler(int choice);
 boolean auto_hasRetrocape();
 boolean auto_configureRetrocape(string hero, string tag);
 boolean auto_handleRetrocape();
+boolean auto_buyCrimboCommerceMallItem();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -732,15 +732,15 @@ boolean auto_handleRetrocape()
 	string tempHero = hero;
 	if (hero == "muscle")
 	{
-		temphero = "vampire";
+		tempHero = "vampire";
 	}
 	if (hero == "mysticality")
 	{
-		temphero = "heck";
+		tempHero = "heck";
 	}
 	if (hero == "moxie")
 	{
-		temphero = "robot";
+		tempHero = "robot";
 	}
 
 	// avoid uselessly reconfiguring the cape
@@ -754,4 +754,37 @@ boolean auto_handleRetrocape()
 		equip($item[unwrapped knock-off retro superhero cape]); // already configured, just equip
 	}
 	return get_property("retroCapeSuperhero") == tempHero && get_property("retroCapeWashingInstructions") == tag && have_equipped($item[unwrapped knock-off retro superhero cape]);
+}
+
+boolean auto_buyCrimboCommerceMallItem()
+{
+	if (!auto_is_valid($familiar[Ghost of Crimbo Commerce]))
+	{
+		return false;
+	}
+
+	string ghostItemString = get_property("commerceGhostItem");
+	if (ghostItemString == "")
+	{
+		// haven't triggered the greedy ghost message at least once yet.
+		return false;
+	}
+
+	if (get_property("auto_boughtCommerceGhostItem") == ghostItemString)
+	{
+		// already bought the item.
+		return false;
+	}
+
+	auto_log_info(`Commerce Ghost wants us to buy a {ghostItemString} which will give us roughly {my_level()*25} substats in the next combat with it.`);
+	string output = cli_execute_output(`buy from mall {ghostItemString}`);
+	if (!output.contains_text("Purchases complete."))
+	{
+		abort(`Something went wrong buying {ghostItemString} from the mall.`);
+	}
+	else
+	{
+		set_property("auto_boughtCommerceGhostItem", ghostItemString);
+	}
+	return true;
 }

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -766,8 +766,9 @@ boolean L9_twinPeak()
 		}
 	}
 
-	if ($location[Twin Peak].turns_spent != 0 && auto_canCamelSpit() && auto_canMapTheMonsters())
+	if (get_property("auto_shinningStarted").to_boolean() && auto_canCamelSpit() && auto_canMapTheMonsters())
 	{
+		// Shh! You want to get sued?
 		if (adjustForYellowRayIfPossible($monster[bearpig topiary animal]))
 		{
 			if (auto_mapTheMonsters())

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -766,7 +766,7 @@ boolean L9_twinPeak()
 		}
 	}
 
-	if (auto_canCamelSpit() && auto_canMapTheMonsters())
+	if ($location[Twin Peak].turns_spent != 0 && auto_canCamelSpit() && auto_canMapTheMonsters())
 	{
 		if (adjustForYellowRayIfPossible($monster[bearpig topiary animal]))
 		{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1128,31 +1128,7 @@ boolean L12_sonofaBeach()
 
 	if(auto_my_path() != "Live. Ascend. Repeat.")
 	{
-		if(equipped_item($slot[acc1]) == $item[over-the-shoulder folder holder])
-		{
-			if((item_amount($item[Ass-Stompers of Violence]) > 0) && (equipped_item($slot[acc1]) != $item[Ass-Stompers of Violence]) && can_equip($item[Ass-Stompers of Violence]))
-			{
-				equip($slot[acc1], $item[Ass-Stompers of Violence]);
-			}
-			else
-			{
-				equip($slot[acc1], $item[bejeweled pledge pin]);
-			}
-		}
-		if(item_amount($item[portable cassette player]) > 0)
-		{
-			equip($slot[acc2], $item[portable cassette player]);
-		}
-		if(numeric_modifier("Combat Rate") <= 9.0)
-		{
-			if(possessEquipment($item[Carpe]))
-			{
-				equip($slot[Back], $item[Carpe]);
-			}
-		}
-		asdonBuff($effect[Driving Obnoxiously]);
-
-		if(numeric_modifier("Combat Rate") < 0.0)
+		if (providePlusCombat(25, true, true) < 0.0)
 		{
 			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
 			equipBaseline();


### PR DESCRIPTION
# Description

- add the 3 Crimbo Ghosts to familiars
- add handling to buy the Commerce ghost item from the mall so we get the stats in the next combat we win with it (25 * current level substats is better than a Volleyball will give).
- update min mafia version to fix issues with Crimbo Cafe consumables that were renamed causing consumption to break.
- exclude miniature crystal ball from being equipped as it overrides astral pet sweater and other useful familiar equips (e.g. dromedary drinking helmet)
- add Crimbo 2020 skill book consumables to MP burning summons list
- make adjustForSniffingIfPossible actually make sure we have enough MP to cast Olfaction if we're about to go somewhere we want to use Olfaction
- don't use Map the Monsters in Twin Peak until we've passed the intro adventure
- update L12_sonofaBeach() to call providePlusCombat() to check if we can get a suitable combat rate instead of a load of hardcoded casts which will waste resources and still fail to do the beach.

Fixes #656 #647

## How Has This Been Tested?

Ran 2 Normal Standard runs with these changes (PM & TT). About to start a 3rd (SC this time).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
