### PR TITLE
dark gyfte fix nightcap recommendation error

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1166,6 +1166,10 @@ ConsumeAction auto_bestNightcap()
 
 void auto_printNightcap()
 {
+	if(my_path() == "Dark Gyffte")
+	{
+		return;		//disable it for now. TODO make a custom function for vampyre nightcap drinking specifically
+	}
 	auto_log_info("Nightcap is: " + to_pretty_string(auto_bestNightcap()), "blue");
 }
 
@@ -1178,7 +1182,7 @@ void auto_drinkNightcap()
 	}
 	if(my_path() == "Dark Gyffte")
 	{
-		return;		//disable for it now. TODO make a custom function for vampyre nightcap drinking specifically
+		return;		//disable it for now. TODO make a custom function for vampyre nightcap drinking specifically
 	}
 	if(!can_drink())
 	{


### PR DESCRIPTION
dark gyfte fix nightcap recommendation error when it tries to load the consumable list

## How Has This Been Tested?

validates. copy pasted from the drink function (which has been tested) into the print function

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
