### PR TITLE
kill ghosts if proton pack unavailable

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -992,10 +992,8 @@ boolean haveGhostReport()
 
 boolean LX_ghostBusting()
 {
-	if(!possessEquipment($item[Protonic Accelerator Pack]) || !auto_can_equip($item[Protonic Accelerator Pack]))
-	{
-		return false;
-	}
+	//a function for busting or killing ghosts associated with [Protonic Accelerator Pack].
+	//do not check if we have the IOTM because [Almost-dead_walkie-talkie] gives access to these ghosts without the proton pack.
 	if(get_property("questPAGhost") == "unstarted")
 	{
 		if(!expectGhostReport())
@@ -1037,14 +1035,20 @@ boolean LX_ghostBusting()
 		return false;
 	}
 
-	auto_log_info("Ghost busting time! At: " +goal, "blue");
-	autoForceEquip($item[Protonic Accelerator Pack]);
+	if(possessEquipment($item[Protonic Accelerator Pack]) && auto_can_equip($item[Protonic Accelerator Pack]))
+	{
+		auto_log_info("Ghost busting time! At: " +goal, "blue");
+		autoForceEquip($item[Protonic Accelerator Pack]);
+	}
+	else	//hypothetical future path where pack cannot be equipped. or we used [Almost-dead_walkie-talkie] to get a ghost without the pack
+	{
+		auto_log_info("We can not bust ghosts. but we can still kill them and get ~100 MP worth of restore items. killing ghost at: " +goal, "blue");
+	}
 	if(goal == $location[Inside The Palindome])
 	{
 		autoForceEquip($slot[acc3], $item[Talisman O\' Namsilat]);
 	}
 	acquireHP();
-	auto_log_info("Time to bust some ghosts!!!", "green");
 	return autoAdv(goal);
 }
 


### PR DESCRIPTION
kill ghosts if protonic pack is unavailable. which requires either:
1. a hypothetical future path that blocks back slot
2. using almost-dead walkie talkie to get a ghost without owning the IOTM.

walkie talkie is a very cheap item to get in the mall. as they are common drops from the proton pack and not that popular.
however almost-dead walkie talkie is not tracked by mafia correctly. when used the tracking does not update.
as such you need to perform a `refresh quests` command after using the walkie talkie.
autoscend automatically performs a single `refresh all` when it starts. so if a user used a walkie talkie and then ran autoscend then it will work

## How Has This Been Tested?

BIG run with all perms and most IOTMs. successfully busted ghosts
can't really test walkie talkie yet until mafia fixes its tracking of them

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
