### PR TITLE
fix infinite loop in bees hate you

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -44,10 +44,12 @@ boolean LX_bitchinMeatcar()
 		return false;
 	}
 	
-	if(item_amount($item[Gnollish Toolbox]) > 0)
+	if(item_amount($item[Gnollish Toolbox]) > 0 && auto_is_valid($item[Gnollish Toolbox]))
 	{
-		use(1, $item[Gnollish Toolbox]);
-		return true;
+		if(use(1, $item[Gnollish Toolbox]))
+		{
+			return true;
+		}
 	}
 	
 	//if you reached this point then it means you need to spend adventures to acquire more parts

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -10,6 +10,10 @@ boolean LX_bitchinMeatcar()
 	{
 		return false;
 	}
+	if(in_bhy() && !inKnollSign())		//it is impossible to make a meatcar in this combo of path and signs.
+	{
+		return false;
+	}
 	
 	//calculate meat costs of building your meatcar.
 	//if player manually partially assembled it then it will work, just think it costs slightly more meat than it actually does
@@ -94,6 +98,11 @@ boolean LX_unlockDesert()
 			auto_log_info("In Nuclear Autumn you get a free desert pass at level 11. skipping unlocking it for now", "blue");
 			return false;
 		}
+	}
+	
+	if(in_bhy() && !inKnollSign())		//it is impossible to make a meatcar in this combo of path and signs.
+	{
+		return LX_desertAlternate();	//so buying a bus ticket is the only possible way to unlock the desert for this combo
 	}
 	
 	//knollsign lets you buy the meatcar for less meat than a desert pass without spending any adv.


### PR DESCRIPTION
* fix infinite loop in bees hate you when trying to use gnollish toolbox to make bitchin' meatcar
* it is impossible to make a meatcar in bees hate you path if your sign is not a knollsign. with the infinite loop fixed above this will in turn just waste adventures achieving nothing. now it will instead use the alternative unlock method

## How Has This Been Tested?

I was stuck at said infinite loop. until I used this code

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
