### PR TITLE
Add car battery and candy to nuns

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3830,6 +3830,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Busy Bein\' Delicious]:		useItem = $item[Crimbo fudge];					break;
 	case $effect[Butt-Rock Hair]:				useItem = $item[Hair Spray];					break;
 	case $effect[Can\'t Smell Nothin\']:	useItem = $item[Dogsgotnonoz pills];	break;
+	case $effect[Car-Charged]:	useItem = $item[Battery (car)];	break;
 	case $effect[Carlweather\'s Cantata of Confrontation]:useSkill = $skill[Carlweather\'s Cantata of Confrontation];break;
 	case $effect[Carol Of The Bulls]: useSkill = $skill[Carol Of The Bulls]; break;
 	case $effect[Carol Of The Hells]: useSkill = $skill[Carol Of The Hells]; break;
@@ -3969,6 +3970,12 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Hardly Poisoned At All]:		useSkill = $skill[Disco Nap];					break;
 	case $effect[Healthy Blue Glow]:			useItem = $item[gold star];						break;
 	case $effect[Heightened Senses]:			useItem = $item[airborne mutagen];				break;
+	case $effect[Heart of Green]:			useItem = $item[green candy heart];				break;
+	case $effect[Heart of Lavender]:			useItem = $item[lavender candy heart];				break;
+	case $effect[Heart of Orange]:			useItem = $item[orange candy heart];				break;
+	case $effect[Heart of Pink]:			useItem = $item[pink candy heart];				break;
+	case $effect[Heart of White]:			useItem = $item[white candy heart];				break;
+	case $effect[Heart of Yellow]:			useItem = $item[yellow candy heart];				break;
 	case $effect[Hide of Sobek]:				useSkill = $skill[Hide of Sobek];				break;
 	case $effect[High Colognic]:				useItem = $item[Musk Turtle];					break;
 	case $effect[Hippy Stench]:					useItem = $item[reodorant];						break;
@@ -4251,6 +4258,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Superheroic]:					useItem = $item[Confiscated Comic Book];		break;
 	case $effect[Superhuman Sarcasm]:			useItem = $item[Serum of Sarcasm];				break;
 	case $effect[Suspicious Gaze]:				useSkill = $skill[Suspicious Gaze];				break;
+	case $effect[Sweet Heart]:					useItem = $item[love song of sugary cuteness];			break;
 	case $effect[Sweet\, Nuts]:					useItem = $item[Crimbo Candied Pecan];			break;
 	case $effect[Sweetbreads Flamb&eacute;]:	useItem = $item[Greek Fire];					break;
 	case $effect[Takin\' It Greasy]:			useSkill = $skill[Grease Up];					break;

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -833,6 +833,7 @@ boolean L12_filthworms()
 		buffMaintain($effect[Human-Machine Hybrid], 0, 1, 1);
 		buffMaintain($effect[Unusual Perspective], 0, 1, 1);
 		buffMaintain($effect[Eagle Eyes], 0, 1, 1);
+		buffMaintain($effect[Heart of Lavender], 0, 1, 1);
 		asdonBuff($effect[Driving Observantly]);
 		bat_formBats();
 
@@ -1550,6 +1551,10 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
 	buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
 	buffMaintain($effect[Patent Avarice], 0, 1, 1);
+	buffMaintain($effect[Car-Charged], 0, 1, 1);
+	buffMaintain($effect[Heart of Pink], 0, 1, 1);
+	buffMaintain($effect[Sweet Heart], 0, 1, 20);
+		
 	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
 	{
 		autoChew(1, $item[body spradium]);
@@ -1656,6 +1661,9 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
 	buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
 	buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
+	buffMaintain($effect[Car-Charged], 0, 1, 1);
+	buffMaintain($effect[Heart of Pink], 0, 1, 1);
+	buffMaintain($effect[Sweet Heart], 0, 1, 20);
 	bat_formWolf();
 	zataraSeaside("meat");
 


### PR DESCRIPTION
# Description

Adds a couple of effects - candy hearts, a love song, and most notably the car battery from the potted power plant IOTM. These are current used for nuns, nowhere else.

Fixes # (issue)

## How Has This Been Tested?

Ran one ascension with my only equipped character, seemed to work.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
