### PR TITLE
exploathing battlefield fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -466,6 +466,9 @@ boolean auto_run_choice(int choice, string page)
 		case 1342: // Torpor (Dark Gyffte)
 			bat_reallyPickSkills(20);
 			break;
+		case 1391: // Rationing out Destruction (Kingdom of Exploathing)
+			koe_RationingOutDestruction();
+			break;
 		case 1410: // The Mushy Center (Your Mushroom Garden)
 			mushroomGardenChoiceHandler(choice);
 			break;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -617,6 +617,7 @@ boolean LX_koeInvaderHandler();
 item koe_L12FoodSelect();
 void koe_RationingOutDestruction();
 boolean L12_koe_clearBattlefield();
+boolean L12_koe_finalizeWar();
 
 ########################################################################################################
 //Defined in autoscend/paths/kolhs.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -612,7 +612,11 @@ boolean L13_towerFinalHeavyRains();
 //Defined in autoscend/paths/kingdom_of_exploathing.ash
 boolean in_koe();
 boolean koe_initializeSettings();
+int koe_rmi_count();
 boolean LX_koeInvaderHandler();
+item koe_L12FoodSelect();
+void koe_RationingOutDestruction();
+boolean L12_koe_clearBattlefield();
 
 ########################################################################################################
 //Defined in autoscend/paths/kolhs.ash

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -142,7 +142,7 @@ boolean L12_koe_clearBattlefield()
 	}
 	if(internalQuestStatus("questL12HippyFrat") != 0)
 	{
-		//questL12War is used in most paths. but not used in koe
+		//questL12War is used in most paths. but not used in koe except to set it to finished after you turn in the quest.
 		//questL12HippyFrat is used exclusively in koe. it only has the values of: unstarted, started, finished.
 		return false;
 	}
@@ -200,7 +200,7 @@ boolean L12_koe_finalizeWar()
 	}
 	if(internalQuestStatus("questL12HippyFrat") != 0)
 	{
-		//questL12War is used in most paths. but not used in koe
+		//questL12War is used in most paths. but not used in koe except to set it to finished after you turn in the quest.
 		//questL12HippyFrat is used exclusively in koe. it only has the values of: unstarted, started, finished.
 		return false;
 	}
@@ -214,5 +214,18 @@ boolean L12_koe_finalizeWar()
 	acquireHP();
 	acquireMP(60);
 	auto_log_info("Let's fight the final boss of the frat-hippy war!", "blue");
-	return autoAdv($location[The Exploaded Battlefield]);
+	boolean retval = autoAdv($location[The Exploaded Battlefield]);
+	council();		//need to visit to grab 10 rare meat isotopes and get next quests
+	cli_execute("refresh quests");		//needed to recognize that war is over
+	if(!retval)
+	{
+		abort("failed to fight the final boss of the frat-hippy war");
+	}
+	if(get_property("questL12War") != "finished")
+	{
+		//only place this property is used in koe is when you turn in the quest to council.
+		//which results in Preference questL12War changed from unstarted to finished
+		abort("I fought the final boss of L12 frat hippy war. I visited the council. and somehow the quest is still incomplete. something is wrong");
+	}
+	return retval;
 }

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -140,8 +140,10 @@ boolean L12_koe_clearBattlefield()
 	{
 		return false;
 	}
-	if(internalQuestStatus("questL12HippyFrat") > 1)
+	if(internalQuestStatus("questL12HippyFrat") != 0)
 	{
+		//questL12War is used in most paths. but not used in koe
+		//questL12HippyFrat is used exclusively in koe. it only has the values of: unstarted, started, finished.
 		return false;
 	}
 	if(get_property("hippiesDefeated").to_int() >= 333 || get_property("fratboysDefeated").to_int() >= 333)
@@ -187,5 +189,30 @@ boolean L12_koe_clearBattlefield()
 		autoEquip($slot[weapon], warKillDoubler);
 	}
 
