### PR TITLE
Add support for some of the Emotion Chip skills

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -9,7 +9,7 @@ Pygmy Bowler
 Pygmy Witch Surgeon
 pygmy witch accountant	loc:The Hidden Office Building
 pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
-Pygmy Janitor	!tavern:true
+Pygmy Janitor	loc:The Hidden Park;!tavern:true
 Quiet Healer
 Tomb Rat
 Blooper	loc:8-Bit Realm

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -106,7 +106,7 @@ sniff	7	Pygmy Bowler
 sniff	8	Pygmy Witch Surgeon
 sniff	9	pygmy witch accountant	loc:The Hidden Office Building
 sniff	10	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
-sniff	11	Pygmy Janitor	!tavern:true
+sniff	11	Pygmy Janitor	loc:The Hidden Park;!tavern:true
 sniff	12	Quiet Healer
 sniff	13	Tomb Rat
 sniff	14	Blooper	loc:8-Bit Realm

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -42,6 +42,7 @@ import <autoscend/iotms/mr2017.ash>
 import <autoscend/iotms/mr2018.ash>
 import <autoscend/iotms/mr2019.ash>
 import <autoscend/iotms/mr2020.ash>
+import <autoscend/iotms/mr2021.ash>
 
 import <autoscend/paths/actually_ed_the_undying.ash>
 import <autoscend/paths/avatar_of_boris.ash>

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -291,6 +291,11 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		return result();
 	}
 
+	// Feeling Lonely can only be used 3 times per day.
+	if (auto_canFeelLonely() && tryEffects($effects[Feeling Lonely])) {
+		return result();
+	}
+
 	//blooper ink costs 15 coins without which it will error when trying to buy it, so that is the bare minimum we need to check for
 	//However we don't want to waste our early coins on it as they are precious. So require at least 400 coins before buying it.
 	if (in_zelda() && 0 == have_effect($effect[Blooper Inked]) && item_amount($item[coin]) > 400) {
@@ -653,6 +658,11 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 	]))
 		return result();
 
+	// Feeling Peaceful can only be used 3 times per day.
+	if (auto_canFeelPeaceful() && tryEffects($effects[Feeling Peaceful])) {
+		return result();
+	}
+
 	if(bat_formMist(speculative))
 		handleEffect($effect[Mist Form]);
 	if(pass())
@@ -896,6 +906,11 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 
 	if(pass())
 		return result();
+
+	// Feeling Excited can only be used 3 times per day.
+	if (auto_canFeelExcitement() && tryEffects($effects[Feeling Excited])) {
+		return result();
+	}
 
 	// buffs from items
 	if(doEquips)

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -292,7 +292,8 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 	}
 
 	// Feeling Lonely can only be used 3 times per day.
-	if (auto_canFeelLonely() && tryEffects($effects[Feeling Lonely])) {
+	if (auto_canFeelLonely() && tryEffects($effects[Feeling Lonely]))
+	{
 		return result();
 	}
 
@@ -659,7 +660,8 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		return result();
 
 	// Feeling Peaceful can only be used 3 times per day.
-	if (auto_canFeelPeaceful() && tryEffects($effects[Feeling Peaceful])) {
+	if (auto_canFeelPeaceful() && tryEffects($effects[Feeling Peaceful]))
+	{
 		return result();
 	}
 
@@ -908,7 +910,8 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 		return result();
 
 	// Feeling Excited can only be used 3 times per day.
-	if (auto_canFeelExcitement() && tryEffects($effects[Feeling Excited])) {
+	if (auto_canFeelExcitement() && tryEffects($effects[Feeling Excited]))
+	{
 		return result();
 	}
 

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -276,7 +276,8 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		Gummed Shoes,
 		Simply Invisible,
 		Inky Camouflage,	
-		Celestial Camouflage
+		Celestial Camouflage,
+		Feeling Lonely,
 	])) {
 		return result();
 	}
@@ -288,12 +289,6 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 		handleEffect($effect[Driving Stealthily]);
 	}
 	if(pass()) {
-		return result();
-	}
-
-	// Feeling Lonely can only be used 3 times per day.
-	if (auto_canFeelLonely() && tryEffects($effects[Feeling Lonely]))
-	{
 		return result();
 	}
 
@@ -656,14 +651,9 @@ int [element] provideResistances(int [element] amt, boolean doEquips, boolean sp
 		Scarysauce,
 		Blessing of the Bird,
 		Blessing of Your Favorite Bird,
+		Feeling Peaceful,
 	]))
 		return result();
