### PR TITLE
We can now track Ensorcelled Monsters

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -574,6 +574,8 @@ boolean[skill] bat_desiredSkills(int hpLeft, boolean[skill] forcedPicks);
 void bat_reallyPickSkills(int hpLeft);
 void bat_reallyPickSkills(int hpLeft, boolean[skill] requiredSkills);
 boolean bat_shouldPickSkills(int hpLeft);
+boolean bat_haveEnsorcelee();
+phylum bat_ensorceledMonster();
 boolean bat_shouldEnsorcel(monster m);
 int bat_creatable_amount(item desired);
 boolean bat_multicraft(string mode, boolean [item] options);

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -365,21 +365,14 @@ boolean bat_shouldPickSkills(int hpLeft)
 
 boolean bat_haveEnsorcelee() // checks if you have a current Ensorceled Monster
 {
-	if(my_class() != $class[Vampyre] || !auto_have_skill($skill[Ensorcel]))
+	if(!auto_have_skill($skill[Ensorcel]))
 		return false;
 
-	if(get_property("ensorcelee") == $monster[none])
-		return false;
-	
-	return true;
+	return get_property("ensorcelee") != "";
 }
 
 phylum bat_ensorceledMonster() //returns phylum of current Ensorceled Monster (if you have one)
 {
-	if(!bat_haveEnsorcelee()){
-		return $phylum[none];
-	}
-
 	return monster_phylum(to_monster(get_property("ensorcelee")));
 }	
 

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -366,7 +366,7 @@ boolean bat_shouldPickSkills(int hpLeft)
 boolean bat_haveEnsorcelee() // checks if you have a current Ensorceled Monster
 {
 	if(!auto_have_skill($skill[Ensorcel]))
-		return false;
+		return false; //in case mafia doesn't clear ensorcelee property when you change skills and drop Ensorcel.
 
 	return get_property("ensorcelee") != "";
 }
@@ -386,7 +386,7 @@ boolean bat_shouldEnsorcel(monster m)
 	if(m.monster_phylum() == $phylum[goblin] && !isFreeMonster(m) && !bat_haveEnsorcelee()) //stop wasting additional Ensorcel casts once we already have an Ensorcelee
 		return true;
 
-	//code to be added for getting other types of monster (beasts / bugs presumably) where appropriate.
+	//TODO code for getting other types of monster (beasts / bugs presumably) where appropriate.
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -363,6 +363,26 @@ boolean bat_shouldPickSkills(int hpLeft)
 	return false;
 }
 
+boolean bat_haveEnsorcelee() // checks if you have a current Ensorceled Monster
+{
+	if(my_class() != $class[Vampyre] || !auto_have_skill($skill[Ensorcel]))
+		return false;
+
+	if(get_property("ensorcelee") == $monster[none])
+		return false;
+	
+	return true;
+}
+
+phylum bat_ensorceledMonster() //returns phylum of current Ensorceled Monster (if you have one)
+{
+	if(!bat_haveEnsorcelee()){
+		return $phylum[none];
+	}
+
+	return monster_phylum(to_monster(get_property("ensorcelee")));
+}	
+
 boolean bat_shouldEnsorcel(monster m)
 {
 	if(my_class() != $class[Vampyre] || !auto_have_skill($skill[Ensorcel]))
@@ -370,8 +390,10 @@ boolean bat_shouldEnsorcel(monster m)
 
 	// until we have a way to tell what we already have as an ensorcelee, just ensorcel goblins
 	// to help avoid getting beaten up...
-	if(m.monster_phylum() == $phylum[goblin] && !isFreeMonster(m))
+	if(m.monster_phylum() == $phylum[goblin] && !isFreeMonster(m) && !bat_haveEnsorcelee()) //stop wasting additional Ensorcel casts once we already have an Ensorcelee
 		return true;
+
+	//code to be added for getting other types of monster (beasts / bugs presumably) where appropriate.
 
 	return false;
 }


### PR DESCRIPTION
# Description

Added in functions for checking if we have an Ensorceled Monster & getting the phylum of the Ensorcelled monster. Also amended the current "do we want to cast ensorcel" function to not waste additional casts on goblins if we currently have an ensorcel

Fixes # (issue)

## How Has This Been Tested?

tested the internal code for the `bat_ensorcelledMonster` via ash commands in CLI

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
