### PR TITLE
NC 1119 fixed and migrated to auto_choice_adv.ash & NC 1115 fixed missing break

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1775,7 +1775,6 @@ boolean LX_freeCombats(boolean powerlevel)
 	if(!in_koe() && get_property("_machineTunnelsAdv").to_int() < 5 && canChangeToFamiliar($familiar[Machine Elf]))
 	{
 		auto_log_debug("LX_freeCombats is adventuring in [The Deep Machine Tunnels]");
-		backupSetting("choiceAdventure1119", 1);
 
 		familiar bjorn = my_bjorned_familiar();
 		if(bjorn == $familiar[Machine Elf])

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -507,6 +507,9 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(6); // skip
 			}
 			break;
+		case 1119: // Blue Sideways In Time (Machine Elf)
+			run_choice(1); // acquire some abstractions
+			break;
 		case 1310: // Granted a Boon (God Lobster)
 			int goal = get_property("_auto_lobsterChoice").to_int();
 			string search = "I'd like part of your regalia.";

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -506,6 +506,7 @@ boolean auto_run_choice(int choice, string page)
 			} else {
 				run_choice(6); // skip
 			}
+			break;
 		case 1310: // Granted a Boon (God Lobster)
 			int goal = get_property("_auto_lobsterChoice").to_int();
 			string search = "I'd like part of your regalia.";

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -242,6 +242,7 @@ void auto_settingsDelete()
 	remove_property("auto_shareMaximizer");
 	remove_property("auto_allowSharingData");
 	remove_property("auto_mummeryChoice");
+	remove_property("auto_choice1119");
 }
 
 void defaultConfig(string prop, string val)

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -1172,27 +1172,32 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	if(!in_koe() && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 10) && canChangeToFamiliar($familiar[Machine Elf]) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_daycount() == 2))
+	//every sixth machine elf tunnels visit will be a noncombat. This prepares for it and executes it.
+	if(in_koe())
 	{
-		backupSetting("choiceAdventure1119", 1);
-
-		familiar bjorn = my_bjorned_familiar();
-		if(bjorn == $familiar[Machine Elf])
-		{
-			handleBjornify($familiar[Grinning Turtle]);
-		}
-		handleFamiliar($familiar[Machine Elf]);
-		autoAdv(1, $location[The Deep Machine Tunnels]);
-		if(bjorn == $familiar[Machine Elf])
-		{
-			handleBjornify(bjorn);
-		}
-		
-		restoreSetting("choiceAdventure1119");
-		handleFamiliar("item");
-		return true;
+		return false;
 	}
-	return false;
+	if(!canChangeToFamiliar($familiar[Machine Elf]))
+	{
+		return false;
+	}
+	if(get_property("_machineTunnelsAdv").to_int() != 5)
+	{
+		return false;
+	}
+
+	familiar bjorn = my_bjorned_familiar();
+	if(bjorn == $familiar[Machine Elf])
+	{
+		handleBjornify($familiar[Grinning Turtle]);
+	}
+	handleFamiliar($familiar[Machine Elf]);
+	boolean retval = autoAdv(1, $location[The Deep Machine Tunnels]);
+	if(bjorn == $familiar[Machine Elf])
+	{
+		handleBjornify(bjorn);
+	}
+	return retval;
 }
 
 boolean LX_dinseylandfillFunbucks()

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -1186,18 +1186,8 @@ boolean resolveSixthDMT()
 		return false;
 	}
 
-	familiar bjorn = my_bjorned_familiar();
-	if(bjorn == $familiar[Machine Elf])
-	{
-		handleBjornify($familiar[Grinning Turtle]);
-	}
 	handleFamiliar($familiar[Machine Elf]);
-	boolean retval = autoAdv(1, $location[The Deep Machine Tunnels]);
-	if(bjorn == $familiar[Machine Elf])
-	{
-		handleBjornify(bjorn);
-	}
-	return retval;
+	return autoAdv($location[The Deep Machine Tunnels]);
 }
 
 boolean LX_dinseylandfillFunbucks()

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -699,7 +699,7 @@ boolean LA_cs_communityService()
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					return autoAdv(1, $location[The Deep Machine Tunnels]);
+					return autoAdv($location[The Deep Machine Tunnels]);
 				}
 
 				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && canChangeToFamiliar($familiar[Machine Elf]))
