### PR TITLE
Prevent nightcap consumption if limitConsume is set,

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1172,7 +1172,7 @@ void auto_printNightcap()
 void auto_drinkNightcap()
 {
 	//function to overdrink a nightcap at the end of day
-	if(get_property("auto_skipNightcap").to_boolean())
+	if(get_property("auto_skipNightcap").to_boolean() || get_property("auto_limitConsume").to_boolean())
 	{
 		return;
 	}


### PR DESCRIPTION
# Description

Presently, if we do not have skipNightcap set to true, we drink a nightcap automatically. This behaviour has been changed to prevent nightcapping if limitConsume is set as well.

## How Has This Been Tested?

Local casual testing

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
