### PR TITLE
Can Haz Cyborger isn't freely shruggable

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2528,7 +2528,7 @@ void resetState() {
 			equip($item[none], it.to_slot());
 		}
 	}
-	foreach eff in $effects[Can Has Cyborger, Dis Abled, Haiku State of Mind, Just the Best Anapests, O Hai!, Robocamo, Yes\, Can Haz]
+	foreach eff in $effects[Dis Abled, Haiku State of Mind, Just the Best Anapests, O Hai!, Robocamo, Yes\, Can Haz]
 	{
 		// as do these which can all be freely shrugged.
 		if (have_effect(eff) > 0)


### PR DESCRIPTION
# Description

Got the Crimbo P.R.E.S.S.I.E in a QT run. It gave the buff. Next iteration of doTasks script aborted because of no SGEEA to uneffect  Can Haz Cyborger.

## How Has This Been Tested?

Removed and could continue.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
