### PR TITLE
Update Green Ops Soldier sniff.dat

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -16,7 +16,7 @@ Blooper	loc:8-Bit Realm
 Bob Racecar	!sniffed:Racecar Bob
 Racecar Bob	!sniffed:Bob Racecar
 Government Scientist	class:Ed
-Green Ops Soldier	!path:Kingdom of Exploathing
+Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
 Possessed Wine Rack


### PR DESCRIPTION
wait until Green Ops Soldier can appear before preparing to sniff it:

added one property in sniff data

to avoid wasting uneffect when starting battlefield
