### PR TITLE
KGB fix infinite loop in bedtime if we can not find any buffs

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -405,6 +405,7 @@ boolean kgbWasteClicks()
 	# Yes, this will not be pleasant if we matched our number and each page click changes the buttons.
 	while((get_property("_kgbClicksUsed").to_int() < 22) && (clicked < 9))
 	{
+		int start = clicked;
 		foreach ef in $effects[Items Are Forever, A View To Some Meat, Light!, The Spy Who Loved XP, Initiative And Let Die, The Living Hitpoints, License To Punch, Goldentongue, Thunderspell]
 		{
 			if(contains_text(get_property("auto_kgbTracker"), ":" + to_int(ef)))
@@ -423,6 +424,10 @@ boolean kgbWasteClicks()
 					break;
 				}
 			}
+		}
+		if(start == clicked)	//we were unable to find a single thing to waste clicks on
+		{
+			break;		//prevent infinite loop
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -427,6 +427,7 @@ boolean kgbWasteClicks()
 		}
 		if(start == clicked)	//we were unable to find a single thing to waste clicks on
 		{
+			auto_log_warning("kgbWasteClicks() was unable to spend your remaining KGB clicks on buffs for some reason. Please spend them manually");
 			break;		//prevent infinite loop
 		}
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -395,6 +395,7 @@ boolean kgbWasteClicks()
 		return false;
 	}
 
+	auto_log_info("kgbWasteClicks() will now use up remaining KGB clicks");
 	int clicked = 0;
 	while(kgbDiscovery() && (clicked < 10))
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -425,7 +425,7 @@ boolean kgbWasteClicks()
 				}
 			}
 		}
-		if(start == clicked)	//we were unable to find a single thing to waste clicks on
+		if(start == clicked)
 		{
 			auto_log_warning("kgbWasteClicks() was unable to spend your remaining KGB clicks on buffs for some reason. Please spend them manually");
 			break;		//prevent infinite loop


### PR DESCRIPTION
fix infinite loop in kgbWasteClicks() when we are unable to find any valid buff to spend our clicks on
this usually happens if we used an external script to use the kgb.
this PR solves the infinite loop by detecting it and breaking the while function. It does not add special handling to spend your remaining clicks in such a scenario. That should be done in a future PR

## How Has This Been Tested?

end of day. was constantly getting the inf loop. tries with the fixed code and it did not.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
