### PR TITLE
refactored toot oriole quest

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -71,6 +71,7 @@ import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
 import <autoscend/paths/low_key_summer.ash>
 
+import <autoscend/quests/level_01.ash>
 import <autoscend/quests/level_02.ash>
 import <autoscend/quests/level_03.ash>
 import <autoscend/quests/level_04.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20653;	// min mafia revision needed to run this script. Last update: Torso Awaregness -> Torso Awareness
+since r20655;	// min mafia revision needed to run this script. Last update: questM05Toot tracking will correct to finished when refreshing quests
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -1112,6 +1112,9 @@ void initializeDay(int day)
 	{
 		use_skill(1, $skill[Iron Palm Technique]);
 	}
+	
+	//you must finish the Toot Oriole quest to unlock council quests.
+	tootOriole();
 
 	ed_initializeDay(day);
 	boris_initializeDay(day);
@@ -1161,9 +1164,6 @@ void initializeDay(int day)
 				visit_url("clan_viplounge.php?action=floundry");
 			}
 
-			visit_url("tutorial.php?action=toot");
-			use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
-			use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
 			tootGetMeat();
 
 			hr_initializeDay(day);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1624,35 +1624,6 @@ item whatHiMein()
 	return $item[crudles];
 }
 
-void tootOriole()
-{
-	//Toot Oriole must be visited each ascension to unlock other quests from the council
-	if(get_property("questM05Toot") == "finished")
-	{
-		return;
-	}
-	
-	visit_url("tutorial.php?action=toot");		//do quest
-	//finishing toot quest is not correctly noticed by mafia. r20655 has workaround of correcting this by refreshing quests
-	cli_execute("refresh quests");
-	
-	if(get_property("questM05Toot") == "finished")
-	{
-		use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
-		use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
-		council();
-	}
-	else abort("Failed to finish the Toot Oriole quest. This prevents us from getting other quests from council");
-}
-
-void tootGetMeat()
-{
-	auto_autosell(min(5, item_amount($item[hamethyst])), $item[hamethyst]);
-	auto_autosell(min(5, item_amount($item[baconstone])), $item[baconstone]);
-	auto_autosell(min(5, item_amount($item[porquoise])), $item[porquoise]);
-}
-
-
 boolean ovenHandle()
 {
 	if((auto_get_campground() contains $item[Dramatic&trade; range]) && !get_property("auto_haveoven").to_boolean())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1624,6 +1624,27 @@ item whatHiMein()
 	return $item[crudles];
 }
 
+void tootOriole()
+{
+	//Toot Oriole must be visited each ascension to unlock other quests from the council
+	if(get_property("questM05Toot") == "finished")
+	{
+		return;
+	}
+	
+	visit_url("tutorial.php?action=toot");		//do quest
+	//finishing toot quest is not correctly noticed by mafia. r20655 has workaround of correcting this by refreshing quests
+	cli_execute("refresh quests");
+	
+	if(get_property("questM05Toot") == "finished")
+	{
+		use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
+		use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
+		council();
+	}
+	else abort("Failed to finish the Toot Oriole quest. This prevents us from getting other quests from council");
+}
+
 void tootGetMeat()
 {
 	auto_autosell(min(5, item_amount($item[hamethyst])), $item[hamethyst]);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1283,6 +1283,7 @@ boolean buyableMaintain(item toMaintain, int howMany, int meatMin);
 boolean buyableMaintain(item toMaintain, int howMany, int meatMin, boolean condition);
 effect whatStatSmile();
 item whatHiMein();
+void tootOriole();
 void tootGetMeat();
 boolean ovenHandle();
 boolean isGhost(monster mon);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -727,6 +727,11 @@ float tcrs_expectedAdvPerFill(string quality);
 boolean tcrs_maximize_with_items(string maximizerString);
 
 ########################################################################################################
+//Defined in autoscend/quests/level_01.ash
+void tootOriole();
+void tootGetMeat();
+
+########################################################################################################
 //Defined in autoscend/quests/level_02.ash
 boolean L2_mosquito();
 
@@ -1283,8 +1288,6 @@ boolean buyableMaintain(item toMaintain, int howMany, int meatMin);
 boolean buyableMaintain(item toMaintain, int howMany, int meatMin, boolean condition);
 effect whatStatSmile();
 item whatHiMein();
-void tootOriole();
-void tootGetMeat();
 boolean ovenHandle();
 boolean isGhost(monster mon);
 boolean isProtonGhost(monster mon);

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -90,12 +90,7 @@ void ed_initializeDay(int day)
 			{
 				use(1, $item[Xiblaxian holo-wrist-puter simcode]);
 			}
-
-			visit_url("tutorial.php?action=toot");
-			use(item_amount($item[Letter to Ed the Undying]), $item[Letter to Ed the Undying]);
-			use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
 			tootGetMeat();
-
 			equipBaseline();
 		}
 	}

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -2930,9 +2930,6 @@ void cs_initializeDay(int day)
 				use_skill(1, $skill[Spirit of Peppermint]);
 			}
 
