### PR TITLE
Some QT path handling stuff

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20730;	// min mafia revision needed to run this script. Last update: questM05Toot tracking will correct to finished when refreshing quests
+since r20731;	// min mafia revision needed to run this script. Last update: Grim Brother and Red-Nosed Snapper now usable in Quantum Terrarium
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -66,6 +66,7 @@ import <autoscend/paths/one_crazy_random_summer.ash>
 import <autoscend/paths/path_of_the_plumber.ash>
 import <autoscend/paths/picky.ash>
 import <autoscend/paths/pocket_familiars.ash>
+import <autoscend/paths/quantum_terrarium.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
 import <autoscend/paths/low_key_summer.ash>
@@ -236,6 +237,7 @@ void initializeSession() {
 	// anything that needs to be set only for the duration the script is running
 	// should be set in here.
 
+	auto_enableBackupCameraReverser();
 	ed_initializeSession();
 	bat_initializeSession();
 }

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1198,7 +1198,18 @@ boolean auto_autoConsumeOne(string type, boolean simulate)
 	int organLeft()
 	{
 		if (type == "eat") return fullness_left();
-		if (type == "drink") return inebriety_left();
+		if (type == "drink") 
+		{
+			if (in_quantumTerrarium() && my_familiar() == $familiar[Stooper])
+			{
+				// we can't change familiars so don't drink to full liver as we'll be overdrunk when it changes familiar.
+				return (my_inebriety() < inebriety_limit() ? inebriety_left() - 1 : 0);
+			}
+			else
+			{
+				return inebriety_left();
+			}
+		}
 		abort("Unrecognized organ type: should be 'eat' or 'drink', was " + type);
 		return 0;
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -102,19 +102,18 @@ boolean pathHasFamiliar()
 
 boolean pathAllowsChangingFamiliar()
 {
-    if(!pathHasFamiliar())
-    {
-        return false;
-    }
+		if (!pathHasFamiliar())
+		{
+			return false;
+		}
 
+		// path check for case(s) where Path has familiars but forces you to use one of its choice
+		if (in_quantumTerrarium())
+		{
+			return false;
+		}
 
-	//path check for case(s) where Path has familiars but forces you to use one of its choice
-    if ( $strings[Quantum Terrarium] contains auto_my_path() )
-    {
-        return false;
-    }
-
-    return true;
+	return true;
 }
 
 boolean auto_have_familiar(familiar fam)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -405,7 +405,7 @@ boolean auto_handleRetrocape();
 boolean auto_buyCrimboCommerceMallItem();
 
 ########################################################################################################
-//Defined in autoscend/iotms/mr2020.ash
+//Defined in autoscend/iotms/mr2021.ash
 boolean auto_haveEmotionChipSkills();
 boolean auto_canFeelEnvy();
 boolean auto_canFeelHatred();
@@ -416,6 +416,9 @@ boolean auto_canFeelLonely();
 boolean auto_canFeelExcitement();
 boolean auto_canFeelNervous();
 boolean auto_canFeelPeaceful();
+boolean auto_haveBackupCamera();
+void auto_enableBackupCameraReverser();
+int auto_backupUsesLeft();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
@@ -712,6 +715,13 @@ string pokefam_defaultMaximizeStatement();
 boolean digimon_makeTeam();
 boolean LM_digimon();
 boolean digimon_autoAdv(int num, location loc, string option);
+
+########################################################################################################
+//Defined in autoscend/paths/quantum_terrarium.ash
+boolean in_quantumTerrarium();
+familiar qt_nextQuantumFamiliar();
+int qt_turnsToNextQuantumAlignment();
+boolean LX_quantumTerrarium();
 
 ########################################################################################################
 //Defined in autoscend/paths/the_source.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -943,8 +943,7 @@ boolean auto_changeSnapperPhylum(phylum toChange)
 	{
 		return false;
 	}
-	string phylumString = toChange.to_string();
-	set_property("auto_snapperPhylum", phylumString);
+	set_property("auto_snapperPhylum", toChange);
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -94,3 +94,22 @@ boolean auto_canFeelPeaceful()
 	}
 	return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed") < 3;
 }
+
+boolean auto_haveBackupCamera()
+{
+	return possessEquipment($item[backup camera]) && auto_is_valid($item[backup camera]);
+}
+
+void auto_enableBackupCameraReverser()
+{
+	if (auto_haveBackupCamera() && !get_property("backupCameraReverserEnabled").to_boolean())
+	{
+		cli_execute("backupcamera reverser on");
+	}
+}
+
+int auto_backupUsesLeft()
+{
+	// incorrect for You, Robot. Also don't care.
+	return 11 - get_property("_backUpUses").to_int();
+}

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -1,0 +1,20 @@
+boolean in_quantumTerrarium()
+{
+	return auto_my_path() == "Quantum Terrarium";
+}
+
+familiar qt_nextQuantumFamiliar()
+{
+	return get_property("nextQuantumFamiliar").to_familiar();
+}
+
+int qt_turnsToNextQuantumAlignment()
+{
+	return total_turns_played() - get_property("_nextQuantumAlignment").to_int();
+}
+
+boolean LX_quantumTerrarium()
+{
+	// TODO. Pathing goes here.
+	return false;
+}


### PR DESCRIPTION
# Description

- attempt to handle not overdrinking with Stooper in Quantum Terrarium path
- enable backup camera reverser if not enabled
- some as yet unused functions for backup camera and QT path support and some tidying up of earlier merges.

## How Has This Been Tested?

Ran 2 Normal QT's, one with IotMs & one without. Fortuitously the one with IotMs got the Stooper as it was on full organs & running out of adventures. It stopped on 2 advs with 14/15 liver available so I can say it's been tested now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
