### PR TITLE
don't pull Antique Machete when we have Muculent Machete

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1454,13 +1454,17 @@ boolean L11_hiddenCityZones()
 	{
 		if (auto_can_equip($item[Antique Machete]))
 		{
-			if (!possessEquipment($item[Antique Machete]))
+			if (possessEquipment($item[Antique Machete]))
+			{
+				return autoForceEquip($item[Antique Machete]);
+			}
+			else if (!possessEquipment($item[Muculent Machete]))
 			{
 				pullXWhenHaveY($item[Antique Machete], 1, 0);
+				return autoForceEquip($item[Antique Machete]);
 			}
-			return autoForceEquip($item[Antique Machete]);
 		}
-		else
+		if (auto_can_equip($item[Muculent Machete]))
 		{
 			if (!possessEquipment($item[Muculent Machete]))
 			{


### PR DESCRIPTION
# Description

don't pull Antique Machete when we have Muculent Machete

## How Has This Been Tested?

loaded the script

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
