### PR TITLE
automatic nightcap drinking

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -15,7 +15,8 @@ auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are i
 auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
+auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
 auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
 auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -26,36 +26,37 @@ any	13	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goal
 any	14	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
 any	15	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 any	16	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	17	auto_limitConsume	boolean	When true, will not eat or drink anything automatically.
-any	18	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	19	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	20	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	21	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	22	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	23	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	24	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	25	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	26	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	27	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	28	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	29	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	30	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	31	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	37	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	38	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	39	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	40	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	41	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	42	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	43	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
-any	44	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	45	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	46	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	17	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	18	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	19	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	20	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	21	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	22	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	23	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	24	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	25	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	26	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	27	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	28	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	29	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	30	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	31	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	32	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	33	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	34	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	36	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	38	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	39	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	40	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	41	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	42	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	43	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -564,6 +564,7 @@ boolean doBedtime()
 	}
 
 	auto_beachUseFreeCombs();
+	auto_drinkNightcap();
 
 	boolean done = (my_inebriety() > inebriety_limit()) || (my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]);
 	if(in_gnoob() || !can_drink() || out_of_blood)
@@ -593,7 +594,7 @@ boolean doBedtime()
 			auto_log_info("You have a rain man to cast, please do so before overdrinking and then run me again.", "red");
 			return false;
 		}
-		auto_autoDrinkNightcap(true); // simulate;
+		auto_printNightcap();
 		auto_log_warning("You need to overdrink and then run me again. Beep.", "red");
 		if(have_skill($skill[The Ode to Booze]))
 		{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1143,6 +1143,10 @@ void auto_drinkNightcap()
 	{
 		return;		//current path cannot drink booze at all
 	}
+	if(auto_freeCombatsRemaining() > 0)
+	{
+		return;		//do not overdrink if we still have free fights we want to do. undesireable free fights are not counted by that function
+	}
 	//you can't overdrink if already overdrunk. TODO account for green beer on cinco de mayo
 	if(auto_have_familiar($familiar[Stooper]))
 	{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1109,7 +1109,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	return true;
 }
 
-void auto_autoDrinkNightcap(boolean simulate)
+ConsumeAction auto_bestNightcap()
 {
 	ConsumeAction[int] actions;
 	loadConsumables("drink", actions);
@@ -1123,16 +1123,56 @@ void auto_autoDrinkNightcap(boolean simulate)
 	}
 
 	int best = 0;
-	for (int i=1; i < count(actions); i++)
+	for(int i=1; i < count(actions); i++)
 	{
-		if (desirability(i) > desirability(best)) best = i;
+		if(desirability(i) > desirability(best)) best = i;
 	}
 
-	auto_log_info("Nightcap is: " + to_pretty_string(actions[best]), "blue");
+	return actions[best];
+}
 
-	if (simulate) return;
+void auto_printNightcap()
+{
+	auto_log_info("Nightcap is: " + to_pretty_string(auto_bestNightcap()), "blue");
+}
 
-	autoConsume(actions[best]);
+void auto_drinkNightcap()
+{
+	//function to overdrink a nightcap at the end of day
+	if(!can_drink())
+	{
+		return;		//current path cannot drink booze at all
+	}
+	//you can't overdrink if already overdrunk. TODO account for green beer on cinco de mayo
+	if(auto_have_familiar($familiar[Stooper]))
+	{
+		if($familiar[Stooper] == my_familiar() && inebriety_left() < 0) return;		//stooper is current familiar and overdrunk
+		else if(inebriety_left() < -1) return;		//stooper not current familiar. but will be overdrunk even if switching to it
+	}
+	else if(inebriety_left() < 0) return;	//we can not use stooper and are overdrunk
+	
+	familiar start_fam = my_familiar();
+	if(auto_have_familiar($familiar[Stooper]) //drinking does not break 100fam runs so do not use canChangeToFamiliar
+	&& start_fam != $familiar[Stooper])
+	{
+		use_familiar($familiar[Stooper]);
+	}
+	
+	//fill up remaining liver first. such as stooper space.
+	while(inebriety_left() > 0 && auto_autoConsumeOne("drink", false));
+	
+	//drink your nightcap to become overdrunk
+	ConsumeAction target = auto_bestNightcap();
+	if(!autoPrepConsume(target))
+	{
+		abort("Unexpectedly couldn't prep " + to_pretty_string(target));
+	}
+	autoConsume(target);
+	
+	if(start_fam != my_familiar())
+	{
+		use_familiar(start_fam);
+	}
 }
 
 boolean auto_autoConsumeOne(string type, boolean simulate)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1004,7 +1004,8 @@ boolean canEat(item toEat);
 boolean canChew(item toChew);
 void consumeStuff();
 boolean consumeFortune();
-void auto_autoDrinkNightcap(boolean simulate);
+void auto_printNightcap();
+void auto_drinkNightcap();
 boolean auto_autoConsumeOne(string type, boolean simulate);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
 


### PR DESCRIPTION
add the ability to automatically consume nightcap. It will not drink nightcap if you have free fights remaining (in case you disabled automatic free fights fighting).
if you do not want autoscend to drink nightcap you can disable it via the GUI. the setting is called
auto_skipNightcap
and if set to true will prevent nightcap drinking

## How Has This Been Tested?

ash calls
4 standard HC runs with disco bandit. and 1 with accordion thief
HC boris run
HC ed
SC exploathing (to test switching to stooper and back)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
