### PR TITLE
prevent bedtime error in QT from familiar change attempt during nightcap

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1230,7 +1230,7 @@ void auto_drinkNightcap()
 	}
 	autoDrink(1, target.it, true); // added a silent flag to autoDrink to avoid the overdrink confirmation popup
 	
-	if(start_fam != my_familiar())
+	if(start_fam != my_familiar() && pathAllowsChangingFamiliar())	//familiar can change when crafting the drink
 	{
 		use_familiar(start_fam);
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1230,7 +1230,7 @@ void auto_drinkNightcap()
 	}
 	autoDrink(1, target.it, true); // added a silent flag to autoDrink to avoid the overdrink confirmation popup
 	
-	if(start_fam != my_familiar() && pathAllowsChangingFamiliar())	//familiar can change when crafting the drink
+	if(start_fam != my_familiar() && pathAllowsChangingFamiliar())	//familiar can change when crafting the drink in QT
 	{
 		use_familiar(start_fam);
 	}


### PR DESCRIPTION
# Description

void auto_drinkNightcap() could have caused an error in quantum terrarium by trying to return your familiar to the pre_stooper familiar. this only happened if crafting your nightcap drink just happened to push you over the line and cause QT to randomly change your familiar

## How Has This Been Tested?

too hard to reproduce and it is a one line fix.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
