### PR TITLE
glover fixes. crashing due to mosquito larvae & emotion chip & more

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -805,6 +805,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	boolean canConsume(item it, boolean checkValidity)
 	{
+		if(checkValidity && isClipartItem(it) && !auto_is_valid($skill[summon clip art]) && !can_interact())
+		{
+			//workaround for this mafia bug https://kolmafia.us/threads/g-lovers-clip-art-create-function-failure.26007/
+			return false;
+		}
 		return type == SL_ORGAN_STOMACH ? canEat(it, checkValidity) : canDrink(it, checkValidity);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -730,9 +730,14 @@ void hatchList()
 	}
 	//TODO return if no terrarium installed in camp.
 	
+	if(get_propery("questL02Larva") == "finished")
+	{
+		//only try to hatch this after the quest is finished. first copy is given to concil which returns it to you if you need to hatch it
+		hatchFamiliar($familiar[Mosquito]);		//quest item dropped every ascension until hatched
+	}
+	
 	foreach fam in $familiars[
 	Reassembled Blackbird,				//quest item dropped every ascension
-	Mosquito,							//quest item dropped every ascension
 	reconstituted crow,					//quest item dropped in bees hate you
 	Black Cat,							//quest item dropped in bad moon
 	Grue,								//you get one egg every ascension.

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -730,7 +730,7 @@ void hatchList()
 	}
 	//TODO return if no terrarium installed in camp.
 	
