### PR TITLE
checking that gardens aren't blocked by standard restrictions

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1316,7 +1316,7 @@ void initializeDay(int day)
 	{
 		cli_execute("garden pick");
 	}
-	if(contains_text(campground, "thanksgardenmega.gif") && is_unrestricted($item[packet of thansgarden seeds]))
+	if(contains_text(campground, "thanksgardenmega.gif") && is_unrestricted($item[packet of thanksgarden seeds]))
 	{
 		cli_execute("garden pick");
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1308,15 +1308,15 @@ void initializeDay(int day)
 	}
 
 	string campground = visit_url("campground.php");
-	if(contains_text(campground, "beergarden7.gif"))
+	if(contains_text(campground, "beergarden7.gif") && is_unrestricted($item[packet of beer seeds]))
 	{
 		cli_execute("garden pick");
 	}
-	if(contains_text(campground, "wintergarden3.gif"))
+	if(contains_text(campground, "wintergarden3.gif") && is_unrestricted($item[packet of winter seeds]))
 	{
 		cli_execute("garden pick");
 	}
-	if(contains_text(campground, "thanksgardenmega.gif"))
+	if(contains_text(campground, "thanksgardenmega.gif") && is_unrestricted($item[packet of thansgarden seeds]))
 	{
 		cli_execute("garden pick");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1855,7 +1855,7 @@ boolean L12_clearBattlefield()
 	if(!inAftercore() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
 	{
 		int[item] camp = auto_get_campground();
-		if((camp contains $item[Packet of Thanksgarden Seeds]) && (camp contains $item[Cornucopia]) && (camp[$item[Cornucopia]] > 0) && (internalQuestStatus("questL12War") >= 1) && is_unrestricted($item[packet of thansgarden seeds]))
+		if((camp contains $item[Packet of Thanksgarden Seeds]) && (camp contains $item[Cornucopia]) && (camp[$item[Cornucopia]] > 0) && (internalQuestStatus("questL12War") >= 1) && is_unrestricted($item[packet of thanksgarden seeds]))
 		{
 			cli_execute("garden pick");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1855,7 +1855,7 @@ boolean L12_clearBattlefield()
 	if(!inAftercore() && (my_inebriety() < inebriety_limit()) && !get_property("_gardenHarvested").to_boolean())
 	{
 		int[item] camp = auto_get_campground();
-		if((camp contains $item[Packet of Thanksgarden Seeds]) && (camp contains $item[Cornucopia]) && (camp[$item[Cornucopia]] > 0) && (internalQuestStatus("questL12War") >= 1))
+		if((camp contains $item[Packet of Thanksgarden Seeds]) && (camp contains $item[Cornucopia]) && (camp[$item[Cornucopia]] > 0) && (internalQuestStatus("questL12War") >= 1) && is_unrestricted($item[packet of thansgarden seeds]))
 		{
 			cli_execute("garden pick");
 		}


### PR DESCRIPTION
# Description

Just adding a check before using gardens to make sure we're not trying to use them when standard restrictions would prevent us from being able to do so.

## How Has This Been Tested?

Tested via CLI in QT.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.