### PR TITLE
optional quests fixes

### DIFF
--- a/BUILD/settings_extra/post.dat
+++ b/BUILD/settings_extra/post.dat
@@ -27,5 +27,6 @@ auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm
 auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
 auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
+auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
 auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
 auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -48,8 +48,9 @@ post	25	auto_needLegs	boolean	In Ed, do we require getting legs before trying to
 post	26	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 post	27	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
 post	28	auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
-post	29	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
-post	30	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
+post	29	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
+post	30	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+post	31	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
 #
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -162,6 +162,7 @@ void initializeSettings() {
 	set_property("auto_haveoven", false);
 	set_property("auto_doGalaktik", false);
 	set_property("auto_doArmory", false);
+	set_property("auto_doMeatsmith", false);
 	set_property("auto_L8_ninjaAssassinFail", false);
 	set_property("auto_L8_extremeInstead", false);
 	set_property("auto_haveSourceTerminal", false);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2720,7 +2720,8 @@ boolean doTasks()
 	if(LX_faxing())						return true;
 	if(LX_artistQuest())				return true;
 	if(LX_galaktikSubQuest())			return true;
-	if(LX_armorySideQuest())				return true;
+	if(LX_armorySideQuest())			return true;
+	if(LX_meatsmithSubQuest())			return true;
 	if(L9_leafletQuest())				return true;
 	if(L5_findKnob())					return true;		//use encryption key to unlock possible delay zone if you have it
 	if(L12_sonofaPrefix())				return true;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -793,7 +793,7 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[Madness Bakery]:
+	case $location[Madness Bakery]:		//can also be unlocked via hypnotic breadcrumbs. which matter in koe and nuclear autumn. but currently not tracked
 		if(internalQuestStatus("questM25Armorer") >= 0)
 		{
 			retval = true;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -947,6 +947,7 @@ boolean finishGalaktikSubQuest();
 boolean LX_galaktikSubQuest();
 boolean startMeatsmithSubQuest();
 boolean finishMeatsmithSubQuest();
+boolean LX_meatsmithSubQuest();
 boolean LX_pirateOutfit();
 void piratesCoveChoiceHandler(int choice);
 string beerPong(string page);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -939,6 +939,7 @@ boolean LX_melvignShirt();
 boolean LX_steelOrgan();
 boolean LX_guildUnlock();
 boolean startArmorySubQuest();
+boolean finishArmorySideQuest();
 boolean LX_armorySideQuest();
 void considerGalaktikSubQuest();
 boolean startGalaktikSubQuest();

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -529,7 +529,6 @@ boolean LA_cs_communityService()
 						cli_execute("make " + $item[Skeleton Key]);
 					}
 				}
-				set_property("choiceAdventure1060", 2);
 				if(!cs_healthMaintain()){
 					abort("Wasnt able to maintain health.");
 				}

