### PR TITLE
Only attempt to make dinghy if we have no other access

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -171,7 +171,7 @@ boolean LX_islandAccess()
 
 	boolean canDesert = (get_property("lastDesertUnlock").to_int() == my_ascensions());
 
-	if((item_amount($item[Shore Inc. Ship Trip Scrip]) >= 3) && (item_amount($item[Dingy Dinghy]) == 0) && (my_meat() >= npc_price($item[dingy planks])) && isGeneralStoreAvailable())
+	if((item_amount($item[Shore Inc. Ship Trip Scrip]) >= 3) && (get_property("lastIslandUnlock").to_int() != my_ascensions()) && (my_meat() >= npc_price($item[dingy planks])) && isGeneralStoreAvailable())
 	{
 		cli_execute("make dinghy plans");
 		buyUpTo(1, $item[dingy planks]);


### PR DESCRIPTION
# Description

Presently, if we have the scrip available, we will attempt to make a dinghy even if we already have island access. This change makes us only make a dinghy if mafia thinks we have no island access.

## How Has This Been Tested?

Has been run with skeletal skiff already pulled, did not attempt to make a dinghy

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [NA] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
