### PR TITLE
Use new logPreferenceChangeFilter function to silence maximizerMRUist, testitudinalTeachings and auto_maximize_current properties

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20749;	//min mafia revision needed to run this script. Last update: Fix Quantum Terrarium Request parsing breaking on melodramedary
+since r20762;	//min mafia revision needed to run this script. Last update: Add 'logPreferenceChangeFilter', which is a comma separated list of preferences to not log when logPreferenceChange is enabled
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -2519,6 +2519,23 @@ void resetState() {
 		use_familiar($familiar[Left-Hand Man]);
 		equip($slot[familiar], $item[none]);
 	}
+
+	foreach it in $items[staph of homophones, sword behind inappropriate prepositions]
+	{
+		// these screw with text in the game which breaks mafia's parsing in a lot of places.
+		if (have_equipped(it))
+		{
+			equip($item[none], it.to_slot());
+		}
+	}
+	foreach eff in $effects[Can Has Cyborger, Dis Abled, Haiku State of Mind, Just the Best Anapests, O Hai!, Robocamo, Yes, Can Haz]
+	{
+		// as do these which can all be freely shrugged.
+		if (have_effect(eff) > 0)
+		{
+			cli_execute(`uneffect {eff.to_string()}`);
+		}
+	}
 }
 
 boolean process_tasks()
@@ -2844,6 +2861,7 @@ void auto_begin()
 	backupSetting("currentMood", "apathetic");
 
 	backupSetting("logPreferenceChange", "true");
+	backupSetting("logPreferenceChangeFilter" "maximizerMRUList, testudinalTeachings, auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	
 	backupSetting("choiceAdventure1107", 1);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2528,7 +2528,7 @@ void resetState() {
 			equip($item[none], it.to_slot());
 		}
 	}
-	foreach eff in $effects[Can Has Cyborger, Dis Abled, Haiku State of Mind, Just the Best Anapests, O Hai!, Robocamo, Yes, Can Haz]
+	foreach eff in $effects[Can Has Cyborger, Dis Abled, Haiku State of Mind, Just the Best Anapests, O Hai!, Robocamo, Yes\, Can Haz]
 	{
 		// as do these which can all be freely shrugged.
 		if (have_effect(eff) > 0)
@@ -2861,7 +2861,7 @@ void auto_begin()
 	backupSetting("currentMood", "apathetic");
 
 	backupSetting("logPreferenceChange", "true");
-	backupSetting("logPreferenceChangeFilter" "maximizerMRUList, testudinalTeachings, auto_maximize_current");
+	backupSetting("logPreferenceChangeFilter" "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	
 	backupSetting("choiceAdventure1107", 1);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2861,7 +2861,7 @@ void auto_begin()
 	backupSetting("currentMood", "apathetic");
 
 	backupSetting("logPreferenceChange", "true");
-	backupSetting("logPreferenceChangeFilter" "maximizerMRUList,testudinalTeachings,auto_maximize_current");
+	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	
 	backupSetting("choiceAdventure1107", 1);

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -233,17 +233,6 @@ string defaultMaximizeStatement()
 	return res;
 }
 
-void auto_set_maximize_current(string to_set)
-{
-	string logPrefValue = get_property("logPreferenceChange");
-	if (logPrefValue.to_boolean())
-	{
-		set_property("logPreferenceChange", "false");
-	}
-	set_property("auto_maximize_current", to_set);
-	set_property("logPreferenceChange", logPrefValue);
-}
-
 void resetMaximize()
 {
 	string res = get_property("auto_maximize_baseline");	//user configured override baseline statement.
@@ -301,7 +290,7 @@ void resetMaximize()
 		}
 	}
 	
-	auto_set_maximize_current(res);
+	set_property("auto_maximize_current", res);
 	auto_log_debug("Resetting auto_maximize_current to " + res, "gold");
 
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
@@ -385,7 +374,7 @@ void addToMaximize(string add)
 		add = add.substring(1);
 	}
 	res += add;
-	auto_set_maximize_current(res);
+	set_property("auto_maximize_current", res);
 }
 
 void removeFromMaximize(string rem)
@@ -405,7 +394,7 @@ void removeFromMaximize(string rem)
 	{
 		res = res.substring(1);
 	}
-	auto_set_maximize_current(res);
+	set_property("auto_maximize_current", res);
 }
 
 boolean maximizeContains(string check)
@@ -418,7 +407,7 @@ boolean simMaximize()
 	string backup = get_property("auto_maximize_current");
 	finalizeMaximize();
 	boolean res = autoMaximize(get_property("auto_maximize_current"), true);
-	auto_set_maximize_current(backup);
+	set_property("auto_maximize_current", backup);
 	return res;
 }
 
@@ -428,7 +417,7 @@ boolean simMaximizeWith(string add)
 	addToMaximize(add);
 	auto_log_debug("Simulating: " + get_property("auto_maximize_current"), "gold");
 	boolean res = simMaximize();
-	auto_set_maximize_current(backup);
+	set_property("auto_maximize_current", backup);
 	return res;
 }
 
@@ -440,13 +429,7 @@ float simValue(string modifier)
 void equipMaximizedGear()
 {
 	finalizeMaximize();
-	string logPrefValue = get_property("logPreferenceChange");
-	if (logPrefValue.to_boolean())
-	{
-		set_property("logPreferenceChange", "false");
-	}
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
-	set_property("logPreferenceChange", logPrefValue);
 }
 
 void equipOverrides()

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -7,14 +7,7 @@ boolean autoMaximize(string req, boolean simulate)
 		debugMaximize(req, 0);
 		tcrs_maximize_with_items(req);
 	}
-	string logPrefValue = get_property("logPreferenceChange");
-	if (logPrefValue.to_boolean())
-	{
-		set_property("logPreferenceChange", "false");
-	}
-	boolean didmax = maximize(req, simulate);
-	set_property("logPreferenceChange", logPrefValue);
-	return didmax;
+	return maximize(req, simulate);
 }
 
 boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
@@ -24,14 +17,7 @@ boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate)
 		debugMaximize(req, maxPrice);
 		tcrs_maximize_with_items(req);
 	}
-	string logPrefValue = get_property("logPreferenceChange");
-	if (logPrefValue.to_boolean())
-	{
-		set_property("logPreferenceChange", "false");
-	}
-	boolean didmax = maximize(req, maxPrice, priceLevel, simulate);
-	set_property("logPreferenceChange", logPrefValue);
-	return didmax;
+	return maximize(req, maxPrice, priceLevel, simulate);
 }
 
 aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate, boolean includeEquip)
@@ -41,14 +27,7 @@ aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulat
 		debugMaximize(req, maxPrice);
 		tcrs_maximize_with_items(req);
 	}
-	string logPrefValue = get_property("logPreferenceChange");
-	if (logPrefValue.to_boolean())
-	{
-		set_property("logPreferenceChange", "false");
-	}
-	aggregate maxrecord = maximize(req, maxPrice, priceLevel, simulate, includeEquip);
-	set_property("logPreferenceChange", logPrefValue);
-	return maxrecord;
+	return maximize(req, maxPrice, priceLevel, simulate, includeEquip);
 }
 
 void debugMaximize(string req, int meat)	//This function will be removed.


### PR DESCRIPTION
# Description

- Revert changes from #763 
- Use new logPreferenceChangeFilter function to silence maximizerMRUist, testitudinalTeachings and auto_maximize_current properties
- unequip and shrug stuff that messes with text in game so we don't break mafia tracking.

## How Has This Been Tested?

Haven't yet. It's halloween so my accounts are busy right now. Will test after rollover.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
