### PR TITLE
canPull respect custom autoBuyPriceLimit && fix consume code issues with key lime pies

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -917,7 +917,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			(organCost(it) > 0) &&
 			(it.fullness == 0 || it.inebriety == 0) &&
 			auto_is_valid(it) &&
-			(historical_price(it) <= 20000 || (KEY_LIME_PIES contains it && historical_price(it) < 40000)))
+			historical_price(it) <= 20000)
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
 			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
@@ -947,13 +947,16 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 				craftables[it] = min(howmany, max(0, creatable_amount(it) - auto_reserveCraftAmount(it)));
 			}
 			// speakeasy drinks are not available as items and will cause a crash here if not excluded.
-			if (is_tradeable(it) && !isSpeakeasyDrink(it))
+			if (is_tradeable(it) && !isSpeakeasyDrink(it) && canPull(it))
 			{
-				pullables[it] = min(howmany, pulls_remaining());
-			}
-			if ((KEY_LIME_PIES contains it) && !(pullables contains it) && !in_hardcore() && historical_price(it) <= get_property("autoBuyPriceLimit").to_int())
-			{
-				pullables[it] = 1;		//we do not have one. but under these conditions we plan to mallbuy one then pull it
+				if(KEY_LIME_PIES contains it)
+				{
+					pullables[it] = 1;		//limit key lime pies to 1 pull only
+				}
+				else
+				{
+					pullables[it] = min(howmany, pulls_remaining());
+				}
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -951,9 +951,9 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				pullables[it] = min(howmany, pulls_remaining());
 			}
-			if ((KEY_LIME_PIES contains it) && !(pullables contains it) && !in_hardcore())
+			if ((KEY_LIME_PIES contains it) && !(pullables contains it) && !in_hardcore() && historical_price(it) <= get_property("autoBuyPriceLimit").to_int())
 			{
-				pullables[it] = 1;
+				pullables[it] = 1;		//we do not have one. but under these conditions we plan to mallbuy one then pull it
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -917,7 +917,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			(organCost(it) > 0) &&
 			(it.fullness == 0 || it.inebriety == 0) &&
 			auto_is_valid(it) &&
-			historical_price(it) <= 20000)
+			historical_price(it) <= get_property("autoBuyPriceLimit").to_int())
 		{
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
 			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3063,7 +3063,7 @@ boolean canPull(item it)
 		meat = max(meat, my_meat() - 5000);
 	}
 	int curPrice = auto_mall_price(it);
-	if (curPrice >= 20000)
+	if (curPrice > 20000 || curPrice > get_property("autoBuyPriceLimit").to_int())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3063,7 +3063,7 @@ boolean canPull(item it)
 		meat = max(meat, my_meat() - 5000);
 	}
 	int curPrice = auto_mall_price(it);
-	if (curPrice > 20000 || curPrice > get_property("autoBuyPriceLimit").to_int())
+	if (curPrice > get_property("autoBuyPriceLimit").to_int())
 	{
 		return false;
 	}


### PR DESCRIPTION
* boolean canPull(item it) will now respect autoBuyPriceLimit setting instead of assuming it is set to the default value of 20k
* loadConsumables will now actually check `canPull(it)` before adding an item to the pullable table.
* loadConsumables fixed incorrect custom pullable check for key_lime_pies. it was incorrectly its independent function instead of a sub function of pullable. thus was missing some of the necessary checks and verifications
* loadConsumables will now use autoBuyPriceLimit instead of assuming it is 20k.
** removed the override for key lime pies where they were set at 40k. that override just resulted in failure to do anything as they were above the autoBuyPriceLimit and as such not purchased

## How Has This Been Tested?

was stuck at trying yet failing to mallbuy jerlsberg's key lime pie at 35k meat (due to it being over the default value of autoBuyPriceLimit being set to 20k meat)
used fixed code and it successfully handled diet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
