### PR TITLE
fix error in datafile for config page

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -33,7 +33,7 @@ auto_consultClan	string	The clan name of the player you want to do Zatara consul
 auto_consultChoice	string	The name of the player you want to do Zatara consults with.
 auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
 auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-auto_skipUnlockGuild    boolean When true, don't unlock the guild.
+auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
 auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
 auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
 auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -27,7 +27,7 @@ drop	0	Fist Turkey	prop:_turkeyBooze<5
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
 drop	1	Puck Man	item:Yellow Pixel<20
 drop	2	Ms. Puck Man	item:Yellow Pixel<20
-# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
 drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
 drop	4	Rockin' Robin	prop:rockinRobinProgress>=25

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -44,7 +44,7 @@ any	31	auto_consultClan	string	The clan name of the player you want to do Zatara
 any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
 any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
 any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	35	auto_skipUnlockGuild    boolean When true, don't unlock the guild.
+any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
 any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
 any	37	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
 any	38	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.


### PR DESCRIPTION
auto_skipUnlockGuild setting had space instead of tab which resulted in a broken config line in the GUI for that specific setting

## How Has This Been Tested?

copied altered files to autoscend and then rerun the GUI, confirming that this fixed the issue

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
