### PR TITLE
ensure noncom choice is set prior to backfarming a EBK

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ chunkinaround (IGN: threebullethamburgler (#1993636))
 
 Phillammon (IGN: Phillammon (#2393910))
 
+Tokoeka (IGN: Asmodais (#2071543))
+
 ## Special Thanks
 
 This script would obviously not be possible without the work of Cheesecookie and soolar.

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -175,6 +175,15 @@ boolean auto_run_choice(int choice, string page)
 		case 597: // When visiting the Cake-Shaped Arena with a Reagnimated Gnome
 			auto_reagnimatedGetPart(choice);
 			break;
+		case 672: //There's No Ability Like Possibility (Castle in the Clouds in the Sky (Ground Floor))
+			run_choice(3);
+			break;
+		case 673: // Putting Off Is Off-Putting (Castle in the Clouds in the Sky (Ground Floor))
+			run_choice(1); //Very Overdue Library Book then Skip
+			break;
+		case 674: // Huzzah! (Castle in the Clouds in the Sky (Ground Floor))
+			run_choice(3);
+			break;
 		case 689: // The Final Reward (Daily Dungeon 15th room)
 		case 690: // The First Chest Isn't the Deepest. (Daily Dungeon 5th room)
 		case 691: // Second Chest (Daily Dungeon 10th room)
@@ -417,6 +426,17 @@ boolean auto_run_choice(int choice, string page)
 		case 1024:  // Like a Bat out of Hell (Actually Ed the Undying)
 			edUnderworldChoiceHandler(choice);
 			break;
+		case 1026: // Home on the Free Range (Castle in the Clouds in the Sky (Ground Floor))
+			if (isActuallyEd() || in_pokefam()) //paths that don't require a boning Knife for the tower - possibly add Bugbear Invasion if we add support for it?
+			{
+				set_property("choiceAdventure1026", 3); //Skip
+			}
+			else
+			{
+				set_property("choiceAdventure1026", 2); // Get Electric Boning Knife then Skip
+			}
+			break;
+
 		case 1060: // Temporarily Out of Skeletons (The Skeleton Store)
 			if (item_amount($item[Skeleton Store office key]) == 0) {
 				run_choice(1); // Skeleton Store office key

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -225,17 +225,6 @@ boolean L10_ground()
 	}
 
 	auto_log_info("Castle Ground Floor, boring!", "blue");
-	set_property("choiceAdventure672", 3); // There's No Ability Like Possibility: Skip
-	set_property("choiceAdventure673", 1); // Putting Off Is Off-Putting: Very Overdue Library Book then Skip
-	set_property("choiceAdventure674", 3); // Huzzah!: Skip
-	if (isActuallyEd() || in_pokefam())
-	{
-		set_property("choiceAdventure1026", 3); // Home on the Free Range: Skip
-	}
-	else
-	{
-		set_property("choiceAdventure1026", 2); // Home on the Free Range: Get Electric Boning Knife then Skip
-	}
 
 	auto_sourceTerminalEducate($skill[Extract], $skill[Portscan]);
 

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1126,6 +1126,10 @@ boolean L13_towerNSTower()
 		
 		if(get_property("auto_getBoningKnife").to_boolean())	//grab boning knife if we deemed it necessary
 		{
+			if(get_property("choiceAdventure1026") != 2)
+			{
+				set_property("choiceAdventure1026", 2);
+			}
 			if(canGroundhog($location[The Castle in the Clouds in the Sky (Ground Floor)]))
 			{
 				auto_log_info("Backfarming an Electric Boning Knife", "green");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1218,7 +1218,19 @@ boolean L13_towerNSTower()
 		}
 		if(n_healing_items < 5)
 		{
-			int create_target = min(creatable_amount($item[red pixel potion]), 5 - n_healing_items);
+			int pull_target = 5 - n_healing_items; //pull healing items if we have any pulls left because its not like we need pulls for anything else at this point
+			int pulled_items = 0;
+			foreach it in $items[gauze garter, filthy poultice, red pixel potion]
+			{
+				while(pulled_items < pull_target && canPull(it))
+				{
+						take_storage(1, it);
+						pulled_items += 1;
+				}
+			
+			}
+
+			int create_target = min(creatable_amount($item[red pixel potion]), pull_target - pulled_items);
 			if(create_target > 0)
 			{
 				if(create(create_target, $item[red pixel potion]))

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1126,10 +1126,6 @@ boolean L13_towerNSTower()
 		
 		if(get_property("auto_getBoningKnife").to_boolean())	//grab boning knife if we deemed it necessary
 		{
-			if(get_property("choiceAdventure1026") != 2)
-			{
-				set_property("choiceAdventure1026", 2);
-			}
 			if(canGroundhog($location[The Castle in the Clouds in the Sky (Ground Floor)]))
 			{
 				auto_log_info("Backfarming an Electric Boning Knife", "green");


### PR DESCRIPTION
# Description

We've had report in Discord of choiceadventure preference for EBK noncom not being set when backfarming during the tower. This PR ensures the appropriate preference is set at that point to prevent any issues like this occuring.

Also added in an attempt to pull healing items when at the shadow if we have any pulls left as per #757 

## How Has This Been Tested?

It hasn't.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
