### PR TITLE
Some Ed fixes/debugging info and a fix for Commerce Ghost item buying

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -544,7 +544,7 @@ void consumeStuff()
 		return;
 	}
 
-	boolean edSpleenCheck = (isActuallyEd() && spleen_left() > 0); // Ed should fill spleen first
+	boolean edSpleenCheck = (isActuallyEd() && my_level() < 11 && spleen_left() > 0); // Ed should fill spleen first
 	
 	if (my_adventures() < 10 && fullness_left() > 0 && in_boris())
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -914,7 +914,7 @@ boolean canYellowRay(monster target)
 	}
 	# Pulled Yellow Taffy	- How do we handle the underwater check?
 	# He-Boulder?			- How do we do this?
-	return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal] contains target) != "";
+	return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "";
 }
 
 boolean canYellowRay()
@@ -1340,7 +1340,7 @@ boolean adjustForYellowRayIfPossible(monster target)
 {
 	if(canYellowRay(target))
 	{
-		string yr_string = yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal] contains target);
+		string yr_string = yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target);
 		auto_log_info("Adjusting to have YR available for " + target + ": " + yr_string, "blue");
 		return adjustForYellowRay(yr_string);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -777,6 +777,16 @@ boolean auto_buyCrimboCommerceMallItem()
 	}
 
 	auto_log_info(`Commerce Ghost wants us to buy a {ghostItemString} which will give us roughly {my_level()*25} substats in the next combat with it.`);
+
+	if (ghostItemString.contains_text(",")) {
+		// buy from mall doesn't handle items with commas in the name
+		// but if we strip it out, fuzzy matching will map it back to a $item.
+		// yes cli_execute is bad and should feel bad but buy from mall 
+		// doesn't have an ASH equivalent (yet)
+		buffer newGhostItemString = ghostItemString.replace_string(",", "");
+		ghostItemString = newGhostItemString;
+	}
+
 	string output = cli_execute_output(`buy from mall {ghostItemString}`);
 	if (!output.contains_text("Purchases complete."))
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -778,16 +778,7 @@ boolean auto_buyCrimboCommerceMallItem()
 
 	auto_log_info(`Commerce Ghost wants us to buy a {ghostItemString} which will give us roughly {my_level()*25} substats in the next combat with it.`);
 
