### PR TITLE
Reagnimated Gnome handling, and Shorter-Order Cook boss familiar tag

### DIFF
--- a/BUILD/familiars/boss.dat
+++ b/BUILD/familiars/boss.dat
@@ -1,5 +1,6 @@
 Machine Elf
 Fist Turkey
+Shorter-Order Cook
 Mu
 Warbear Drone
 Mosquito

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -13,9 +13,10 @@
 
 boss	0	Machine Elf
 boss	1	Fist Turkey
-boss	2	Mu
-boss	3	Warbear Drone
-boss	4	Mosquito
+boss	2	Shorter-Order Cook
+boss	3	Mu
+boss	4	Warbear Drone
+boss	5	Mosquito
 
 # "drop" type is used when we want to grab a familiar that drops items themselves rather than boosting the odds of the enemy dropping items.
 #
@@ -27,7 +28,7 @@ drop	0	Fist Turkey	prop:_turkeyBooze<5
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
 drop	1	Puck Man	item:Yellow Pixel<20
 drop	2	Ms. Puck Man	item:Yellow Pixel<20
-# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink
+# 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
 drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
 drop	4	Rockin' Robin	prop:rockinRobinProgress>=25

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -172,6 +172,28 @@ boolean auto_run_choice(int choice, string page)
 		case 584: // Unconfusing Buttons (The Hidden Temple)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
