### PR TITLE
ci fixes for jenkins changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,20 @@ jobs:
       id: mafia
       run: |
         set -o pipefail
-        export MAFIA_VERSION=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
-        if [[ -z "$MAFIA_VERSION" ]]; then
-          echo "Couldn't determine required mafia version!"
+        export AUTOSCEND_VERSION_REQ=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
+        if [[ -z "$AUTOSCEND_VERSION_REQ" ]]; then
+          echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.AUTOSCEND_VERSION_REQ))) | .[] | .number' | head -n1)
         if [[ -z "$MAFIA_BUILD" ]]; then
-          echo "Couldn't determine Jenkins mafia version!"
+          echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1
         fi
         export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/lastCompletedBuild/artifact/dist/KoLmafia-${MAFIA_BUILD}.jar"
         echo "::set-output name=jenkins::$JENKINS_URL"
         echo "::set-output name=build::$MAFIA_BUILD"
-        echo "::set-output name=version::$MAFIA_VERSION"
+        echo "::set-output name=version::$AUTOSCEND_VERSION_REQ"
 
     - name: Cache KoLmafia
       id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.changeSet[]])
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]])
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+')
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           exit 1
         fi
         export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]')
+        echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .github/kolmafia.jar
-        key: kolmafia-${{steps.mafia.outputs.build}}-${{steps.mafia.outputs.version}}
+        key: kolmafia-${{steps.mafia.outputs.build}}
 
     - name: Download KoLmafia
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]])
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]]')
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]]')
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]] | map(select(.changeSet[].items | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         echo "::set-output name=jenkins::$JENKINS_URL"
         echo "Jenkins URL = ${JENKINS_URL}"
         echo "::set-output name=build::$MAFIA_BUILD"
-        echo "Jenkins Mafia Build = ${JENKINS_URL}"
+        echo "Jenkins Mafia Build = ${MAFIA_BUILD}"
         echo "::set-output name=version::$AUTOSCEND_VERSION_REQ"
-        echo "Autoscend mafia version required = ${JENKINS_URL}"
+        echo "Autoscend mafia version required = ${AUTOSCEND_VERSION_REQ}"
 
     - name: Cache KoLmafia
       id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.AUTOSCEND_VERSION_REQ))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].fileName | contains(env.AUTOSCEND_VERSION_REQ))) | .[] | .number' | head -n1)
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].fileName | contains(env.AUTOSCEND_VERSION_REQ))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]')
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
           echo "Couldn't determine required mafia version!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=builds[number,artifacts[relativePath]]' | jq '[.builds[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[relativePath]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Couldn't determine Jenkins build number!"
           exit 1
         fi
-        export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/${MAFIA_BUILD}/artifact/dist/KoLmafia-${MAFIA_VERSION}.jar"
+        export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/lastCompletedBuild/artifact/dist/KoLmafia-${MAFIA_BUILD}.jar"
         echo "::set-output name=jenkins::$JENKINS_URL"
         echo "::set-output name=build::$MAFIA_BUILD"
         echo "::set-output name=version::$MAFIA_VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,17 @@ jobs:
           exit 1
         fi
         export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+')
-        echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1
         fi
         export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/lastCompletedBuild/artifact/dist/KoLmafia-${MAFIA_BUILD}.jar"
         echo "::set-output name=jenkins::$JENKINS_URL"
+        echo "Jenkins URL = ${JENKINS_URL}"
         echo "::set-output name=build::$MAFIA_BUILD"
+        echo "Jenkins Mafia Build = ${JENKINS_URL}"
         echo "::set-output name=version::$AUTOSCEND_VERSION_REQ"
+        echo "Autoscend mafia version required = ${JENKINS_URL}"
 
     - name: Cache KoLmafia
       id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
       id: mafia
       run: |
         set -o pipefail
-        export AUTOSCEND_VERSION_REQ=$(head -n1 RELEASE/scripts/autoscend.ash | grep -o '[0-9]\+')
-        if [[ -z "$AUTOSCEND_VERSION_REQ" ]]; then
-          echo "Could not determine minimum mafia version required by autoscend!"
-          exit 1
-        fi
         export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+')
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
@@ -38,8 +33,6 @@ jobs:
         echo "Jenkins URL = ${JENKINS_URL}"
         echo "::set-output name=build::$MAFIA_BUILD"
         echo "Jenkins Mafia Build = ${MAFIA_BUILD}"
-        echo "::set-output name=version::$AUTOSCEND_VERSION_REQ"
-        echo "Autoscend mafia version required = ${AUTOSCEND_VERSION_REQ}"
 
     - name: Cache KoLmafia
       id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           echo "Couldn't determine required mafia version!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[relativePath]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[artifacts[fileName]]' | jq '[.lastCompletedBuild[]] | map(select(.artifacts[].relativePath | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
         if [[ -z "$MAFIA_BUILD" ]]; then
-          echo "Couldn't determine Jenkins build number!"
+          echo "Couldn't determine Jenkins mafia version!"
           exit 1
         fi
         export JENKINS_URL="https://ci.kolmafia.us/job/Kolmafia/lastCompletedBuild/artifact/dist/KoLmafia-${MAFIA_BUILD}.jar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       id: mafia
       run: |
         set -o pipefail
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+')
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '.lastCompletedBuild.changeSet.items[0].revision')
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]')
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.changeSet[]])
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Could not determine minimum mafia version required by autoscend!"
           exit 1
         fi
-        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | jq '[.lastCompletedBuild[]] | map(select(.changeSet[].items | contains(env.MAFIA_VERSION))) | .[] | .number' | head -n1)
+        export MAFIA_BUILD=$(curl --fail --silent --globoff 'https://ci.kolmafia.us/job/Kolmafia/api/json?tree=lastCompletedBuild[changeSet[items[revision]]]' | grep -o '[0-9]\+)
         echo "$MAFIA_BUILD";
         if [[ -z "$MAFIA_BUILD" ]]; then
           echo "Could not determine mafia version of Jenkins last completed build!"

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,6 @@
-since r20655;	// min mafia revision needed to run this script. Last update: questM05Toot tracking will correct to finished when refreshing quests
+since r20655;	// min mafia revision needed to run this script.
+//do not include numbers in the comments of above line. as our CI script takes all numbers from the above line to determine revision
+//Last update: questM05Toot tracking will correct to finished when refreshing quests
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,6 +1,4 @@
-since r20655;	// min mafia revision needed to run this script.
-//do not include numbers in the comments of above line. as our CI script takes all numbers from the above line to determine revision
-//Last update: questM05Toot tracking will correct to finished when refreshing quests
+since r20655;	// min mafia revision needed to run this script. Last update: questM05Toot tracking will correct to finished when refreshing quests
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here


### PR DESCRIPTION
# Description

a few months ago jenkins had to be rebuilt. this resulted in some changes to it which broke our ci automatic verification before merging a commit is allowed. this PR fixes it

## How Has This Been Tested?

since I am fixing github checks before merger is allowed, then testing is done via github
look at the `Checks` tab above

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
