### PR TITLE
Casual fixes

### DIFF
--- a/RELEASE/data/autoscend_restoration.txt
+++ b/RELEASE/data/autoscend_restoration.txt
@@ -17,7 +17,7 @@
 16	Doc Galaktik's Pungent Unguent	item	4	0	0	0	none	none
 17	palm-frond fan	item	40	40	0	0	none	none
 18	Cloaca-Cola	item	0	12	0	0	none	none
-19	scroll of drastic healing	item	ALL	0	0	0	none	none
+19	scroll of drastic healing	item	100000	0	0	0	none	none
 20	warm El Vibrato drone	item	ALL	0	0	0	none	Well-preserved
 21	Camp Scout pup tent	item	1000	0	0	0	none	none
 22	really thick bandage	item	110	0	0	0	none	none

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -203,6 +203,7 @@ void initializeSettings() {
 	remove_property("auto_minedCells");
 	remove_property("auto_shinningStarted");
 	remove_property("auto_boughtCommerceGhostItem");
+	remove_property("auto_isAFilthyCasual");
 	beehiveConsider();
 
 	eudora_initializeSettings();
@@ -2824,14 +2825,9 @@ void auto_begin()
 			auto_log_warning("Okay, but the warranty is off.", "red");
 		}
 	}
-
+	
 	//This also should set our path too.
 	string page = visit_url("main.php");
-	page = visit_url("api.php?what=status&for=4", false);
-	if((get_property("_casualAscension").to_int() >= my_ascensions()) && (my_ascensions() > 0))
-	{
-		return;
-	}
 
 	if(contains_text(page, "Being Picky"))
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20762;	//min mafia revision needed to run this script. Last update: Add 'logPreferenceChangeFilter', which is a comma separated list of preferences to not log when logPreferenceChange is enabled
+since r20779;	//min mafia revision needed to run this script. Last update: Add is_casual() function that returns value from api.php
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -2632,9 +2632,10 @@ boolean doTasks()
 	{
 		auto_log_warning("I am in aftercore", "red");
 		return false;
-	}	
-	if(inCasual())
-	{	
+	}
+	if (in_casual() && get_property("_casualAscension").to_int() != -1)
+	{
+		set_property("_casualAscension", my_ascensions());
 		auto_log_warning("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");
 		return false;	
 	}
@@ -2825,10 +2826,10 @@ void auto_begin()
 			auto_log_warning("Okay, but the warranty is off.", "red");
 		}
 	}
-	
+
 	//This also should set our path too.
 	string page = visit_url("main.php");