-
-	// Feeling Peaceful can only be used 3 times per day.
-	if (auto_canFeelPeaceful() && tryEffects($effects[Feeling Peaceful]))
-	{
-		return result();
-	}
 
 	if(bat_formMist(speculative))
 		handleEffect($effect[Mist Form]);
@@ -898,6 +888,7 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 		// varying effects
 		Blessing of the Bird,
 		Blessing of Your Favorite Bird,
+		Feeling Excited,
 	]))
 		return result();
 
@@ -908,12 +899,6 @@ float [stat] provideStats(int [stat] amt, boolean doEquips, boolean speculative)
 
 	if(pass())
 		return result();
-
-	// Feeling Excited can only be used 3 times per day.
-	if (auto_canFeelExcitement() && tryEffects($effects[Feeling Excited]))
-	{
-		return result();
-	}
 
 	// buffs from items
 	if(doEquips)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4403,16 +4403,21 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}
 	}
 
-	if ($effects[Feeling Lonely, Feeling Excited, Feeling Nervous, Feeling Peaceful] contains buff)
+	if ($effects[Feeling Lonely, Feeling Excited, Feeling Nervous, Feeling Peaceful] contains buff && auto_haveEmotionChipSkills())
 	{
+		skill feeling = buff.to_skill();
 		if (speculative)
 		{
-			skill feeling = buff.to_skill();
 			return feeling.timescast < feeling.dailylimit;
+		}
+		else if (feeling.timescast < feeling.dailylimit)
+		{
+			useSkill = buff.to_skill();
+			handleTracker(useSkill, "auto_otherstuff");
 		}
 		else
 		{
-			useSkill = buff.to_skill();
+			return false;
 		}
 	}
 
@@ -4496,6 +4501,11 @@ location solveDelayZone()
 		// find the delayable zone with the lowest delay left.
 		foreach loc, delay in delayableZones {
 			if (burnZone == $location[none] || delay < delayableZones[burnZone]) {
+				burnZone = loc;
+			}
+			if (loc == $location[The Spooky Forest] && delay == delayableZones[burnZone])
+			{
+				// prioritise the Spooky Forest when its delay remaining equals the lowest delay zone
 				burnZone = loc;
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1073,6 +1073,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Reflex Hammer];
 	}
 
