### PR TITLE
move a bracket so the item we're buying for the crimbo ghost is correctly converted to item id

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -778,7 +778,7 @@ boolean auto_buyCrimboCommerceMallItem()
 
 	auto_log_info(`Commerce Ghost wants us to buy a {ghostItemString} which will give us roughly {my_level()*25} substats in the next combat with it.`);
 
-	string output = cli_execute_output(`buy from mall [{ghostItemString}.to_item().to_int()]`);
+	string output = cli_execute_output(`buy from mall [{ghostItemString.to_item().to_int()}]`);
 	if (!output.contains_text("Purchases complete."))
 	{
 		abort(`Something went wrong buying {ghostItemString} from the mall.`);


### PR DESCRIPTION
bug fix for a bad check in and merge earlier.