### PR TITLE
fix [Red-Nosed Snapper] aborting quantum terrairum

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -348,7 +348,7 @@ boolean auto_pillKeeper(int pill);
 boolean auto_pillKeeper(string pill);
 void auto_deliberate_pizza();
 boolean auto_changeSnapperPhylum(phylum toChange);
-boolean auto_snapperPreAdventure(location loc);
+void auto_snapperPreAdventure(location loc);
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2020.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -954,11 +954,11 @@ boolean auto_changeSnapperPhylum(phylum toChange)
 	return true;
 }
 
-boolean auto_snapperPreAdventure(location loc)
+void auto_snapperPreAdventure(location loc)
 {
 	if (my_familiar() != $familiar[Red-Nosed Snapper])
 	{
-		return false;
+		return;
 	}
 	
 	string desiredPhylum = get_property("auto_snapperPhylum");
@@ -966,13 +966,13 @@ boolean auto_snapperPreAdventure(location loc)
 	{
 		auto_log_warning(`auto_snapperPhylum was set to bad value: {desiredPhylum}. Should be a valid phylum.`, "red");
 		remove_property("auto_snapperPhylum");
-		return false;
+		return;
 	}
 
 	if (get_property("redSnapperPhylum") == desiredPhylum)
 	{
 		auto_log_debug(`Red-Nosed Snapper is already guiding you towards {desiredPhylum}`);
-		return false;
+		return;
 	}
 
 	// this is mainly in case autoChooseFamiliar switches to the Snapper due to no "better" +item familiars being available
@@ -1019,11 +1019,13 @@ boolean auto_snapperPreAdventure(location loc)
 				break;
 			default:
 				auto_log_info(`Going to {loc} with the Red-Nosed Snapper without setting a phylum. This is not necessarily bad but it might be worth checking.`, "blue");
-				return false;
+				return;
 		}
 	}
 
-	cli_execute(`snapper {desiredPhylum}`);
-	auto_log_info(`Red-Nosed Snapper is now guiding you towards {desiredPhylum}`, "blue");
-	return true;
+	if(desiredPhylum != "")
+	{
+		cli_execute(`snapper {desiredPhylum}`);
+		auto_log_info(`Red-Nosed Snapper is now guiding you towards {desiredPhylum}`, "blue");
+	}
 }


### PR DESCRIPTION
fix [Red-Nosed Snapper] aborting quantum terrairum
by fixing auto_snapperPreAdventure(location loc) to not cause pre_adv to abort if it can not find a desired target

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
