### PR TITLE
powerlevel fixes & ghost keys & rare book engorged sausages and you

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2280,6 +2280,13 @@ boolean adventureFailureHandler()
 		{
 			tooManyAdventures = false;
 		}
+		
+		boolean can_powerlevel_stench = elementalPlanes_access($element[stench]) && auto_have_skill($skill[Summon Smithsness]) && get_property("auto_beatenUpCount").to_int() == 0;
+		boolean has_powerlevel_iotm = can_powerlevel_stench || elementalPlanes_access($element[spooky]) || elementalPlanes_access($element[cold]) || elementalPlanes_access($element[sleaze]) || elementalPlanes_access($element[hot]) || neverendingPartyAvailable();
+		if(!has_powerlevel_iotm && $locations[The Haunted Gallery, The Haunted Bedroom] contains place)
+		{
+			tooManyAdventures = false;		//if we do not have iotm powerlevel zones then we are forced to use haunted gallery or bedroom
+		}
 
 		if(tooManyAdventures)
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1566,26 +1566,57 @@ boolean LX_attemptPowerLevel()
 		cloverUsageFinish();
 		if(adv_spent) return true;
 	}
-
-	// [Haunted Gallery] is the optimal powerleveling spot if you have no scaling monsters nor clovers left.
+	
 	if (internalQuestStatus("questM21Dance") > 3)
 	{
-		switch (my_primestat())
+		int goal_count = 0;
+		if(my_primestat() == $stat[Muscle])
 		{
-			case $stat[Muscle]:
-				backupSetting("louvreDesiredGoal", "4"); // get Muscle stats
-				break;
-			case $stat[Mysticality]:
-				backupSetting("louvreDesiredGoal", "5"); // get Myst stats
-				break;
-			case $stat[Moxie]:
-				backupSetting("louvreDesiredGoal", "6"); // get Moxie stats
-				break;
+			goal_count++;
 		}
-		providePlusNonCombat(25, true);
-		if(autoAdv($location[The Haunted Gallery])) {
-			return true;
+		if(my_primestat() == $stat[Mysticality] || my_basestat($stat[Mysticality]) < 70)	//war outfit requires 70 base mys
+		{
+			goal_count++;
 		}
+		if(my_primestat() == $stat[Moxie] || my_basestat($stat[Moxie]) < 70)	//war outfit requires 70 base mox
+		{
+			goal_count++;
+		}
+		if(my_meat() < meatReserve() + 1000)
+		{
+			goal_count++;
+		}
+		boolean prefer_bedroom = false;
+		if(goal_count > 1) //for multiple targets then haunted bedroom is best
+		{
+			prefer_bedroom = true;
+		}
+		else if(providePlusNonCombat(25, true, true) < 15)	//only perform the simulation if goal_count is 1
+		{
+			prefer_bedroom = true;	//for one target it depends on your noncombat. bad -combat prefers bedroom. otherwise prefer haunted gallery
+		}
+		
+		if(prefer_bedroom)
+		{
+			if(autoAdv($location[The Haunted Bedroom])) return true;
+		}
+		else		//do [The Haunted Gallery] instead
+		{
+			switch (my_primestat())		//we only ever do the haunted gallery if the sole stat we want is primestat.
+			{
+				case $stat[Muscle]:
+					backupSetting("louvreDesiredGoal", "4"); // get Muscle stats
+					break;
+				case $stat[Mysticality]:
+					backupSetting("louvreDesiredGoal", "5"); // get Myst stats
+					break;
+				case $stat[Moxie]:
+					backupSetting("louvreDesiredGoal", "6"); // get Moxie stats
+					break;
+			}
+			providePlusNonCombat(25, true);
+			if(autoAdv($location[The Haunted Gallery])) return true;
+		}		
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1578,7 +1578,9 @@ boolean LX_attemptPowerLevel()
 		{
 			goal_count++;
 		}
-		if(my_primestat() == $stat[Moxie] || my_basestat($stat[Moxie]) < 70)	//war outfit requires 70 base mox
+		if(my_primestat() == $stat[Moxie] ||
+		my_basestat($stat[Moxie]) < 70 || 	//war outfit requires 70 base mox
+		get_property("auto_beatenUpCount").to_int() > 5)	//if we are getting beaten up we should raise moxie
 		{
 			goal_count++;
 		}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -326,7 +326,18 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 876: // One Simple Nightstand (The Haunted Bedroom)
-			run_choice(2); // get muscle substats
+			if(my_meat() < 1000 + meatReserve() && auto_is_valid($item[old leather wallet]) && auto_my_path() != "Way of the Surprising Fist")
+			{
+				run_choice(1); //get old leather wallet worth ~500 meat
+			}
+			else if(item_amount($item[ghost key]) > 0 && my_primestat() == $stat[muscle] && my_buffedstat($stat[muscle]) < 150)
+			{
+				run_choice(3); // spend 1 ghost key for primestat, get ~200 muscle XP
+			}
+			else
+			{
+				run_choice(2); // get min(200,muscle) of muscle XP
+			}
 			break;
 		case 877: // One Mahogany Nightstand (The Haunted Bedroom)
 			run_choice(1); // get half of a memo or old coin purse
@@ -342,13 +353,19 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(4); // get disposable instant camera
 			} else if (my_primestat() != $stat[mysticality] || my_meat() < 1000 + meatReserve()) {
 				run_choice(1); // get ~500 meat
+			} else if(item_amount($item[ghost key]) > 0 && my_primestat() == $stat[mysticality] && my_buffedstat($stat[mysticality]) < 150) {
+				run_choice(5); // spend 1 ghost key for primestat, get ~200 mysticality XP
 			} else {
-				run_choice(2); // get mysticality substats
+				run_choice(2); // get min(200,mys) of mys XP
 			}
 			break;
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
-			if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
+			if(options contains 5 && auto_mall_price($item[Engorged Sausages and You]) > 1000) {
+				run_choice(5); // only shows up rarely. when this line was added it was worth 1.3 million in mall
+			} if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
 				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror
+			} else if(item_amount($item[ghost key]) > 0 && my_primestat() == $stat[moxie] && my_buffedstat($stat[moxie]) < 150) {
+				run_choice(4); // spend 1 ghost key for primestat, get ~200 moxie XP
 			} else {
 				run_choice(1); // get moxie substats
 			}


### PR DESCRIPTION
* fix autoscend wasting adventures powerleveling mainstat when we were in fact short of mox or mys for the frat hippy war outfit and not short on mainstat.
* if we do not have iotm powerleveling locations. then do not abort for spending too many adventures in haunted gallery/haunted bedroom as those two are used for powerleveling when there are no iotm locations.
* use the ghost key in haunted bedroom for primestat if it gives at least 50 XP more than non ghost key choice
* grab [engorged sausages and you] if it actually shows up (rare item. currently 1.3 million in mall). will stop grabbing them if mall price ever drops below 1000 meat (min price is 150 for this item)
* One Simple Nightstand will now grab meat if you are short on meat. previously it always took muscle XP. short of meat is defined as(my_meat < reserve target + 1000).
* when powerleveling mainstat and have no iotm scaling monster zones, if we are getting beaten up we should also get moxie alongside our mainstat rather than mainstat alone.

note: despite the number of clauses being checked that can divert it to haunted bedroom, testing showed it still mostly doing haunted gallery. the diverting to bedroom is for when it is actually needed rather than being the new main preference

fixes #701 

## How Has This Been Tested?

a couple of HC ed runs. including one where I was stuck trying to powerlevel mainstat when I was in fact short of moxie

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
