### PR TITLE
Updated Helix Dependency back to Ezandora

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -1,5 +1,5 @@
 https://github.com/Ezandora/Detective-Solver/branches/Release/
-https://github.com/Loathing-Associates-Scripting-Society/Helix-Fossil/branches/Release/
+https://github.com/Ezandora/Helix-Fossil/branches/Release/
 https://github.com/Ezandora/Far-Future/branches/Release/
 https://github.com/Ezandora/Voting-Booth/trunk/Release/
 https://github.com/Ezandora/Comb-Beach/trunk/Release/


### PR DESCRIPTION
Formerly LASS, now back to Ezandora

# Description

Changed dependencies to reference Ezandora Helix Fossil script

## How Has This Been Tested?

Deleted autoscend on a multi and re-installed.

## Checklist:

- [ X ] My code follows the style guidelines of this project.
- [ X ] I have performed a self-review of my own code.
- [ X ] I have commented my code, particularly in hard-to-understand areas.
- [ X ] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
