### PR TITLE
fix popup when trying to overdrink nightcap

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1212,7 +1212,7 @@ void auto_drinkNightcap()
 	{
 		abort("Unexpectedly couldn't prep " + to_pretty_string(target));
 	}
-	autoConsume(target);
+	drinksilent(1, target.it);		//drinksilent avoids the popup asking if we are sure we want to overdrink
 	
 	if(start_fam != my_familiar())
 	{


### PR DESCRIPTION
fixes mafia halting our nightcap drinking to popup a confirmation for the user to click through

## How Has This Been Tested?

4 accounts doing greygoo.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
