### PR TITLE
Fix Attempt of Ed pausing at Lvl 13

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -136,6 +136,9 @@ boolean L13_ed_towerHandler()
 	{
 		return false;
 	}
+
+	council(); //Visit prior to checking the quest status to ensure we have correct quest status
+
 	if (internalQuestStatus("questL13Final") < 0 || internalQuestStatus("questL13Final") > 11)
 	{
 		return false;
@@ -146,7 +149,7 @@ boolean L13_ed_towerHandler()
 		return true;
 	}
 
-	council();
+
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_10_sorcfight"))
 	{
 		auto_log_info("We found the jerkwad!! Revenge!!!!!", "blue");


### PR DESCRIPTION
# Description

Autoscend has been stopping at level 13 recently. Reported by multiple users in the autoscend discord channel. From investigating on my multi, I believe this may be due either Ed council text not stacking, or where the character has not got to level 13 by the time they have completed the last on-lvl-13 quest. This fixes those issues by moving a call to visit the council within the structure of  ` L13_ed_towerHandler()` to before it checks the Internal Quest Status

## Testing

Not yet tested but my no-iotm multi has just started a new Edscension today so can be tested via them in a few days if needed.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