-			visit_url("tutorial.php?action=toot");
-			use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
-			use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
 			tootGetMeat();
 
 			auto_sourceTerminalEducate($skill[Extract], $skill[Turbo]);

--- a/RELEASE/scripts/autoscend/quests/level_01.ash
+++ b/RELEASE/scripts/autoscend/quests/level_01.ash
@@ -6,20 +6,21 @@ void tootOriole()
 		return;
 	}
 	
-	visit_url("tutorial.php?action=toot");		//do quest
+	//do quest
+	visit_url("tutorial.php?action=toot");
+	if(isActuallyEd())
+	{
+		use(item_amount($item[Letter to Ed the Undying]), $item[Letter to Ed the Undying]);
+	}
+	else
+	{
+		use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
+	}
 	//finishing toot quest is not correctly noticed by mafia. r20655 has workaround of correcting this by refreshing quests
 	cli_execute("refresh quests");
 	
 	if(get_property("questM05Toot") == "finished")
 	{
-		if(isActuallyEd())
-		{
-			use(item_amount($item[Letter to Ed the Undying]), $item[Letter to Ed the Undying]);
-		}
-		else
-		{
-			use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
-		}
 		use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
 		council();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_01.ash
+++ b/RELEASE/scripts/autoscend/quests/level_01.ash
@@ -1,0 +1,27 @@
+void tootOriole()
+{
+	//Toot Oriole must be visited each ascension to unlock other quests from the council
+	if(get_property("questM05Toot") == "finished")
+	{
+		return;
+	}
+	
+	visit_url("tutorial.php?action=toot");		//do quest
+	//finishing toot quest is not correctly noticed by mafia. r20655 has workaround of correcting this by refreshing quests
+	cli_execute("refresh quests");
+	
+	if(get_property("questM05Toot") == "finished")
+	{
+		use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
+		use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
+		council();
+	}
+	else abort("Failed to finish the Toot Oriole quest. This prevents us from getting other quests from council");
+}
+
+void tootGetMeat()
+{
+	auto_autosell(min(5, item_amount($item[hamethyst])), $item[hamethyst]);
+	auto_autosell(min(5, item_amount($item[baconstone])), $item[baconstone]);
+	auto_autosell(min(5, item_amount($item[porquoise])), $item[porquoise]);
+}

--- a/RELEASE/scripts/autoscend/quests/level_01.ash
+++ b/RELEASE/scripts/autoscend/quests/level_01.ash
@@ -29,6 +29,10 @@ void tootOriole()
 
 void tootGetMeat()
 {
+	if(can_interact())		//avoid selling gems in casual
+	{
+		return;
+	}
 	auto_autosell(min(5, item_amount($item[hamethyst])), $item[hamethyst]);
 	auto_autosell(min(5, item_amount($item[baconstone])), $item[baconstone]);
 	auto_autosell(min(5, item_amount($item[porquoise])), $item[porquoise]);

--- a/RELEASE/scripts/autoscend/quests/level_01.ash
+++ b/RELEASE/scripts/autoscend/quests/level_01.ash
@@ -12,7 +12,14 @@ void tootOriole()
 	
 	if(get_property("questM05Toot") == "finished")
 	{
-		use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
+		if(isActuallyEd())
+		{
+			use(item_amount($item[Letter to Ed the Undying]), $item[Letter to Ed the Undying]);
+		}
+		else
+		{
+			use(item_amount($item[Letter From King Ralph XI]), $item[Letter From King Ralph XI]);
+		}
 		use(item_amount($item[Pork Elf Goodies Sack]), $item[Pork Elf Goodies Sack]);
 		council();
 	}


### PR DESCRIPTION
refactored toot oriole quest
* toot quest will now recover if for some reason failed to initialize on day 1
* will be done in all paths (for some paths we just assumed it would be done via a 3rd party)
* more error checking and reporting
* has its own function now. also moved tootGetMeat() to level_01.ash
* make use of quest tracking correction option (via refresh quests) added in r20655

## How Has This Been Tested?
tested in ed, greygoo, and standard
using both ash calls and running autoscend

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