-
+	page = visit_url("api.php?what=status&for=4", false);
 	if(contains_text(page, "Being Picky"))
 	{
 		picky_startAscension();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -203,7 +203,6 @@ void initializeSettings() {
 	remove_property("auto_minedCells");
 	remove_property("auto_shinningStarted");
 	remove_property("auto_boughtCommerceGhostItem");
-	remove_property("auto_isAFilthyCasual");
 	beehiveConsider();
 
 	eudora_initializeSettings();

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -576,7 +576,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			if (my_class() == $class[Sauceror] || can_interact())
 			{
 				// your MP cup runneth over
-				meat_per_mp = 0.1;
+				meat_per_mp = 0;
 			}
 			skill s = to_skill(metadata.name);
 			return (mp_cost(s) * meat_per_mp);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -511,7 +511,6 @@ boolean L13_bhy_towerFinal();
 
 ########################################################################################################
 //Defined in autoscend/paths/casual.ash
-boolean inCasual();
 boolean inAftercore();
 boolean inPostRonin();
 boolean L8_slopeCasual();

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -738,7 +738,7 @@ int auto_pillKeeperUses()
 
 boolean auto_pillKeeperFreeUseAvailable()
 {
-	return !get_property("_freePillKeeperUsed").to_boolean();
+	return auto_havePillKeeper() && !get_property("_freePillKeeperUsed").to_boolean();
 }
 
 boolean auto_pillKeeperAvailable()

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -1,7 +1,17 @@
 boolean inCasual()
 {
-	if(get_property("_casualAscension").to_int() >= my_ascensions())
+	// remove this once mafia has a in_casual() function.
+	if (get_property("auto_isAFilthyCasual") == "")
 	{
+		string page = visit_url("api.php?what=status&for=4", false);
+		set_property("auto_isAFilthyCasual", page.contains_text(`"casual":"1"`));
+	}
+	if (get_property("auto_isAFilthyCasual").to_boolean())
+	{
+		if (get_property("_casualAscension") == "")
+		{
+			set_property("_casualAscension", my_ascensions());
+		}
 		return true;
 	}
 	return false;

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -1,22 +1,3 @@
-boolean inCasual()
-{
-	// remove this once mafia has a in_casual() function.
-	if (get_property("auto_isAFilthyCasual") == "")
-	{
-		string page = visit_url("api.php?what=status&for=4", false);
-		set_property("auto_isAFilthyCasual", page.contains_text(`"casual":"1"`));
-	}
-	if (get_property("auto_isAFilthyCasual").to_boolean())
-	{
-		if (get_property("_casualAscension") == "")
-		{
-			set_property("_casualAscension", my_ascensions());
-		}
-		return true;
-	}
-	return false;
-}
-
 boolean inAftercore()
 {
 	return get_property("kingLiberated").to_boolean();
@@ -25,7 +6,7 @@ boolean inAftercore()
 boolean inPostRonin()
 {
 	//can interact means you are not in ronin and not in hardcore. It returns true in casual, aftercore, and postronin
-	if(can_interact() && !inCasual() && !inAftercore())
+	if(can_interact() && !in_casual() && !inAftercore())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -14,28 +14,29 @@ boolean L4_batCave()
 	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 
 	int batStatus = internalQuestStatus("questL04Bat");
-	if(batStatus < 3)
+	if (batStatus < 3)
 	{
-		boolean can_use_biscuit = auto_is_valid($item[Sonar-In-A-Biscuit]);
-		if(can_use_biscuit && item_amount($item[Sonar-In-A-Biscuit]) > 0)
+		if (auto_is_valid($item[Sonar-In-A-Biscuit]))
 		{
-			if(use(1, $item[Sonar-In-A-Biscuit]))
+			if (item_amount($item[Sonar-In-A-Biscuit]) == 0 && can_interact())
 			{
-				return true;
+				//if in post ronin or in casual, buy Sonar-In-A-Biscuit if cheaper than what it would cost to get with adventures and clovers.
+				int valueOfSonar = (get_property("valueOfAdventure").to_int() + min(mall_price($item[disassembled clover]), mall_price($item[ten-leaf clover]))) * 0.5;
+				buyUpTo(1, $item[Sonar-In-A-Biscuit], valueOfSonar);
 			}
-			else
+			if (item_amount($item[Sonar-In-A-Biscuit]) > 0)
 			{
-				auto_log_warning("Failed to use [Sonar-In-A-Biscuit] for some reason. refreshing inventory and skipping", "red");
-				visit_url("place.php?whichplace=bathole");
-				cli_execute("refresh inv");
-			}
-		}
-		else if(can_use_biscuit && can_interact())
-		{
-			//if in post ronin or in casual, buy and use [Sonar-In-A-Biscuit] if cheaper than 500 meat.
-			if(buyUpTo(1, $item[Sonar-In-A-Biscuit], 500))
-			{
-				if(use(1, $item[Sonar-In-A-Biscuit])) return true;
+				if (use(1, $item[Sonar-In-A-Biscuit]))
+				{
+					return true;
+				}
+				else
+				{
+					auto_log_warning("Failed to use Sonar-In-A-Biscuit for some reason. refreshing inventory and skipping", "red");
+					visit_url("place.php?whichplace=bathole");
+					cli_execute("refresh inv");
+					return false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description

- Detect casual ascensions properly (workaround until mafia adds a function)
- fix auto_forceNextNoncombat to work when the user doesn't have a pillkeeper.
- change restore code to not give skills an MP cost if Sauceror or in Casual/Post-Ronin (fixes using items on hand instead of casting restore skills)
- untangle the spaghetti of using Sonar-In-A-Biscuits in L4 quest.

## How Has This Been Tested?

Waiting for rollover to run another Casual.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
