### PR TITLE
don't insist on inebriety > 8 for pool if our liver is full at less than that

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -393,7 +393,7 @@ boolean LX_unlockHauntedLibrary()
 			resetMaximize();	//cancel equipping pool cue
 			return false;
 		}
-		if(my_inebriety() < 8)
+		if((my_inebriety() < inebriety_limit()) && my_inebriety() < 8)
 		{
 			auto_log_info("I will come back when I had more to drink.", "green");
 			resetMaximize();	//cancel equipping pool cue


### PR DESCRIPTION
The script waits until at least 8 drunk before attempting to play pool. This is bad if your liver is less than that. This update makes it happy to play pool as long as you're at max liver, even at less than 8.

# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Run through 2 Ed ascension with the new version, and Spookyraven properly unlocks on day1, rather than waiting until the end of the ascension.

## Checklist:

- [x ] My code follows the style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [ It's trivial] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
