### PR TITLE
exploathing wand fix

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -613,11 +613,13 @@ boolean L13_towerFinalHeavyRains();
 boolean in_koe();
 boolean koe_initializeSettings();
 int koe_rmi_count();
+boolean koe_acquire_rmi();
 boolean LX_koeInvaderHandler();
 item koe_L12FoodSelect();
 void koe_RationingOutDestruction();
 boolean L12_koe_clearBattlefield();
 boolean L12_koe_finalizeWar();
+boolean L13_koe_towerNSNagamar();
 
 ########################################################################################################
 //Defined in autoscend/paths/kolhs.ash

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1369,7 +1369,10 @@ boolean L13_towerNSNagamar()
 	// quest step12 means you fought the sorceress and lost due to not having a wand.
 	// autoscend only reaches step12 of the quest if autoscend was incapable of acquiring a wand before the sorceress
 	// it then has to fallback to bear verb orgy, which itself cannot be done until step12
-	
+	if(in_koe())
+	{
+		return L13_koe_towerNSNagamar();
+	}
 	if (!get_property("auto_wandOfNagamar").to_boolean() && internalQuestStatus("questL13Final") != 12)
 	{
 		return false;
@@ -1380,18 +1383,6 @@ boolean L13_towerNSNagamar()
 		return false;
 	}
 	
-	if(in_koe() && item_amount($item[rare Meat Isotope]) >= 30)
-	{
-		buy($coinmaster[Cosmic Ray\'s Bazaar], 1, $item[Wand of Nagamar]);
-		if(item_amount($item[Wand of Nagamar]) > 0)
-		{
-			return true;
-		}
-		else
-		{
-			auto_log_warning("Buying [Wand of Nagamar] using rare Meat Isotopes failed even thought we had 30 isotopes... trying alternatives", "red");
-		}
-	}
 	if(auto_my_path() == "Disguises Delimit" && internalQuestStatus("questL13Final") == 12)
 	{
 		cli_execute("refresh quests");


### PR DESCRIPTION
includes PR#697 which should be merged and then rebased before this is merged

fix wand of nagamar in kingdom of exploathing path:
* boolean koe_acquire_rmi(int target)
* boolean L13_koe_towerNSNagamar() spunoff from L13_towerNSNagamar() and had its code refactored
* fix repeatedly dying to sorceress due to not having wand in koe. an intermittent problem.
* prefer to to pull WA and ND in softcore koe rather than spending 30k meat (or equivalent rmi) on wand of nagamar
* convert meat to rare meat isotopes for the purpose of buying wand of nagamar if needed

## How Has This Been Tested?

tested in a SC exploathing run with all perms and most IOTMs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
