### PR TITLE
[The Tunnel of L.O.V.E.] is actually allowed while overdrunk

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -502,8 +502,13 @@ boolean auto_pre_adventure()
 		auto_log_warning("We don't have a lot of MP but we are chugging along anyway", "red");
 	}
 	groundhogAbort(place);
-	if (my_inebriety() > inebriety_limit()) {
-		abort("You are overdrunk. Stop it.");
+	if (my_inebriety() > inebriety_limit())
+	{
+		if($locations[The Tunnel of L.O.V.E.] contains place)
+		{
+			auto_log_info("Trying to adv in [" +place+ "] while overdrunk... is actually permitted", "blue");
+		}
+		else abort("You are overdrunk. Stop it.");
 	}
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -508,7 +508,7 @@ boolean auto_pre_adventure()
 		{
 			auto_log_info("Trying to adv in [" +place+ "] while overdrunk... is actually permitted", "blue");
 		}
-		else abort("You are overdrunk. Stop it.");
+		else abort("Trying to adv in [" +place+ "] while overdrunk... Stop it.");
 	}
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");


### PR DESCRIPTION
* [The Tunnel of L.O.V.E.] is actually allowed while overdrunk. so do not abort during pre_adv when trying to do so.
* pre_adv report to user the target location when aborting due to being overdrunk to help debug

## How Has This Been Tested?

dropped standard while overdrunk. originally it aborted doBedtime(). with this code it did not abort and instead started the tunnel of love and killed the first enemy inside.
although mafia did lose track of where it was halfway into the tunnel. requiring manual finishing of the tunnel. still an improvement compared to aborting before starting. and should be able to finish it if mafia fixes the issue with tracking location while overdrunk.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
