### PR TITLE
Mini-Adventurer handling and poolSharkCount warning removal

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -120,11 +120,6 @@ void initializeSettings() {
 		int curSkill = to_int(my_pool.group(1));
 		int sharkCountMin = ceil((curSkill * curSkill) / 4);
 		int sharkCountMax = ceil((curSkill + 1) * (curSkill + 1) / 4);
-		if(get_property("poolSharkCount").to_int() < sharkCountMin || get_property("poolSharkCount").to_int() >= sharkCountMax)
-		{
-			auto_log_warning("poolSharkCount set to incorrect value.", "red");
-			auto_log_info("You can \"set poolSharkCount="+sharkCountMin+"\" to use the least optimistic value consistent with your pool skill.", "blue");
-		}
 	}
 
 	set_property("auto_abooclover", true);

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -180,6 +180,22 @@ boolean auto_run_choice(int choice, string page)
 			dailyDungeonChoiceHandler(choice, options);
 			break;
 		case 700: // Delirium in the Cafeterium (KOLHS 22nd adventure every day)
+		case 768: // The Littlest Identity Crisis (Mini-adventurer initialization)
+			if (in_quantumTerrarium()) {
+				if (my_location() == $location[The Themthar Hills]) {
+					run_choice(4); // Sauceror is a lep and starfish
+				}
+				else if (my_level() < 13) {
+					run_choice(2); // Turtle Tamer is a volleyball and a starfish at level 5
+				}
+				else {
+					run_choice(6); // Accordion Thief is a fairy and ghoul whelp, with some free buffs.
+				}
+			}
+			else {
+				run_choice(2); // Turtle Tamer is a decent fallback pick.
+			}
+			break;
 		case 772: // Saved by the Bell (KOLHS after school)
 			kolhsChoiceHandler(choice);
 			break;


### PR DESCRIPTION
# Description

I'm adding some barebones handling for the mini-adventurer to prevent the need for manual intervention in QT, also removing the warning generated by having a poolSharkCount that falls outside the expected range, this warning serves no purpose.

## How Has This Been Tested?

Plain and simple, this hasn't been tested. The nature of QT means my opportunities to test familiar-related stuff is limited. Please, please, look carefully over my choice adventure logic, it's the first choice adventure I've written and it is untested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
