### PR TITLE
Mumming Trunk Rework

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -11,7 +11,6 @@ auto_confidence	boolean	If true, we'll get the confidence buff instead of breaki
 auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
 auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
 auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
 auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
 auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -22,41 +22,40 @@ any	9	auto_confidence	boolean	If true, we'll get the confidence buff instead of 
 any	10	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
 any	11	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
 any	12	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	13	auto_mummeryChoice	string	Force mummery usage. Use familiar name and goals are in order (1..7) (Use ; to separate, leave blank to skip a goal).
-any	14	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	15	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	16	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	17	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
-any	18	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
-any	19	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	20	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	21	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	22	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	23	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	24	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	25	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	26	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	27	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	28	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	29	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	30	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	31	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	32	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	33	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	34	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	36	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	39	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	40	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	41	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	42	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	43	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
-any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	13	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	14	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
+any	15	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	16	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	17	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	18	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	19	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	20	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	21	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	22	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	23	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	24	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	25	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	26	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	27	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	28	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	29	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	30	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	31	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	37	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	38	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	39	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	40	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	41	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	42	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	43	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	44	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	45	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	46	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1013,19 +1013,6 @@ void initializeDay(int day)
 
 	auto_barrelPrayers();
 
-	if(get_property("auto_mummeryChoice") != "")
-	{
-		string[int] mummeryChoice = split_string(get_property("auto_mummeryChoice"), ";");
-		foreach idx, opt in mummeryChoice
-		{
-			int goal = idx + 1;
-			if((opt == "") || (goal > 7))
-			{
-				continue;
-			}
-			mummifyFamiliar(to_familiar(opt), goal);
-		}
-	}
 
 	if(!get_property("_pottedTeaTreeUsed").to_boolean() && (auto_get_campground() contains $item[Potted Tea Tree]) && !inAftercore())
 	{
@@ -2192,10 +2179,6 @@ boolean LX_craftAcquireItems()
 				break;
 			}
 		}
-		mummifyFamiliar($familiar[Intergnat], my_primestat());
-		mummifyFamiliar($familiar[Hobo Monkey], "meat");
-		mummifyFamiliar($familiar[XO Skeleton], "mpregen");
-		#set_property("_dailyCreates", true);
 	}
 
 	return false;

--- a/RELEASE/scripts/autoscend/auto_deprecation.ash
+++ b/RELEASE/scripts/autoscend/auto_deprecation.ash
@@ -323,6 +323,7 @@ boolean settingFixer()
 	}
 	remove_property("auto_shareMaximizer");
 	remove_property("auto_allowSharingData");
+	remove_property("auto_mummeryChoice");
 
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -708,7 +708,7 @@ void preAdvUpdateFamiliar(location place)
 		}
 	}
 
-	if(my_path() != "Community Service")
+	if(my_path() != "Community Service" && !auto_checkFamiliarMummery(my_familiar()))
 	{
 		mummifyFamiliar();
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -707,6 +707,11 @@ void preAdvUpdateFamiliar(location place)
 			}
 		}
 	}
+
+	if(my_path() != "Community Service")
+	{
+		mummifyFamiliar();
+	}
 }
 
 boolean hatchFamiliar(familiar adult)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -194,6 +194,8 @@ boolean rethinkingCandy(effect acquire, boolean simulate);
 ########################################################################################################
 //Defined in autoscend/iotms/mr2017.ash
 boolean mummifyFamiliar(familiar fam, string bonus);
+boolean mummifyFamiliar(familiar fam);
+boolean mummifyFamiliar();
 boolean pantogramPants();
 boolean pantogramPants(stat st, element el, int hpmp, int meatItemStats, int misc);
 boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int loveEffect, boolean equivocator, int giftItem);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -193,6 +193,8 @@ boolean rethinkingCandy(effect acquire, boolean simulate);
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2017.ash
+boolean auto_hasMummingTrunk();
+boolean auto_checkFamiliarMummery(familiar fam);
 boolean mummifyFamiliar(familiar fam, string bonus);
 boolean mummifyFamiliar(familiar fam);
 boolean mummifyFamiliar();

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1,9 +1,27 @@
 #	This is meant for items that have a date of 2017.
 
 // This should probably only be called directly from community_service.ash.
+boolean auto_hasMummingTrunk()
+{
+	if(!pathHasFamiliar()  || item_amount($item[Mumming Trunk]) == 0 || !auto_is_valid($item[Mumming Trunk]))
+	{
+		return false;
+	}
+	return true;
+}
+
+boolean auto_checkFamiliarMummery(familiar fam)
+{
+	if (contains_text(get_property("_mummeryMods"), fam.to_string()))
+	{
+		return false;
+	}
+	return true;
+}
+
 boolean mummifyFamiliar(familiar fam, string bonus)
 {
-	if(!pathHasFamiliar()  || item_amount($item[Mumming Trunk]) == 0 || !auto_is_valid($item[Mumming Trunk]) || !canChangeToFamiliar(fam) || !auto_is_valid(fam))
+	if (!canChangeToFamiliar(fam) || !auto_hasMummingTrunk() || !auto_checkFamiliarMummery(fam))
 	{
 		return false;
 	}
@@ -79,7 +97,7 @@ boolean mummifyFamiliar(familiar fam, string bonus)
 // Will provide the appropriate bonus to an arbitrary familiar.
 boolean mummifyFamiliar(familiar fam)
 {
-	if (!pathHasFamiliar()  || item_amount($item[Mumming Trunk]) == 0 || !auto_is_valid($item[Mumming Trunk]) || !canChangeToFamiliar(fam) || !auto_is_valid(fam))
+	if (!auto_hasMummingTrunk() || !auto_checkFamiliarMummery(fam))
 	{
 		return false;
 	}
@@ -109,10 +127,12 @@ boolean mummifyFamiliar(familiar fam)
 
 boolean mummifyFamiliar()
 {
-	if (!pathHasFamiliar() || item_amount($item[Mumming Trunk]) == 0 || !auto_is_valid($item[Mumming Trunk]) || my_path() == "Community Service")
+	auto_hasMummingTrunk();
+	if (my_path() == "Community Service")
 	{
 		return false;
-	}	
+	}
+	
 	return mummifyFamiliar(my_familiar());
 }
 

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -8,17 +8,6 @@ void glover_initializeDay(int day)
 	if (!in_glover()) {
 		return;
 	}
-
-	if((item_amount($item[Mumming Trunk]) > 0) && !get_property("_mummifyDone").to_boolean())
-	{
-		mummifyFamiliar($familiar[Disgeist], "myst");
-		mummifyFamiliar($familiar[Slimeling], "mpregen");
-		mummifyFamiliar($familiar[Intergnat], "item");
-		mummifyFamiliar($familiar[Gelatinous Cubeling], "muscle");
-		mummifyFamiliar($familiar[God Lobster], "moxie");
-		mummifyFamiliar($familiar[Garbage Fire], "meat");
-		set_property("_mummifyDone", true);
-	}
 }
 
 void glover_initializeSettings()


### PR DESCRIPTION
# Description

This is a rework of the current mummifyFamiliar function, with the goal of being a little bit more adaptable to varying sets of available familiars. While glover-specific support should no longer be necessary (and is removed for that reason), CS handles familiars differently than other paths so these changes were made with the idea in mind that current CS handling wouldn't change at all.

## How Has This Been Tested?

Tested on 4 days of AWOL, seems to be working just fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