--- a/RELEASE/scripts/autoscend/paths/the_source.ash
+++ b/RELEASE/scripts/autoscend/paths/the_source.ash
@@ -120,12 +120,6 @@ boolean LX_theSource()
 	location goal = get_property("sourceOracleTarget").to_location();
 	if((goal != $location[none]) && (item_amount($item[No Spoon]) == 0))
 	{
-		if(item_amount($item[Check to the Meatsmith]) > 0)
-		{
-			string temp = visit_url("shop.php?whichshop=meatsmith");
-			temp = visit_url("choice.php?pwd=&whichchoice=1059&option=2");
-			return true;
-		}
 		if((goal == $location[The Batrat and Ratbat Burrow]) && (internalQuestStatus("questL04Bat") < 1))
 		{
 			return false;

--- a/RELEASE/scripts/autoscend/paths/the_source.ash
+++ b/RELEASE/scripts/autoscend/paths/the_source.ash
@@ -120,52 +120,10 @@ boolean LX_theSource()
 	location goal = get_property("sourceOracleTarget").to_location();
 	if((goal != $location[none]) && (item_amount($item[No Spoon]) == 0))
 	{
-		if(goal == $location[The Skeleton Store])
-		{
-			if(internalQuestStatus("questM23Meatsmith") == 0)
-			{
-				if(item_amount($item[Skeleton Store Office Key]) > 0)
-				{
-					set_property("choiceAdventure1060", 4);
-				}
-				else
-				{
-					set_property("choiceAdventure1060", 1);
-				}
-			}
-			else
-			{
-				set_property("choiceAdventure1060", 2);
-			}
-		}
 		if(item_amount($item[Check to the Meatsmith]) > 0)
 		{
 			string temp = visit_url("shop.php?whichshop=meatsmith");
 			temp = visit_url("choice.php?pwd=&whichchoice=1059&option=2");
-			return true;
-		}
-		if(goal == $location[Madness Bakery])
-		{
-			if(internalQuestStatus("questM25Armorer") <= 1)
-			{
-				set_property("choiceAdventure1061", 1);
-			}
-			else
-			{
-				set_property("choiceAdventure1061", 5);
-			}
-		}
-		if(item_amount($item[no-handed pie]) > 0)
-		{
-			string temp = visit_url("shop.php?whichshop=armory");
-			temp = visit_url("choice.php?pwd=&whichchoice=1065&option=2");
-			return true;
-		}
-		if((item_amount($item[Swindleblossom]) >= 3) && (item_amount($item[Fraudwort]) >= 3) && (item_amount($item[Shysterweed]) >= 3))
-		{
-			string temp = visit_url("shop.php?whichshop=doc");
-			temp = visit_url("shop.php?whichshop=doc&action=talk");
-			temp = visit_url("choice.php?pwd=&whichchoice=1064&option=2");
 			return true;
 		}
 		if((goal == $location[The Batrat and Ratbat Burrow]) && (internalQuestStatus("questL04Bat") < 1))

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -599,6 +599,10 @@ void considerGalaktikSubQuest()
 	{
 		return;		//give it some turns to see how well we handle things before deciding if galaktik is needed
 	}
+	if(in_koe())
+	{
+		return;		//galaktik is unavailable in kingdom of exploathing
+	}
 	if(my_class() == $class[Vampyre] || in_zelda())
 	{
 		return;		//these classes cannot use galaktik restorers.

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -633,6 +633,10 @@ void considerGalaktikSubQuest()
 
 boolean startGalaktikSubQuest()
 {
+	if(internalQuestStatus("questM24Doc") != -1)
+	{
+		return false;	//quest already started
+	}
 	if(auto_my_path() == "Nuclear Autumn" || in_koe())
 	{
 		//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
@@ -642,14 +646,11 @@ boolean startGalaktikSubQuest()
 		}
 		return false;
 	}
-	if(internalQuestStatus("questM24Doc") == -1)
-	{
-		visit_url("shop.php?whichshop=doc");
-		visit_url("shop.php?whichshop=doc&action=talk");
-		run_choice(1);
-		return true;
-	}
-	return false;
+
+	visit_url("shop.php?whichshop=doc");
+	visit_url("shop.php?whichshop=doc&action=talk");
+	run_choice(1);
+	return internalQuestStatus("questM24Doc") > -1;
 }
 
 boolean finishGalaktikSubQuest()

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -492,28 +492,34 @@ boolean startArmorySubQuest()
 	return false;
 }
 
+boolean finishArmorySideQuest()
+{
+	if(internalQuestStatus("questM25Armorer") != 4)		//step4 == have [no-handed pie]. need to turn it in.
+	{
+		return false;
+	}
+	auto_log_info("finishing quest [Lending a Hand (and a Foot)]");
+	visit_url("shop.php?whichshop=armory");
+	run_choice(2);		//give no-handed pie to finish the quest
+	return true;
+}
+
 boolean LX_armorySideQuest()
 {
 	//do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
 	//step2 = need to kill the cake lord
 	//step3 = killed the cake lord
 	//step4 = clicked through the mandatory noncombat pages after the cake lord was killed
+	startArmorySubQuest();							//always start the quest to unlock the zone. costs no adv
+	if(finishArmorySideQuest()) return true;		//always finish the quest if possible. unlocks a shop.
+
 	if(!get_property("auto_doArmory").to_boolean())		//post setting indicating we should do this quest this ascension
 	{
 		return false;
-	}
-	startArmorySubQuest();
-	
+	}	
 	if(internalQuestStatus("questM25Armorer") > -1 && internalQuestStatus("questM25Armorer") < 4)
 	{
 		return autoAdv($location[Madness Bakery]);
-	}
-	if(internalQuestStatus("questM25Armorer") == 4)		//got no-handed pie. need to turn it in.
-	{
-		auto_log_info("finishing quest [Lending a Hand (and a Foot)]");
-		visit_url("shop.php?whichshop=armory");
-		run_choice(2);		//give no-handed pie to finish the quest
-		return true;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -502,7 +502,7 @@ boolean finishArmorySideQuest()
 	auto_log_info("finishing quest [Lending a Hand (and a Foot)]");
 	visit_url("shop.php?whichshop=armory");
 	run_choice(2);		//give no-handed pie to finish the quest
-	return true;
+	return internalQuestStatus("questM25Armorer") > 4;
 }
 
 boolean LX_armorySideQuest()

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -555,6 +555,24 @@ boolean finishMeatsmithSubQuest()
 	return false;
 }
 
+boolean LX_meatsmithSubQuest()
+{
+	//do meatsmith optional subquest.
+	if(startMeatsmithSubQuest()) return true;		//always start the quest if available
+	if(finishMeatsmithSubQuest()) return true;		//always turn the quest in if possible
+	
+	if(internalQuestStatus("questM23Meatsmith") != 0)
+	{
+		return false;	
+	}
+	if(!get_property("auto_doMeatsmith").to_boolean())
+	{
+		return false;		//by default we do not want to do this quest.
+	}
+	
+	return autoAdv($location[The Skeleton Store]);
+}
+
 void considerGalaktikSubQuest()
 {
 	//by default we do not do doc galaktik quest. user can manually enable it via gui for this current ascension.

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -643,9 +643,9 @@ boolean startGalaktikSubQuest()
 	}
 	if(internalQuestStatus("questM24Doc") == -1)
 	{
-		string temp = visit_url("shop.php?whichshop=doc");
-		temp = visit_url("shop.php?whichshop=doc&action=talk");
-		temp = visit_url("choice.php?pwd=&whichchoice=1064&option=1");
+		visit_url("shop.php?whichshop=doc");
+		visit_url("shop.php?whichshop=doc&action=talk");
+		run_choice(1);
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -632,7 +632,7 @@ void considerGalaktikSubQuest()
 
 boolean startGalaktikSubQuest()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(auto_my_path() == "Nuclear Autumn" || in_koe())
 	{
 		if(item_amount($item[Map to a Hidden Booze Cache]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -527,23 +527,28 @@ boolean LX_armorySideQuest()
 
 boolean startMeatsmithSubQuest()
 {
+	if(in_koe())
+	{
+		return false;	//quest cannot be started and zone cannot be unlocked.
+	}
+	if(internalQuestStatus("questM23Meatsmith") != -1)
+	{
+		return false;	//quest already started
+	}
 	if(auto_my_path() == "Nuclear Autumn")
 	{
 		if(item_amount($item[Bone With a Price Tag On It]) > 0)
 		{
-			use(1, $item[Bone With a Price Tag On It]);
-			return true;
+			//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
+			return use(1, $item[Bone With a Price Tag On It]);
 		}
 		return false;
 	}
-	if(internalQuestStatus("questM23Meatsmith") == -1)
-	{
-		string temp = visit_url("shop.php?whichshop=meatsmith");
-		temp = visit_url("shop.php?whichshop=meatsmith&action=talk");
-		temp = visit_url("choice.php?pwd=&whichchoice=1059&option=1");
-		return true;
-	}
-	return false;
+
+	visit_url("shop.php?whichshop=meatsmith");
+	visit_url("shop.php?whichshop=meatsmith&action=talk");
+	run_choice(1);
+	return internalQuestStatus("questM23Meatsmith") > -1;
 }
 
 boolean finishMeatsmithSubQuest()

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -472,6 +472,7 @@ boolean startArmorySubQuest()
 {
 	if(in_koe() || auto_my_path() == "Nuclear Autumn")
 	{
+		//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
 		if(item_amount($item[Hypnotic Breadcrumbs]) > 0)
 		{
 			return use(1, $item[Hypnotic Breadcrumbs]);
@@ -634,6 +635,7 @@ boolean startGalaktikSubQuest()
 {
 	if(auto_my_path() == "Nuclear Autumn" || in_koe())
 	{
+		//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
 		if(item_amount($item[Map to a Hidden Booze Cache]) > 0)
 		{
 			return use(1, $item[Map to a Hidden Booze Cache]);

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -636,10 +636,9 @@ boolean finishGalaktikSubQuest()
 boolean LX_galaktikSubQuest()
 {
 	//do doc galaktik optional subquest.
-	
-	if(startGalaktikSubQuest()) return true;
-	if(finishGalaktikSubQuest()) return true;
-	considerGalaktikSubQuest();
+	if(startGalaktikSubQuest()) return true;	//always start the quest if available
+	if(finishGalaktikSubQuest()) return true;	//always turn the quest in if possible
+	considerGalaktikSubQuest();					//if allowed will automatically enable the quest in some cases
 	
 	if(internalQuestStatus("questM24Doc") != 0)
 	{

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -547,7 +547,12 @@ boolean startMeatsmithSubQuest()
 
 boolean finishMeatsmithSubQuest()
 {
-	if (internalQuestStatus("questM23Meatsmith") == 1) {
+	if(internalQuestStatus("questM23Meatsmith") != 1)
+	{
+		return false;
+	}
+	if(item_amount($item[Check to the Meatsmith]) > 0)
+	{
 		visit_url("shop.php?whichshop=meatsmith");
 		run_choice(2);
 		return true;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -636,8 +636,7 @@ boolean startGalaktikSubQuest()
 	{
 		if(item_amount($item[Map to a Hidden Booze Cache]) > 0)
 		{
-			use(1, $item[Map to a Hidden Booze Cache]);
-			return true;
+			return use(1, $item[Map to a Hidden Booze Cache]);
 		}
 		return false;
 	}


### PR DESCRIPTION
optional quests:
* comments for galaktik quest
* boolean finishArmorySideQuest() was spunoff from boolean LX_armorySideQuest()
* make sure we have check for the meatsmith before finishing that quest
* add extra post setting auto_doMeatsmith indicating we should do the meatsmith quest this ascension. false by default
* boolean LX_meatsmithSubQuest(). will start and finish quest. if auto_doMeatsmith is true will also do the quest
* galaktik unavailable in koe
* startGalaktikSubQuest() url cleanup
* do not assume success when using $item[Map to a Hidden Booze Cache]
* finishArmorySideQuest() do not assume success
* startGalaktikSubQuest() do not assume success
* boolean startMeatsmithSubQuest() fixes
** fix infinite loop in koe
** cleaned up url
** do not assume success (avoids infinite loops)

cleanup
* remove vestigial choiceAdventure1061 (armory sidequest) handling from the_source.ash. it is already handled in auto_choice_adv.ash
* the source. remove vestigial choiceAdventure1060 handling for meatsmith quest
* the source. remove vestigial turning in of galaktik quest and armory quest (lending a hand and a foot).
* community service remove vestigial choiceAdventure1060 handling. it is handled already in auto_choice_adv.ash
* remove redundant finishing of meatsmith quest from LX_theSource()

## How Has This Been Tested?

meatsmith quest tested in HC boris and HC ed
armory tested in HC ed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
