### PR TITLE
grey goo

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2667,7 +2667,7 @@ boolean doTasks()
 	{
 		return true;
 	}
-	if(auto_my_path() == "Grey Goo")
+	if(in_ggoo())
 	{
 		abort("Should not have gotten here, aborted LA_grey_goo_tasks method allowed return to caller. Uh oh.");
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -592,8 +592,11 @@ boolean LM_jello();
 
 ########################################################################################################
 //Defined in autoscend/paths/grey_goo.ash
+boolean in_ggoo();
 void grey_goo_initializeSettings();
 void grey_goo_initializeDay(int day);
+boolean greygoo_fortuneCollect();
+boolean greygoo_oddJobs();
 boolean LA_grey_goo_tasks();
 
 ########################################################################################################
@@ -959,6 +962,7 @@ boolean LX_pirateQuest();
 boolean LX_acquireEpicWeapon();
 boolean LX_NemesisQuest();
 void houseUpgrade();
+boolean LX_oddJobs(int target);
 
 ########################################################################################################
 //Defined in autoscend/auto_adventure.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -595,8 +595,6 @@ boolean LM_jello();
 boolean in_ggoo();
 void grey_goo_initializeSettings();
 void grey_goo_initializeDay(int day);
-boolean greygoo_fortuneCollect();
-boolean greygoo_oddJobs();
 boolean LA_grey_goo_tasks();
 
 ########################################################################################################
@@ -962,7 +960,6 @@ boolean LX_pirateQuest();
 boolean LX_acquireEpicWeapon();
 boolean LX_NemesisQuest();
 void houseUpgrade();
-boolean LX_oddJobs(int target);
 
 ########################################################################################################
 //Defined in autoscend/auto_adventure.ash

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -1,14 +1,20 @@
+boolean in_ggoo()
+{
+	return auto_my_path() == "Grey Goo";
+}
+
 void grey_goo_initializeSettings()
 {
-	if (my_path() != "Grey Goo")
+	if(!in_ggoo())
 	{
 		return;
 	}
+	set_property("auto_paranoia", 1);		//greygoo has broken tracking verified for: questL02Larva && questM19Hippy. probably more things
 }
 
 void grey_goo_initializeDay(int day)
 {
-	if (my_path() != "Grey Goo")
+	if(!in_ggoo())
 	{
 		return;
 	}
@@ -16,18 +22,20 @@ void grey_goo_initializeDay(int day)
 
 boolean LA_grey_goo_tasks()
 {
-	if (my_path() != "Grey Goo")
+	if(!in_ggoo())
 	{
 		return false;
 	}
 
-	print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
-
-	if (my_daycount() >= 3)
+	if(my_daycount() < 3)
 	{
-		abort("You made it beyond the dawn of the third day and can now ascend. Congratulations!");
+		print("You are currently on day " +my_daycount()+ " out of 3 of this grey goo run","red");
+	}
+	else
+	{
+		print("You are done with this grey goo ascension. please enter the astral gash","green");
 	}
 	
-	abort("Please come back in " + (3 - my_daycount()) + " days.");
-	return true;
+	set_property("_auto_doneToday", true);		//skip doTasks() and go to doBedtime()
+	return true;		//restart doTasks() loop so we can notice the above setting
 }

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -10,6 +10,7 @@ void grey_goo_initializeSettings()
 		return;
 	}
 	set_property("auto_paranoia", 1);		//greygoo has broken tracking verified for: questL02Larva && questM19Hippy. probably more things
+	set_property("auto_doGalaktik", true);	//we are adventuring in greygoo for meat. this saves meat
 }
 
 void grey_goo_initializeDay(int day)
@@ -20,12 +21,94 @@ void grey_goo_initializeDay(int day)
 	}
 }
 