+		case 597: // When visiting the Cake-Shaped Arena with a Reagnimated Gnome
+			if (available_amount($item[gnomish housemaid's kgnee] == 0)) // The housemaid's kgnee is the equipment that justified using the gnome.
+			{
+				run_choice(4);
+			}
+			else if (available_amount($item[gnomish coal miner's lung] == 0)) // May as well get the rest of these on subsequent days.
+			{
+				run_choice(2);
+			}
+			else if (available_amount($item[gnomish athlete's foot] == 0))
+			{
+				run_choice(5);
+			}
+			else if (available_amount($item[gnomish tennis elbow] == 0))
+			{
+				run_choice(3);
+			}
+			else if (available_amount($item[gnomish swimmer's ears] == 0))
+			{
+				run_choice(1);
+			}
+			break;
 		case 689: // The Final Reward (Daily Dungeon 15th room)
 		case 690: // The First Chest Isn't the Deepest. (Daily Dungeon 5th room)
 		case 691: // Second Chest (Daily Dungeon 10th room)

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -173,26 +173,7 @@ boolean auto_run_choice(int choice, string page)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
 		case 597: // When visiting the Cake-Shaped Arena with a Reagnimated Gnome
-			if (available_amount($item[gnomish housemaid's kgnee]) == 0) // The housemaid's kgnee is the equipment that justified using the gnome.
-			{
-				run_choice(4);
-			}
-			else if (available_amount($item[gnomish coal miner's lung]) == 0) // May as well get the rest of these on subsequent days.
-			{
-				run_choice(2);
-			}
-			else if (available_amount($item[gnomish athlete's foot]) == 0)
-			{
-				run_choice(5);
-			}
-			else if (available_amount($item[gnomish tennis elbow]) == 0)
-			{
-				run_choice(3);
-			}
-			else if (available_amount($item[gnomish swimmer's ears]) == 0)
-			{
-				run_choice(1);
-			}
+			auto_reagnimatedGetPart(choice);
 			break;
 		case 689: // The Final Reward (Daily Dungeon 15th room)
 		case 690: // The First Chest Isn't the Deepest. (Daily Dungeon 5th room)

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -173,23 +173,23 @@ boolean auto_run_choice(int choice, string page)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
 		case 597: // When visiting the Cake-Shaped Arena with a Reagnimated Gnome
-			if (available_amount($item[gnomish housemaid's kgnee] == 0)) // The housemaid's kgnee is the equipment that justified using the gnome.
+			if (available_amount($item[gnomish housemaid's kgnee]) == 0) // The housemaid's kgnee is the equipment that justified using the gnome.
 			{
 				run_choice(4);
 			}
-			else if (available_amount($item[gnomish coal miner's lung] == 0)) // May as well get the rest of these on subsequent days.
+			else if (available_amount($item[gnomish coal miner's lung]) == 0) // May as well get the rest of these on subsequent days.
 			{
 				run_choice(2);
 			}
-			else if (available_amount($item[gnomish athlete's foot] == 0))
+			else if (available_amount($item[gnomish athlete's foot]) == 0)
 			{
 				run_choice(5);
 			}
-			else if (available_amount($item[gnomish tennis elbow] == 0))
+			else if (available_amount($item[gnomish tennis elbow]) == 0)
 			{
 				run_choice(3);
 			}
-			else if (available_amount($item[gnomish swimmer's ears] == 0))
+			else if (available_amount($item[gnomish swimmer's ears]) == 0)
 			{
 				run_choice(1);
 			}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -682,6 +682,16 @@ void preAdvUpdateFamiliar(location place)
 		}
 	}
 
+	if (my_familiar() == $familiar[Reagnimated Gnome])
+	{
+		if (get_property("_auto_gnomeArenaVisited").to_boolean() != true)
+		{
+			visit_url("arena.php");
+			set_property("_auto_gnomeArenaVisited", "true");
+		}
+		autoEquip($slot[familiar], $item[gnomish housemaid's kgnee]);
+	}
+
 	if(my_familiar() == $familiar[Trick-Or-Treating Tot])
 	{
 		if($locations[A-Boo Peak, The Haunted Kitchen] contains place)

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -688,7 +688,7 @@ void preAdvUpdateFamiliar(location place)
 		if (!get_property("_auto_gnomeArenaVisited").to_boolean())
 		{
 			visit_url("arena.php");
-			run_choice();
+			run_choice(-1);
 			set_property("_auto_gnomeArenaVisited", "true");
 		}
 		autoEquip($slot[familiar], $item[gnomish housemaid's kgnee]);

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -688,6 +688,7 @@ void preAdvUpdateFamiliar(location place)
 		if (!get_property("_auto_gnomeArenaVisited").to_boolean())
 		{
 			visit_url("arena.php");
+			run_choice();
 			set_property("_auto_gnomeArenaVisited", "true");
 		}
 		autoEquip($slot[familiar], $item[gnomish housemaid's kgnee]);

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -684,6 +684,7 @@ void preAdvUpdateFamiliar(location place)
 
 	if (my_familiar() == $familiar[Reagnimated Gnome])
 	{
+		// This arena visit to obtain gnome familiar equips is turn free and can be done once a day.
 		if (!get_property("_auto_gnomeArenaVisited").to_boolean())
 		{
 			visit_url("arena.php");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -106,7 +106,7 @@ boolean isClipartItem(item it);
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2012.ash
-boolean auto_reagnimatedGetPart();
+void auto_reagnimatedGetPart(int choice);
 boolean handleRainDoh();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/iotms/mr2012.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2012.ash
@@ -1,29 +1,31 @@
 #	This is meant for items that have a date of 2012
 
-boolean auto_reagnimatedGetPart()
+void auto_reagnimatedGetPart(int choice)
 {
-	// UNTESTED, DON'T ACTUALLY CALL UNTIL TESTED
-	if(!auto_have_familiar($familiar[Reagnimated Gnome]))
+	if (available_amount($item[gnomish housemaid's kgnee]) == 0) // The housemaid's kgnee is the equipment that justified using the gnome.
 	{
-		return false;
+		run_choice(4);
 	}
-
-	use_familiar($familiar[Reagnimated Gnome]);
-	foreach part in $items[gnomish housemaid's kgnee, gnomish coal miner's lung, gnomish athlete's foot, gnomish tennis elbow, gnomish swimmer's ears]
+	else if (available_amount($item[gnomish coal miner's lung]) == 0) // May as well get the rest of these on subsequent days.
 	{
-		if(possessEquipment(part))
-		{
-			continue;
-		}
-
-		int selection = part.to_int() - $item[gnomish swimmer\'s ears].to_int() + 1;
-		set_property("choiceAdventure597", selection);
-		visit_url("arena.php");
-
-		return possessEquipment(part);
+		run_choice(2);
 	}
-
-	return false;
+	else if (available_amount($item[gnomish athlete's foot]) == 0)
+	{
+		run_choice(5);
+	}
+	else if (available_amount($item[gnomish tennis elbow]) == 0)
+	{
+		run_choice(3);
+	}
+	else if (available_amount($item[gnomish swimmer's ears]) == 0)
+	{
+		run_choice(1);
+	}
+	else
+	{
+		abort("unhandled choice in auto_reagnimatedGetPart");
+	}
 }
 
 boolean handleRainDoh()


### PR DESCRIPTION
# Description

- Added Shorty to the list of boss-applicable familiars.
- Added handling for the Reagnimated Gnome.

## How Has This Been Tested?

As of yet, untested. Pretty much harmless if it doesn't work though.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.