### PR TITLE
silence the maximizerMRUList and auto_maximize_current pref setting

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -233,6 +233,17 @@ string defaultMaximizeStatement()
 	return res;
 }
 
+void auto_set_maximize_current(string to_set)
+{
+	string logPrefValue = get_property("logPreferenceChange");
+	if (logPrefValue.to_boolean())
+	{
+		set_property("logPreferenceChange", "false");
+	}
+	set_property("auto_maximize_current", to_set);
+	set_property("logPreferenceChange", logPrefValue);
+}
+
 void resetMaximize()
 {
 	string res = get_property("auto_maximize_baseline");	//user configured override baseline statement.
@@ -290,7 +301,7 @@ void resetMaximize()
 		}
 	}
 	
-	set_property("auto_maximize_current", res);
+	auto_set_maximize_current(res);
 	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");
 
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
@@ -374,7 +385,7 @@ void addToMaximize(string add)
 		add = add.substring(1);
 	}
 	res += add;
-	set_property("auto_maximize_current", res);
+	auto_set_maximize_current(res);
 }
 
 void removeFromMaximize(string rem)
@@ -394,7 +405,7 @@ void removeFromMaximize(string rem)
 	{
 		res = res.substring(1);
 	}
-	set_property("auto_maximize_current", res);
+	auto_set_maximize_current(res);
 }
 
 boolean maximizeContains(string check)
@@ -407,7 +418,7 @@ boolean simMaximize()
 	string backup = get_property("auto_maximize_current");
 	finalizeMaximize();
 	boolean res = autoMaximize(get_property("auto_maximize_current"), true);
-	set_property("auto_maximize_current", backup);
+	auto_set_maximize_current(backup);
 	return res;
 }
 
@@ -417,7 +428,7 @@ boolean simMaximizeWith(string add)
 	addToMaximize(add);
 	auto_log_debug("Simulating: " + get_property("auto_maximize_current"), "gold");
 	boolean res = simMaximize();
-	set_property("auto_maximize_current", backup);
+	auto_set_maximize_current(backup);
 	return res;
 }
 
@@ -429,7 +440,13 @@ float simValue(string modifier)
 void equipMaximizedGear()
 {
 	finalizeMaximize();
+	string logPrefValue = get_property("logPreferenceChange");
+	if (logPrefValue.to_boolean())
+	{
+		set_property("logPreferenceChange", "false");
+	}
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
+	set_property("logPreferenceChange", logPrefValue);
 }
 
 void equipOverrides()

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -6,9 +6,14 @@ boolean autoMaximize(string req, boolean simulate)
 	{
 		debugMaximize(req, 0);
 		tcrs_maximize_with_items(req);
-#		user_confirm("Beep");
+	}
+	string logPrefValue = get_property("logPreferenceChange");
+	if (logPrefValue.to_boolean())
+	{
+		set_property("logPreferenceChange", "false");
 	}
 	boolean didmax = maximize(req, simulate);
+	set_property("logPreferenceChange", logPrefValue);
 	return didmax;
 }
 
@@ -18,9 +23,14 @@ boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
 	{
 		debugMaximize(req, maxPrice);
 		tcrs_maximize_with_items(req);
-#		user_confirm("Beep");
+	}
+	string logPrefValue = get_property("logPreferenceChange");
+	if (logPrefValue.to_boolean())
+	{
+		set_property("logPreferenceChange", "false");
 	}
 	boolean didmax = maximize(req, maxPrice, priceLevel, simulate);
+	set_property("logPreferenceChange", logPrefValue);
 	return didmax;
 }
 
@@ -29,10 +39,15 @@ aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulat
 	if(!simulate)
 	{
 		debugMaximize(req, maxPrice);
-#		user_confirm("Beep");
 		tcrs_maximize_with_items(req);
 	}
+	string logPrefValue = get_property("logPreferenceChange");
+	if (logPrefValue.to_boolean())
+	{
+		set_property("logPreferenceChange", "false");
+	}
 	aggregate maxrecord = maximize(req, maxPrice, priceLevel, simulate, includeEquip);
+	set_property("logPreferenceChange", logPrefValue);
 	return maxrecord;
 }
 


### PR DESCRIPTION
# Description

I figured out what the problem was with the previous attempt at implementing this. If the user had `logPreferenceChange` set to false when they started the script, we back that up and set it to true.
Subsequently, if we call `backupSetting()` again on the same property to set it to false, it doesn't resave it because it's already been saved. So when we then call `restoreSetting()` to restore it to true, it's actually restoring it to false from the original user's setting. So it gets stuck as false from that point onwards (as we only force it to true when starting the script).
Hence handling it "manually" in these changes.

## How Has This Been Tested?

Started day 3 of QT Normal on my IotM-less test account. Seems fine. You do get a bunch of stuff like this
```
[INFO] - Turn(462): Starting with 161 left and 16 pulls left at Level: 11
[INFO] - Encounter: -5.0 Exp Bonus: 24.76666666666667
[INFO] - Meat Drop: 40.0 Item Drop: 152.66479394838265
[INFO] - HP: 200/212, MP: 233/332, Meat: 18025
[INFO] - Tummy: 2/15 Liver: 6/19 Spleen: 0/15
[INFO] - ML: 98 control: 10
[INFO] - Soulsauce: 27
Preference _auto_tunedElement changed from cold to
logPreferenceChange => false
Preference logPreferenceChange changed from true to false
logPreferenceChange => true
[INFO] - In Quantum Terrarium. Current familiar = Pair of Stomping Boots. Next familiar = Autonomous Disco Ball
logPreferenceChange => false
Preference logPreferenceChange changed from true to false
logPreferenceChange => true
logPreferenceChange => false
Preference logPreferenceChange changed from true to false
logPreferenceChange => true
```
in your cli and session log now but it's not spamming multi-line preference changes for auto_maximize_current and maximizerMRUList with to and from all over the place. Anyone complaining about that is getting blacklisted from running the script (not joking).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
