### PR TITLE
boris

### DIFF
--- a/BUILD/settings_extra/post.dat
+++ b/BUILD/settings_extra/post.dat
@@ -26,5 +26,6 @@ _auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actuall
 auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
 auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
+auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
 auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
 auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -47,8 +47,9 @@ post	24	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is
 post	25	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
 post	26	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 post	27	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
-post	28	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
-post	29	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
+post	28	auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
+post	29	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+post	30	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
 #
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2720,7 +2720,7 @@ boolean doTasks()
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;
 	if(LX_galaktikSubQuest())			return true;
-	if(armorySideQuest())				return true;
+	if(LX_armorySideQuest())				return true;
 	if(L9_leafletQuest())				return true;
 	if(L5_findKnob())					return true;		//use encryption key to unlock possible delay zone if you have it
 	if(L12_sonofaPrefix())				return true;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -161,6 +161,7 @@ void initializeSettings() {
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
 	set_property("auto_doGalaktik", false);
+	set_property("auto_doArmory", false);
 	set_property("auto_L8_ninjaAssassinFail", false);
 	set_property("auto_L8_extremeInstead", false);
 	set_property("auto_haveSourceTerminal", false);
@@ -2719,6 +2720,7 @@ boolean doTasks()
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;
 	if(LX_galaktikSubQuest())			return true;
+	if(armorySideQuest())				return true;
 	if(L9_leafletQuest())				return true;
 	if(L5_findKnob())					return true;		//use encryption key to unlock possible delay zone if you have it
 	if(L12_sonofaPrefix())				return true;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -393,7 +393,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 1061: // Heart of Madness (Madness Bakery Quest)
-			if(internalQuestStatus("questM25Armorer") <= 1) {
+			if(internalQuestStatus("questM25Armorer") <= 2) {
 				run_choice(1);
 			} else {
 				run_choice(5);

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1825,6 +1825,10 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 		return true;
 	}
 
+	if(in_boris())
+	{
+		return borisAcquireHP(goal);
+	}
 	if (my_class() == $class[Plumber])
 	{
 		while (my_hp() < goal && my_hp() < my_maxhp() && item_amount($item[coin]) > 400)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -938,7 +938,7 @@ boolean LX_melvignShirt();
 boolean LX_steelOrgan();
 boolean LX_guildUnlock();
 boolean startArmorySubQuest();
-boolean armorySideQuest();
+boolean LX_armorySideQuest();
 void considerGalaktikSubQuest();
 boolean startGalaktikSubQuest();
 boolean finishGalaktikSubQuest();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -465,6 +465,7 @@ void boris_initializeDay(int day);
 void boris_buySkills();
 boolean borisDemandSandwich(boolean immediately);
 void borisWastedMP();
+boolean borisAcquireHP(int goal);
 boolean LM_boris();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -937,6 +937,7 @@ boolean LX_melvignShirt();
 boolean LX_steelOrgan();
 boolean LX_guildUnlock();
 boolean startArmorySubQuest();
+boolean armorySideQuest();
 void considerGalaktikSubQuest();
 boolean startGalaktikSubQuest();
 boolean finishGalaktikSubQuest();

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -43,6 +43,7 @@ void boris_initializeSettings()
 		auto_log_info("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
 		set_property("auto_wandOfNagamar", false);
+		set_property("auto_doArmory", true);
 
 		# Mafia r16876 does not see the Boris Helms in storage and will not pull them.
 		# We have to force the issue.

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -370,7 +370,6 @@ boolean borisAcquireHP(int goal)
 {
 	//boris cannot use the normal acquireHP function until it is modified allow multi using skills.
 	//that fix is nontrivial so until such a change is made here is a function that makes boris playable
-	
 	if(!in_boris())
 	{
 		return false;
@@ -382,10 +381,11 @@ boolean borisAcquireHP(int goal)
 	{
 		//we need to loop a few times because our MP tank might be too small to allow us to fully heal in one go. also to prevent wasteage we calculate as if we would get max rolls instead of avg rolls on healed amount when multi casting.
 		int missingHP = goal - my_hp();
-		boolean failed_acquireMP = false;
+		boolean failed_acquireMP = my_maxmp() < 11;
 		int castAmount = missingHP / 2;
 		int mp_desired = min(castAmount, (0.9 * my_maxmp()));
-		if(my_mp() < mp_desired )	//I do not have enough MP to cast as many laugh it off as I would like
+		if(my_mp() < mp_desired &&		//I do not have enough MP to cast as many laugh it off as I would like
+		my_maxmp() > 10)				//if maxMP is too low. do not wastefully try restoring it.
 		{
 			if(!acquireMP(mp_desired))		//try to acquireMP to target. if we already have it acquireMP will just return true.
 			{

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -383,6 +383,10 @@ boolean borisAcquireHP(int goal)
 		int missingHP = goal - my_hp();
 		boolean failed_acquireMP = my_maxmp() < 11;
 		int castAmount = missingHP / 2;
+		if(missingHP == 1)	//at 1 HP short there is a 50% chance of wasting 1 point of HP healed. a risk worth taking to achieve target HP.
+		{
+			castAmount = 1;	//prevents an infinite loop at 1HP missing. since int 1 divided by 2 = 0
+		}
 		int mp_desired = min(castAmount, (0.9 * my_maxmp()));
 		if(my_mp() < mp_desired &&		//I do not have enough MP to cast as many laugh it off as I would like
 		my_maxmp() > 10)				//if maxMP is too low. do not wastefully try restoring it.
@@ -394,14 +398,8 @@ boolean borisAcquireHP(int goal)
 		}
 		castAmount = min(my_mp(), castAmount);		//regardless of MP restore success or failure. we can not spend MP we do not have
 		
-		//if we are exactly 1 HP short there is a 50% chance of wasting 1 point of HP healed. a risk worth taking to achieve target HP.
-		//also this prevents an infinite loop at 1HP missing. Keep that in mind if you remove this
-		if(missingHP == 1)	
-		{
-			castAmount = min(1, castAmount);		//use min in case we had 0 MP left and failed to restore.
-		}
-		
-		use_skill(castAmount, $skill[Laugh it Off]);
+		if(my_mp() == 0) break;				//if I reached this point with no MP I am done
+		use_skill(castAmount, $skill[Laugh it Off]);	//multi restore HP
 		if(failed_acquireMP) break;			//MP restore failed so we are done.
 		if(goal > my_maxhp()) break;		//just in case to prevent infinite loop
 	}

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -383,7 +383,7 @@ boolean borisAcquireHP(int goal)
 		int missingHP = goal - my_hp();
 		boolean failed_acquireMP = my_maxmp() < 11;
 		int castAmount = missingHP / 2;
-		if(missingHP == 1)	//at 1 HP short there is a 50% chance of wasting 1 point of HP healed. a risk worth taking to achieve target HP.
+		if(missingHP == 1)	//at 1 HP less than maxHP there is a 50% chance of wasting 1 point of HP healed. a risk worth taking to achieve target HP.
 		{
 			castAmount = 1;	//prevents an infinite loop at 1HP missing. since int 1 divided by 2 = 0
 		}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -491,7 +491,7 @@ boolean startArmorySubQuest()
 	return false;
 }
 
-boolean armorySideQuest()
+boolean LX_armorySideQuest()
 {
 	//do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
 	//step2 = need to kill the cake lord

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -502,7 +502,6 @@ boolean armorySideQuest()
 	
 	if(internalQuestStatus("questM25Armorer") > -1 && internalQuestStatus("questM25Armorer") < 4)
 	{
-		set_property("choiceAdventure1061", 1);			//try to enter office
 		return autoAdv($location[Madness Bakery]);
 	}
 	if(internalQuestStatus("questM25Armorer") == 4)		//got no-handed pie. need to turn it in.

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -494,6 +494,9 @@ boolean startArmorySubQuest()
 boolean armorySideQuest()
 {
 	//do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
+	//step2 = need to kill the cake lord
+	//step3 = killed the cake lord
+	//step4 = clicked through the mandatory noncombat pages after the cake lord was killed
 	if(!get_property("auto_doArmory").to_boolean())		//post setting indicating we should do this quest this ascension
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -331,17 +331,14 @@ boolean LX_steelOrgan()
 		{
 			foreach it in $items[Hilarious Comedy Prop, Victor\, the Insult Comic Hellhound Puppet, Observational Glasses]
 			{
-				if(possessEquipment(it))
+				if(possessEquipment(it) && auto_can_equip(it))
 				{
 					autoForceEquip(it);
-					string temp = visit_url("pandamonium.php?action=mourn&whichitem=" + to_int(it) + "&pwd=");
+					visit_url("pandamonium.php?action=mourn&whichitem=" + to_int(it) + "&pwd=");
 				}
-				else
+				else if(available_amount(it) == 0)
 				{
-					if(available_amount(it) == 0)
-					{
-						abort("Somehow we do not have " + it + " at this point...");
-					}
+					abort("Somehow we do not have " + it + " at this point...");
 				}
 			}
 		}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -480,13 +480,37 @@ boolean startArmorySubQuest()
 
 	if(internalQuestStatus("questM25Armorer") == -1)
 	{
-		string temp = visit_url("shop.php?whichshop=armory");
-		temp = visit_url("shop.php?whichshop=armory&action=talk");
-		temp = visit_url("choice.php?pwd=&whichchoice=1065&option=1");
+		visit_url("shop.php?whichshop=armory");
+		visit_url("shop.php?whichshop=armory&action=talk");
+		visit_url("choice.php?pwd=&whichchoice=1065&option=1");
 		if(internalQuestStatus("questM25Armorer") > -1)
 		{
 			return true;
 		}
+	}
+	return false;
+}
+
+boolean armorySideQuest()
+{
+	//do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
+	if(!get_property("auto_doArmory").to_boolean())		//post setting indicating we should do this quest this ascension
+	{
+		return false;
+	}
+	startArmorySubQuest();
+	
+	if(internalQuestStatus("questM25Armorer") > -1 && internalQuestStatus("questM25Armorer") < 4)
+	{
+		set_property("choiceAdventure1061", 1);			//try to enter office
+		return autoAdv($location[Madness Bakery]);
+	}
+	if(internalQuestStatus("questM25Armorer") == 4)		//got no-handed pie. need to turn it in.
+	{
+		auto_log_info("finishing quest [Lending a Hand (and a Foot)]");
+		visit_url("shop.php?whichshop=armory");
+		run_choice(2);		//give no-handed pie to finish the quest
+		return true;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -586,7 +586,7 @@ void considerGalaktikSubQuest()
 		set_property("auto_doGalaktik", true);
 		return;
 	}
-	if(my_meat() + 100 < meatReserve())
+	if(my_meat() < meatReserve() + 100)
 	{
 		auto_log_info("Our meat reserves are far too low, we still need to save up some for quests. Enabling Galaktik quest for this ascension", "red");
 		set_property("auto_doGalaktik", true);


### PR DESCRIPTION
* boolean armorySubQuest() added
** do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
** added extra setting called auto_doArmory. when true it means doing armory sidequest this ascension. by default enabled in boris and disabled in other paths on initialize
* fix considerGalaktikSubQuest()
** had the +100 on the wrong side of the equation. meat would never drop below reserve so it never worked.
* boolean borisAcquireHP(int goal)
** boris cannot use the normal acquireHP function until it recieves a major refactoring. until such a change is made here is a function that makes boris playable on low IOTM accounts by allowing boris to actually use laugh it off to restore HP
* make sure we can equip an item before trying to wear it and visiting mourn

## How Has This Been Tested?

day 1-2 of HC boris with 0 IOTMs and 0 perms. successfully did armory quest
day 1-2 of HC boris with most IOTMs and 17 perms. successfully did armory quest

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
