### PR TITLE
God Lobster Quantum Terrarium

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -746,6 +746,7 @@ boolean in_quantumTerrarium();
 boolean qt_currentFamiliar(familiar fam);
 familiar qt_nextQuantumFamiliar();
 int qt_turnsToNextQuantumAlignment();
+boolean LX_qt_godLobster();
 boolean LX_quantumTerrarium();
 void qt_initializeSettings();
 boolean qt_FamiliarAvailable (familiar fam);

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -185,8 +185,11 @@ boolean godLobsterCombat(item it, int goal, string option)
 		return false;
 	}
 
-	handleFamiliar($familiar[God Lobster]);
-	use_familiar($familiar[God Lobster]);
+	handleFamiliar($familiar[God Lobster]);			//prevent pre_adventure from changing familiar away from god lobster
+	if(my_familiar() != $familiar[God Lobster])		//prevent quantum terrarium crash
+	{
+		use_familiar($familiar[God Lobster]);		//immediately switch to god lobster so we can fight it
+	}
 
 	if((equipped_item($slot[familiar]) != it) && (it != $item[none]))
 	{

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -18,6 +18,29 @@ int qt_turnsToNextQuantumAlignment()
 	return total_turns_played() - get_property("_nextQuantumAlignment").to_int();
 }
 
+boolean LX_qt_godLobster()
+{
+	//fight godlobster for XP if it happens to show up and we want XP
+	if(!in_quantumTerrarium() || my_familiar() != $familiar[God Lobster])
+	{
+		return false;	//can not change familiar in quantum terrarium
+	}
+	if(my_level() < 5)
+	{
+		return false;	//do not really trust it to fight it at such a low level
+	}
+	if(my_adventures() < 2)
+	{
+		return false;
+	}
+	if(!disregardInstantKarma())
+	{
+		return false;	//trying for instant karma as per user preference
+	}
+	
+	return godLobsterCombat();
+}
+
 boolean LX_quantumTerrarium()
 {
 	if (in_quantumTerrarium())
@@ -25,6 +48,8 @@ boolean LX_quantumTerrarium()
 		// placeholder. Just spam the console with familiar info for now.
 		auto_log_info(`In Quantum Terrarium. Current familiar = {my_familiar()}. Next familiar = {get_property("nextQuantumFamiliar")}`);
 	}
+	if(LX_qt_godLobster()) return true;
+	
 	return false;
 }
 


### PR DESCRIPTION
* Fix bedtime crashing when trying to fight god lobster during quantum terrarium if you luck out and happen to have god lobster as your QT familiar during bedtime. this also should fix it if you happened to try to powerlevel while god lobster happened to be the familiar
* Added a function to check every adv if we happened to get god lobster in QT. if we did and we determine that we want to fight it then do so

## How Has This Been Tested?

was at a position where running autoscend crashed at bedtime on god lobster fight. used this code and it fixed it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
