### PR TITLE
Added a silent flag to autoDrink for night capping.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -84,6 +84,11 @@ boolean canOde(item toDrink)
 
 boolean autoDrink(int howMany, item toDrink)
 {
+	return autoDrink(howMany, toDrink, false);
+}
+
+boolean autoDrink(int howMany, item toDrink, boolean silent)
+{
 	if((toDrink == $item[none]) || (howMany <= 0))
 	{
 		return false;
@@ -132,7 +137,14 @@ boolean autoDrink(int howMany, item toDrink)
 	{
 		if(!isSpeakeasy)
 		{
-			retval = drink(1, toDrink);
+			if(silent)
+			{
+				retval = drinksilent(1, toDrink);
+			}
+			else
+			{
+				retval = drink(1, toDrink);
+			}
 		}
 		else
 		{
@@ -1216,7 +1228,7 @@ void auto_drinkNightcap()
 	{
 		abort("Unexpectedly couldn't prep " + to_pretty_string(target));
 	}
-	drinksilent(1, target.it);		//drinksilent avoids the popup asking if we are sure we want to overdrink
+	autoDrink(1, target.it, true); // added a silent flag to autoDrink to avoid the overdrink confirmation popup
 	
 	if(start_fam != my_familiar())
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1031,6 +1031,7 @@ boolean saucemavenApplies(item it);
 float expectedAdventuresFrom(item it);
 boolean canOde(item toDrink);
 boolean autoDrink(int howMany, item toDrink);
+boolean autoDrink(int howMany, item toDrink, boolean silent);
 boolean autoOverdrink(int howMany, item toOverdrink);
 string cafeFoodName(int id);
 string cafeDrinkName(int id);


### PR DESCRIPTION
# Description

Added a silent flag to autoDrink for night capping.

## How Has This Been Tested?

I ran autoscend in aftercore and confirmed that ode to booze was cast and that the "are you sure..." confirmation box did not appear.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
