### PR TITLE
get the logging hatchet before starting to build the bridge

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -151,6 +151,7 @@ boolean L9_chasmBuild()
 		return false;
 	}
 
+	if (LX_loggingHatchet()) { return true; } // turn free, might save some adventures. May as well get it if we can.
 
 	auto_log_info("Chasm time", "blue");
 	


### PR DESCRIPTION
# Description

Call LX_loggingHatchet() in L9_chasmBuild()

## How Has This Been Tested?

Frankly, it hasn't yet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
