### PR TITLE
fix auto_pre_adv.ash interrupt

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -539,5 +539,6 @@ void main()
 			auto_log_error("Error running auto_pre_adv.ash, setting auto_interrupt=true");
 			set_property("auto_interrupt", true);
 		}
+		auto_interruptCheck();
 	}
 }


### PR DESCRIPTION
* auto_pre_adv.ash should perform an auto_interruptCheck() check to properly abort before spending the adventure. this also fixes some adventuring without maximizing gear properly

## How Has This Been Tested?

in quantum terrarium run with mini hipster while trying to do the steel organ quest tested the fixed pre_adv interrupt and it now works correctly and does a proper shutdown before spending the adv when pre_adv fails

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
