### PR TITLE
familiar hatching

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2593,6 +2593,7 @@ boolean doTasks()
 	auto_latteRefill();
 	auto_buyCrimboCommerceMallItem();
 	houseUpgrade();
+	hatchList();			//hatch familiars that are commonly dropped in run
 
 	//This just closets stuff so G-Lover does not mess with us.
 	if(LM_glover())						return true;

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -675,9 +675,9 @@ void preAdvUpdateFamiliar(location place)
 	}
 }
 
-boolean hatchFamiliar(item hatchling, familiar adult)
+boolean hatchFamiliar(familiar adult)
 {
-	//This functions converts an item named hatchling into a familiar named adult.
+	//This functions hatches a familiar named adult.
 	//Returns true if you end up having the hatched familiar. False if you do not.
 	if(!pathAllowsFamiliar())
 	{
@@ -685,11 +685,12 @@ boolean hatchFamiliar(item hatchling, familiar adult)
 	}
 	//TODO return false if no terrarium installed in camp.
 	
-	//do not use auto_have_familiar. we want to know if it exists in the terrarium and do not care about limitations on use
+	//do not use auto_have_familiar. we want to know if it exists in the terrarium and do not care about path limitations on use
 	if(have_familiar(adult))
 	{
 		return true;	//we already have desired familiar
 	}
+	item hatchling = adult.hatchling;
 	if(item_amount(hatchling) == 0)
 	{
 		return false;	//we need to actually own the hatchling to hatch it
@@ -716,23 +717,21 @@ void hatchList()
 	}
 	//TODO return if no terrarium installed in camp.
 	
-	//quest items that are familiar hatchlings. must be hatched before they disappear
-	hatchFamiliar($item[reassembled blackbird], $familiar[Reassembled Blackbird]);		//every ascension
-	hatchFamiliar($item[mosquito larva], $familiar[Mosquito]);							//every ascension
-	hatchFamiliar($item[reconstituted crow], $familiar[reconstituted crow]);			//bees hate you
-	hatchFamiliar($item[black kitten], $familiar[Black Cat]);							//bad moon
-
-	//you get one egg every ascension. often it gets eaten. but you should hatch it if you do not own the familiar
-	hatchFamiliar($item[grue egg], $familiar[Grue]);
-	
-	//hatchling is a common drop. So might as well hatch them if you got one.
-	hatchFamiliar($item[sleeping wereturtle], $familiar[Wereturtle]);
-	
-	//nemesis quest familiars.
-	hatchFamiliar($item[adorable seal larva], $familiar[Adorable Seal Larva]);			//seal clubber
-	hatchFamiliar($item[untamable turtle], $familiar[Untamed Turtle]);					//turtle tamer
-	hatchFamiliar($item[macaroni duck], $familiar[Animated Macaroni Duck]);				//pastamancer
-	hatchFamiliar($item[friendly cheez blob], $familiar[Pet Cheezling]);				//sauceror
-	hatchFamiliar($item[unusual disco ball], $familiar[Autonomous Disco Ball]);			//disco bandit
-	hatchFamiliar($item[stray chihuahua], $familiar[Mariachi Chihuahua]);				//accordion thief
+	foreach fam in $familiars[
+	Reassembled Blackbird,				//quest item dropped every ascension
+	Mosquito,							//quest item dropped every ascension
+	reconstituted crow,					//quest item dropped in bees hate you
+	Black Cat,							//quest item dropped in bad moon
+	Grue,								//you get one egg every ascension.
+	Wereturtle,							//common drop
+	Adorable Seal Larva,				//nemesis quest: seal clubber
+	Untamed Turtle,						//nemesis quest: turtle tamer
+	Animated Macaroni Duck,				//nemesis quest: pastamancer
+	Pet Cheezling,						//nemesis quest: sauceror
+	Autonomous Disco Ball,				//nemesis quest: disco bandit
+	Mariachi Chihuahua					//nemesis quest: accordion thief
+	]
+	{
+		hatchFamiliar(fam);
+	}
 }

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -674,3 +674,65 @@ void preAdvUpdateFamiliar(location place)
 		}
 	}
 }
