### PR TITLE
remove maximize anti-spam measures

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -421,9 +421,7 @@ float simValue(string modifier)
 void equipMaximizedGear()
 {
 	finalizeMaximize();
-	backupSetting("logPreferenceChange", "false");
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
-	restoreSetting("logPreferenceChange");
 }
 
 void equipOverrides()
@@ -578,9 +576,7 @@ void equipRollover()
 	if(my_familiar() == $familiar[none] && auto_have_familiar($familiar[Mosquito]))
 		to_max += ",switch Mosquito";
 
-	backupSetting("logPreferenceChange", "false");
 	maximize(to_max, false);
-	restoreSetting("logPreferenceChange");
 
 	if(!in_hardcore())
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -8,9 +8,7 @@ boolean autoMaximize(string req, boolean simulate)
 		tcrs_maximize_with_items(req);
 #		user_confirm("Beep");
 	}
-	backupSetting("logPreferenceChange", "false");
 	boolean didmax = maximize(req, simulate);
-	restoreSetting("logPreferenceChange");
 	return didmax;
 }
 
@@ -22,9 +20,7 @@ boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
 		tcrs_maximize_with_items(req);
 #		user_confirm("Beep");
 	}
-	backupSetting("logPreferenceChange", "false");
 	boolean didmax = maximize(req, maxPrice, priceLevel, simulate);
-	restoreSetting("logPreferenceChange");
 	return didmax;
 }
 
@@ -36,9 +32,7 @@ aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulat
 #		user_confirm("Beep");
 		tcrs_maximize_with_items(req);
 	}
-	backupSetting("logPreferenceChange", "false");
 	aggregate maxrecord = maximize(req, maxPrice, priceLevel, simulate, includeEquip);
-	restoreSetting("logPreferenceChange");
 	return maxrecord;
 }
 
@@ -5744,9 +5738,7 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//but I am labeling them seperate from buffs in case we ever need to split this function.
 	
 	//if you have something that reduces the cost of casting buffs, wear it now.
-	backupSetting("logPreferenceChange", "false");
 	maximize("-mana cost, -tie", false);
-	restoreSetting("logPreferenceChange");
 	
 	//Passive damage
 	if(passive_dmg_allowed)

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -132,9 +132,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
-		backupSetting("logPreferenceChange", "false");
 		maximize("mp,-tie", false);
-		restoreSetting("logPreferenceChange");
 	}
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...
 	// but meh.


### PR DESCRIPTION
Just removing the backup and restore of logPreferenceChange around all the calls to maximize.
I added these to cut down on the session log spam but the restore is failing and making it way more difficult to diagnose anything.