### PR TITLE
some ed stuff and removing dependence day clovers

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1944,7 +1944,6 @@ boolean LX_hardcoreFoodFarm()
 
 boolean LX_craftAcquireItems()
 {
-	//dependenceDayClovers(); Green rockets are no longer sold on Dependence Day.
 	if((item_amount($item[Ten-Leaf Clover]) > 0) && glover_usable($item[Ten-Leaf Clover]))
 	{
 		use(item_amount($item[Ten-Leaf Clover]), $item[Ten-Leaf Clover]);
@@ -2958,6 +2957,7 @@ void auto_begin()
 	backupSetting("currentMood", "apathetic");
 
 	backupSetting("logPreferenceChange", "true");
+	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	
 	backupSetting("choiceAdventure1107", 1);
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -931,7 +931,6 @@ boolean LX_dailyDungeonToken();
 void dailyDungeonChoiceHandler(int choice, string[int] options);
 boolean LX_dolphinKingMap();
 boolean LX_meatMaid();
-boolean dependenceDayClovers();
 
 ########################################################################################################
 //Defined in autoscend/quests/optional.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -196,8 +196,13 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 			loopHandlerDelayAll();
 			return "skill" + $skill[Fire the Jokester\'s Gun];
 		}
-	}
 
+		if (canUse($skill[Slay the Dead]) && enemy.phylum == $phylum[undead])
+		{
+			// instakills Undead and reduces evilness in Cyrpt zones.
+			return useSkill($skill[Slay the Dead]);
+		}
+	}
 
 	if(get_property("auto_edStatus") == "UNDYING!")
 	{
@@ -709,10 +714,10 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 		if (canUse($item[Seal Tooth], false))
 		{
-			return useItem($item[Seal Tooth], false);
+			return "use Seal Tooth; repeat; ";
 		}
 
-		return useSkill($skill[Mild Curse], false);
+		return "skill Mild Curse; repeat; ";
 	}
 
 	// Actually killing stuff starts here

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -291,28 +291,25 @@ void ed_ServantBugWorkaround(string page) {
 	matcher servants_quarters = create_matcher("The Servants' Quarters", page);
 	if (!servants_quarters.find()) {
 		auto_log_info("You may have hit the servant bug.");
-		// looks like we hit the bug. Let's double check though
-		if (my_level() >= 3 && !have_servant($servant[Priest])) {
-			// yeah definitely bugged. Lets try the simple fix.
-			set_property("auto_edServantBugCount", get_property("auto_edServantBugCount").to_int() + 1);
-			auto_log_critical(`You definitely hit the servant bug. It is now {get_property("auto_edServantBugCount").to_int()} times this ascension.`);
-			foreach lackey in $servants[Priest, Cat, Scribe, Maid] {
-				use_servant(lackey);
-				if (my_servant() == lackey) {
-					auto_log_info("Servant was changed successfully. Maybe one day the KoL devs will give a shit about this bug?");
-					break;
-				}
+		// looks like we hit the bug. Lets try the simple fix.
+		set_property("auto_edServantBugCount", get_property("auto_edServantBugCount").to_int() + 1);
+		auto_log_critical(`You definitely hit the servant bug. It is now {get_property("auto_edServantBugCount").to_int()} times this ascension.`);
+		foreach lackey in $servants[Priest, Cat, Scribe, Maid] {
+			use_servant(lackey);
+			if (my_servant() == lackey) {
+				auto_log_info("Servant was changed successfully. Maybe one day the KoL devs will give a shit about this bug?");
+				break;
 			}
-			if (my_servant() == $servant[none]) {
-				// ok that didn't fix it, lets smash the door down and see if that works.
-				visit_url("place.php?whichplace=edbase&action=edbase_door");
-				visit_url("choice.php?forceoption=1");
-				use_servant($servant[Priest]);
-				if (my_servant() != $servant[Priest]) {
-					abort("Failed to change servant. Report this to the KoL dev team (the little bug icon on your top bar in the relay browser).");
-				} else {
-					auto_log_info("Servant was changed successfully. Maybe one day the KoL devs will give a shit about this bug?");
-				}
+		}
+		if (my_servant() == $servant[none]) {
+			// ok that didn't fix it, lets smash the door down and see if that works.
+			visit_url("place.php?whichplace=edbase&action=edbase_door");
+			visit_url("choice.php?forceoption=1");
+			use_servant($servant[Priest]);
+			if (my_servant() != $servant[Priest]) {
+				abort("Failed to change servant. Report this to the KoL dev team (the little bug icon on your top bar in the relay browser).");
+			} else {
+				auto_log_info("Servant was changed successfully. Maybe one day the KoL devs will give a shit about this bug?");
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -983,7 +983,7 @@ void ed_handleAdventureServant(location loc)
 	// Default to the Priest as we need Ka to get upgrades and fill spleen (and other miscellanea)
 	servant myServant = $servant[Priest];
 
-	page = visit_url("place.php?whichplace=edbase&action=edbase_door");
+	string page = visit_url("place.php?whichplace=edbase&action=edbase_door");
 	ed_ServantBugWorkaround(page); // need to make sure we're not hitting the bug otherwise have_servant will always wrongly return false.
 
 	if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]) && my_level() < 13 && have_servant($servant[Scribe]))

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -290,10 +290,9 @@ boolean ed_doResting()
 void ed_ServantBugWorkaround(string page) {
 	matcher servants_quarters = create_matcher("The Servants' Quarters", page);
 	if (!servants_quarters.find()) {
-		auto_log_info("You may have hit the servant bug.");
 		// looks like we hit the bug. Lets try the simple fix.
 		set_property("auto_edServantBugCount", get_property("auto_edServantBugCount").to_int() + 1);
-		auto_log_critical(`You definitely hit the servant bug. It is now {get_property("auto_edServantBugCount").to_int()} times this ascension.`);
+		auto_log_critical(`You hit the servant bug. It is now {get_property("auto_edServantBugCount").to_int()} times this ascension.`);
 		foreach lackey in $servants[Priest, Cat, Scribe, Maid] {
 			use_servant(lackey);
 			if (my_servant() == lackey) {

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -985,6 +985,7 @@ void ed_handleAdventureServant(location loc)
 
 	string page = visit_url("place.php?whichplace=edbase&action=edbase_door");
 	ed_ServantBugWorkaround(page); // need to make sure we're not hitting the bug otherwise have_servant will always wrongly return false.
+	visit_url("place.php?whichplace=edbase"); // leave the choice
 
 	if (my_spleen_use() == 35 && have_skill($skill[Even More Elemental Wards]) && my_level() < 13 && have_servant($servant[Scribe]))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -666,33 +666,3 @@ boolean LX_meatMaid()
 	}
 	return false;
 }
-
-boolean dependenceDayClovers()
-{
-	if(get_property("_fireworkUsed").to_boolean())
-	{
-		return false;	//only 1 firework per day allowed
-	}
-	if(holiday() != "Dependence Day")
-	{
-		return false;	//it is not dependence day today
-	}
-	if(isActuallyEd() && get_property("lastIslandUnlock").to_int() != my_ascensions())
-	{
-		return false;	//buying it before unlocking the island on day 1 makes you too poor to unlock it on day 1 and adds days to the run
-	}
-	
-	auto_log_info("Today is Dependence Day and I want to use a [green rocket] for some clovers", "green");
-	if(item_amount($item[green rocket]) == 0 && my_meat() < npc_price($item[green rocket]))
-	{
-		auto_log_info("I can't afford a [green rocket]. I will try again later");
-		return false;
-	}
-	
-	buyUpTo(1, $item[green rocket]);
-	if(item_amount($item[green rocket]) > 0)
-	{
-		return use(1, $item[green rocket]);
-	}
-	return false;
-}


### PR DESCRIPTION
# Description

General:
- remove the dependence day clovers function and calls
- set maximizerMRUSize to 0 to remove all the maximizer spam 🎉

Actually Ed:
- add using Slay the Dead for Ed same as non-Ed combat handling (this really needs refactored but 🤷)
- when UNDYING in combat, send BALLS macro with repeat rather than CCS commands repeatedly to reduce server hits
- add an abort once the Macguffin is found in the he Secret Council Warehouse so Ed works same as all other paths which have a class choice.
- increase the meat amount for buying a Seal Tooth, it was too low and could lead to not having enough meat to make the dingy dinghy if the Hippy Camp is needed for Ka farming
- first attempt at a workaround for the KoL servant bug (if mafia gets a workaround for this we can remove it)

## How Has This Been Tested?

Ran one HC Ed with all these. Just started another. Some of it has been tested more than others. I haven't tested the Slay the Dead change as I run Ed on an IotM-less account but it's a copy & paste of the code I wrote and tested for non-Ed combat.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