-	if(get_propery("questL02Larva") == "finished")
+	if(get_property("questL02Larva") == "finished")
 	{
 		//only try to hatch this after the quest is finished. first copy is given to concil which returns it to you if you need to hatch it
 		hatchFamiliar($familiar[Mosquito]);		//quest item dropped every ascension until hatched

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -679,21 +679,34 @@ boolean hatchFamiliar(familiar adult)
 {
 	//This functions hatches a familiar named adult.
 	//Returns true if you end up having the hatched familiar. False if you do not.
+	
+	item hatchling = adult.hatchling;
 	if(!pathAllowsFamiliar())
 	{
 		return false;	//we can not hatch familiars in a path that does not use them. nor properly check the terrarium's contents.
 	}
-	//TODO return false if no terrarium installed in camp.
-	
-	//do not use auto_have_familiar. we want to know if it exists in the terrarium and do not care about path limitations on use
-	if(have_familiar(adult))
+	if(auto_my_path() == "G-Lover")
 	{
-		return true;	//we already have desired familiar
+		//have_familiar is inconsistent. it usually returns true if you have a familiar in the terrairum regardless on its usability.
+		//in glover it returns false for unusuable familiars. as such we should test both hatchling and familiar in glover path
+		if(!glover_usable(adult) || !glover_usable(hatchling))
+		{
+			return false;
+		}
 	}
-	item hatchling = adult.hatchling;
+	//TODO return false if no terrarium installed in camp.
+	if(have_familiar(adult))		//do not use auto_have_familiar here. we can have an unusable adult in a path that can hatch the hatchling
+	{
+		return true;		//we already have desired familiar. no point it trying to hatch it a second time
+	}
 	if(item_amount(hatchling) == 0)
 	{
-		return false;	//we need to actually own the hatchling to hatch it
+		return false;		//we need to actually own the hatchling to hatch it
+	}
+	if(!auto_is_valid(hatchling) && !in_bhy())		//is hatchling usable in this path?
+	{
+		//all hatchlings are valid in bhy. easier to include !in_bhy() here instead of modifying auto_is_valid to check familiar hatchlings
+		return false;
 	}
 	
 	auto_log_info("Trying to hatch hatchling item [" +hatchling+ "] into the adult familiar [" +adult+ "]", "blue");

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -689,7 +689,7 @@ boolean hatchFamiliar(familiar adult)
 	{
 		//have_familiar is inconsistent. it usually returns true if you have a familiar in the terrairum regardless on its usability.
 		//in glover it returns false for unusuable familiars. as such we should test both hatchling and familiar in glover path
-		if(!glover_usable(adult) || !glover_usable(hatchling))
+		if(!glover_usable(adult.to_string()) || !glover_usable(hatchling.to_string()))
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -2,59 +2,95 @@
 
 boolean auto_haveEmotionChipSkills()
 {
-  return auto_is_valid($skill[Emotionally Chipped]) && have_skill($skill[Emotionally Chipped]);
+	return auto_is_valid($skill[Emotionally Chipped]) && have_skill($skill[Emotionally Chipped]);
 }
 
 boolean auto_canFeelEnvy()
 {
-  // Combat Skill - Forces drops like Spooky Jelly (doesn't insta-kill though, still need to win combat)
-  return auto_haveEmotionChipSkills() && get_property("_feelEnvyUsed") < 3;
+	// Combat Skill - Forces drops like Spooky Jelly (doesn't insta-kill though, still need to win combat)
+	if(!auto_is_valid($skill[Feel Envy]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelEnvyUsed") < 3;
 }
 
 boolean auto_canFeelHatred()
 {
-  // Combat Skill - 50 turn banish (doesn't cost a turn)
-  return auto_haveEmotionChipSkills() && get_property("_feelHatredUsed") < 3;
+	// Combat Skill - 50 turn banish (doesn't cost a turn)
+	if(!auto_is_valid($skill[Feel Hatred]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelHatredUsed") < 3;
 }
 
 boolean auto_canFeelNostalgic()
 {
-  // Combat Skill - adds drop table from last copyable monster to the current (see feelNostalgicMonster property)
-  return auto_haveEmotionChipSkills() && get_property("_feelNostalgicUsed") < 3;
+	// Combat Skill - adds drop table from last copyable monster to the current (see feelNostalgicMonster property)
+	if(!auto_is_valid($skill[Feel Nostalgic]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelNostalgicUsed") < 3;
 }
 
 boolean auto_canFeelPride()
 {
-  // Combat Skill - Triples stat gain from the current fight.
-  return auto_haveEmotionChipSkills() && get_property("_feelPrideUsed") < 3;
+	// Combat Skill - Triples stat gain from the current fight.
+	if(!auto_is_valid($skill[Feel Pride]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelPrideUsed") < 3;
 }
 
 boolean auto_canFeelSuperior()
 {
-  // Combat Skill - Does 20% of monsters max HP as damage and gives +1 PvP fight if it kills the monster.
-  return auto_haveEmotionChipSkills() && get_property("_feelSuperiorUsed") < 3;
+	// Combat Skill - Does 20% of monsters max HP as damage and gives +1 PvP fight if it kills the monster.
+	if(!auto_is_valid($skill[Feel Superior]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelSuperiorUsed") < 3;
 }
 
 boolean auto_canFeelLonely()
 {
-  // Non-Combat Skill - -5% combat rate (20 adventures)
-  return auto_haveEmotionChipSkills() && get_property("_feelLonelyUsed") < 3;
+	// Non-Combat Skill - -5% combat rate (20 adventures)
+	if(!auto_is_valid($skill[Feel Lonely]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelLonelyUsed") < 3;
 }
 
 boolean auto_canFeelExcitement()
 {
-  // Non-Combat Skill - +25 to all stats (20 adventures)
-  return auto_haveEmotionChipSkills() && get_property("_feelExcitementUsed") < 3;
+	// Non-Combat Skill - +25 to all stats (20 adventures)
+	if(!auto_is_valid($skill[Feel Excitement]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelExcitementUsed") < 3;
 }
 
 boolean auto_canFeelNervous()
 {
-  // Non-Combat Skill - deals passive damage on hit starting at 20 decrementing by 1 every proc (20 adventures)
-  return auto_haveEmotionChipSkills() && get_property("_feelNervousUsed") < 3;
+	// Non-Combat Skill - deals passive damage on hit starting at 20 decrementing by 1 every proc (20 adventures)
+	if(!auto_is_valid($skill[Feel Nervous]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelNervousUsed") < 3;
 }
 
 boolean auto_canFeelPeaceful()
 {
-  // Non-Combat Skill - +2 all res, +10 DR, +100 DA (20 adventures)
-  return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed") < 3;
+	// Non-Combat Skill - +2 all res, +10 DR, +100 DA (20 adventures)
+	if(!auto_is_valid($skill[Feel Peaceful]))
+	{
+		return false;
+	}
+	return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed") < 3;
 }


### PR DESCRIPTION
* fix for glover crashing when it tries to hatch mosquito larvae. note that because the hatchling is a quest item, it disappears after the failed use. unlike normal hatchlings which do not. as such this is not a persistent issue. it aborts once during the run and then you can run autoscend again and have it complete the run. still it is better to fix it
* glover fix for emotion chip combat skills
* fix mosquito larva hatching prematurely. only try to hatch this after the quest is finished. first copy is given to concil which returns it to you if you need to hatch it
* workaround for mafia bug of using create() function in g-lovers path to create clip art tome items 
https://kolmafia.us/threads/g-lovers-clip-art-create-function-failure.26007/

## How Has This Been Tested?

day 1 & 2 of glover softcore run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
