### PR TITLE
familiar acquisition

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -13,6 +13,7 @@ auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; t
 auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
 auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+auto_hatchRagamuffinImp	boolean	If set we will acquire and hatch Ragamuffin Imp in postronin. One per account. some people prefer it in the display case so we require opt in.
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 auto_limitConsume	boolean	When true will not eat or drink anything automatically.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -24,39 +24,40 @@ any	11	auto_floundryChoice	string	Force floundry usage. Must use the item name (
 any	12	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 any	13	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
 any	14	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	15	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	16	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	17	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
-any	18	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
-any	19	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	20	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	21	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	22	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	23	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	24	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	25	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	26	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	27	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	28	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	29	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	30	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	31	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	32	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	33	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	34	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	36	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	39	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	40	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	41	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	42	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	43	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
-any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	15	auto_hatchRagamuffinImp	boolean	If set we will acquire and hatch Ragamuffin Imp in postronin. One per account. some people prefer it in the display case so we require opt in.
+any	16	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	17	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	18	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	19	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	20	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	21	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	22	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	23	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	24	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	25	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	26	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	27	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	28	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	29	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	30	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	31	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	32	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	33	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	34	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	35	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	37	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	38	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	45	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	46	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	47	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	48	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2663,6 +2663,8 @@ boolean doTasks()
 	auto_latteRefill();
 	auto_buyCrimboCommerceMallItem();
 	houseUpgrade();
+	getTerrarium();			//get a familiar terrarium if you do not have one yet so you can use familiars
+	acquireFamiliars();		//get useful and cheap familiars
 	hatchList();			//hatch familiars that are commonly dropped in run
 
 	//This just closets stuff so G-Lover does not mess with us.

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -509,6 +509,9 @@ boolean inCasual();
 boolean inAftercore();
 boolean inPostRonin();
 boolean L8_slopeCasual();
+void acquireFamiliarRagamuffinImp();
+void acquireFamiliarsCasual();
+boolean LX_acquireFamiliarLeprechaun();
 boolean LM_canInteract();
 
 ########################################################################################################
@@ -1102,8 +1105,11 @@ boolean autoChooseFamiliar(location place);
 boolean haveSpleenFamiliar();
 boolean wantCubeling();
 void preAdvUpdateFamiliar(location place);
+boolean checkTerrarium();
+void getTerrarium();
 boolean hatchFamiliar(familiar adult);
 void hatchList();
+void acquireFamiliars();
 
 ########################################################################################################
 //Defined in autoscend/auto_list.ash

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -50,11 +50,217 @@ boolean L8_slopeCasual()
 	return false;
 }
 
