### PR TITLE
retrocape fix for paths where armory and leggery is unavailable

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -599,7 +599,7 @@ boolean auto_forceEquipSword() {
 		drowsy sword, knob goblin deluxe scimitar, knob goblin scimitar, lupine sword, muculent machete,
 		ridiculously huge sword, serpentine sword, vorpal blade, white sword, sweet ninja sword]
 		{
-			if (possessEquipment(it) && can_equip(it))
+			if (possessEquipment(it) && auto_can_equip(it))
 			{
 				swordToEquip = it;
 				break;

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -607,13 +607,19 @@ boolean auto_forceEquipSword() {
 		}
 	}
 
-	if (swordToEquip == $item[none])
+	if (swordToEquip == $item[none] && isArmoryAndLeggeryStoreAvailable() && my_meat() > 49)
 	{
 		// if we still don't have a sword available, buy one for a trivial amount of meat.
+		// we must check availability first. retrieve_item does not return false on failure. it aborts on failure.
 		if (retrieve_item(1, $item[sweet ninja sword])) // costs 50 meat from the armorer and leggerer
 		{
 			swordToEquip = $item[sweet ninja sword];
 		}
+	}
+	
+	if (swordToEquip == $item[none])	//we do not want to force equip none and then report success.
+	{
+		return false;
 	}
 
 	return autoForceEquip($slot[weapon], swordToEquip);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1925,6 +1925,23 @@ boolean isGeneralStoreAvailable()
 	return true;
 }
 
+boolean isArmoryAndLeggeryStoreAvailable()
+{
+	if(auto_my_path() == "Nuclear Autumn")
+	{
+		return false;
+	}
+	if(auto_my_path() == "Zombie Master")
+	{
+		return false;
+	}
+	if(in_koe())
+	{
+		return false;
+	}
+	return true;
+}
+
 boolean isMusGuildStoreAvailable()
 {
 	if ($classes[seal clubber, turtle tamer] contains my_class() && guild_store_available())

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1303,6 +1303,7 @@ boolean acquireHermitItem(item it);
 boolean isHermitAvailable();
 boolean isGalaktikAvailable();
 boolean isGeneralStoreAvailable();
+boolean isArmoryAndLeggeryStoreAvailable();
 boolean isMusGuildStoreAvailable();
 boolean isMystGuildStoreAvailable();
 boolean isArmoryAvailable();


### PR DESCRIPTION
* forceEquipSword check auto_can_equip() instead of can_equip()
* boolean isArmoryAndLeggeryStoreAvailable() created
* fix auto_forceEquipSword() for paths where you cannot just buy a sword in armory and leggery

## How Has This Been Tested?

tried it in koe where it was erroring. fixed by this code

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
