### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This work is licensed under a [Creative Commons Attribution-NonCommercial-ShareA
 
 Run this command in the graphical CLI:
 ```
-svn checkout https://github.com/Loathing-Associates-Scripting-Society/autoscend/trunk/RELEASE/
+svn checkout https://github.com/Loathing-Associates-Scripting-Society/autoscend/branches/master/RELEASE/
 ```
 Will require [a recent build of KoLMafia](http://builds.kolmafia.us/job/Kolmafia/lastSuccessfulBuild/).
 


### PR DESCRIPTION
updates install address in readme

for some odd reason mafia does not want to use /trunk/ anymore ever since we deleted beta.
I did not get this problem with tortoisegit, but with mafia we need to resort to /branches/master/ instead