### PR TITLE
Stopping calling dependenceDayClover()

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1944,7 +1944,7 @@ boolean LX_hardcoreFoodFarm()
 
 boolean LX_craftAcquireItems()
 {
-	//dependenceDayClovers();
+	//dependenceDayClovers(); Green rockets are no longer sold on Dependence Day.
 	if((item_amount($item[Ten-Leaf Clover]) > 0) && glover_usable($item[Ten-Leaf Clover]))
 	{
 		use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1944,7 +1944,7 @@ boolean LX_hardcoreFoodFarm()
 
 boolean LX_craftAcquireItems()
 {
-	dependenceDayClovers();
+	//dependenceDayClovers();
 	if((item_amount($item[Ten-Leaf Clover]) > 0) && glover_usable($item[Ten-Leaf Clover]))
 	{
 		use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);


### PR DESCRIPTION
# Description

Green rockets are no longer sold on Dependence Day, so there's no point in checking to see if it is Dependence Day or trying to acquire a green rocket if it is. I'm not sure on how content that has been phased out of the game is handled from the perspective of autoscend, so I didn't mess with the dependenceDayClover() function in level_any.ash.

## How Has This Been Tested?

I ran autoscend after incorporating this change and didn't run into any issues.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
