### PR TITLE
fix Cargo Shorts monster handling and fight a Smut Orc Pervert

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -477,6 +477,10 @@ boolean auto_cargoShortsOpenPocket(int pocket)
 	if (!auto_cargoShortsCanOpenPocket(pocket))
 		return false;
 
+	if (monster_pockets() contains pocket)
+	{
+		return auto_cargoShortsOpenPocket(pocket_monster(pocket));
+	}
 	return pick_pocket(pocket);
 }
 
@@ -492,8 +496,16 @@ boolean auto_cargoShortsOpenPocket(monster m)
 {
 	if (!auto_cargoShortsCanOpenPocket(m))
 		return false;
-
-	return pick_pocket(available_pocket(m));
+	
+	string[int] pages;
+	pages[0] = "inventory.php?action=pocket";
+	pages[1] = `choice.php?pwd={my_hash()}&whichchoice=1420&option=1&pocket={available_pocket(m)}`;
+	if (autoAdvBypass(0, pages, $location[Noob Cave], ""))
+	{
+		handleTracker(m, $item[Cargo Cultist Shorts], "auto_copies");
+		return true;
+	}
+	return false;
 }
 
 boolean auto_cargoShortsOpenPocket(effect e)

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -158,6 +158,13 @@ boolean L9_chasmBuild()
 	// make sure our progress count is correct before we do anything.
 	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 
+	if (!in_glover() && get_property("chasmBridgeProgress").to_int() < 30 && auto_cargoShortsOpenPocket(666))
+	{
+ 		// fight Smut Orc Pervert from Cargo Shorts for a Smut Orc Keepsake Box
+ 		use(1, $item[Smut Orc Keepsake Box]);
+		return true;
+	}
+
 	// -Combat is useless here since NC is triggered by killing Orcs...So we kill orcs better!
 	// -ML helps us deal more cold damage and trigger the NC faster.
 	asdonBuff($effect[Driving Intimidatingly]);


### PR DESCRIPTION
# Description
- fix Cargo Shorts monster handling
- use Cargo Shorts for a Smut Orc Pervert when we start building a bridge.

## How Has This Been Tested?

Ran 2 Normal QT Sauceror runs back to back. Seems fine.
```
Inspecting Cargo Cultist Shorts
picking pocket 666
Preference _cargoPocketEmptied changed from false to true
Preference cargoPocketsEmptied changed from  to 666
Preference lastAdventure changed from Camp Logging Camp to None
Preference nextAdventure changed from Noob Cave to None

[99] Cargo Cultist Shorts
Preference lastEncounter changed from Axes of Evil to smut orc pervert
Encounter: smut orc pervert
Preference _lastCombatStarted changed from 20210601000609 to 20210601000628
Round 0: Player Two wins initiative!
<snip>
Round 5: Player Two wins the fight!
After Battle: You gain 50 Mana Points
After Battle: You pause for a moment to warm your hands at the crackling fire within Fiery Cochran.
After Battle: You gain 45 hit points
After Battle: You gain 68 Mana Points
After Battle: The dancing flames inside Fiery Cochran light up the area, making it easier to spot items.
You acquire an item: smut orc keepsake box
You acquire an item: red pixel
After Battle: You gain 10 Beefiness
After Battle: You gain 45 Magicalness
After Battle: You gain 24 Smarm
You gain 5 Soulsauce
Preference testudinalTeachings changed from 282:3|47:2|203:3|65:1|260:4|128:0|80:5|14:3|214:3 to 282:3|47:2|203:3|65:1|260:4|128:0|80:5|14:3|214:4
Preference garbageFireProgress changed from 4 to 5
This combat did not cost a turn
Preference lastAdventure changed from None to Camp Logging Camp
Preference relayCounters changed from 248:Fortune Cookie:fortune.gif:99:Quantum Familiar loc=*:spacebeastlet.gif to 248:Fortune Cookie:fortune.gif
Preference relayCounters changed from 248:Fortune Cookie:fortune.gif to 248:Fortune Cookie:fortune.gif:99:Quantum Familiar loc=*:spacebeastlet.gif
> [INFO] - Post Adventure done, beep.
Preference auto_copies changed from  to (1:smut orc pervert:Cargo Cultist Shorts:98)

use 1 smut orc keepsake box
You acquire weirdwood plank (2)
You acquire morningwood plank (3)
You acquire long hard screw (2)
You acquire messy butt joint (2)
You acquire an item: thick caulk
```
![image](https://user-images.githubusercontent.com/50261170/120402911-0c5c8500-c2f8-11eb-9e36-edf91f223ae7.png)

## Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
