### PR TITLE
disable auto nightcap for vampyres

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1139,6 +1139,10 @@ void auto_printNightcap()
 void auto_drinkNightcap()
 {
 	//function to overdrink a nightcap at the end of day
+	if(my_path() == "Dark Gyffte")
+	{
+		return;		//disable for it now. TODO make a custom function for vampyre nightcap drinking specifically
+	}
 	if(!can_drink())
 	{
 		return;		//current path cannot drink booze at all


### PR DESCRIPTION
as it currently causes an abort for trying to call loadConsumables() in dark gyffte

## How Has This Been Tested?

validation

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
