### PR TITLE
Update reference to lastCopyableMonster

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -27,7 +27,7 @@ boolean auto_canFeelHatred()
 
 boolean auto_canFeelNostalgic()
 {
-	// Combat Skill - adds drop table from last copyable monster to the current (see feelNostalgicMonster property)
+	// Combat Skill - adds drop table from last copyable monster to the current (see lastCopyableMonster property)
 	if(!auto_is_valid($skill[Feel Nostalgic]))
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -110,6 +110,5 @@ void auto_enableBackupCameraReverser()
 
 int auto_backupUsesLeft()
 {
-	// incorrect for You, Robot. Also don't care.
-	return 11 - get_property("_backUpUses").to_int();
+	return 11 + (my_path() == "You, Robot" ? 5 : 0) - get_property("_backUpUses").to_int();
 }


### PR DESCRIPTION
# Description

feelsNostalgicMonster has been renamed lastCopyableMonster in Mafia. Updated reference to it

also fixed `auto_backupUsesLeft` to be correct in You Robot.


## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
