### PR TITLE
Adding Familiar Swapping functionality for QT

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -228,6 +228,7 @@ void initializeSettings() {
 	lowkey_initializeSettings();
 	bhy_initializeSettings();
 	grey_goo_initializeSettings();
+	qt_initializeSettings();
 
 	set_property("auto_doneInitialize", my_ascensions());
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -722,6 +722,9 @@ boolean in_quantumTerrarium();
 familiar qt_nextQuantumFamiliar();
 int qt_turnsToNextQuantumAlignment();
 boolean LX_quantumTerrarium();
+void qt_initializeSettings();
+boolean qt_FamiliarAvailable (familiar fam);
+boolean qt_FamiliarSwap (familiar fam);
 
 ########################################################################################################
 //Defined in autoscend/paths/the_source.ash

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -18,3 +18,44 @@ boolean LX_quantumTerrarium()
 	// TODO. Pathing goes here.
 	return false;
 }
+
+string qt_TerrariumPage = visit_url("qterrarium.php");
+
+boolean qt_FamiliarAvailable (familiar fam)
+//Check to see if target familiar can be forced.
+{
+   string qt_FamiliarKey = "<option value=\"" + fam.to_int().to_string() + "\">";
+   matcher qt_FamiliarSearch = create_matcher(qt_FamiliarKey, qt_TerrariumPage);
+
+   if (qt_turnsToNextQuantumAlignment() > 1)
+   {
+      return false;
+   }
+   else if (find(qt_FamiliarSearch))
+   {
+      return true;
+   }
+   else 
+   {
+      return false;
+   }
+}
+
+boolean qt_FamiliarSwap (familiar fam)
+//Swap/designate next familiar swap if possible.
+{
+   if(fam == $familiar[none])
+   {
+      print(fam.to_string() + " is not a valid familiar, weird behaviour.");
+      return false;
+   }
+   else if (qt_FamiliarAvailable(fam))
+   {
+      visit_url("qterrarium.php?pwd=&action=fam&fid="+ fam.to_int());
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -19,6 +19,14 @@ boolean LX_quantumTerrarium()
 	return false;
 }
 
+void qt_initializeSettings()
+{
+   if (in_quantumTerrarium())
+   {
+      set_property("auto_skipNuns", true);   //Remove when leprechaun swapping is supported at nuns.
+   }
+}
+
 string qt_TerrariumPage = visit_url("qterrarium.php");
 
 boolean qt_FamiliarAvailable (familiar fam)


### PR DESCRIPTION
# Description

Adding a function to check if a familiar is available to be swapped to in QT and for designating a swap after checking if the familiar is available.

## How Has This Been Tested?

Both functions were tested in mafia. Due to path limitations, I was only able to test forcing a few swaps.

Also added a settings initialization for QT, which currently just sets auto_skipNuns to true since there's currently no handling to swap to a leprechaun type familiar at Nuns - this prevents getting inhaler for no reason and prevents potentially starting nuns and losing a leprechaun midway through.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