+	return autoAdv($location[The Exploaded Battlefield]);
+}
+
+boolean L12_koe_finalizeWar()
+{
+	if(!in_koe())
+	{
+		return false;
+	}
+	if(internalQuestStatus("questL12HippyFrat") != 0)
+	{
+		//questL12War is used in most paths. but not used in koe
+		//questL12HippyFrat is used exclusively in koe. it only has the values of: unstarted, started, finished.
+		return false;
+	}
+	if(get_property("hippiesDefeated").to_int() < 333 && get_property("fratboysDefeated").to_int() < 333)
+	{
+		return false;	//there are 333 of each enemy in koe. if either side had all 333 defeated then this will not return false here.
+	}
+	
+	//koe does not have coin masters. there is nothing to sell here.
+	warOutfit(false);
+	acquireHP();
+	acquireMP(60);
+	auto_log_info("Let's fight the final boss of the frat-hippy war!", "blue");
 	return autoAdv($location[The Exploaded Battlefield]);
 }

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1921,6 +1921,10 @@ boolean L12_clearBattlefield()
 
 boolean L12_finalizeWar()
 {
+	if(in_koe())
+	{
+		return L12_koe_finalizeWar();
+	}
 	if (internalQuestStatus("questL12War") != 1)
 	{
 		return false;
@@ -2056,22 +2060,14 @@ boolean L12_finalizeWar()
 
 	location bossFight = $location[Noob Cave];
 
-	if (in_koe())
-	{
-		bossFight = 533.to_location();
-	}
-
 	if(auto_have_familiar($familiar[Machine Elf]))
 	{
 		handleFamiliar($familiar[Machine Elf]);
 	}
 	string[int] pages;
-	if (!in_koe())
-	{
-		pages[0] = "bigisland.php?place=camp&whichcamp=1";
-		pages[1] = "bigisland.php?place=camp&whichcamp=2";
-		pages[2] = "bigisland.php?action=bossfight&pwd";
-	}
+	pages[0] = "bigisland.php?place=camp&whichcamp=1";
+	pages[1] = "bigisland.php?place=camp&whichcamp=2";
+	pages[2] = "bigisland.php?action=bossfight&pwd";
 	if(!autoAdvBypass(0, pages, bossFight, ""))
 	{
 		auto_log_warning("Boss already defeated, ignoring", "red");

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1875,99 +1875,46 @@ boolean L12_clearBattlefield()
 {
 	if(in_koe())
 	{
-		if (internalQuestStatus("questL12HippyFrat") < 2 && get_property("hippiesDefeated").to_int() < 333 && get_property("fratboysDefeated").to_int() < 333 && possessOutfit("Frat Warrior Fatigues", true))
-		{
-			if(haveWarOutfit())
-			{
-				warOutfit(false);
-			}
-
-			item warKillDoubler = my_primestat() == $stat[mysticality] ? $item[Jacob\'s rung] : $item[Haunted paddle-ball];
-			pullXWhenHaveY(warKillDoubler, 1, 0);
-			if(possessEquipment(warKillDoubler))
-			{
-				autoEquip($slot[weapon], warKillDoubler);
-			}
-
-			item food_item = $item[none];
-			foreach it in $items[pie man was not meant to eat, spaghetti with Skullheads, gnocchetti di Nietzsche, Spaghetti con calaveras, space chowder, Spaghetti with ghost balls, Crudles, Agnolotti arboli, Shells a la shellfish, Linguini immondizia bianco, Fettucini Inconnu, ghuol guolash, suggestive strozzapreti, Fusilli marrownarrow]
-			{
-				if(item_amount(it) > 0)
-				{
-					food_item = it;
-					break;
-				}
-			}
-			if(food_item == $item[none])
-			{
-				if(creatable_amount($item[space chowder]) > 6)
-				{
-					create(1, $item[space chowder]);
-					food_item = $item[space chowder];
-				}
-				else
-				{
-					abort("Couldn't find a good food item for the war.");
-				}
-			}
-
-			// TODO: Mafia should really be tracking this.
-			if(!autoAdvBypass("adventure.php?snarfblat=533", $location[The Exploaded Battlefield]))
-			{
-				if(get_property("lastEncounter") == "Rationing out Destruction")
-				{
-					visit_url("choice.php?whichchoice=1391&option=1&tossid=" + food_item.to_int() + "&pwd=" + my_hash(), true);
-				}
-			}
-
-			if(item_amount($item[solid gold bowling ball]) > 0)
-			{
-				council();
-			}
-			return true;
-		}
-		return false;
+		return L12_koe_clearBattlefield();
 	}
-	else
+
+	if (get_property("hippiesDefeated").to_int() < 64 && get_property("fratboysDefeated").to_int() < 64 && internalQuestStatus("questL12War") == 1)
 	{
-		if (get_property("hippiesDefeated").to_int() < 64 && get_property("fratboysDefeated").to_int() < 64 && internalQuestStatus("questL12War") == 1)
+		auto_log_info("First 64 combats. To orchard/lighthouse", "blue");
+		if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cashew]) >= 3))
 		{
-			auto_log_info("First 64 combats. To orchard/lighthouse", "blue");
+			cli_execute("make 1 stuffing fluffer");
+		}
+		if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cornucopia]) > 0) && glover_usable($item[Cornucopia]))
+		{
+			use(1, $item[Cornucopia]);
 			if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cashew]) >= 3))
 			{
 				cli_execute("make 1 stuffing fluffer");
 			}
