### PR TITLE
Level_13.ash adjustments

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -729,6 +729,7 @@ boolean digimon_autoAdv(int num, location loc, string option);
 ########################################################################################################
 //Defined in autoscend/paths/quantum_terrarium.ash
 boolean in_quantumTerrarium();
+boolean qt_currentFamiliar(familiar fam);
 familiar qt_nextQuantumFamiliar();
 int qt_turnsToNextQuantumAlignment();
 boolean LX_quantumTerrarium();

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -478,6 +478,13 @@ boolean auto_spoonReadyToTuneMoon()
 
 	if(inKnollSign() && !toKnoll)
 	{
+		if(get_property("questM01Untinker") != "finished")
+		{
+			// just finish the untinker quest if we can, it's free.
+			visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
+			visit_url("place.php?whichplace=knoll_friendly&action=dk_innabox");
+			visit_url("place.php?whichplace=forestvillage&action=fv_untinker");
+		}
 		if(!isDesertAvailable())
 		{
 			// we want to get the meatcar via the knoll store

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -3,6 +3,11 @@ boolean in_quantumTerrarium()
 	return auto_my_path() == "Quantum Terrarium";
 }
 
+boolean qt_currentFamiliar(familiar fam)
+{
+	return in_quantumTerrarium() && my_familiar() == fam;
+}
+
 familiar qt_nextQuantumFamiliar()
 {
 	return get_property("nextQuantumFamiliar").to_familiar();
@@ -56,7 +61,7 @@ boolean qt_FamiliarAvailable (familiar fam)
 boolean qt_FamiliarSwap (familiar fam)
 {
 	//Swap/designate next familiar swap if possible.
-	if(fam == $familiar[none])
+	if (fam == $familiar[none])
 	{
 		print(fam.to_string() + " is not a valid familiar, weird behaviour.");
 		return false;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -940,12 +940,22 @@ boolean L13_towerNSTower()
 		{
 			sources = sources + 1;
 		}
-		if(canChangeToFamiliar($familiar[Imitation Crab]))
+		if(canChangeToFamiliar($familiar[Shorter-Order Cook]) || qt_currentFamiliar($familiar[Shorter-Order Cook]))
+		{
+			handleFamiliar($familiar[Shorter-Order Cook]);
+			sources = sources + 6;
+		}		
+		else if(canChangeToFamiliar($familiar[Mu]) || qt_currentFamiliar($familiar[Mu]))
+		{
+			handleFamiliar($familiar[Mu]);
+			sources = sources + 5;
+		}
+		else if(canChangeToFamiliar($familiar[Imitation Crab]) || qt_currentFamiliar($familiar[Imitation Crab]))
 		{
 			handleFamiliar($familiar[Imitation Crab]);
 			sources = sources + 4;
 		}
-		else if(canChangeToFamiliar($familiar[warbear drone]))
+		else if(canChangeToFamiliar($familiar[warbear drone]) || qt_currentFamiliar($familiar[warbear drone]))
 		{
 			sources = sources + 2;
 			handleFamiliar($familiar[Warbear Drone]);
@@ -961,7 +971,7 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if(canChangeToFamiliar($familiar[Sludgepuppy]))
+		else if(canChangeToFamiliar($familiar[Sludgepuppy] || qt_currentFamiliar($familiar[Sludgepuppy])))
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1078,6 +1078,14 @@ boolean L13_towerNSTower()
 		buffMaintain($effect[Big Meat Big Prizes], 0, 1, 1);
 		buffMaintain($effect[Patent Avarice], 0, 1, 1);
 		bat_formWolf();
+		if(auto_birdModifier("Meat Drop") > 0)
+		{
+			buffMaintain($effect[Blessing of the Bird], 0, 1, 1);
+		}
+		if(auto_favoriteBirdModifier("Meat Drop") > 0)
+		{
+			buffMaintain($effect[Blessing of Your Favorite Bird], 0, 1, 1);
+		}
 		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 		{
 			cli_execute("concert 2");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -971,7 +971,7 @@ boolean L13_towerNSTower()
 				sources = sources + 2;
 			}
 		}
-		else if(canChangeToFamiliar($familiar[Sludgepuppy] || qt_currentFamiliar($familiar[Sludgepuppy])))
+		else if(canChangeToFamiliar($familiar[Sludgepuppy]) || qt_currentFamiliar($familiar[Sludgepuppy]))
 		{
 			handleFamiliar($familiar[Sludgepuppy]);
 			sources = sources + 3;


### PR DESCRIPTION
# Description

A couple little additions to level_13.ash: 

- Added Shorter-Order Cook and Mu to the list of Wall of Skin familiars.
- Added checks to see if the current QT familiar was a Wall of Skin familiar.
- Added handling for bird skills before Wall of Meat.

Additionally, made sure to try to finish the Untinkerer quest before swapping from a knoll sign.

## How Has This Been Tested?

I haven't tested these changes yet, but they're pretty simple, self-explanatory changes. I will update the PR description after I have an opportunity to test the changes.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
