### PR TITLE
Pick batteries every day, and support crafting them.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1459,7 +1459,8 @@ boolean dailyEvents()
 
 	auto_getGuzzlrCocktailSet();
 	auto_latheAppropriateWeapon();
-
+	auto_harvestBatteries();
+	
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -421,6 +421,11 @@ boolean auto_canFeelPeaceful();
 boolean auto_haveBackupCamera();
 void auto_enableBackupCameraReverser();
 int auto_backupUsesLeft();
+void auto_harvestBatteries();
+int batteryPoints(item battery);
+int totalBatteryPoints();
+boolean batteryCombine(item battery);
+boolean auto_getBattery(item battery, int qty);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -110,6 +110,254 @@ void auto_enableBackupCameraReverser()
 
 int auto_backupUsesLeft()
 {
-	// incorrect for You, Robot. Also don't care.
+	// // You, Robot gets 16 uses, every other path gets 11.
+	// if (my_path() == "You, Robot")
+	// {
+	// 	return 16 - get_property("_backUpUses").to_int();
+	// }
 	return 11 - get_property("_backUpUses").to_int();
+}
+
+boolean auto_havePowerPlant()
+{
+	return possessEquipment($item[potted power plant]) && auto_is_valid($item[potted power plant]);
+}
+
+void auto_harvestBatteries()
+{
+	if (auto_havePowerPlant())
+	{
+		// Stolen straight from mafia's breakfast handling.
+		cli_execute("inv_use.php?pwd&whichitem=" + $item[potted power plant].to_int());
+		
+		string [int] status = split_string(get_property("_pottedPowerPlant"), ",");
+
+		for ( int pp = 0; pp < status.count(); pp++ )
+		{
+			if ( status[pp] > 0)
+			{
+				cli_execute("choice.php?pwd&whichchoice=1448&option=1&pp=" + ( pp + 1 ));
+			}
+		}
+	}
+}
+
+// These points the value of a battery represented in AAAs.
+int batteryPoints(item battery)
+{
+	int points = 0;
+	switch (battery)
+	{
+		case $item[battery (AAA)]:
+			points = 1;
+			break;
+		case $item[battery (AA)]:
+			points = 2;
+			break;
+		case $item[battery (D)]:
+			points = 3;
+			break;
+		case $item[battery (9-Volt)]:
+			points = 4;
+			break;
+		case $item[battery (lantern)]:
+			points = 5;
+			break;
+		case $item[battery (car)]:
+			points = 6;
+			break;
+	}
+	return points;
+}
+
+// These points represent a quantity of AAAs if all batteries were untinkered.
+int totalBatteryPoints()
+{
+	// If the untinker function can't be used, there's effectively no points.
+	if (get_property("questM01Untinker") != "finished")
+	{
+		return 0;
+	}
+
+	int totalPoints = 0;
+
+	foreach it in $items[battery (AAA), battery (AA), battery (D), battery (9-Volt), battery (lantern), battery (car)]
+	{
+		totalPoints += available_amount(it) * batteryPoints(it);
+	}
+
+	return totalPoints;
+}
+
+// Mafia's handling of the create() function is currently not flexible enough for crafting batteries.
+// This is very dense, apologies.
+boolean batteryCombine(item battery)
+{
+	// We already have this battery, no need to make more yet.
+	if (available_amount(battery) >= 1)
+	{
+		return true;
+	}
+	
+	// We're targetting a AA.
+	if (battery == $item[battery (AA)])
+	{
+		// There's only one way to craft a AA.
+		if (available_amount($item[battery (AAA)]) >= 2)
+		{
+			craft("combine", 1, $item[battery (AAA)], $item[battery (AAA)]);
+			return (available_amount($item[battery (AA)]) >= 1);
+		}
+		return false;
+	}
+
+	else if (battery == $item[battery (D)])
+	{
+		// From here on out, we try to resolve the crafting in a single step if possible, starting with largest battery + smallest battery.
+		if (available_amount($item[battery (AA)]) >= 1 && available_amount($item[battery (AAA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (AA)], $item[battery (AAA)]);
+			return (available_amount($item[battery (D)]) >= 1);
+		}
+		// If crafting requires multiple steps, we rely on recursion.
+		else if (available_amount($item[battery (AAA)]) >= 3)
+		{
+			batteryCombine($item[battery (AA)]);
+			craft("combine", 1, $item[battery (AA)], $item[battery (AAA)]);
+			return (available_amount($item[battery (D)]) >= 1);
+		}
+
+		return false;
+	}
+
+	else if (battery == $item[battery (9-Volt)])
+	{
+		// Single step.
+		if (available_amount($item[battery (D)]) >= 1 && available_amount($item[battery (AAA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (D)], $item[battery (AAA)]);
+			return (available_amount($item[battery (9-Volt)]) >= 1);
+		}
+		// Single step.
+		else if (available_amount($item[battery (AA)]) >= 2)
+		{
+			craft("combine", 1, $item[battery (AA)], $item[battery (AA)]);
+			return (available_amount($item[battery (9-Volt)]) >= 1);
+		}
+		// Every multi step case with recusion.
+		else if (available_amount($item[battery (AAA)]) >= 4 ||
+		 (available_amount($item[battery (AA)]) >= 1 && available_amount($item[battery (AAA)]) >= 2))
+		{
+			batteryCombine($item[battery (D)]);
+			craft("combine", 1, $item[battery (D)], $item[battery (AAA)]);
+			return (available_amount($item[battery (9-Volt)]) >= 1);
+		}
+		return false;
+	}
+
+	else if (battery == $item[battery (lantern)])
+	{
+		// Single step.
+		if (available_amount($item[battery (9-Volt)]) >= 1 && available_amount($item[battery (AAA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (9-Volt)], $item[battery (AAA)]);
+			return (available_amount($item[battery (lantern)]) >= 1);
+		}
+		// Single step.
+		else if (available_amount($item[battery (D)]) >= 1 && available_amount($item[battery (AA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (D)], $item[battery (AA)]);
+			return (available_amount($item[battery (lantern)]) >= 1);
+		}
+		// Every multi step case with recusion.
+		else if (available_amount($item[battery (AAA)]) >= 5 ||
+		 (available_amount($item[battery (AA)]) >= 1 && available_amount($item[battery (AAA)]) >= 3) ||
+		 (available_amount($item[battery (D)]) >= 1 && available_amount($item[battery (AAA)]) >= 2) ||
+		 (available_amount($item[battery (AA)]) >= 2 && available_amount($item[battery (AAA)]) >= 1))
+		{
+			batteryCombine($item[battery (9-Volt)]);
+			craft("combine", 1, $item[battery (9-Volt)], $item[battery (AAA)]);
+			return (available_amount($item[battery (lantern)]) >= 1);
+		}
+		return false;
+	}
+
+	else if (battery == $item[battery (car)])
+	{
+		// Single step.
+		if (available_amount($item[battery (lantern)]) >= 1 && available_amount($item[battery (AAA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (lantern)], $item[battery (AAA)]);
+			return (available_amount($item[battery (car)]) >= 1);
+		}
+		// Single step.
+		else if (available_amount($item[battery (9-Volt)]) >= 1 && available_amount($item[battery (AA)]) >= 1)
+		{
+			craft("combine", 1, $item[battery (9-Volt)], $item[battery (AA)]);
+			return (available_amount($item[battery (car)]) >= 1);
+		}
+		// Single step.
+		else if (available_amount($item[battery (D)]) >= 2)
+		{
+			craft("combine", 1, $item[battery (D)], $item[battery (D)]);
+			return (available_amount($item[battery (car)]) >= 1);
+		}
+		// The only multi-step case that can't be resolved by the same function (can't turn AAs into a lantern without a AA or D)
+		else if (available_amount($item[battery (AA)]) >= 3)
+		{
+			batteryCombine($item[battery (9-volt)]);
+			craft("combine", 1, $item[battery (9-Volt)], $item[battery (AA)]);
+			return (available_amount($item[battery (car)]) >= 1);
+		}
+		// Every other multi step case with recusion.
+		else if (available_amount($item[battery (AAA)]) >= 6 ||
+		 (available_amount($item[battery (AA)]) >= 1 && available_amount($item[battery (AAA)]) >= 4) ||
+		 (available_amount($item[battery (D)]) >= 1 && available_amount($item[battery (AAA)]) >= 3) ||
+		 (available_amount($item[battery (9-Volt)]) >= 1 && available_amount($item[battery (AAA)]) >= 2) ||
+		 (available_amount($item[battery (AA)]) >= 2 && available_amount($item[battery (AAA)]) >= 2) ||
+		 (available_amount($item[battery (D)]) >= 1 && available_amount($item[battery (AA)]) >= 1 && available_amount($item[battery (AAA)]) >= 1))
+		{
+			batteryCombine($item[battery (lantern)]);
+			craft("combine", 1, $item[battery (lantern)], $item[battery (AAA)]);
+			return (available_amount($item[battery (car)]) >= 1);
+		}
+	}
+
+	return false;
+}
+
+// This function will ensure a battery is available before use, if possible.
+boolean auto_getBattery(item battery)
+{
+	// If we have the desired battery then we're done here.
+	if (available_amount(battery) >= 1)
+	{
+		return true;
+	}
+		
+	// We'll try to create the battery, if it works then great, if not, we keep going.
+	if (batteryCombine(battery))
+	{
+		return true;
+	}
+
+	// We need to check that we can untinker (handled by totalBatteryPoints), 
+	// then make sure we have enough AAA value to craft the target battery.
+	if (totalBatteryPoints() > batteryPoints(battery))
+	{
+		// We're going to break down each battery one at a time from largest to smallest, and attempt to craft.
+		foreach it in $items[battery (car), battery (lantern), battery (9-Volt), battery (D), battery (AA)]
+		{
+			for i from 1 to available_amount(it)
+			{
+				visit_url("place.php?whichplace=forestvillage&action=fv_untinker&pwd=&preaction=untinker&whichitem=" + it.to_int().to_string());
+				
+				if (batteryCombine(battery))
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
 }


### PR DESCRIPTION
# Description

This adds support to obtain a particular battery, untinkering from larger batteries if necessary and possible, and mimics the code that mafia uses to pick batteries during breakfast to pick batteries each day.

The battery combining is a nightmare to look at, I apologize in advance.

## How Has This Been Tested?

Tested the individual battery crafting functions pretty extensively in the CLI, tested the battery picking function across two days of autoscending QT.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