-			if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cornucopia]) > 0) && glover_usable($item[Cornucopia]))
-			{
-				use(1, $item[Cornucopia]);
-				if((item_amount($item[Stuffing Fluffer]) == 0) && (item_amount($item[Cashew]) >= 3))
-				{
-					cli_execute("make 1 stuffing fluffer");
-				}
-				return true;
-			}
-			if(item_amount($item[Stuffing Fluffer]) > 0)
-			{
-				use(1, $item[Stuffing Fluffer]);
-				return true;
-			}
-			warOutfit(false);
-			return warAdventure();
+			return true;
 		}
-
-		if (get_property("hippiesDefeated").to_int() < 192 && get_property("fratboysDefeated").to_int() < 192 && internalQuestStatus("questL12War") == 1)
+		if(item_amount($item[Stuffing Fluffer]) > 0)
 		{
-			auto_log_info("Getting to the nunnery/junkyard", "blue");
-			warOutfit(false);
-			return warAdventure();
+			use(1, $item[Stuffing Fluffer]);
+			return true;
 		}
+		warOutfit(false);
+		return warAdventure();
+	}
 
-		if ((get_property("sidequestNunsCompleted") != "none" || get_property("auto_skipNuns").to_boolean()) && (get_property("hippiesDefeated").to_int() < 1000 && get_property("fratboysDefeated").to_int() < 1000) && internalQuestStatus("questL12War") == 1)
-		{
-			auto_log_info("Doing the wars.", "blue");
-			warOutfit(false);
-			return warAdventure();
-		}
+	if (get_property("hippiesDefeated").to_int() < 192 && get_property("fratboysDefeated").to_int() < 192 && internalQuestStatus("questL12War") == 1)
+	{
+		auto_log_info("Getting to the nunnery/junkyard", "blue");
+		warOutfit(false);
+		return warAdventure();
+	}
+
+	if ((get_property("sidequestNunsCompleted") != "none" || get_property("auto_skipNuns").to_boolean()) && (get_property("hippiesDefeated").to_int() < 1000 && get_property("fratboysDefeated").to_int() < 1000) && internalQuestStatus("questL12War") == 1)
+	{
+		auto_log_info("Doing the wars.", "blue");
+		warOutfit(false);
+		return warAdventure();
 	}
 	return false;
 }


### PR DESCRIPTION
kingdom of exploathing battlefield fixes
* fix failing to process the noncombat where you murder enemies with food. moved it to new method
* fixed potential infinite loop on quest turnin for casual (in case you drop or break ronin)
* fixed failing to buy space chowder. thus leaving you stuck at the choice advance with nothing to throw. wasting the choice adventure and significantly slowing you down.
* fixed not fighting the final boss of the frat-hippy war
* special handling for turning in the quest and verifying it worked.
* refactored code heavily. creating functions:
** int koe_rmi_count();
** item koe_L12FoodSelect();
** void koe_RationingOutDestruction();
** boolean L12_koe_clearBattlefield();
** boolean L12_koe_finalizeWar();

Fixes #683

note: there is heavy whitespace changes here. I recommend setting it to hide those

## How Has This Been Tested?

normal koe run with all perms and lots of IOTMs. it successfully handled the NC in battlefield, and I can confirm that the issue with failing to purchase cosmic chowder before entering it has been resolved. Also it now fights the final boss and kills him. and can confirm it correctly set questL12HippyFrat to finished afterwards

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
