### PR TITLE
Offhand restricted path fixes

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1455,13 +1455,9 @@ boolean L11_hiddenCityZones()
 
 	L11_hiddenTavernUnlock();
 
-	boolean needMachete = !possessEquipment($item[Antique Machete]);
+	boolean canUseMachete = !in_boris() && auto_my_path() != "Way of the Surprising Fist" && !in_pokefam();
+	boolean needMachete = canUseMachete && !possessEquipment($item[Antique Machete]) && in_hardcore();
 	boolean needRelocate = (get_property("relocatePygmyJanitor").to_int() != my_ascensions());
-
-	if (!in_hardcore() || in_boris() || auto_my_path() == "Way of the Surprising Fist" || in_pokefam())
-	{
-		needMachete = false;
-	}
 
 	if (needMachete || needRelocate) {
 		if (handleFamiliar($familiar[Red-Nosed Snapper])) {
@@ -1471,28 +1467,28 @@ boolean L11_hiddenCityZones()
 	}
 
 	if (get_property("hiddenApartmentProgress") == 0) {
-		if (!equipMachete()) {
+		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Northwest)]);
 	}
 
 	if (get_property("hiddenOfficeProgress") == 0) {
-		if (!equipMachete()) {
+		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Northeast)]);
 	}
 
 	if (get_property("hiddenHospitalProgress") == 0) {
-		if (!equipMachete()) {
+		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Southwest)]);
 	}
 
 	if (get_property("hiddenBowlingAlleyProgress") == 0) {
-		if (!equipMachete()) {
+		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Southeast)]);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1614,6 +1614,11 @@ boolean L11_mauriceSpookyraven()
 		{
 			return autoAdv($location[The Haunted Gallery]);
 		}
+		//3rd floor unlock fix. can manually adv without starting quest. but autoAdv fails until quest is started. so start the quest
+		if(internalQuestStatus("questM17Babies") == -1)
+		{
+			visit_url("place.php?whichplace=manor3&action=manor3_ladys");	//talk to 3rd floor ghost to start quest
+		}
 		if(item_amount($item[Detartrated Anhydrous Sublicalc]) == 0)
 		{
 			return autoAdv($location[The Haunted Laboratory]);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1600,33 +1600,27 @@ boolean L11_mauriceSpookyraven()
 		# I suppose we can let anyone in without the Spectacles.
 		if(item_amount($item[Loosening Powder]) == 0)
 		{
-			autoAdv($location[The Haunted Kitchen]);
-			return true;
+			return autoAdv($location[The Haunted Kitchen]);
 		}
 		if(item_amount($item[Powdered Castoreum]) == 0)
 		{
-			autoAdv($location[The Haunted Conservatory]);
-			return true;
+			return autoAdv($location[The Haunted Conservatory]);
 		}
 		if(item_amount($item[Drain Dissolver]) == 0)
 		{
-			autoAdv($location[The Haunted Bathroom]);
-			return true;
+			return autoAdv($location[The Haunted Bathroom]);
 		}
 		if(item_amount($item[Triple-Distilled Turpentine]) == 0)
 		{
-			autoAdv($location[The Haunted Gallery]);
-			return true;
+			return autoAdv($location[The Haunted Gallery]);
 		}
 		if(item_amount($item[Detartrated Anhydrous Sublicalc]) == 0)
 		{
-			autoAdv($location[The Haunted Laboratory]);
-			return true;
+			return autoAdv($location[The Haunted Laboratory]);
 		}
 		if(item_amount($item[Triatomaceous Dust]) == 0)
 		{
-			autoAdv($location[The Haunted Storage Room]);
-			return true;
+			return autoAdv($location[The Haunted Storage Room]);
 		}
 
 		visit_url("place.php?whichplace=manor4&action=manor4_chamberwall");


### PR DESCRIPTION
Fixed some issues with paths where off-hand equipment are banned. (boris, way of surprising fist, pokefam)
* L11 scavenger haunt fix (alternate fulminate).
** do not assume success after adventuring in a zone. Fixes an infinite loop which was caused by the next bug.
** fix mafia failing to adv in 3rd floor zones. mafia thinks I must first talk to lady spookyraven and start quest questM17Babies before we can autoadventure there.
* machete logic fix for L11 quest in offhand restricted paths
** our machete code was trying to account for off-hand restricted paths, but was accounting for them incorrectly.

## How Has This Been Tested?

3rd floor unlocking code tested on HC boris account with 0 iotms and 0 perms
machete code tested on account with all the skills and lots of perms. I was stuck at the start where autoscend kept on failing on me. after I switched to fixed code it worked and completed the quest

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
