### PR TITLE
choice adventure 878

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -299,6 +299,8 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(3); // get Lord Spookyraven's spectacles
 			} else if (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1) {
 				run_choice(4); // get disposable instant camera
+			} else if (my_primestat() != $stat[mysticality] || my_meat() < 1000 + meatReserve()) {
+				run_choice(1); // get ~500 meat
 			} else {
 				run_choice(2); // get mysticality substats
 			}


### PR DESCRIPTION
choice adventure 878 One Ornate Nightstand (The Haunted Bedroom). if your meat is too low or if your primestat is not myst, then you should prefer to take 500 meat instead of myst XP

## How Has This Been Tested?

tested in aftercore by using a modified autoscend.ash set to autoAdv in haunted bedroom instead of quitting.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
