### PR TITLE
Yellow rocket support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20779;	//min mafia revision needed to run this script. Last update: Add is_casual() function that returns value from api.php
+since r20782;	//min mafia revision needed to run this script. Last update: Initial support for July IotM
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -884,12 +884,14 @@ boolean canYellowRay(monster target)
 			my_meat() > npc_price($item[yellow rocket]))	// ensure we have enough meat
 		{
 			cli_execute("acquire " + $item[yellow rocket]);
-			if (item_amount($item[yellow rocket]) > 0 &&
-				yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "")
-			{
-				// Yellow rocket has the lowest cooldown, and is unlimited, so prioritize over other sources
-				return true;
-			}
+		}
+
+		// Yellow rocket has the lowest cooldown, and is unlimited, so prioritize over other sources
+		if (item_amount($item[yellow rocket]) > 0 &&
+			auto_is_valid($item[yellow rocket]) &&
+			yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "")
+		{
+			return true;
 		}
 
 		if(canChangeToFamiliar($familiar[Crimbo Shrub]))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1265,6 +1265,10 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 		{
 			return "item " + $item[yellow rocket]; // 75 turns
 		}
+		if(inCombat ? have_skill($skill[Unleash the Devil's Kiss]) : possessEquipment($item[unwrapped knock-off retro superhero cape]))
+		{
+			return "skill " + $skill[Unleash the Devil's Kiss]; // 99 turns
+		}
 		if(auto_have_skill($skill[Disintegrate]) && (my_mp() >= mp_cost($skill[Disintegrate])))
 		{
 			return "skill " + $skill[Disintegrate]; // 100 trurns
@@ -1299,10 +1303,6 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 		if((inCombat ? my_familiar() == $familiar[Crimbo Shrub] : auto_have_familiar($familiar[Crimbo Shrub])) && (get_property("shrubGifts") == "yellow"))
 		{
 			return "skill " + $skill[Open a Big Yellow Present]; // 149 turns
-		}
-		if(inCombat ? have_skill($skill[Unleash the Devil's Kiss]) : possessEquipment($item[unwrapped knock-off retro superhero cape]))
-		{
-			return "skill " + $skill[Unleash the Devil's Kiss]; // 99 turns
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -874,27 +874,46 @@ boolean canYellowRay(monster target)
 {
 	# Use this to determine if it is safe to enter a yellow ray combat.
 
-	// first, do any necessary prep to use a yellow ray
-	if(canChangeToFamiliar($familiar[Crimbo Shrub]))
+	if(have_effect($effect[Everything Looks Yellow]) <= 0)
 	{
-		if(item_amount($item[box of old Crimbo decorations]) == 0)
+		// first, do any necessary prep to use a yellow ray
+		if(item_amount($item[Clan VIP Lounge Key]) > 0 &&	// Need VIP access
+			get_property("_fireworksShop").to_boolean() &&	// in a clan that has the Underground Fireworks Shop
+			item_amount($item[yellow rocket]) == 0 &&		// Don't buy if we already have one
+			auto_is_valid($item[yellow rocket]) &&			// or if it's not valid
+			my_meat() > npc_price($item[yellow rocket]))	// ensure we have enough meat
 		{
-			familiar curr = my_familiar();
-			use_familiar($familiar[Crimbo Shrub]);
-			use_familiar(curr);
+			cli_execute("acquire " + $item[yellow rocket]);
+			if (item_amount($item[yellow rocket]) > 0 &&
+				yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "")
+			{
+				// Yellow rocket has the lowest cooldown, and is unlimited, so prioritize over other sources
+				return true;
+			}
 		}
-		if(get_property("shrubGifts") != "yellow" && !get_property("_shrubDecorated").to_boolean())
+
+		if(canChangeToFamiliar($familiar[Crimbo Shrub]))
 		{
-			string temp = visit_url("inv_use.php?pwd=&which=3&whichitem=7958");
-			temp = visit_url("choice.php?pwd=&whichchoice=999&option=1&topper=1&lights=1&garland=1&gift=1");
+			if(item_amount($item[box of old Crimbo decorations]) == 0)
+			{
+				familiar curr = my_familiar();
+				use_familiar($familiar[Crimbo Shrub]);
+				use_familiar(curr);
+			}
+			if(get_property("shrubGifts") != "yellow" && !get_property("_shrubDecorated").to_boolean())
+			{
+				string temp = visit_url("inv_use.php?pwd=&which=3&whichitem=7958");
+				temp = visit_url("choice.php?pwd=&whichchoice=999&option=1&topper=1&lights=1&garland=1&gift=1");
+			}
 		}
-	}
-	if(!get_property("_internetViralVideoBought").to_boolean() &&	//can only buy 1 per day
-	(item_amount($item[BACON]) >= 20) &&	//it costs 20 bacon
-	auto_is_valid($item[Viral Video]) &&	//do not bother buying it if it is not valid
-	!in_koe())	//bacon store is unreachable in kingdom of exploathing
-	{
-		cli_execute("make " + $item[Viral Video]);
+
+		if(!get_property("_internetViralVideoBought").to_boolean() &&	//can only buy 1 per day
+			(item_amount($item[BACON]) >= 20) &&	//it costs 20 bacon
+			auto_is_valid($item[Viral Video]) &&	//do not bother buying it if it is not valid
+			!in_koe())	//bacon store is unreachable in kingdom of exploathing
+		{
+			cli_execute("make " + $item[Viral Video]);
+		}
 	}
 	# Pulled Yellow Taffy	- How do we handle the underwater check?
 	# He-Boulder?			- How do we do this?
@@ -1238,46 +1257,50 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 	{
 		if((item_amount($item[Yellowcake Bomb]) > 0) && auto_is_valid($item[Yellowcake Bomb]))
 		{
-			return "item " + $item[Yellowcake Bomb];
+			return "item " + $item[Yellowcake Bomb]; // 75 turns
+		}
+		if((item_amount($item[yellow rocket]) > 0) && auto_is_valid($item[yellow rocket]))
+		{
+			return "item " + $item[yellow rocket]; // 75 turns
 		}
 		if(auto_have_skill($skill[Disintegrate]) && (my_mp() >= mp_cost($skill[Disintegrate])))
 		{
-			return "skill " + $skill[Disintegrate];
+			return "skill " + $skill[Disintegrate]; // 100 trurns
 		}
 		if(auto_have_skill($skill[Ball Lightning]) && (my_lightning() >= lightning_cost($skill[Ball Lightning])))
 		{
-			return "skill " + $skill[Ball Lightning];
+			return "skill " + $skill[Ball Lightning]; // 99 turns
 		}
 		if(auto_have_skill($skill[Wrath of Ra]) && (my_mp() >= mp_cost($skill[Wrath of Ra])))
 		{
-			return "skill " + $skill[Wrath of Ra];
+			return "skill " + $skill[Wrath of Ra]; // 100 turns
 		}
 		if((item_amount($item[Mayo Lance]) > 0) && (get_property("mayoLevel").to_int() > 0) && auto_is_valid($item[Mayo Lance]))
 		{
-			return "item " + $item[Mayo Lance];
+			return "item " + $item[Mayo Lance]; // 0 - 145 turns
 		}
 		if((get_property("peteMotorbikeHeadlight") == "Ultrabright Yellow Bulb") && auto_have_skill($skill[Flash Headlight]) && (my_mp() >= mp_cost($skill[Flash Headlight])))
 		{
-			return "skill " + $skill[Flash Headlight];
+			return "skill " + $skill[Flash Headlight]; // 100 turns
 		}
 		foreach it in $items[Golden Light, Pumpkin Bomb, Unbearable Light, Viral Video, micronova]
 		{
 			if((item_amount(it) > 0) && auto_is_valid(it))
 			{
-				return "item " + it;
+				return "item " + it; // ~150 turns
 			}
 		}
 		if(auto_have_skill($skill[Unleash Cowrruption]) && (have_effect($effect[Cowrruption]) >= 30))
 		{
-			return "skill " + $skill[Unleash Cowrruption];
+			return "skill " + $skill[Unleash Cowrruption]; // 149 turns
 		}
 		if((inCombat ? my_familiar() == $familiar[Crimbo Shrub] : auto_have_familiar($familiar[Crimbo Shrub])) && (get_property("shrubGifts") == "yellow"))
 		{
-			return "skill " + $skill[Open a Big Yellow Present];
+			return "skill " + $skill[Open a Big Yellow Present]; // 149 turns
 		}
 		if(inCombat ? have_skill($skill[Unleash the Devil's Kiss]) : possessEquipment($item[unwrapped knock-off retro superhero cape]))
 		{
-			return "skill " + $skill[Unleash the Devil's Kiss];
+			return "skill " + $skill[Unleash the Devil's Kiss]; // 99 turns
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -881,7 +881,7 @@ boolean canYellowRay(monster target)
 			get_property("_fireworksShop").to_boolean() &&	// in a clan that has the Underground Fireworks Shop
 			item_amount($item[yellow rocket]) == 0 &&		// Don't buy if we already have one
 			auto_is_valid($item[yellow rocket]) &&			// or if it's not valid
-			my_meat() > npc_price($item[yellow rocket]))	// ensure we have enough meat
+			my_meat() > npc_price($item[yellow rocket]) + meatReserve())
 		{
 			cli_execute("acquire " + $item[yellow rocket]);
 		}


### PR DESCRIPTION
# Description

Consider yellow rocket from the clan VIP lounge as a yellow ray source, and prioritize it as it is unlimited and has the lowest cooldown.

Fixes # N/A

## How Has This Been Tested?

```
> ash import autoscend; canYellowRay($monster[beanbat])

Putting on Travoltan trousers...
Equipment changed.
Purchasing yellow rocket (1 @ 213)...
You spent 225 Meat
You acquire an item: yellow rocket
Unexpected error, debug log printed.
Purchases complete.
Putting on purpleheart "pants"...
Equipment changed.
Returned: true

> ash import autoscend; yellowRayCombatString($monster[beanbat], false, false)

Returned: item yellow rocket
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
