### PR TITLE
Nash Crosby's Still

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1,3 +1,74 @@
+void bedtime_still()
+{
+	//quickly use up all remaining uses of Nash Crosby's Still during bedtime
+	if(!stillReachable())
+	{
+		return;		//we can not reach the still
+	}
+	while(stills_available() > 0)	//spend remaining still uses
+	{
+		item target = $item[none];
+		
+		//first try to get at least 1 each of each of the imrpoved booze if possible
+		foreach it in $items[bottle of Calcutta Emerald, bottle of Lieutenant Freeman, bottle of Jorge Sinsonte, bottle of Definit, bottle of Domesticated Turkey, boxed champagne, bottle of Pete\'s Sake]
+		{
+			if(target == $item[none] && item_amount(it) == 0 && item_amount(still_targetToOrigin(it)) > 0)
+			{
+				target = it;
+			}
+		}
+		
+		//tonic water is an excellent MP restorer and also can be used to craft some drinks.
+		if(target == $item[none] && my_meat() > meatReserve() + 100 && isGeneralStoreAvailable())
+		{
+			if(buyUpTo(1, $item[soda water]))
+			{
+				target = $item[tonic water];
+			}
+		}
+		
+		//if we can not afford tonic water use it on the improved item we have the least of.
+		if(target == $item[none])	//below we will replace target with a better target. only do so if we reached this spot without a target
+		{
+			//all possible still items except [tonic water] and [bottle of Ooze-O]
+			foreach it in $items[bottle of Calcutta Emerald, bottle of Lieutenant Freeman, bottle of Jorge Sinsonte, bottle of Definit, bottle of Domesticated Turkey, boxed champagne, bottle of Pete\'s Sake, tangerine, kiwi, cocktail onion, kumquat, raspberry]
+			{
+				if(target == $item[none] && item_amount(still_targetToOrigin(it)) > 0)	//do not have a target yet
+				{
+					target = it;
+				}
+				if(target != $item[none] &&		//have a target and seek a better one
+				item_amount(it) < item_amount(target) &&	//we want the target we have the least of
+				item_amount(still_targetToOrigin(it)) > 0)	//we need to actually be able to make it
+				{
+					target = it;
+				}
+			}
+		}
+		
+		//finally distill the target
+		if(target != $item[none])
+		{
+			if(!distill(target))	//try to distill target. do something if it fails
+			{
+				auto_log_warning("bedtime_still() failed to distill [" +target+ "] in Nash Crosby's Still and is giving up to avoid infinite loop");
+				break;
+			}
+		}
+		else 		//avoid infinite loop if we did not find any valid targets to distill
+		{
+			auto_log_warning("bedtime_still() could not find any valid targets to distill");
+			break;
+		}
+	
+	}
+	
+	if(stills_available() > 0)
+	{
+		auto_log_info("You have " + stills_available() + " uses of Nash Crosby's Still left.", "red");
+	}
+}
+
 boolean doBedtime()
 {
 	auto_log_info("Starting bedtime: Pulls Left: " + pulls_remaining(), "blue");
@@ -661,10 +732,7 @@ boolean doBedtime()
 			auto_log_info("You can still fight a Chateau Mangtegna Painting today.", "blue");
 		}
 
-		if(stills_available() > 0)
-		{
-			auto_log_info("You have " + stills_available() + " uses of Nash Crosby's Still left.", "blue");
-		}
+		bedtime_still();	//quickly use up all remaining uses of Nash Crosby's Still during bedtime
 
 		if(!get_property("_streamsCrossed").to_boolean() && possessEquipment($item[Protonic Accelerator Pack]))
 		{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -10,7 +10,7 @@ void bedtime_still()
 		item target = $item[none];
 		
 		//first try to get at least 1 each of each of the imrpoved booze if possible
-		foreach it in $items[bottle of Calcutta Emerald, bottle of Lieutenant Freeman, bottle of Jorge Sinsonte, bottle of Definit, bottle of Domesticated Turkey, boxed champagne, bottle of Pete\'s Sake]
+		foreach it in $items[bottle of Calcutta Emerald, bottle of Lieutenant Freeman, bottle of Jorge Sinsonte, bottle of Definit, bottle of Domesticated Turkey, boxed champagne]
 		{
 			if(target == $item[none] && item_amount(it) == 0 && item_amount(still_targetToOrigin(it)) > 0)
 			{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1430,29 +1430,31 @@ boolean auto_breakfastCounterVisit() {
 item still_targetToOrigin(item target)
 {
 	//Nash Crosby's Still can convert Origin item into Target item. This function takes a target and tells us which origin it needs.
-	item retval = $item[none];
-	switch(target)
+	static item[item] originNeeded = {
+	$item[bottle of Calcutta Emerald]:		$item[bottle of gin],
+	$item[bottle of Lieutenant Freeman]:	$item[bottle of rum],
+	$item[bottle of Jorge Sinsonte]:		$item[bottle of tequila],
+	$item[bottle of Definit]:				$item[bottle of vodka],
+	$item[bottle of Domesticated Turkey]:	$item[bottle of whiskey],
+	$item[boxed champagne]:					$item[boxed wine],
+	$item[bottle of Pete\'s Sake]:			$item[bottle of sake],
+	$item[bottle of Ooze-O]:				$item[bottle of sewage schnapps],
+	$item[tangerine]:						$item[grapefruit],
+	$item[kiwi]:							$item[lemon],
+	$item[cocktail onion]:					$item[olive],
+	$item[kumquat]:							$item[orange],
+	$item[raspberry]:						$item[strawberry],
+	$item[tonic water]:						$item[soda water]
+	};
+	if(originNeeded contains target)
 	{
-	case $item[bottle of Calcutta Emerald]:			retval = $item[bottle of gin];				break;
-	case $item[bottle of Lieutenant Freeman]:		retval = $item[bottle of rum];				break;
-	case $item[bottle of Jorge Sinsonte]:			retval = $item[bottle of tequila];			break;
-	case $item[bottle of Definit]:					retval = $item[bottle of vodka];				break;
-	case $item[bottle of Domesticated Turkey]:		retval = $item[bottle of whiskey];			break;
-	case $item[boxed champagne]:					retval = $item[boxed wine];					break;
-	case $item[bottle of Pete\'s Sake]:				retval = $item[bottle of sake];				break;
-	case $item[bottle of Ooze-O]:					retval = $item[bottle of sewage schnapps];	break;
-	case $item[tangerine]:							retval = $item[grapefruit];					break;
-	case $item[kiwi]:								retval = $item[lemon];						break;
-	case $item[cocktail onion]:						retval = $item[olive];						break;
-	case $item[kumquat]:							retval = $item[orange];						break;
-	case $item[raspberry]:							retval = $item[strawberry];					break;
-	case $item[tonic water]:						retval = $item[soda water];					break;
+		return originNeeded[target];
 	}
-	if(retval == $item[none])
+	else
 	{
 		auto_log_debug("still_targetToOrigin failed to lookup the item [" +target+ "]");
 	}
-	return retval;
+	return $item[none];
 }
 
 boolean stillReachable()

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1426,3 +1426,31 @@ boolean auto_breakfastCounterVisit() {
 	}
 	return false; // not adventuring, no need to restart doTasks loop.
 }
+
+item still_targetToOrigin(item target)
+{
+	//Nash Crosby's Still can convert Origin item into Target item. This function takes a target and tells us which origin it needs.
+	item retval = $item[none];
+	switch(target)
+	{
+	case $item[bottle of Calcutta Emerald]:			retval = $item[bottle of gin];				break;
+	case $item[bottle of Lieutenant Freeman]:		retval = $item[bottle of rum];				break;
+	case $item[bottle of Jorge Sinsonte]:			retval = $item[bottle of tequila];			break;
+	case $item[bottle of Definit]:					retval = $item[bottle of vodka];				break;
+	case $item[bottle of Domesticated Turkey]:		retval = $item[bottle of whiskey];			break;
+	case $item[boxed champagne]:					retval = $item[boxed wine];					break;
+	case $item[bottle of Pete\'s Sake]:				retval = $item[bottle of sake];				break;
+	case $item[bottle of Ooze-O]:					retval = $item[bottle of sewage schnapps];	break;
+	case $item[tangerine]:							retval = $item[grapefruit];					break;
+	case $item[kiwi]:								retval = $item[lemon];						break;
+	case $item[cocktail onion]:						retval = $item[olive];						break;
+	case $item[kumquat]:							retval = $item[orange];						break;
+	case $item[raspberry]:							retval = $item[strawberry];					break;
+	case $item[tonic water]:						retval = $item[soda water];					break;
+	}
+	if(retval == $item[none])
+	{
+		auto_log_debug("still_targetToOrigin failed to lookup the item [" +target+ "]");
+	}
+	return retval;
+}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1454,3 +1454,38 @@ item still_targetToOrigin(item target)
 	}
 	return retval;
 }
+
+boolean stillReachable()
+{
+	//can we reach Nash Crosby's Still.
+	//stills_available() insufficient. it returns 0 if your class can not unlock still and 10 if your class can unlock it but did not.
+	if(my_class() == $class[Avatar of Sneaky Pete])
+	{
+		return true;
+	}
+	return guild_store_available() && $classes[Accordion Thief, Disco Bandit] contains my_class();
+}
+
+boolean distill(item target)
+{
+	//use Nash Crosby's Still to create target
+	auto_log_debug("distill(item target) called to create [" +target+ "]");
+	if(!stillReachable())
+	{
+		auto_log_warning("distill(item target) tried to create [" +target+ "] but Nash Crosby's Still is not reachable");
+		return false;
+	}
+	if(stills_available() == 0)
+	{
+		auto_log_warning("distill(item target) tried to create [" +target+ "] but Nash Crosby's Still is out of uses");
+		return false;
+	}
+	int start_amount = item_amount(target);
+	create(1, target);			//use the still to create target
+	if(start_amount + 1 == item_amount(target))
+	{
+		return true;
+	}
+	auto_log_warning("distill(item target) mysteriously failed to create [" +target+ "]");
+	return false;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1001,6 +1001,7 @@ boolean autoAdvBypass(string url, string option);
 
 ########################################################################################################
 //Defined in autoscend/auto_bedtime.ash
+void bedtime_still();
 boolean doBedtime();
 
 ########################################################################################################
@@ -1034,6 +1035,8 @@ boolean auto_autoConsumeOne(string type, boolean simulate);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
 boolean auto_breakfastCounterVisit();
 item still_targetToOrigin(item target);
+boolean stillReachable();
+boolean distill(item target);
 
 ########################################################################################################
 //Defined in autoscend/auto_deprecation.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1033,6 +1033,7 @@ void auto_drinkNightcap();
 boolean auto_autoConsumeOne(string type, boolean simulate);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
 boolean auto_breakfastCounterVisit();
+item still_targetToOrigin(item target);
 
 ########################################################################################################
 //Defined in autoscend/auto_deprecation.ash


### PR DESCRIPTION
* boolean stillReachable() created = stills_available() insufficient. it returns 0 if your class can not unlock still and 10 if your class can unlock it but did not.
* boolean distill(item target) created = use Nash Crosby's Still to create target
* item still_targetToOrigin(item target) created = Nash Crosby's Still can convert Origin item into Target item. This function takes a target and tells us what origin it needs.
* void bedtime_still() created = during bedtime use up all remaining uses of Nash Crosby's Still. warn if fail to do so

## How Has This Been Tested?

tested during bedtime with my main account. it crafted 4 drinks for me

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
