### PR TITLE
prevent infinite loop in softcore exploathing

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -895,7 +895,10 @@ boolean canYellowRay(monster target)
 			temp = visit_url("choice.php?pwd=&whichchoice=999&option=1&topper=1&lights=1&garland=1&gift=1");
 		}
 	}
-	if(!get_property("_internetViralVideoBought").to_boolean() && (item_amount($item[BACON]) >= 20) && auto_is_valid($item[Viral Video]))
+	if(!get_property("_internetViralVideoBought").to_boolean() &&	//can only buy 1 per day
+	(item_amount($item[BACON]) >= 20) &&	//it costs 20 bacon
+	auto_is_valid($item[Viral Video]) &&	//do not bother buying it if it is not valid
+	!in_koe())	//bacon store is unreachable in kingdom of exploathing
 	{
 		cli_execute("make " + $item[Viral Video]);
 	}

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -11,6 +11,7 @@ boolean koe_initializeSettings()
 		set_property("auto_holeinthesky", false);
 		set_property("auto_paranoia", 3);
 		set_property("auto_skipL12Farm", "true");
+		set_property("auto_grimstoneOrnateDowsingRod", false);
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -11,7 +11,7 @@ boolean koe_initializeSettings()
 		set_property("auto_holeinthesky", false);
 		set_property("auto_paranoia", 3);
 		set_property("auto_skipL12Farm", "true");
-		set_property("auto_grimstoneOrnateDowsingRod", false);
+		set_property("auto_grimstoneOrnateDowsingRod", false);		//location not reachable in koe
 		return true;
 	}
 	return false;


### PR DESCRIPTION
* prevent infinite loop in softcore exploathing. when trying to get ornate dowsing rod via grimstone mask. as the zone is not reachable
* fix yellow ray. preparing for yellow ray in softcore exploathing would give constant errors as it would repeatedly try to buy viral video for 20 bacon (from infinite bacon machine) every loop and fail because bacon store does not work in exploathing

## How Has This Been Tested?

grimstone mask test:
reached infinite loop spot. used
`set auto_grimstoneOrnateDowsingRod = false`
and it stopped giving me that infinite loop

bacon test: just ran the code and it stopped failing to buy viral video every loop.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
