### PR TITLE
Help Fix Team Building in Pokefam

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2727,7 +2727,6 @@ boolean doTasks()
 	if(LM_jello())						return true;
 	if(LM_fallout())					return true;
 	if(LM_groundhog())					return true;
-	if(LM_pokefam())					return true;
 	if(LM_majora())						return true;
 	if(LM_batpath()) 					return true;
 	if(doHRSkills())					return true;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -738,7 +738,6 @@ void pokefam_initializeDay(int day);
 void pokefam_initializeSettings();
 string pokefam_defaultMaximizeStatement();
 boolean pokefam_makeTeam();
-boolean LM_pokefam();
 boolean pokefam_autoAdv(int num, location loc, string option);
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -31,13 +31,16 @@ string pokefam_defaultMaximizeStatement()
 
 boolean pokefam_makeTeam()
 {
-	// choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up
-	if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
+	if(in_pokefam())
 	{
+		// choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up
+		if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
+		{
 		auto_log_info("Setting our team via Ezandora:", "green");
 		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");
 		return true;
-	}
+		}
+	}	
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -31,85 +31,14 @@ string pokefam_defaultMaximizeStatement()
 
 boolean pokefam_makeTeam()
 {
-	if(in_pokefam())
+	// choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up
+	if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
 	{
-		string temp = visit_url("famteam.php", false);
-
-		familiar back = $familiar[Killer Bee];
-		foreach fam in $familiars[Killer Bee, Slotter]
-		{
-			if(have_familiar(fam))
-			{
-				back = fam;
-			}
-		}
-
-		temp = visit_url("famteam.php?slot=3&fam=" + to_int(back) + "&pwd&action=slot");
-		if(get_property("_pokefamBack").to_familiar() != back)
-		{
-			set_property("_pokefamBack", back);
-		}
-
-		familiar middle = $familiar[Scary Death Orb];
-		foreach fam in $familiars[]
-		{
-			if((fam.poke_move_2 == "Backstab") && have_familiar(fam) && (back != fam) && (fam.poke_level != 5))
-			{
-				middle = fam;
-			}
-		}
-
-		temp = visit_url("famteam.php?slot=2&fam=" + to_int(middle) + "&pwd&action=slot");
-		if(get_property("_pokefamMiddle").to_familiar() != middle)
-		{
-			set_property("_pokefamMiddle", middle);
-		}
-
-		familiar front = $familiar[none];
-		foreach fam in $familiars[]
-		{
-			if((fam.poke_attribute == "Smart") && have_familiar(fam) && (back != fam) && (middle != fam) && (fam.poke_level != 5))
-			{
-				front = fam;
-			}
-		}
-		if(front == $familiar[none])
-		{
-			foreach fam in $familiars[]
-			{
-				if(have_familiar(fam) && (back != fam) && (middle != fam) && (fam.poke_level != 5))
-				{
-					front = fam;
-				}
-			}
-		}
-
-		if(front == $familiar[none])
-		{
-			front = $familiar[Levitating Potato];
-		}
-
-		auto_log_info("Choosing " + front + " for front slot.", "green");
-		temp = visit_url("famteam.php?slot=1&fam=" + to_int(front) + "&pwd&action=slot");
-		if(get_property("_pokefamFront").to_familiar() != front)
-		{
-			set_property("_pokefamFront", front);
-		}
+		auto_log_info("Setting our team via Ezandora:", "green");
+		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");
+		return true;
 	}
 	return true;
-}
-
-boolean LM_pokefam()
-{
-	if(in_pokefam())
-	{
-		pokefam_makeTeam();
-		if((my_primestat() == $stat[Muscle]) && !possessEquipment($item[Dented Scepter]) && (my_level() < 13))
-		{
-			auto_advWitchess("king");
-		}
-	}
-	return false;
 }
 
 boolean pokefam_autoAdv(int num, location loc, string option)


### PR DESCRIPTION
Improves team building and weasels around the non-standard issues with the pocket familiars.  Things are still broken but are now slightly less broken.  Also removes an out-of-standard call to Witchess as it is not needed.

# Description

Removes some of the hard codes in the "team building" aspect of the script.  This lets Ezandora's script handle team building based upon your ideal "strongest team" and still offers a spot to level other familiars.  With the existing pocket familiars not currently parsed as "standard" this somehow lets you use them.  It currently only runs at the beginning of the day so next step is putting it in pre_adv.  Baby steps for a guy with no coding experience.

## How Has This Been Tested?

I have been running this on a multi in HC pokefam.  This part works

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
