### PR TITLE
LX_ghostBusting() refactor

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -992,7 +992,7 @@ boolean haveGhostReport()
 
 boolean LX_ghostBusting()
 {
-	if(!possessEquipment($item[Protonic Accelerator Pack]))
+	if(!possessEquipment($item[Protonic Accelerator Pack]) || !auto_can_equip($item[Protonic Accelerator Pack]))
 	{
 		return false;
 	}
@@ -1007,181 +1007,45 @@ boolean LX_ghostBusting()
 			return false;
 		}
 	}
-
+	// goal & progress specific reasons to skip busting this turn go below.
 	location goal = get_property("ghostLocation").to_location();
-	boolean canAttempt = have_equipped($item[Protonic Accelerator Pack]);
-	if(possessEquipment($item[Protonic Accelerator Pack]) && can_equip($item[Protonic Accelerator Pack]))
+	if(goal == $location[none])
 	{
-		canAttempt = true;
+		return false;
+	}
+	if(auto_my_path() == "Community Service" && my_daycount() == 1 && goal == $location[The Spooky Forest])
+	{
+		return false;
+	}
+	if(goal == $location[Inside The Palindome] && !possessEquipment($item[Talisman O\' Namsilat]))
+	{
+		return false;
+	}
+	
+	//zone unlocks which require no adv spent. ghost will not show up here unless zone is available. no need to skip ghost if zone unavailable.
+	startHippyBoatmanSubQuest();	//unlocks $location[The Old Landfill].
+	
+	//zone unlocks which require no adv spent. where a ghost can show up even if you did not unlock the zone. if failed to unlock we skip this ghost
+	startMeatsmithSubQuest();		//unlocks $location[The Skeleton Store]
+	startArmorySubQuest();			//unlocks $location[Madness Bakery]
+	startGalaktikSubQuest();		//unlocks $location[The Overgrown Lot]
+	if($locations[The Skeleton Store, Madness Bakery, The Overgrown Lot] contains goal && !zone_available(goal))
+	{
+		auto_log_critical("Failed to unlock the location [" +goal+ "]. skipping this ghost...", "red");
+		set_property("questPAGhost", "unstarted");
+		set_property("ghostLocation", "");
+		return false;
 	}
 
-	if((goal != $location[none]) && canAttempt)
+	auto_log_info("Ghost busting time! At: " +goal, "blue");
+	autoForceEquip($item[Protonic Accelerator Pack]);
+	if(goal == $location[Inside The Palindome])
 	{
-		if((auto_my_path() == "Community Service") && (my_daycount() == 1) && (goal == $location[The Spooky Forest]))
-		{
-			return false;
-		}
-
-		acquireHP();
-		auto_log_info("Ghost busting time! At: " + get_property("ghostLocation"), "blue");
-		boolean newbieFail = false;
-		if(goal == $location[The Skeleton Store])
-		{
-			startMeatsmithSubQuest();
-			if(internalQuestStatus("questM23Meatsmith") == -1)
-			{
-				auto_log_warning("Failed to unlock [The Skeleton Store] for ghostbusting", "red");
-				newbieFail = true;
-			}
-			else if(internalQuestStatus("questM23Meatsmith") == 0)
-			{
-				if(item_amount($item[Skeleton Store Office Key]) > 0)
-				{
-					set_property("choiceAdventure1060", 4);
-				}
-				else
-				{
-					set_property("choiceAdventure1060", 1);
-				}
-			}
-			else
-			{
-				set_property("choiceAdventure1060", 2);
-			}
-		}
-		if(item_amount($item[Check to the Meatsmith]) > 0)
-		{
-			string temp = visit_url("shop.php?whichshop=meatsmith");
-			temp = visit_url("choice.php?pwd=&whichchoice=1059&option=2");
-			return true;
-		}
-		if(goal == $location[Madness Bakery])
-		{
-			startArmorySubQuest();
-			if(internalQuestStatus("questM25Armorer") == -1)
-			{
-				auto_log_warning("Failed to unlock [Madness Bakery] for ghostbusting", "red");
-				newbieFail = true;
-			}
-			else if(internalQuestStatus("questM25Armorer") <= 1)
-			{
-				set_property("choiceAdventure1061", 1);
-			}
-			else
-			{
-				set_property("choiceAdventure1061", 5);
-			}
-		}
-		if(item_amount($item[no-handed pie]) > 0)
-		{
-			string temp = visit_url("shop.php?whichshop=armory");
-			temp = visit_url("choice.php?pwd=&whichchoice=1065&option=2");
-			return true;
-		}
-		if(goal == $location[The Overgrown Lot])
-		{
-			//Meh.
-			startGalaktikSubQuest();
-			if(internalQuestStatus("questM24Doc") == -1)
-			{
-				auto_log_warning("Failed to unlock [The Overgrown Lot] for ghostbusting", "red");
-				newbieFail = true;
-			}
-		}
-		if((item_amount($item[Swindleblossom]) >= 3) && (item_amount($item[Fraudwort]) >= 3) && (item_amount($item[Shysterweed]) >= 3))
-		{
-			string temp = visit_url("shop.php?whichshop=doc");
-			temp = visit_url("shop.php?whichshop=doc&action=talk");
-			temp = visit_url("choice.php?pwd=&whichchoice=1064&option=2");
-			return true;
-		}
-		if((goal == $location[The Batrat and Ratbat Burrow]) && (internalQuestStatus("questL04Bat") < 1))
-		{
-			return false;
-		}
-		if((goal == $location[Cobb\'s Knob Laboratory]) && (item_amount($item[Cobb\'s Knob Lab Key]) == 0))
-		{
-			return false;
-		}
-
-		if (goal == $location[Lair of the Ninja Snowmen] && internalQuestStatus("questL08Trapper") < 2)
-		{
-			return false;
-		}
-		if (goal == $location[The VERY Unquiet Garves] && get_property("questL07Cyrptic") != "finished")
-		{
-			return false;
-		}
-		if(goal == $location[The Castle in the Clouds in the Sky (Top Floor)])
-		{
-			if (internalQuestStatus("questL10Garbage") < 9)
-			{
-				return false;
-			}
-			if(L10_topFloor() || L10_holeInTheSkyUnlock())
-			{
-				return true;
-			}
-		}
-		if(goal == $location[Lair of the Ninja Snowmen])
-		{
-			if(L8_trapperNinjaLair())
-			{
-				return true;
-			}
-		}
-
-		if((goal == $location[The Red Zeppelin]) && (internalQuestStatus("questL11Ron") < 3))
-		{
-			return false;
-		}
-		if (goal == $location[The Hidden Park] && internalQuestStatus("questL11Worship") > 3)
-		{
-			return false;
-		}
-
-		item replaceAcc3 = $item[none];
-		if(goal == $location[Inside The Palindome])
-		{
-			if(!possessEquipment($item[Talisman O\' Namsilat]))
-			{
-				return false;
-			}
-			if(equipped_item($slot[acc3]) != $item[Talisman O\' Namsilat])
-			{
-				replaceAcc3 = equipped_item($slot[acc3]);
-				autoEquip($slot[acc3], $item[Talisman O\' Namsilat]);
-			}
-		}
-
-		if(newbieFail)
-		{
-			auto_log_critical("Can't bust that ghost, we don't feel good!! skipping this ghost...", "red");
-			set_property("questPAGhost", "unstarted");
-			set_property("ghostLocation", "");
-			return false;
-		}
-
-		if((equipped_item($slot[Back]) != $item[Protonic Accelerator Pack]) && can_equip($item[Protonic Accelerator Pack]))
-		{
-			autoEquip($slot[Back], $item[Protonic Accelerator Pack]);
-		}
-
-		auto_log_info("Time to bust some ghosts!!!", "green");
-		boolean advVal = autoAdv(goal);
-		if(replaceAcc3 != $item[none])
-		{
-			autoEquip($slot[acc3], replaceAcc3);
-		}
-		if(have_effect($effect[Beaten Up]) == 0)
-		{
-			set_property("questPAGhost", "unstarted");
-			set_property("ghostLocation", "");
-		}
-
-		return advVal;
+		autoForceEquip($slot[acc3], $item[Talisman O\' Namsilat]);
 	}
-	return false;
+	acquireHP();
+	auto_log_info("Time to bust some ghosts!!!", "green");
+	return autoAdv(goal);
 }
 
 int timeSpinnerRemaining()


### PR DESCRIPTION
LX_ghostBusting() refactor:
* remove redundant checks for whether you possess the proton pack
* use auto_can_equip instead of can_equip
* (goal == none) moved from wrapping around the entire function to instead just be an initial check on its own at the front. lots of whitespace changed to account for this change
* remove vestigial choiceAdventure1061 setting. already handled in auto_choice_adv.ash
* removed vestigial turning in of finished armorySubQuest. it has its own separate handling
* remove vestigial turning in of doc galaktik quest. it has its own function and handling elsewhere
* remove unnecessary temp string for visit_url
* remove vestigial choiceAdventure1060 handling
* cleanup protonic accelerator pack equipping
* reorganize goal and quest progress specific abandonment to happen first.
* reorganized and refactored free zone unlocking.
* removed calling external functions to adventure. they are all for hypothetical zones that ended up not having a ghost in them.
* rewrote and relocated palindrome talisman handling
* removes redundant meatsmith quest finishing from ghostbusting function. it has its own function elsewhere.
* removed zone handling for zones which do not actually contain ghosts for busting
* use autoForceEquip
* use startHippyBoatmanSubQuest() to unlocks $location[The Old Landfill] to unlock the possibility of a ghost showing there. the item it drops is pretty good and it does not cost anything to unlock the zone.
* use zone_available() when checking zone availability instead of a custom written if check for each separate zone.
* removed obsolete code for clearing mafia tracking once a ghost is killed. not necessary since mafia does it automatically by now.

## How Has This Been Tested?

one HC exploathing run with many iotms
softcore pathless accordion thief. ghosts were busted

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
