### PR TITLE
fix issue with Ed failing to do the Hidden City

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1344,7 +1344,7 @@ boolean edAcquireHP()
 	}
 	if(my_hp() > 0)
 	{
-		return false;	// Ed doesn't need to heal outside of combat unless on 0 hp
+		return true;	// Ed doesn't need to heal outside of combat unless on 0 hp
 	}
 	foreach it in $items[linen bandages,cotton bandages,silk bandages]
 	{


### PR DESCRIPTION
# Description

Reported in discord.
edAcquireHP should return true if we don't need to heal not false.

## How Has This Been Tested?

Hasn't TBH but the one place the return value from `edAcquireHP` is used is in `acquireHP` which is what's returning false and causing the Hidden City not to be completed as Ed.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