+	if (auto_canFeelHatred() && !(used contains "Feel Hatred"))
+	{
+		return "skill " + $skill[Feel Hatred];
+	}
+
 	if ((inCombat ? have_equipped($item[Fourth of May cosplay saber]) : possessEquipment($item[Fourth of May cosplay saber])) && auto_saberChargesAvailable() > 0 && !(used contains "Saber Force")) {
 		// can't use the force on uncopyable monsters
 		if (enemy == $monster[none] || enemy.copyable) {
@@ -1274,6 +1279,11 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 	if(asdonCanMissile())
 	{
 		return "skill " + $skill[Asdon Martin: Missile Launcher];
+	}
+
+	if (auto_canFeelEnvy())
+	{
+		return "skill " + $skill[Feel Envy];
 	}
 
 	if((inCombat ? have_equipped($item[Fourth of May cosplay saber]) : possessEquipment($item[Fourth of May cosplay saber])) && (auto_saberChargesAvailable() > 0))
@@ -3864,6 +3874,10 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Faboooo]:						useItem = $item[Fabiotion];						break;
 	case $effect[Far Out]:						useItem = $item[Patchouli Incense Stick];		break;
 	case $effect[Fat Leon\'s Phat Loot Lyric]:	useSkill = $skill[Fat Leon\'s Phat Loot Lyric];	break;
+	case $effect[Feeling Lonely]:					useSkill = $skill[none];						break;
+	case $effect[Feeling Excited]:					useSkill = $skill[none];						break;
+	case $effect[Feeling Nervous]:					useSkill = $skill[none];						break;
+	case $effect[Feeling Peaceful]:					useSkill = $skill[none];						break;
 	case $effect[Feeling Punchy]:				useItem = $item[Punching Potion];				break;
 	case $effect[Feroci Tea]:					useItem = $item[cuppa Feroci tea];				break;
 	case $effect[Fever From the Flavor]:	useItem = $item[bottle of antifreeze];	break;
@@ -4386,6 +4400,19 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		else
 		{
 			return auto_powerfulGloveNoncombat();
+		}
+	}
+
+	if ($effects[Feeling Lonely, Feeling Excited, Feeling Nervous, Feeling Peaceful] contains buff)
+	{
+		if (speculative)
+		{
+			skill feeling = buff.to_skill();
+			return feeling.timescast < feeling.dailylimit;
+		}
+		else
+		{
+			useSkill = buff.to_skill();
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -412,6 +412,19 @@ boolean auto_handleRetrocape();
 boolean auto_buyCrimboCommerceMallItem();
 
 ########################################################################################################
+//Defined in autoscend/iotms/mr2020.ash
+boolean auto_haveEmotionChipSkills();
+boolean auto_canFeelEnvy();
+boolean auto_canFeelHatred();
+boolean auto_canFeelNostalgic();
+boolean auto_canFeelPride();
+boolean auto_canFeelSuperior();
+boolean auto_canFeelLonely();
+boolean auto_canFeelExcitement();
+boolean auto_canFeelNervous();
+boolean auto_canFeelPeaceful();
+
+########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
 boolean isActuallyEd();
 int ed_spleen_limit();

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -1,0 +1,60 @@
+# This is meant for items that have a date of 2021
+
+boolean auto_haveEmotionChipSkills()
+{
+  return auto_is_valid($skill[Emotionally Chipped]) && have_skill($skill[Emotionally Chipped]);
+}
+
+boolean auto_canFeelEnvy()
+{
+  // Combat Skill - Forces drops like Spooky Jelly (doesn't insta-kill though, still need to win combat)
+  return auto_haveEmotionChipSkills() && get_property("_feelEnvyUsed") < 3;
+}
+
+boolean auto_canFeelHatred()
+{
+  // Combat Skill - 50 turn banish (doesn't cost a turn)
+  return auto_haveEmotionChipSkills() && get_property("_feelHatredUsed") < 3;
+}
+
+boolean auto_canFeelNostalgic()
+{
+  // Combat Skill - adds drop table from last copyable monster to the current (see feelNostalgicMonster property)
+  return auto_haveEmotionChipSkills() && get_property("_feelNostalgicUsed") < 3;
+}
+
+boolean auto_canFeelPride()
+{
+  // Combat Skill - Triples stat gain from the current fight.
+  return auto_haveEmotionChipSkills() && get_property("_feelPrideUsed") < 3;
+}
+
+boolean auto_canFeelSuperior()
+{
+  // Combat Skill - Does 20% of monsters max HP as damage and gives +1 PvP fight if it kills the monster.
+  return auto_haveEmotionChipSkills() && get_property("_feelSuperiorUsed") < 3;
+}
+
+boolean auto_canFeelLonely()
+{
+  // Non-Combat Skill - -5% combat rate (20 adventures)
+  return auto_haveEmotionChipSkills() && get_property("_feelLonelyUsed") < 3;
+}
+
+boolean auto_canFeelExcitement()
+{
+  // Non-Combat Skill - +25 to all stats (20 adventures)
+  return auto_haveEmotionChipSkills() && get_property("_feelExcitementUsed") < 3;
+}
+
+boolean auto_canFeelNervous()
+{
+  // Non-Combat Skill - deals passive damage on hit starting at 20 decrementing by 1 every proc (20 adventures)
+  return auto_haveEmotionChipSkills() && get_property("_feelNervousUsed") < 3;
+}
+
+boolean auto_canFeelPeaceful()
+{
+  // Non-Combat Skill - +2 all res, +10 DR, +100 DA (20 adventures)
+  return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed") < 3;
+}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -803,7 +803,7 @@ boolean L9_oilPeak()
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean needJar = ((oilProgress & 4) == 0) && item_amount($item[Jar Of Oil]) == 0;
-		if (!needJar)
+		if (!needJar || in_bhy())
 		{
 			return false;
 		}


### PR DESCRIPTION
# Description

- add Feeling Lonely to providePlusNonCombat
- add Feeling Peaceful to provideResistances
- add Feeling Excited to provideStats
- add Feel Hatred to Banishers
- add Feel Envy to Yellow Rays

Also 3 minor bug fixes.
- fix for BHY to not waste turns in Oil Peak (reported in Discord).
- fix for wasting SGEEAs in the Hidden City every turn.
- when burning delay, give the Spooky Forest priority when delay is equal with the current lowest delay zone since we want it unlocked for the SR.

## How Has This Been Tested?

Ran Normal Standard Pastamancer and Sauceror runs with these changes. Uses all the skills when expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