+boolean greygoo_fortuneCollect()
+{
+	if(!contains_text(get_counters("Fortune Cookie", 0, 0), "Fortune Cookie"))
+	{
+		return false;	//semirare not currently about to happen
+	}
+	
+	//Semi-rare Handler
+	auto_log_info("Semi rare time!", "blue");
+	cli_execute("counters");
+
+	location goal;
+	location lastsr = get_property("semirareLocation").to_location();
+	
+	if(lastsr != $location[The Sleazy Back Alley])		//can not get the same SR twice. so do not waste it
+	{
+		goal = $location[The Sleazy Back Alley];	//grab epic drink
+	}
+	else
+	{
+		goal = $location[The Haunted Pantry];		//grab epic food
+	}
+	
+	return autoAdv(goal);
+}
+
+boolean greygoo_oddJobs()
+{
+	//spend all your remaining adv on the odd jobs board for ~100 meat per adv and some stats
+	if(my_adventures() < 10)
+	{
+		while(my_meat() > 1000 && auto_autoConsumeOne("drink", false));		//try to fill up on drink
+		while(my_meat() > 1000 && auto_autoConsumeOne("eat", false));		//try to fill up on food
+		if((my_adventures() < 10 && my_daycount() < 3 ) || my_adventures() < 3)
+		{
+			return false;		//not enough adv left
+		}
+	}
+	
+	int target = 1;		//choice 1 == costs 3 adv and balanced stats
+	if(my_adventures() > 9)
+	{
+		if($classes[Seal Clubber, Turtle Tamer] contains my_class())
+		{
+			target = 2;		//choice 2 == costs 10 adv and mus focus stats
+		}
+		if($classes[Pastamancer, Sauceror] contains my_class())
+		{
+			target = 3;		//choice 3 == costs 10 adv and mys focus stats
+		}
+		if($classes[Disco Bandit, Accordion Thief] contains my_class())
+		{
+			target = 4;		//choice 4 == costs 10 adv and mox focus stats
+		}
+	}
+	return LX_oddJobs(target);
+}
+
 boolean LA_grey_goo_tasks()
 {
 	if(!in_ggoo())
 	{
 		return false;
 	}
+	
+	if(greygoo_fortuneCollect()) return true;
+	if(my_level() < 3)								//if just started a run do oddjobs to get some levels
+	{
+		if(greygoo_oddJobs()) return true;
+	}
+	if(my_meat() < 300)
+	{
+		if(greygoo_oddJobs()) return true;			//running out of money. so get some more
+	}
+	if(LX_galaktikSubQuest()) return true;			//will only do the quest if auto_doGalaktik is true
+	if(LX_guildUnlock()) return true;
+	
+	//unlock [typical tavern]
+	if(L2_mosquito()) return true;					//must do this quest to unlock typical tavern
+	if(internalQuestStatus("questL03Rat") == 0)		//got the quest from council but yet to speak to bart ender
+	{
+		visit_url("tavern.php?place=barkeep");		//talk to him once to unlock his booze selling.
+	}
+	if(LX_armorySideQuest()) return true;			//unlock [madeline's baking supply] store while getting some food
+	
+	if(LX_freeCombats(true)) return true;
+	if(greygoo_oddJobs()) return true;				//spend remaining adventures on getting meat and XP
+	//fighting greygoo monsters for monster manuel entries will go here
 
 	if(my_daycount() < 3)
 	{
@@ -34,8 +117,7 @@ boolean LA_grey_goo_tasks()
 	else
 	{
 		print("You are done with this grey goo ascension. please enter the astral gash","green");
-	}
-	
+	}	
 	set_property("_auto_doneToday", true);		//skip doTasks() and go to doBedtime()
 	return true;		//restart doTasks() loop so we can notice the above setting
 }

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -9,8 +9,7 @@ void grey_goo_initializeSettings()
 	{
 		return;
 	}
-	set_property("auto_paranoia", 1);		//greygoo has broken tracking verified for: questL02Larva && questM19Hippy. probably more things
-	set_property("auto_doGalaktik", true);	//we are adventuring in greygoo for meat. this saves meat
+	set_property("auto_paranoia", 1);		//greygoo has broken tracking verified for questL02Larva && questM19Hippy. probably more things
 }
 
 void grey_goo_initializeDay(int day)
@@ -21,64 +20,6 @@ void grey_goo_initializeDay(int day)
 	}
 }
 