@@ -708,7 +708,7 @@ boolean LA_cs_communityService()
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					return autoAdv(1, $location[The Deep Machine Tunnels]);
+					return autoAdv($location[The Deep Machine Tunnels]);
 				}
 			}
 
@@ -2209,7 +2209,7 @@ boolean LA_cs_communityService()
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					return autoAdv(1, $location[The Deep Machine Tunnels]);
+					return autoAdv($location[The Deep Machine Tunnels]);
 				}
 
 				if(canTrySaberTrickMeteorShower() && have_effect($effect[Meteor Showered]) == 0){
@@ -3579,7 +3579,7 @@ boolean cs_giant_growth()
 		if(!cs_healthMaintain() || !cs_mpMaintain()){
 			abort("Wasnt able to maintain health and mp.");
 		}
-		autoAdv(1, $location[The Deep Machine Tunnels], "cs_combatLTB");
+		autoAdv($location[The Deep Machine Tunnels], "cs_combatLTB");
 	}
 	else if(cs_healthMaintain() && !godLobsterCombat($item[none], 3, "cs_combatLTB"))
 	{

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -695,28 +695,20 @@ boolean LA_cs_communityService()
 			{
 				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && canChangeToFamiliar($familiar[Machine Elf]))
 				{
-					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					autoAdv(1, $location[The Deep Machine Tunnels]);
-					restoreSetting("choiceAdventure1119");
-					set_property("choiceAdventure1119", "");
-					return true;
+					return autoAdv(1, $location[The Deep Machine Tunnels]);
 				}
 
 				if(have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() == 5) && ($location[The Deep Machine Tunnels].turns_spent == 5) && (my_adventures() > 0) && canChangeToFamiliar($familiar[Machine Elf]))
 				{
-					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					autoAdv(1, $location[The Deep Machine Tunnels]);
-					restoreSetting("choiceAdventure1119");
-					set_property("choiceAdventure1119", "");
-					return true;
+					return autoAdv(1, $location[The Deep Machine Tunnels]);
 				}
 			}
 
@@ -2213,15 +2205,11 @@ boolean LA_cs_communityService()
 				}
 				if(get_property("_machineTunnelsAdv").to_int() < 2 && canChangeToFamiliar($familiar[Machine Elf]))
 				{
-					backupSetting("choiceAdventure1119", 1);
 					handleFamiliar($familiar[Machine Elf]);
 					if(!cs_healthMaintain() || !cs_mpMaintain()){
 						abort("Wasnt able to maintain health and mp.");
 					}
-					autoAdv(1, $location[The Deep Machine Tunnels]);
-					restoreSetting("choiceAdventure1119");
-					set_property("choiceAdventure1119", "");
-					return true;
+					return autoAdv(1, $location[The Deep Machine Tunnels]);
 				}
 
 				if(canTrySaberTrickMeteorShower() && have_effect($effect[Meteor Showered]) == 0){
@@ -3587,14 +3575,11 @@ boolean cs_giant_growth()
 
 	if(my_familiar() == $familiar[Machine Elf])
 	{
-		backupSetting("choiceAdventure1119", 1);
 		handleFamiliar($familiar[Machine Elf]);
 		if(!cs_healthMaintain() || !cs_mpMaintain()){
 			abort("Wasnt able to maintain health and mp.");
 		}
 		autoAdv(1, $location[The Deep Machine Tunnels], "cs_combatLTB");
-		restoreSetting("choiceAdventure1119");
-		set_property("choiceAdventure1119", "");
 	}
 	else if(cs_healthMaintain() && !godLobsterCombat($item[none], 3, "cs_combatLTB"))
 	{


### PR DESCRIPTION
* fix NC 1115 missing a `break;` resulting in it spilling over to god lobster NC 1310
* NC 1119 moved to auto_choice_adv.ash and fixed to always grab abstractions (previously it sometimes grabbed abstractions and sometimes failed and aborted)
* fixed resolveSixthDMT() function not actually working properly.

## How Has This Been Tested?

validation. for the most part this deletions. also I do not have a machine elf to properly test it with.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
