### PR TITLE
fix auto_skipNightcap setting

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1144,6 +1144,10 @@ void auto_printNightcap()
 void auto_drinkNightcap()
 {
 	//function to overdrink a nightcap at the end of day
+	if(get_property("auto_skipNightcap").to_boolean())
+	{
+		return;
+	}
 	if(my_path() == "Dark Gyffte")
 	{
 		return;		//disable for it now. TODO make a custom function for vampyre nightcap drinking specifically


### PR DESCRIPTION
fix auto_skipNightcap setting not working

## How Has This Been Tested?

tested in standard hc accordion thief.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