-boolean greygoo_fortuneCollect()
-{
-	if(!contains_text(get_counters("Fortune Cookie", 0, 0), "Fortune Cookie"))
-	{
-		return false;	//semirare not currently about to happen
-	}
-	
-	//Semi-rare Handler
-	auto_log_info("Semi rare time!", "blue");
-	cli_execute("counters");
-
-	location goal;
-	location lastsr = get_property("semirareLocation").to_location();
-	
-	if(lastsr != $location[The Sleazy Back Alley])		//can not get the same SR twice. so do not waste it
-	{
-		goal = $location[The Sleazy Back Alley];	//grab epic drink
-	}
-	else
-	{
-		goal = $location[The Haunted Pantry];		//grab epic food
-	}
-	
-	return autoAdv(goal);
-}
-
-boolean greygoo_oddJobs()
-{
-	//spend all your remaining adv on the odd jobs board for ~100 meat per adv and some stats
-	if(my_adventures() < 10)
-	{
-		while(my_meat() > 1000 && auto_autoConsumeOne("drink", false));		//try to fill up on drink
-		while(my_meat() > 1000 && auto_autoConsumeOne("eat", false));		//try to fill up on food
-		if((my_adventures() < 10 && my_daycount() < 3 ) || my_adventures() < 3)
-		{
-			return false;		//not enough adv left
-		}
-	}
-	
-	int target = 1;		//choice 1 == costs 3 adv and balanced stats
-	if(my_adventures() > 9)
-	{
-		if($classes[Seal Clubber, Turtle Tamer] contains my_class())
-		{
-			target = 2;		//choice 2 == costs 10 adv and mus focus stats
-		}
-		if($classes[Pastamancer, Sauceror] contains my_class())
-		{
-			target = 3;		//choice 3 == costs 10 adv and mys focus stats
-		}
-		if($classes[Disco Bandit, Accordion Thief] contains my_class())
-		{
-			target = 4;		//choice 4 == costs 10 adv and mox focus stats
-		}
-	}
-	return LX_oddJobs(target);
-}
-
 boolean LA_grey_goo_tasks()
 {
 	if(!in_ggoo())
@@ -86,17 +27,8 @@ boolean LA_grey_goo_tasks()
 		return false;
 	}
 	
-	if(greygoo_fortuneCollect()) return true;
-	if(my_level() < 3)								//if just started a run do oddjobs to get some levels
-	{
-		if(greygoo_oddJobs()) return true;
-	}
-	if(my_meat() < 300)
-	{
-		if(greygoo_oddJobs()) return true;			//running out of money. so get some more
-	}
 	if(LX_galaktikSubQuest()) return true;			//will only do the quest if auto_doGalaktik is true
-	if(LX_guildUnlock()) return true;
+	//if(LX_guildUnlock()) return true;
 	
 	//unlock [typical tavern]
 	if(L2_mosquito()) return true;					//must do this quest to unlock typical tavern
@@ -107,8 +39,6 @@ boolean LA_grey_goo_tasks()
 	if(LX_armorySideQuest()) return true;			//unlock [madeline's baking supply] store while getting some food
 	
 	if(LX_freeCombats(true)) return true;
-	if(greygoo_oddJobs()) return true;				//spend remaining adventures on getting meat and XP
-	//fighting greygoo monsters for monster manuel entries will go here
 
 	if(my_daycount() < 3)
 	{

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -27,27 +27,15 @@ boolean LA_grey_goo_tasks()
 		return false;
 	}
 	
-	if(LX_galaktikSubQuest()) return true;			//will only do the quest if auto_doGalaktik is true
-	//if(LX_guildUnlock()) return true;
-	
-	//unlock [typical tavern]
-	if(L2_mosquito()) return true;					//must do this quest to unlock typical tavern
-	if(internalQuestStatus("questL03Rat") == 0)		//got the quest from council but yet to speak to bart ender
-	{
-		visit_url("tavern.php?place=barkeep");		//talk to him once to unlock his booze selling.
-	}
-	if(LX_armorySideQuest()) return true;			//unlock [madeline's baking supply] store while getting some food
-	
-	if(LX_freeCombats(true)) return true;
+	if(LX_galaktikSubQuest()) return true;			//only if user manually set auto_doGalaktik to true this ascension
+	if(LX_armorySideQuest()) return true;			//only if user manually set auto_doArmory to true this ascension
 
-	if(my_daycount() < 3)
+	print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
+	if (my_daycount() >= 3)
 	{
-		print("You are currently on day " +my_daycount()+ " out of 3 of this grey goo run","red");
+		print("You made it beyond the dawn of the third day and can now ascend. Congratulations!", "blue");
+		abort();
 	}
