### PR TITLE
Adding workaround to current mafia evil eye bug

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -72,7 +72,8 @@ boolean L7_crypt()
 		auto_log_info("The Alcove! (" + initiative_modifier() + ")", "blue");
 		return autoAdv($location[The Defiled Alcove]);
 	}
-
+	//current mafia bug causes us to lose track of the amount of Evil Eyes in inventory so adding a refresh here
+	cli_execute("refresh inv");
 	// In KoE, skeleton astronauts are random encounters that drop Evil Eyes.
 	// We might be able to reach the Nook boss without adventuring.
 


### PR DESCRIPTION
Adding workaround to fixing evil eye tracking

# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)
This was reported on the discord as having happened multiple times

## How Has This Been Tested?

It hasn't and I'm not in position to do a run. 

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
