### PR TITLE
ed catch island unlock failure.

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1140,6 +1140,20 @@ boolean L1_ed_islandFallback()
 	{
 		return true;
 	}
+	if(get_property("lastIslandUnlock").to_int() != my_ascensions())	//somehow island was not unlocked!
+	{
+		//if we fail to unlock the island at this stage our run will be crippled. normally this does not occur.
+		//but if initialization fails or if user played some turns before running autoscend this can happen.
+		if(my_meat() < 1900)
+		{
+			abort("Island failed to unlock because you do not have enough meat. This is a critical problem for ed pathing. Have at least 1900 meat then run autoscend again");
+		}
+		if(my_adventures() <= 9)
+		{
+			abort("Island failed to unlock because you do not have enough adventures. This is a critical problem for ed pathing. Have at least 10 adv then run autoscend again");
+		}
+		abort("Island failed to unlock for an unknown reason. This is a critical problem for ed pathing. Please unlock the island then run autoscend again");
+	}
 
 	if (my_servant() == $servant[Priest] && my_servant().experience < 196)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -203,7 +203,7 @@ boolean LX_islandAccess()
 		return LX_desertAlternate();
 	}
 
-	if((my_adventures() <= 9) || (my_meat() <= 1900))
+	if((my_adventures() <= 9) || (my_meat() < 1900))
 	{
 		return false;
 	}


### PR DESCRIPTION
* ed catch island unlock failure. which is a critical issue with pathing ed that can easily turn a 3 day run into a 10 day run if not resolved in a timely manner.
this should not really happen. I have only seen it happen when it failed to initialize due to some mafia issue. or because the user tried to play a few turns before running autoscend.

## How Has This Been Tested?

tested it on a broken run. this caught the issue and alerted me to get more meat. which allowed the run to recover

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