-	else
-	{
-		print("You are done with this grey goo ascension. please enter the astral gash","green");
-	}	
-	set_property("_auto_doneToday", true);		//skip doTasks() and go to doBedtime()
-	return true;		//restart doTasks() loop so we can notice the above setting
+	abort("Please come back in " + (3 - my_daycount()) + " days.");
+	return true;
 }

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -390,7 +390,7 @@ boolean LX_guildUnlock()
 	{
 		return false;
 	}
-	if (!($strings[Picky, Community Service, Low Key Summer, Grey Goo] contains auto_my_path())
+	if (!($strings[Picky, Community Service, Low Key Summer] contains auto_my_path())
 		&& get_property('auto_skipUnlockGuild').to_boolean())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -390,10 +390,14 @@ boolean LX_guildUnlock()
 	{
 		return false;
 	}
-	if (!($strings[Picky, Community Service, Low Key Summer] contains auto_my_path())
+	if (!($strings[Picky, Community Service, Low Key Summer, Grey Goo] contains auto_my_path())
 		&& get_property('auto_skipUnlockGuild').to_boolean())
 	{
 		return false;
+	}
+	if(in_ggoo() && $classes[Seal Clubber, Turtle Tamer] contains my_class())
+	{
+		return false;	//muscle classes cannot unlock guild in grey goo
 	}
 	auto_log_info("Let's unlock the guild.", "green");
 

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1057,39 +1057,3 @@ void houseUpgrade()
 		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
 	}
 }
-
-boolean LX_oddJobs(int target)
-{
-	//use odd jobs board for roughly ~100 meat per adv and some stats.
-	//choice 1 == costs 3 adv and balanced stats
-	//choice 2 == costs 10 adv and mus focus stats
-	//choice 3 == costs 10 adv and mys focus stats
-	//choice 4 == costs 10 adv and mox focus stats
-	if(target < 1 || target > 4)
-	{
-		abort("LX_oddJobs has been given an invalid target");
-	}
-	
-	int adv_needed = 10;
-	if (target == 1)
-	{
-		adv_needed = 3;
-	}
-	if(my_adventures() < adv_needed)
-	{
-		auto_log_warning("LX_oddJobs does not have enough adv left to do desired oddjob");
-		return false;
-	}
-	
-	int start_adv = my_adventures();
-	visit_url("place.php?whichplace=town&action=town_oddjobs");
-	run_choice(target);
-	
-	if(my_adventures() == start_adv - adv_needed)
-	{
-		cli_execute("auto_post_adv.ash");
-		return true;
-	}
-	abort("LX_oddJobs() error detected. target = " +target+ ". start_adv = " +start_adv+ ". adventures = " +my_adventures()+ ".");
-	return false;
-}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1057,3 +1057,39 @@ void houseUpgrade()
 		use(1, $item[Frobozz Real-Estate Company Instant House (TM)]);
 	}
 }
+
+boolean LX_oddJobs(int target)
+{
+	//use odd jobs board for roughly ~100 meat per adv and some stats.
+	//choice 1 == costs 3 adv and balanced stats
+	//choice 2 == costs 10 adv and mus focus stats
+	//choice 3 == costs 10 adv and mys focus stats
+	//choice 4 == costs 10 adv and mox focus stats
+	if(target < 1 || target > 4)
+	{
+		abort("LX_oddJobs has been given an invalid target");
+	}
+	
+	int adv_needed = 10;
+	if (target == 1)
+	{
+		adv_needed = 3;
+	}
+	if(my_adventures() < adv_needed)
+	{
+		auto_log_warning("LX_oddJobs does not have enough adv left to do desired oddjob");
+		return false;
+	}
+	
+	int start_adv = my_adventures();
+	visit_url("place.php?whichplace=town&action=town_oddjobs");
+	run_choice(target);
+	
+	if(my_adventures() == start_adv - adv_needed)
+	{
+		cli_execute("auto_post_adv.ash");
+		return true;
+	}
+	abort("LX_oddJobs() error detected. target = " +target+ ". start_adv = " +start_adv+ ". adventures = " +my_adventures()+ ".");
+	return false;
+}


### PR DESCRIPTION
# Description

some grey goo improvements.

* added in_ggoo() function
* message telling you that you can ascend in greygoo is now blue instead of red
* enable paranoia in greygoo. mafia has some broken tracking
* gg muscle classes cannot unlock guild
* if user manually set the post type setting to do galaktik or armory sidequests then do them.

## How Has This Been Tested?

ran it in greygoo

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
