### PR TITLE
L11 Hidden Bowling Alley Map the Monsters Issue with Bowling Balls

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1367,7 +1367,7 @@ boolean L11_hiddenCity()
 
 		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 		auto_log_info("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
-		if (canSniff($monster[Pygmy Bowler], $location[The Hidden Bowling Alley]) && auto_mapTheMonsters() && item_amount($item[bowling ball]) < 1)
+		if (canSniff($monster[Pygmy Bowler], $location[The Hidden Bowling Alley]) && item_amount($item[bowling ball]) < 1 && auto_mapTheMonsters())
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Pygmy Bowler.");
 		}


### PR DESCRIPTION
# Description

The hidden bowling alley map the master check would map the monster and then check to see if we had any bowling balls in inventory.  This caused an issue where we would map, adventure in the bowling alley and get Life is Like a Cherry of Bowls, and then adventure elsewhere and throw an error in cartographyChoiceHandler.

## How Has This Been Tested?

I re-ran autoscend with the fix, however I will need to ascend again to potentially test this fix.  It is a pretty minor code change.  Here's a session log showing the original bug.
[bob_sanders_20210603 copy.txt](https://github.com/Loathing-Associates-Scripting-Society/autoscend/files/6595010/bob_sanders_20210603.copy.txt)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
