### PR TITLE
more Actually Ed fixes due to feedback from Beldur

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1420,6 +1420,11 @@ boolean LM_edTheUndying()
 		}
 	}
 
+	// we should open the manor second floor sooner rather than later as starting the level 11 quest
+	// ruins our pool skill and having delay burning zones open is nice.
+	if (LX_unlockManorSecondFloor() || LX_unlockHauntedLibrary() || LX_unlockHauntedBilliardsRoom(true)) {
+		return true;
+	}
 	// as we do hippy side, the war is a 2 Ka quest (excluding sidequests but that shouldn't matter)
 	// once the war is no longer a complete mess of spaghetti code, change this to do the whole war.
 	if (L12_getOutfit() || L12_startWar())
@@ -1473,7 +1478,7 @@ boolean LM_edTheUndying()
 		return true;
 	}
 	// Copperhead Club & Mob of Zeppelin Protestors are 2 Ka zones (with a banish use) but we want to delay them so we can semi-rare Copperhead
-	if (L11_mauriceSpookyraven() || L11_talismanOfNam() || L11_palindome())
+	if (LX_spookyravenManorSecondFloor() || L11_mauriceSpookyraven() || L11_talismanOfNam() || L11_palindome())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1414,7 +1414,12 @@ boolean L11_hiddenCity()
 	if (item_amount($item[stone triangle]) == 4) {
 		auto_log_info("Fighting the out-of-work spirit", "blue");
 		acquireHP();
-		return autoAdv($location[A Massive Ziggurat]);
+		boolean advSpent = autoAdv($location[A Massive Ziggurat]);
+		if (internalQuestStatus("questL11MacGuffin") > 2) {
+			// Actually Ed finishes this quest when all 3 parts of the staff are returned
+			council();
+		}
+		return advSpent;
 	}
 	
 	return false;
@@ -1559,6 +1564,10 @@ boolean L11_mauriceSpookyraven()
 		if (isActuallyEd())
 		{
 			visit_url("place.php?whichplace=manor4&action=manor4_chamberboss");
+			if (internalQuestStatus("questL11MacGuffin") > 2) {
+				// Actually Ed finishes this quest when all 3 parts of the staff are returned
+				council();
+			}
 		}
 		else
 		{
@@ -2184,9 +2193,12 @@ boolean L11_palindome()
 
 		if (isActuallyEd())
 		{
+			if (internalQuestStatus("questL11MacGuffin") > 2) {
+				// Actually Ed finishes this quest when all 3 parts of the staff are returned
+				council();
+			}
 			return true;
 		}
-
 
 		# is step 4 when we got the wet stunt nut stew?
 		if (internalQuestStatus("questL11Palindome") < 5)


### PR DESCRIPTION
# Description

- check if we've finished the L11 quest as Ed when we return any part of his staff
- add doing manor first and second floors to Ed's routing so hopefully it opens the billiards room before losing Ed's Staff at level 11.

## How Has This Been Tested?

Validates. can't really test it fixes the issue(s) reported in Discord without running it on a blinged out account.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
