### PR TITLE
remove the minimum mp check from using Weaksauce as Sauceror as it's MP postive almost all the time

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20494;	//min mafia revision needed to run this script. Last update: Cargo Shorts support complete
+since r20736;	//min mafia revision needed to run this script. Last update: Fix have_familiar and other issues where maifa thinks you have a familiar in your terrarium because you saw it during QT
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -1327,11 +1327,11 @@ string auto_combatHandler(int round, monster enemy, string text)
 			}
 		}
 
-		if(canUse($skill[Curse Of Weaksauce]) && (my_class() == $class[Sauceror]) && (my_mp() >= 20) && doWeaksauce)
+		if (canUse($skill[Curse Of Weaksauce]) && my_class() == $class[Sauceror] && doWeaksauce)
 		{
 			return useSkill($skill[Curse Of Weaksauce]);
 		}
-				  
+
 		if(canUse($skill[Detect Weakness]))
 		{
 			return useSkill($skill[Detect Weakness]);
@@ -1981,7 +1981,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		if(enemy.physical_resistance > 80 && canUse($skill[Saucestorm], false))
 		{
 			attackMinor = useSkill($skill[Saucestorm], false);
-			attackMinor = useSkill($skill[Saucestorm], false);
+			attackMajor = useSkill($skill[Saucestorm], false);
 			costMinor = mp_cost($skill[Saucestorm]);
 			costMajor = mp_cost($skill[Saucestorm]);
 		}
@@ -2014,7 +2014,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		if(enemy.physical_resistance > 80 && canUse($skill[Saucestorm], false))
 		{
 			attackMinor = useSkill($skill[Saucestorm], false);
-			attackMinor = useSkill($skill[Saucestorm], false);
+			attackMajor = useSkill($skill[Saucestorm], false);
 			costMinor = mp_cost($skill[Saucestorm]);
 			costMajor = mp_cost($skill[Saucestorm]);
 		}


### PR DESCRIPTION
# Description

As title.
Also ix the things @Phillammon said he was going to fix for DB and AT (untested)

## How Has This Been Tested?

Ran Normal QT as Sauceror on my no IotMs account from start to finish while testing the task_order branch. It ran out of MP a lot  less than it used to since it generates more MP than it ever uses in combat now which means it dies a lot less since it has MP to adequately buff itself.
DB and AT changes are untested as yet but they're fixing what looks like an oversight or copy/paste issues. They may also die less in combat now too.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
