### PR TITLE
Update the PR Template to not reference the beta Branch

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE
+++ b/docs/PULL_REQUEST_TEMPLATE
@@ -15,4 +15,4 @@ Testing ASH scripts is tricky and generally involves you doing multiple runs wit
 - [ ] My code follows the style guidelines of this project.
 - [ ] I have performed a self-review of my own code.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
+- [ ] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.


### PR DESCRIPTION
# Description

PR template currently references the Beta branch, which is no longer in use/applicable. This should change the PR template to not reference it. 

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
