### PR TITLE
Give scrapbook a moderate maximizer bonus to encourage scrap generation, when you can generate scrap.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -345,6 +345,11 @@ void finalizeMaximize()
 	{
 		addBonusToMaximize($item[Powerful Glove], 1000); // pixels
 	}
+	// Vampyre autogenerates scraps because of some weird ensorcel interaction. Even without ensorcel active.
+	if(pathHasFamiliar() || my_class() == $class[Vampyre])
+	{
+		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
+	}
 	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
 	addBonusToMaximize($item[Mr. Screege's spectacles], 100); // meat stuff
 	if(have_effect($effect[blood bubble]) == 0)


### PR DESCRIPTION
# Description

As per the title.

## How Has This Been Tested?

Ran a bit of autoscend in a path with familiars, saw the bonus added to the maximizer line. Not yet tested in Vampyre or a path without familiars.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