+void acquireFamiliarRagamuffinImp()
+{
+	//attack familiar that is very easy to get. one per account. some people prefer to display instead of hatch. require user opt in.
+	if(!get_property("auto_hatchRagamuffinImp").to_boolean())
+	{
+		return;		//user did not opt in.
+	}
+	if(!pathHasFamiliar() || !pathAllowsChangingFamiliar())
+	{
+		return;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
+	}
+	if(!checkTerrarium())
+	{
+		return;
+	}
+	if(!can_interact())
+	{
+		return;	//we are neither in casual nor postronin
+	}
+	if(have_familiar($familiar[Ragamuffin Imp]))
+	{
+		return;		//already have it
+	}
+	if(item_amount($item[pile of smoking rags]) == 0)
+	{
+		//only one copy allowed per account.
+		if(closet_amount($item[pile of smoking rags]) > 0)
+		{
+			auto_log_warning("Your [pile of smoking rags] is in your closet. We will leave it there. If you actually want the familiar [Ragamuffin Imp] then you need to uncloset it", "red");
+		}
+		else if(display_amount($item[pile of smoking rags]) > 0)
+		{
+			auto_log_warning("Your [pile of smoking rags] is in your display case. We will leave it there. If you actually want the familiar [Ragamuffin Imp] then you need to take it out", "red");
+		}
+		else if(!get_property("demonSummoned").to_boolean() &&		//can only summon one demon a day
+			internalQuestStatus("questL11MacGuffin") > 2 &&			//must have read your father diary
+			internalQuestStatus("questL11Manor") > 3)				//must have killed lord spookyraven
+		{
+			cli_execute("summon Tatter");
+		}
+	}
+	hatchFamiliar($familiar[Ragamuffin Imp]);
+}
+
+void acquireFamiliarsCasual()
+{
+	//casual and postronin specific function which acquires hatchlings for important or easy to get familiars and then hatches them.
+	//use is_unrestricted instead of auto_is_valid because familiar hatching is not using an item and ignores most restrictions.
+	if(!pathHasFamiliar() || !pathAllowsChangingFamiliar())
+	{
+		return;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
+	}
+	if(!checkTerrarium())
+	{
+		return;
+	}
+	if(!can_interact())
+	{
+		return;	//we are neigher in casual nor postronin
+	}
+	
+	//Gelatinous Cubeling familiar costs 27 fat loot tokens and significantly improves doing daily dungeon in run.
+	//if you do not have it already then you are most likely a new and poor account and thus want to get it from vending machine and not the mall.
+	if(!have_familiar($familiar[Gelatinous Cubeling]) && item_amount($item[dried gelatinous cube]) == 0 && item_amount($item[fat loot token]) > 26)
+	{
+		buy($coinmaster[Vending Machine], 1, $item[dried gelatinous cube]);
+	}
+	hatchFamiliar($familiar[Gelatinous Cubeling]);
+	
+	//Levitating Potato blocks enemy attacks and is very cheap. if your account is new enough to not have it then you are poor enough to want to get it via token rather than mallbuy.
+	if(have_familiar($familiar[Gelatinous Cubeling]) &&		//cubeling uses same token to buy. so only buy potato if you already have cubeling
+	!have_familiar($familiar[Levitating Potato]) && item_amount($item[potato sprout]) == 0 && item_amount($item[fat loot token]) > 0)
+	{
+		buy($coinmaster[Vending Machine], 1, $item[potato sprout]);
+	}
+	hatchFamiliar($familiar[Levitating Potato]);
+	
+	//cheap attack familiar
+	if(!have_familiar($familiar[Howling Balloon Monkey]) && item_amount($item[balloon monkey]) == 0 && my_meat() > 10000)
+	{
+		retrieve_item(1, $item[balloon monkey]);		//will likely buy ingredients to craft. or it might mallbuy if cheaper
+	}
+	hatchFamiliar($familiar[Howling Balloon Monkey]);
+
+	//stat gains cheaply. scaling. better at high levels
+	if(!have_familiar($familiar[hovering sombrero]) && item_amount($item[hovering sombrero]) == 0 && my_meat() > 10000)
+	{
+		retrieve_item(1, $item[hovering sombrero]);		//will most likely buy ingredients to meatpaste
+	}
+	hatchFamiliar($familiar[hovering sombrero]);
+	
+	//delevel enemy cheaply
+	if(!have_familiar($familiar[barrrnacle]) && item_amount($item[Barrrnacle]) == 0 && auto_mall_price($item[Barrrnacle]) < 1000 && my_meat() > 10000)
+	{
+		retrieve_item(1, $item[Barrrnacle]);			//will mallbuy it
+	}
+	hatchFamiliar($familiar[Barrrnacle]);
+	
+	//meat, MP/HP, confuse, or attack enemy. cheap
+	if(!have_familiar($familiar[Cocoabo]) && item_amount($item[cocoa egg]) == 0)
+	{
+		retrieve_item(1, $item[cocoa egg]);				//will most likely buy ingredients to craft. might buy directly.
+	}
+	hatchFamiliar($familiar[Cocoabo]);
+	
+	//+initiative for Standard restricted runs. cheap
+	if(!have_familiar($familiar[Oily Woim]) && item_amount($item[woim]) == 0)
+	{
+		retrieve_item(1, $item[woim]);					//will most likely buy ingredients to craft. might buy directly.
+	}
+	hatchFamiliar($familiar[Oily Woim]);
+	
+	//IOTM derivative. +1 liver while equipped allowing better rollover drinking
+	if(!have_familiar($familiar[Stooper]) && item_amount($item[Stooper]) == 0)
+	{
+		int price = auto_mall_price($item[Stooper]);
+		if(price < 20000 && price < my_meat())
+		{
+			retrieve_item($item[Stooper]);
+		}
+		else if(price < my_meat())
+		{
+			auto_log_info("You should consider buying [Stooper] from the mall. it only costs " +price+ " meat and gives you +1 liver space", "blue");
+		}
+	}
+	hatchFamiliar($familiar[Stooper]);
+	
+	//IOTM derivative. +initiative, +hot damage. out of standard
+	if(!have_familiar($familiar[Cute Meteor]) && item_amount($item[cute meteoroid]) == 0)
+	{
+		int price = auto_mall_price($item[cute meteoroid]);
+		if(price < 20000 && price < my_meat())
+		{
+			retrieve_item($item[cute meteoroid]);
+		}
+	}
+	hatchFamiliar($familiar[Cute Meteor]);
+}
+
+boolean LX_acquireFamiliarLeprechaun()
+{
+	//unlike other acquire familiar functions this one actually spends adventures. and also stomach space.
+	//+meat familiar. If you do not have leprechaun you are a new account so poor that it is worth spending resources to get.
+	//only return true if we spent an adventure and want to restart the loop.
+	if(!pathHasFamiliar() || !pathAllowsChangingFamiliar())
+	{
+		return false;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
+	}
+	if(!checkTerrarium())
+	{
+		return false;
+	}
+	if(!can_interact())
+	{
+		return false;	//we are neigher in casual nor postronin
+	}
+	if(have_familiar($familiar[Leprechaun]))
+	{
+		return false;	//already have it
+	}
+	if(item_amount($item[leprechaun hatchling]) == 0 && my_meat() > 10000)
+	{
+		int price_hatch = auto_mall_price($item[leprechaun hatchling]);
+		int price_bowl = auto_mall_price($item[bowl of lucky charms]);
+		if(price_hatch < 8000)		//at this price we might as well mallbuy the hatchling
+		{
+			retrieve_item(1, $item[leprechaun hatchling]);
+		}
+		else if(auto_is_valid($item[bowl of lucky charms]))		//try to get hatchling via eating bowl of lucky charms.
+		{
+			if(item_amount($item[bowl of lucky charms]) == 0)
+			{
+				if(price_bowl < 3000)
+				{
+					retrieve_item(1, $item[bowl of lucky charms]);		//just mallbuy it at this price
+				}
+				else if(zone_available($location[The Spooky Forest]))	//spend 1 adv and one clover to get it instead.
+				{
+					retrieve_item(1, $item[Ten-Leaf Clover]);
+					if(item_amount($item[Ten-Leaf Clover]) > 0)
+					{
+						cloverUsageInit();
+						boolean adventure = autoAdv($location[The Spooky Forest]);
+						cloverUsageFinish();
+						if(adventure) return true;
+					}
+				}
+			}
+			if(item_amount($item[bowl of lucky charms]) > 0 && fullness_left() > 0)
+			{
+				int initial = fullness_left();
+				eat(1, $item[bowl of lucky charms]);	//uses 1 stomach space to give 50% chance of recieving the hatchling.
+				if(initial == fullness_left())
+				{
+					auto_log_warning("Mysteriously failed to eat [bowl of lucky charms]", "red");
+				}
+				else if(item_amount($item[leprechaun hatchling]) == 0)
+				{
+					return true;	//ate a bowl of lucky charms but failed to get hatchling. restart loop to try again.
+				}
+			}
+		}
+	}
+	hatchFamiliar($familiar[Leprechaun]);
+	return false;
+}
+
 boolean LM_canInteract()
 {
 	//this function is called early once every loop of doTasks() in autoscend.ash to do things when we have unlimited mall access
 	//which indicates postronin or casual or aftercore. currently won't get called in aftercore
-	
 	if(!can_interact())
 	{
 		return false;
@@ -64,6 +270,9 @@ boolean LM_canInteract()
 	{
 		cli_execute("pull all");
 	}
+	acquireFamiliarsCasual();
+	acquireFamiliarRagamuffinImp();
+	if(LX_acquireFamiliarLeprechaun()) return true;
 	
 	return false;
 }


### PR DESCRIPTION
acquire familiars then hatch them.

familiars acquired in all paths:
* [Lil\' Barrel Mimic]
* [Blood-Faced Volleyball]

familiars acquired in casual and postronin: 
* [Ragamuffin Imp]. only if user opt in.
* [Leprechaun]. may spend a few adventures/stomach space/ten-leaf clovers
* [Gelatinous Cubeling]
* [Levitating Potato]
* [Howling Balloon Monkey]
* [hovering sombrero]
* [barrrnacle]
* [Cocoabo]
* [Oily Woim]
* [Stooper]
* [Cute Meteor]

New functions:
* boolean checkTerrarium()
* void getTerrarium()
* void acquireFamiliars() a function that acquires hatchling of easy to get or cheap familiars and then hatches them.
* void acquireFamiliarsCasual(). get and hatch familiars in casual
* void acquireFamiliarRagamuffinImp()
** auto_hatchRagamuffinImp setting added
* boolean LX_acquireFamiliarLeprechaun()

TODO in followup PR:
* add general setting for acquisition (waiting on #771 )
* add an opt in setting as well as code for the acquisition of the limited per account familiar [Hovering Skull].

## How Has This Been Tested?

most code was tested using a test function in aftercore
ash calls
used it for a normal account in a casual run.  it did nothing because I already had all those familiars. but that showed it does not break things at least.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
