### PR TITLE
Alter Mumming Trunk logic regarding CanChangetoFamiliar

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -7,6 +7,10 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
+	if(!pathAllowsFamiliarChanging() && my_familiar() !== fam) // cannot mummify a familiar if you can't switch to it.
+	{
+		return false;
+	}
 	if(get_property("_mummifyDone").to_boolean())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -7,10 +7,6 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
-	if(!pathAllowsFamiliarChanging() && my_familiar() !== fam) // cannot mummify a familiar if you can't switch to it.
-	{
-		return false;
-	}
 	if(get_property("_mummifyDone").to_boolean())
 	{
 		return false;
@@ -23,7 +19,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 	{
 		return false;
 	}
-	if(!have_familiar(fam))
+	if(!canChangeToFamiliar(fam)) // Can Change to Familiar checks both whether we have it and if we are allowed to change to it
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Adds a "Can Change to familiar" check to mumming trunk logic. CanChangeToFamiliar already checks if we have a familiar, so having both would be redundant.

## How Has This Been Tested?

Not Tested

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
