### PR TITLE
powerful glove bedtime fixes

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -207,7 +207,7 @@ boolean auto_forceEquipPowerfulGlove()
 
 void auto_burnPowerfulGloveCharges()
 {
-	while (auto_hasPowerfulGlove() && auto_powerfulGloveCharges() >= 5)
+	while(auto_is_valid($skill[CHEAT CODE: Triple Size]) && auto_hasPowerfulGlove() && auto_powerfulGloveCharges() >= 5)
 	{
 		auto_powerfulGloveStats();
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -211,7 +211,7 @@ void auto_burnPowerfulGloveCharges()
 	{
 		if(equipped_amount($item[Powerful Glove]) == 0)
 		{
-			equip($item[Powerful Glove]);	//equip it to prevent the skill use command from doing 20 cycles of equip, cast spell, unequip.
+			equip($item[Powerful Glove]);	//equip it to prevent use command from doing 20 cycles of equip, use skill, unequip.
 		}
 		auto_powerfulGloveStats();
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -209,6 +209,10 @@ void auto_burnPowerfulGloveCharges()
 {
 	while(auto_is_valid($skill[CHEAT CODE: Triple Size]) && auto_hasPowerfulGlove() && auto_powerfulGloveCharges() >= 5)
 	{
+		if(equipped_amount($item[Powerful Glove]) == 0)
+		{
+			equip($item[Powerful Glove]);	//equip it to prevent the skill use command from doing 20 cycles of equip, cast spell, unequip.
+		}
 		auto_powerfulGloveStats();
 	}
 }


### PR DESCRIPTION
* fix infinite loop during auto_burnPowerfulGloveCharges() if the skill Triple Size was invalid
* auto_burnPowerfulGloveCharges() fix doing 20 cycles of equip glove, use skill, unequip glove. instead it will now equip it once and then cast all 20 without further equipping/unequipping

## How Has This Been Tested?

infinite loop was tested in glover where Triple Size is invalid by using ash to import autoscend and call doBedtime()

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