-	if (ghostItemString.contains_text(",")) {
-		// buy from mall doesn't handle items with commas in the name
-		// but if we strip it out, fuzzy matching will map it back to a $item.
-		// yes cli_execute is bad and should feel bad but buy from mall 
-		// doesn't have an ASH equivalent (yet)
-		buffer newGhostItemString = ghostItemString.replace_string(",", "");
-		ghostItemString = newGhostItemString;
-	}
-
-	string output = cli_execute_output(`buy from mall {ghostItemString}`);
+	string output = cli_execute_output(`buy from mall [{ghostItemString}.to_item().to_int()]`);
 	if (!output.contains_text("Purchases complete."))
 	{
 		abort(`Something went wrong buying {ghostItemString} from the mall.`);

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -711,6 +711,7 @@ boolean ed_needShop()
 
 	if (get_property("auto_needLegs").to_boolean() && coins >= ed_KaCost($skill[Upgraded Legs]))
 	{
+		auto_log_info("Ed needs legs (and can afford them)! UNDYING for a free trip to the Underworld!");
 		return true;
 	}
 
@@ -719,6 +720,7 @@ boolean ed_needShop()
 	canEat = max(0, canEat - item_amount($item[Mummified Beef Haunch]));
 	if (canEat > 0 && coins >= 15)
 	{
+		auto_log_info("Ed needs beef haunches (and can afford them)! UNDYING for a free trip to the Underworld!");
 		return true;
 	}
 
@@ -727,6 +729,7 @@ boolean ed_needShop()
 	{
 		if (item_amount($item[Holy Spring Water]) < 1 && item_amount($item[Spirit Beer]) < 1 && item_amount($item[Sacramental Wine]) < 1)
 		{
+			auto_log_info("Ed needs MP restores! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 	}
@@ -736,36 +739,44 @@ boolean ed_needShop()
 	int requiredKa = ed_KaCost(nextUpgrade);
 	if (canEat < 1 && requiredKa != -1 && coins >= requiredKa)
 	{
+		auto_log_info(`Ed needs {nextUpgrade.to_string()} (and can afford it)! UNDYING for a free trip to the Underworld!`);
 		return true;
 	}
 	else if (have_skill($skill[Okay Seriously, This is the Last Spleen]) && canEat < 1)
 	{
 		if (item_amount($item[Talisman of Renenutet]) < 1 && get_property("auto_renenutetBought").to_int() < 7 && coins >= (7 - get_property("auto_renenutetBought").to_int()))
 		{
+			auto_log_info("Ed needs Talismens of Renenutet! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if (item_amount($item[Linen Bandages]) < 1 && coins >= 4)
 		{
+			auto_log_info("Ed needs Linen Bandages! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if (item_amount($item[Holy Spring Water]) < 1 && coins >= 1 && (my_maxmp() - my_mp() < 50))
 		{
+			auto_log_info("Ed needs Holy Spring Water! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if (item_amount($item[Talisman of Horus]) < 1 && coins >= 5)
 		{
+			auto_log_info("Ed needs Talismens of Horus! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if (item_amount($item[Spirit Beer]) < 1 && coins >= 30)
 		{
+			auto_log_info("Ed needs Spirit Beer! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if ((item_amount($item[Soft Green Echo Eyedrop Antidote]) + item_amount($item[Ancient Cure-All])) < 1 && coins >= 30)
 		{
+			auto_log_info("Ed needs Ancient Cure-All! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 		else if (item_amount($item[Sacramental Wine]) < 1 && coins >= 30)
 		{
+			auto_log_info("Ed needs Sacramental Wine! UNDYING for a free trip to the Underworld!");
 			return true;
 		}
 	}
@@ -876,10 +887,10 @@ boolean ed_shopping()
 		else if (have_skill($skill[Okay Seriously, This is the Last Spleen]) && canEat < 1)
 		{
 			while (item_amount($item[Talisman of Renenutet]) < 7 && get_property("auto_renenutetBought").to_int() < 7 && coins >= 1)
-		{
-			auto_log_info("Buying Talisman of Renenutet", "green");
-			visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=439", true);
-			set_property("auto_renenutetBought", 1 + get_property("auto_renenutetBought").to_int());
+			{
+				auto_log_info("Buying Talisman of Renenutet", "green");
+				visit_url("shop.php?pwd=&whichshop=edunder_shopshop&action=buyitem&quantity=1&whichrow=439", true);
+				set_property("auto_renenutetBought", 1 + get_property("auto_renenutetBought").to_int());
 				coins -= 1;
 			}
 			while (item_amount($item[Linen Bandages]) < 4 && coins >= 1)

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -612,7 +612,7 @@ boolean L8_trapperGroar()
 	if(provideResistances(resGoal, false) || provideResistances(resGoal, true))
 	{
 		auto_log_info("Time to take out Gargle, sure, Gargle (Groar)", "blue");
-		addToMaximize("2000cold resistance 5max");
+		equipMaximizedGear();
 		return autoAdv($location[Mist-shrouded Peak]);
 	}
 	return false;


### PR DESCRIPTION
# Description

Fixes for issues raised by users in Discord (or adding logging to help debug an issue).

- Add some logging to why Ed wants to go shopping.
- Ed can eat and drink at level 11 even with spleen still to fill.
- Exclude the Haunted Gallery Knight from Saber YR (breaks for some reason, might be mafia not handling choice -> fight -> choice but I CBA debugging it and TBH it's a waste of a Saber use since if you have the saber, you don't need the serpentine sword for the ML once you lose Ed's Staff at level 11).
- Fix for Commerce Ghost items with commas breaking `buy from mall` cli command.

## How Has This Been Tested?

I've only manually tested the stripping of commas on the CLI by setting the commerceGhostItem property to "Notes from the Elfpocalypse, Chapter IV" and calling the auto_buyCrimboCommerceMallItem() function as that was what it was reported as failing on in Discord.
The Ed changes I've ran with but most of them are just info lines and the others I won't hit as it was on my IotM-less account so testing has been "light" but it at least validates and runs fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
