### PR TITLE
bees hate you item validation & autosellCrap() refactoring

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2355,8 +2355,11 @@ boolean autosellCrap()
 	{
 		return false;		//do not autosell stuff in casual or postronin unless you are very poor
 	}
-	
-	foreach it in $items[dense meat stack, meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
+	if(item_amount($item[dense meat stack]) > 0)	//some people keep their money in dense meat stacks instead of meat format
+	{
+		auto_autosell(min(10, item_amount($item[dense meat stack])), $item[dense meat stack]);
+	}
+	foreach it in $items[meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
 	{
 		if(item_amount(it) > 0)
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2351,37 +2351,34 @@ int speculative_pool_skill()
 
 boolean autosellCrap()
 {
-	if((item_amount($item[dense meat stack]) > 1) && (item_amount($item[dense meat stack]) <= 10))
+	if(can_interact() && my_meat() > 20000)
 	{
-		auto_autosell(1, $item[dense meat stack]);
+		return false;		//do not autosell stuff in casual or postronin unless you are very poor
 	}
-	foreach it in $items[Blue Money Bag, Red Money Bag, White Money Bag]
+	
+	foreach it in $items[dense meat stack, meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
 	{
 		if(item_amount(it) > 0)
 		{
-			auto_autosell(item_amount(it), it);
+			auto_autosell(item_amount(it), it);		//autosell all of this item
 		}
 	}
 	foreach it in $items[Ancient Vinyl Coin Purse, Bag Of Park Garbage, Black Pension Check, CSA Discount Card, Fat Wallet, Gathered Meat-Clip, Old Leather Wallet, Penultimate Fantasy Chest, Pixellated Moneybag, Old Coin Purse, Shiny Stones, Warm Subject Gift Certificate]
 	{
-		if((item_amount(it) > 0) && glover_usable(it) && is_unrestricted(it))
+		if(item_amount(it) > 0 && auto_is_valid(it))
 		{
-			use(1, it);
+			use(item_amount(it), it);
 		}
 	}
-
-	if(!in_hardcore() && !isGuildClass())
+	if(item_amount($item[elegant nightstick]) > 2)
 	{
-		return false;
-	}
-	if(my_meat() > 6500)
-	{
-		return false;
+		auto_autosell(item_amount($item[elegant nightstick])-2, $item[elegant nightstick]);	//keep 2 for double fisting and sell the rest.
 	}
 
-	if(item_amount($item[meat stack]) > 1)
+	//bellow this point are items we only want to sell if we are desperate for meat.
+	if(my_meat() > meatReserve())
 	{
-		auto_autosell(1, $item[meat stack]);
+		return false;
 	}
 
 	foreach it in $items[Anticheese, Awful Poetry Journal, Beach Glass Bead, Beer Bomb, Chaos Butterfly, Clay Peace-Sign Bead, Decorative Fountain, Dense Meat Stack, Empty Cloaca-Cola Bottle, Enchanted Barbell, Fancy Bath Salts, Frigid Ninja Stars, Feng Shui For Big Dumb Idiots, Giant Moxie Weed, Half of a Gold Tooth, Headless Sparrow, Imp Ale, Keel-Haulin\' Knife, Kokomo Resort Pass, Leftovers Of Indeterminate Origin, Mad Train Wine, Mangled Squirrel, Margarita, Meat Paste, Mineapple, Moxie Weed, Patchouli Incense Stick, Phat Turquoise Bead, Photoprotoneutron Torpedo, Plot Hole, Procrastination Potion, Rat Carcass, Smelted Roe, Spicy Jumping Bean Burrito, Spicy Bean Burrito, Strongness Elixir, Sunken Chest, Tambourine Bells, Tequila Sunrise, Uncle Jick\'s Brownie Mix, Windchimes]

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2355,36 +2355,32 @@ boolean autosellCrap()
 	{
 		return false;		//do not autosell stuff in casual or postronin unless you are very poor
 	}
-	if(item_amount($item[dense meat stack]) > 0)	//some people keep their money in dense meat stacks instead of meat format
-	{
-		auto_autosell(min(10, item_amount($item[dense meat stack])), $item[dense meat stack]);
-	}
-	foreach it in $items[meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
+	foreach it in $items[dense meat stack, meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
 	{
 		if(item_amount(it) > 0)
 		{
-			auto_autosell(item_amount(it), it);		//autosell all of this item
+			auto_autosell(min(10,item_amount(it)), it);		//autosell all of this item
 		}
 	}
 	foreach it in $items[Ancient Vinyl Coin Purse, Black Pension Check, CSA Discount Card, Fat Wallet, Gathered Meat-Clip, Old Leather Wallet, Penultimate Fantasy Chest, Pixellated Moneybag, Old Coin Purse, Shiny Stones, Warm Subject Gift Certificate]
 	{
 		if(item_amount(it) > 0 && auto_is_valid(it))
 		{
-			use(item_amount(it), it);
+			use(min(10,item_amount(it)), it);
 		}
 	}
 	foreach it in $items[Bag Of Park Garbage]		//keeping 1 garbage in stock to avoid possible harmful loop with dinseylandfill_garbageMoney()
 	{
 		if(item_amount(it) > 1)		//for these items we want to keep 1 in stock. sell the rest
 		{
-			use(item_amount(it)-1, it);
+			use(min(10,item_amount(it)-1), it);
 		}
 	}
 	foreach it in $items[elegant nightstick]		//keeping 2 nightsticks in stock for double fisting
 	{
 		if(item_amount(it) > 2)		//for these items we want to keep 2 in stock. sell the rest
 		{
-			use(item_amount(it)-2, it);
+			use(min(10,item_amount(it)-2), it);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2363,16 +2363,26 @@ boolean autosellCrap()
 			auto_autosell(item_amount(it), it);		//autosell all of this item
 		}
 	}
-	foreach it in $items[Ancient Vinyl Coin Purse, Bag Of Park Garbage, Black Pension Check, CSA Discount Card, Fat Wallet, Gathered Meat-Clip, Old Leather Wallet, Penultimate Fantasy Chest, Pixellated Moneybag, Old Coin Purse, Shiny Stones, Warm Subject Gift Certificate]
+	foreach it in $items[Ancient Vinyl Coin Purse, Black Pension Check, CSA Discount Card, Fat Wallet, Gathered Meat-Clip, Old Leather Wallet, Penultimate Fantasy Chest, Pixellated Moneybag, Old Coin Purse, Shiny Stones, Warm Subject Gift Certificate]
 	{
 		if(item_amount(it) > 0 && auto_is_valid(it))
 		{
 			use(item_amount(it), it);
 		}
 	}
-	if(item_amount($item[elegant nightstick]) > 2)
+	foreach it in $items[Bag Of Park Garbage]		//keeping 1 garbage in stock to avoid possible harmful loop with dinseylandfill_garbageMoney()
 	{
-		auto_autosell(item_amount($item[elegant nightstick])-2, $item[elegant nightstick]);	//keep 2 for double fisting and sell the rest.
+		if(item_amount(it) > 1)		//for these items we want to keep 1 in stock. sell the rest
+		{
+			use(item_amount(it)-1, it);
+		}
+	}
+	foreach it in $items[elegant nightstick]		//keeping 2 nightsticks in stock for double fisting
+	{
+		if(item_amount(it) > 2)		//for these items we want to keep 2 in stock. sell the rest
+		{
+			use(item_amount(it)-2, it);
+		}
 	}
 
 	//bellow this point are items we only want to sell if we are desperate for meat.

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4594,8 +4594,12 @@ boolean auto_is_valid(item it)
 		if(!isGuildClass())		//it seems like all non core classes are disallowed. need to spade this to verify if any class is exempt
 			return false;
 	}
+	if(in_bhy())
+	{
+		return bhy_is_item_valid(it);
+	}
 	
-	return bees_hate_usable(it.to_string()) && is_unrestricted(it);
+	return is_unrestricted(it);
 }
 
 boolean auto_is_valid(familiar fam)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -487,6 +487,7 @@ boolean awol_buySkills();
 boolean in_bhy();
 void bhy_initializeSettings();
 boolean bees_hate_usable(string str);
+boolean bhy_is_item_valid(item it);
 boolean LM_bhy();
 boolean L13_bhy_towerFinal();
 

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -54,6 +54,26 @@ boolean bees_hate_usable(string str)
 	return true;
 }
 
+boolean bhy_is_item_valid(item it)
+{
+	//returns whether an item is valid while you are in a bees hate you run. Do not call it outside BHY.
+	if(!in_bhy())		//returning true or false here would cause mistakes. so just abort if this ever happens. which it should not.
+	{
+		abort("bhy_is_item_valid(item it) should never be called outside of bees hate you path.");
+	}
+	if(it.to_slot() != $slot[none])
+	{
+		return is_unrestricted(it);		//this is equipment. equipment can be worn. you take backlash damage from it
+	}
+	if($items[Cobb\'s Knob map, Enchanted bean, Ball polish, Black market map, boring binder clip, beehive, electric boning knife] contains it)
+	{
+		return true;					//these items are explicit exceptions which are allowed in BHY
+	}
+	//familiar hatchlings are always allowed. testing is too complicated and it does not really matter
+	//food, drink, combat items, and useable items are forbidden if contain the letter B in the name:
+	return bees_hate_usable(it.to_string()) && is_unrestricted(it);
+}
+
 boolean LM_bhy()
 {
 	if(!in_bhy())


### PR DESCRIPTION
* boolean bhy_is_item_valid(item it) created and used. equipment is valid even if it has a B in the name, you just take backlash damage. there are also some items which are explicit exceptions.

* autosellCrap() refactoring:
** do not autosell stuff at all in casual unless you have less than 20k meat
** use wallets 10 at a time instead of one per loop
** more aggressive selling of meatstack and dense meatstack. no need to keep some in reserve as you can just make them at no meat loss from your meat. however will still only sell 10 per loop just in case the user is doing something weird with them
** autosell spare elegant nightsticks. keep 2 and sell the rest
** fix trying and failing to use forbidden wallets in bees hate you. (they have B in the name. only matters in postronin or if manually pulled)
** softcore avatar paths still need money too. so do autosell stuff in them
** use meatreserve() function instead of 6500 to determine if we are desperate for meat
** added some documentation

## How Has This Been Tested?

item validity tested with ash calls
refactored autosellCrap() tested in bhy. from examining the log it works correctly

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
