### PR TITLE
default maximizer weapon fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -229,10 +229,10 @@ string defaultMaximizeStatement()
 
 void resetMaximize()
 {
-	string res = get_property("auto_maximize_baseline");
+	string res = get_property("auto_maximize_baseline");	//user configured override baseline statement.
 	if (res == "" || res.to_lower_case() == "default" || res.to_lower_case() == "disabled")
 	{
-		res = defaultMaximizeStatement();
+		res = defaultMaximizeStatement();		//automatically generated baseline statement
 	}
 	
 	void exclude(item it)

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -203,7 +203,7 @@ string defaultMaximizeStatement()
 		}
 		else
 		{
-			res += ",1.5weapon damage,-0.75weapon damage percent,1.5elemental damage";
+			res += ",1.5weapon damage,0.75weapon damage percent,1.5elemental damage";
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -412,10 +412,11 @@ boolean simMaximize()
 
 boolean simMaximizeWith(string add)
 {
+	string backup = get_property("auto_maximize_current");
 	addToMaximize(add);
 	auto_log_debug("Simulating: " + get_property("auto_maximize_current"), "gold");
 	boolean res = simMaximize();
-	removeFromMaximize(add);
+	set_property("auto_maximize_current", backup);
 	return res;
 }
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -281,13 +281,14 @@ void resetMaximize()
 			}
 		}
 	}
-	else if (item_amount($item[January's Garbage Tote]) > 0 && in_bhy()) {
-	// workaround mafia bug with the maximizer where it tries to equip tote items even though the tote is unusable
-	foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Tinsel Tights, Wad Of Used Tape, Makeshift Garbage Shirt] {
-		exclude(it);
+	else if (item_amount($item[January's Garbage Tote]) > 0 && in_bhy())
+	{
+		// workaround mafia bug with the maximizer where it tries to equip tote items even though the tote is unusable
+		foreach it in $items[Deceased Crimbo Tree, Broken Champagne Bottle, Tinsel Tights, Wad Of Used Tape, Makeshift Garbage Shirt]
+		{
+			exclude(it);
+		}
 	}
-}
-
 	
 	set_property("auto_maximize_current", res);
 	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -195,7 +195,13 @@ string defaultMaximizeStatement()
 		res += isActuallyEd() ? ",6mp regen" : ",3mp regen";
 	}
 
-	if(!in_zelda())
+	//weapon handling
+	if(in_boris())
+	{
+		borisTrusty();						//forceequip trusty. the modification it makes to the maximizer string will be lost so also do next line
+		res +=	",-weapon,-offhand";		//we do not want maximizer trying to touch weapon or offhand slot in boris
+	}
+	else if(!in_zelda())
 	{
 		if(my_primestat() == $stat[Mysticality])
 		{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -494,6 +494,7 @@ boolean auto_pre_adventure()
 		}
 	}
 	borisWastedMP();
+	borisTrusty();
 
 	acquireMP(32, 1000);
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -452,6 +452,7 @@ void edUnderworldChoiceHandler(int choice);
 ########################################################################################################
 //Defined in autoscend/paths/avatar_of_boris.ash
 boolean in_boris();
+void borisTrusty();
 boolean borisAdjustML();
 void boris_initializeSettings();
 void boris_initializeDay(int day);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -3,6 +3,16 @@ boolean in_boris()
 	return my_class() == $class[Avatar of Boris];
 }
 
+void borisTrusty()
+{
+	//the only time boris wants to take off trusty is if it is bedtime and he wants to wear a halo. Which is unaffected by this
+	if(!in_boris())
+	{
+		return;
+	}
+	autoForceEquip($item[Trusty]);		//ensure we have trusty equipped
+}
+
 boolean borisAdjustML()
 {
 	//set target ML boosts for boris.


### PR DESCRIPTION
* fix boris sometimes going unarmed
* void borisTrustyCheck() created and used
* fix maximizer string for non myst classes. we want +weapon damage percent not -weapon damage percent for a non myst class.
** while more robust, this is not a 100% reliable fix for the possibility of maximizer deciding we should be unarmed. but it will fix it most of the time.
* fix boolean simMaximizeWith(string add)
sometimes changing auto_maximize_current during simulation. for example if the "add" value already existed it will end up being removed during the add, simulate, remove cycle.

## How Has This Been Tested?

ash calls
played in boris run. it fixed him going unarmed
played in glover with all perms and lots of iotms.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
