### PR TITLE
Vampyre's Can't use MP, so don't use Gulp Latte

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -720,7 +720,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Apprivoisez La Tortue], false);
 	}
 
-	if((!in_zelda() || my_class() == $class[Vampyre]) &&	//paths that do not use MP
+	if((!in_zelda() && my_class() != $class[Vampyre] && my_path() != "Zombie Slayer") &&	//paths that do not use MP
 	canUse($skill[Gulp Latte]) &&
 	my_mp() * 2 < my_maxmp())		//gulp latte restores 50% of your MP. do not waste it.
 	{


### PR DESCRIPTION
# Description

Update to auto_combat.ash logic regarding when to use Gulp Latte. Corrected logic regarding Dark Gyffte, and added in logic regarding Zombie Slayer (futureproofing should said path ever get further support)

## How Has This Been Tested?

Has not yet been tested.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