+
+boolean hatchFamiliar(item hatchling, familiar adult)
+{
+	//This functions converts an item named hatchling into a familiar named adult.
+	//Returns true if you end up having the hatched familiar. False if you do not.
+	if(!pathAllowsFamiliar())
+	{
+		return false;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
+	}
+	//TODO return false if no terrarium installed in camp.
+	
+	//do not use auto_have_familiar. we want to know if it exists in the terrarium and do not care about limitations on use
+	if(have_familiar(adult))
+	{
+		return true;	//we already have desired familiar
+	}
+	if(item_amount(hatchling) == 0)
+	{
+		return false;	//we need to actually own the hatchling to hatch it
+	}
+	
+	auto_log_info("Trying to hatch hatchling item [" +hatchling+ "] into the adult familiar [" +adult+ "]", "blue");
+	visit_url("inv_familiar.php?pwd=&which=3&whichitem=" + hatchling.to_int());
+	
+	if(have_familiar(adult))
+	{
+		auto_log_info("Successfully acquired familiar [" + adult + "]", "blue");
+		return true;
+	}
+	auto_log_info("Failed to convert the familiar hatchling [" + hatchling + "] into the familiar [" + adult + "]", "red");
+	return false;
+}
+
+void hatchList()
+{
+	//this function goes through a list of hatchlings to hatch if available.
+	if(!pathAllowsFamiliar())
+	{
+		return;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
+	}
+	//TODO return if no terrarium installed in camp.
+	
+	//quest items that are familiar hatchlings. must be hatched before they disappear
+	hatchFamiliar($item[reassembled blackbird], $familiar[Reassembled Blackbird]);		//every ascension
+	hatchFamiliar($item[mosquito larva], $familiar[Mosquito]);							//every ascension
+	hatchFamiliar($item[reconstituted crow], $familiar[reconstituted crow]);			//bees hate you
+	hatchFamiliar($item[black kitten], $familiar[Black Cat]);							//bad moon
+
+	//you get one egg every ascension. often it gets eaten. but you should hatch it if you do not own the familiar
+	hatchFamiliar($item[grue egg], $familiar[Grue]);
+	
+	//hatchling is a common drop. So might as well hatch them if you got one.
+	hatchFamiliar($item[sleeping wereturtle], $familiar[Wereturtle]);
+	
+	//nemesis quest familiars.
+	hatchFamiliar($item[adorable seal larva], $familiar[Adorable Seal Larva]);			//seal clubber
+	hatchFamiliar($item[untamable turtle], $familiar[Untamed Turtle]);					//turtle tamer
+	hatchFamiliar($item[macaroni duck], $familiar[Animated Macaroni Duck]);				//pastamancer
+	hatchFamiliar($item[friendly cheez blob], $familiar[Pet Cheezling]);				//sauceror
+	hatchFamiliar($item[unusual disco ball], $familiar[Autonomous Disco Ball]);			//disco bandit
+	hatchFamiliar($item[stray chihuahua], $familiar[Mariachi Chihuahua]);				//accordion thief
+}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -14,26 +14,27 @@ boolean is100FamRun()
 boolean doNotBuffFamiliar100Run()
 {
 	//indicates that we are in a 100% familiar run with a familiar that should not be buffed. Either because it hinders you or is useless.
+	//this list was last updated after ghost of crimbo commerce familiar was added.
 	if(!is100FamRun())
 	{
 		return false;
 	}
 	familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
 	
-	//these familiars are only harmful
+	//these familiars always harm you and never aid you
 	if($familiars[black cat, O.A.F.] contains hundred_fam)
 	{
 		return true;
 	}
 	
-	//these familiars sometime attack the enemy
+	//these familiars sometimes harm you and sometimes attack the enemy
 	if($familiars[Fuzzy Dice, Stab Bat, Killer Bee, Scary Death Orb, RoboGoose] contains hundred_fam)
 	{
 		return true;
 	}
 	
-	//these familiars do nothing rather than actively hinder you. Still should not be buffed.
-	if($familiars[Pet Rock, Toothsome Rock, Bulky Buddy Box, Holiday Log, Homemade Robot, Software Bug, Bad Vibe] contains hundred_fam)
+	//these familiars do not actively hinder you. insead they simply do nothing. should not be buffed to save on MP.
+	if($familiars[Pet Rock, Toothsome Rock, Bulky Buddy Box, Holiday Log, Homemade Robot, Software Bug, Bad Vibe, Pet Coral] contains hundred_fam)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1068,7 +1068,7 @@ boolean autoChooseFamiliar(location place);
 boolean haveSpleenFamiliar();
 boolean wantCubeling();
 void preAdvUpdateFamiliar(location place);
-boolean hatchFamiliar(item hatchling, familiar adult);
+boolean hatchFamiliar(familiar adult);
 void hatchList();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1068,6 +1068,8 @@ boolean autoChooseFamiliar(location place);
 boolean haveSpleenFamiliar();
 boolean wantCubeling();
 void preAdvUpdateFamiliar(location place);
+boolean hatchFamiliar(item hatchling, familiar adult);
+void hatchList();
 
 ########################################################################################################
 //Defined in autoscend/auto_list.ash


### PR DESCRIPTION
* pet coral familiar does nothing. added it to doNotBuffFamiliar100Run()
* clarified some comments
* will now automatically hatch common familiars as they drop for you. including quest items that can be hatched into familiars
** boolean hatchFamiliar(familiar adult)
** void hatchList(). hatches a list of common familiars

## How Has This Been Tested?

ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
