### PR TITLE
fix infinite loop in exploathing for people with grimstone golem

### DIFF
--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -12,6 +12,7 @@ boolean koe_initializeSettings()
 		set_property("auto_paranoia", 3);
 		set_property("auto_skipL12Farm", "true");
 		set_property("auto_grimstoneOrnateDowsingRod", false);		//location not reachable in koe
+		set_property("auto_grimstoneFancyOilPainting", false);		//location not reachable in koe
 		return true;
 	}
 	return false;


### PR DESCRIPTION
fix infinite loop in exploathing for people with grimstone golem
addresses one of the subissues in #664

## How Has This Been Tested?

I do not own a grimstone golem so I can not test it. I tested the very similar fix for ornate dowsing rod (which, unlike this issue, can affect people without a grimstone golem).
it is just a one line setting change though so it should be fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
