### PR TITLE
soul food fix && some buff maintainance

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -435,19 +435,15 @@ boolean auto_post_adventure()
 		use_skill(1, $skill[Summon Smithsness]);
 	}
 
-	if($classes[Sauceror, Pastamancer] contains my_class())
-	{
-		//everyone wants these buffs. but they are particularly important to casters which is why they are replicated here.
-		buffMaintain($effect[Springy Fusilli], 30, 1, 5);		//+40 init. 10 MP. 1 MP/adv
-		buffMaintain($effect[Walberg\'s Dim Bulb], 30, 1, 5);	//+10 init. 5 MP. 0.5 MP/adv
-	}
-	if (my_maxhp() < 100)
+	//everyone wants more initiative
+	buffMaintain($effect[Springy Fusilli], 30, 1, 5);			//+40 init. 10 MP. 1 MP/adv
+	buffMaintain($effect[Walberg\'s Dim Bulb], 30, 1, 5);		//+10 init. 5 MP. 0.5 MP/adv
+	if(my_maxhp() < 100 ||			//get some durability to avoid dying
+	!auto_have_skill($skill[Cannelloni Cocoon]))	//!cocoon == expensive heal. +durability to save meat even when maxhp > 100
 	{
 		buffMaintain($effect[Ghostly Shell], 30, 1, 5);			//+80 DA. 6 MP. totem based duration
 		buffMaintain($effect[Astral Shell], 30, 1, 5);			//+80 DA, +1 all res. 10 MP. totem based duration
 		buffMaintain($effect[Reptilian Fortitude], 30, 1, 5);	//+30HP. 10 MP. totem based duration
-		buffMaintain($effect[Springy Fusilli], 30, 1, 5);		//+40 init. 10 MP. 1 MP/adv
-		buffMaintain($effect[Walberg\'s Dim Bulb], 30, 1, 5);	//+10 init. 5 MP. 0.5 MP/adv
 	}
 
 	# This is the list of castables that all MP sequences will use.

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -377,20 +377,11 @@ boolean auto_post_adventure()
 		{
 			use_skill(1, $skill[Soul Rotation]);
 		}
-		int missing = (my_maxmp() - my_mp()) / 15;
-		int casts = (my_soulsauce() - 25) / 5;
-		if(casts < 0)
+		int missing = (my_maxmp() - my_mp()) / 15;		//soul food restores 15 MP per cast.
+		int casts = min(missing, my_soulsauce() / 5);	//soul food costs 5 soulsauce per cast.
+		if(casts > 0)
 		{
-			casts = 0;
-		}
-		int regen = casts;
-		if(casts > missing)
-		{
-			regen = missing;
-		}
-		if(regen > 0)
-		{
-			use_skill(regen, $skill[Soul Food]);
+			use_skill(casts, $skill[Soul Food]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -435,12 +435,19 @@ boolean auto_post_adventure()
 		use_skill(1, $skill[Summon Smithsness]);
 	}
 
-	if (my_maxhp() < 100) {
-		buffMaintain($effect[Ghostly Shell], 6, 1, 5);
-		buffMaintain($effect[Astral Shell], 10, 1, 5);
-		buffMaintain($effect[Reptilian Fortitude], 10, 1, 5);
-		buffMaintain($effect[Springy Fusilli], 10, 1, 5);
-		buffMaintain($effect[Walberg\'s Dim Bulb], 5, 1, 5);
+	if($classes[Sauceror, Pastamancer] contains my_class())
+	{
+		//everyone wants these buffs. but they are particularly important to casters which is why they are replicated here.
+		buffMaintain($effect[Springy Fusilli], 30, 1, 5);		//+40 init. 10 MP. 1 MP/adv
+		buffMaintain($effect[Walberg\'s Dim Bulb], 30, 1, 5);	//+10 init. 5 MP. 0.5 MP/adv
+	}
+	if (my_maxhp() < 100)
+	{
+		buffMaintain($effect[Ghostly Shell], 30, 1, 5);			//+80 DA. 6 MP. totem based duration
+		buffMaintain($effect[Astral Shell], 30, 1, 5);			//+80 DA, +1 all res. 10 MP. totem based duration
+		buffMaintain($effect[Reptilian Fortitude], 30, 1, 5);	//+30HP. 10 MP. totem based duration
+		buffMaintain($effect[Springy Fusilli], 30, 1, 5);		//+40 init. 10 MP. 1 MP/adv
+		buffMaintain($effect[Walberg\'s Dim Bulb], 30, 1, 5);	//+10 init. 5 MP. 0.5 MP/adv
 	}
 
 	# This is the list of castables that all MP sequences will use.


### PR DESCRIPTION
* cleanup soul food code
* do not try to conserve 25 soulsauce when considering if we should use soul food. that causes issues early in the run when we cannot afford to restore MP and repeatedly go into battle where we run out of MP and kill the enemy in melee, thus failing to get the 50MP from exploding curse of weaksauce.
* buffing init should be done regardless of your HP. and be done before buffing DA
* fix the buffs: ghostly shell, astral shell, reptilian fortitude, springy fusilli, wellberg's dim bulb
**which all had not properly set a min MP value below which we do not want to drop when casting them (as **that would leave us too few MP to actually fight and win combat). this value has been set to 30 mp
* get the durability buffs even if your maxhp is over 100 if you do not have cocoon. as healing is expensive without cocoon

## How Has This Been Tested?

tested in sauceror quantum terrarium normal. as well as in hardcore

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
