### PR TITLE
Heal with cocoon more often

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -451,9 +451,11 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 	float hp_restored_per_use()
 	{
 		float restored_amount = metadata.hp_restored;
-		if(metadata.restores_variable_hp == __RESTORE_ALL)
+		// treat cocoon as a full HP restore since rarely > 1000 max HP in run
+		if((metadata.restores_variable_hp == __RESTORE_ALL) || (metadata.name == "cannelloni cocoon"))
 		{
-			restored_amount = my_maxhp();
+			// restores all missing HP. Need to be precise so HP waste optimization calculations are correct
+			restored_amount = my_maxhp() - my_hp();
 		}
 		else if(metadata.restores_variable_hp == __RESTORE_HALF)
 		{
@@ -465,7 +467,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			restored_amount += numeric_modifier("Bonus Resting HP");
 		}
 
-		if (metadata.name == "Disco Nap" && auto_have_skill($skill[Adventurer of Leisure]))
+		if (metadata.name == "disco nap" && auto_have_skill($skill[Adventurer of Leisure]))
 		{
 			restored_amount = 40;
 		}


### PR DESCRIPTION
HP restore optimization algorithm should now use Cocoon instead of multiple Doc heals (wasting small amount of meat, but can matter in HC). 

# Description

auto_restore algorithm didn't use cocoon because it over healed too much. Changed to treat cocoon as a full HP restore which sets waste to 0. Also corrected disco nap capitalization

Fixes # (issue)

## How Has This Been Tested?

Tested in gcli.

**Before change (picked doc elixer):**

> ash import<autoscend.ash> __maximize_restore_options(319,646,0,true)

[DEBUG] - Calculating restore objective values.
[INFO] - Loading restoration data.
[DEBUG] - Applying constraints to 72 objective values.
[DEBUG] - Removed 67 restore options from consideration.
[DEBUG] - Sorting 5 options by primary objectives.
[DEBUG] - Beginning optimization of 5 restoration options.
[DEBUG] - 5 options before optimization: 0 - __RestorationOptimization(name: cannelloni cocoon, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 1000.0, hp_restored_per_use: 1000.0, hp_starting: 200.0, hp_uses_needed_for_goal: 1.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 31.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: 5.95, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 881.0, hp_total_wasted_max: 881.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: 20.0, total_uses_available: 32.0, total_uses_needed: 1.0}); 1 - __RestorationOptimization(name: doc galaktik's homeopathic elixir, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 133.0, hp_restored_per_use: 19.0, hp_starting: 200.0, hp_uses_needed_for_goal: 7.0, meat_available_to_spend: 2614.0, meat_per_use: 120.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 21.0, total_creatable: 0.0, total_uses_remaining: 14.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: 0.14166666666666666, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 14.0, hp_total_wasted_max: 14.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: 0.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: 0.0, total_meat_used: 840.0, total_mp_used: -1.0, total_uses_available: 21.0, total_uses_needed: 7.0}); 2 - __RestorationOptimization(name: doc galaktik's pungent unguent, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 120.0, hp_restored_per_use: 4.0, hp_starting: 200.0, hp_uses_needed_for_goal: 30.0, meat_available_to_spend: 2614.0, meat_per_use: 30.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 87.0, total_creatable: 0.0, total_uses_remaining: 57.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: 0.1322222222222222, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 1.0, hp_total_wasted_max: 1.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: 0.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: 0.0, total_meat_used: 900.0, total_mp_used: -1.0, total_uses_available: 87.0, total_uses_needed: 30.0}); 3 - __RestorationOptimization(name: tongue of the walrus, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 140.0, hp_restored_per_use: 35.0, hp_starting: 200.0, hp_uses_needed_for_goal: 4.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 60.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: 2.975, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 21.0, hp_total_wasted_max: 21.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: 40.0, total_uses_available: 64.0, total_uses_needed: 4.0}); 4 - __RestorationOptimization(name: a relaxing hot tub, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 2.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 319.0, hp_restored_per_use: 319.0, hp_starting: 200.0, hp_uses_needed_for_goal: 1.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 5.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 3.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 0.0, hp_total_wasted_max: 0.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 2.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: -1.0, total_uses_available: 4.0, total_uses_needed: 1.0})
[DEBUG] - Rank 1 optimization, prefer to... remove negative status effects
[DEBUG] - Rank 2 optimization, prefer to... maintain soft reserve limit (keep at least N on hand if possible)
[DEBUG] - Removed from consideration: (a relaxing hot tub, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 3 optimization, prefer to... try not to spend coinmaster tokens, maximizing hp/mp restored per token spent if we must spend
[DEBUG] - Rank 4 optimization, prefer to... try not to spend meat, maximizing hp/mp restored per meat spent if we must spend
[DEBUG] - Removed from consideration: (doc galaktik's pungent unguent, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 5 optimization, prefer to... try to spend less mp, maximizing hp restored per mp spent if we must spend
[DEBUG] - Removed from consideration: (tongue of the walrus, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 6 optimization, prefer to... minimize hp/mp shortage to goal and wasted hp/mp over max
[DEBUG] - Removed from consideration: (cannelloni cocoon, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 7 optimization, prefer to... minimize number of uses needed to reach goal
Returned: aggregate __RestorationOptimization [int]
0 => record __RestorationOptimization
  metadata => record __RestorationMetadata
    name => doc galaktik's homeopathic elixir
    type => item
    hp_restored => 19
    restores_variable_hp =>
    mp_restored => 0
    restores_variable_mp =>
    soft_reserve_limit => 0
    hard_reserve_limit => 0
    removes_beaten_up => false
    removes_effects => aggregate boolean [effect]
    gives_effects => aggregate boolean [effect]
    maxima_values => aggregate int [string]
  vars => aggregate float [string]
    blood_skill_opportunity_casts_goal => 0.0
    blood_skill_opportunity_casts_max => 0.0
    hard_reserve_limit => 0.0
    hp_goal => 319.0
    hp_max => 319.0
    hp_max_restorable => 133.0
    hp_restored_per_use => 19.0
    hp_starting => 200.0
    hp_uses_needed_for_goal => 7.0
    meat_available_to_spend => 2614.0
    meat_per_use => 120.0
    mp_goal => 646.0
    mp_max => 685.0
    mp_max_restorable => 0.0
    mp_restored_per_use => 0.0
    mp_starting => 646.0
    mp_uses_needed_for_goal => 0.0
    soft_reserve_limit => 0.0
    tokens_per_use => 0.0
    total_buyable => 21.0
    total_creatable => 0.0
    total_uses_remaining => 14.0
  objective_values => aggregate float [string]
    hp_per_coinmaster_token_spent => -1.0
    hp_per_meat_spent => 0.14166666666666666
    hp_per_mp_spent => -1.0
    hp_total_restored => 119.0
    hp_total_short_goal => 0.0
    hp_total_short_max => 0.0
    hp_total_wasted_goal => 14.0
    hp_total_wasted_max => 14.0
    mp_per_coinmaster_token_spent => -1.0
    mp_per_meat_spent => 0.0
    mp_total_restored => 0.0
    mp_total_short_goal => 0.0
    mp_total_short_max => 39.0
    mp_total_wasted_goal => 0.0
    mp_total_wasted_max => 0.0
    negative_status_effects_remaining => 0.0
    soft_reserve_limit_uses => 0.0
    total_coinmaster_tokens_used => 0.0
    total_meat_used => 840.0
    total_mp_used => -1.0
    total_uses_available => 21.0
    total_uses_needed => 7.0
  constraints => aggregate boolean [string]
    have_required_resources => true
    is_currently_useable => true
    is_ever_useable => true
    meets_hard_reserve_limit => true
    restores_needed_resources => true

**After change (picked cocoon):**
> ash import<autoscend.ash> __maximize_restore_options(319,646,0,true)

[DEBUG] - Calculating restore objective values.
[INFO] - Loading restoration data.
[DEBUG] - Applying constraints to 72 objective values.
[DEBUG] - Removed 67 restore options from consideration.
[DEBUG] - Sorting 5 options by primary objectives.
[DEBUG] - Beginning optimization of 5 restoration options.
[DEBUG] - 5 options before optimization: 0 - __RestorationOptimization(name: cannelloni cocoon, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 119.0, hp_restored_per_use: 119.0, hp_starting: 200.0, hp_uses_needed_for_goal: 1.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 31.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: 5.95, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 0.0, hp_total_wasted_max: 0.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: 20.0, total_uses_available: 32.0, total_uses_needed: 1.0}); 1 - __RestorationOptimization(name: doc galaktik's homeopathic elixir, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 133.0, hp_restored_per_use: 19.0, hp_starting: 200.0, hp_uses_needed_for_goal: 7.0, meat_available_to_spend: 2614.0, meat_per_use: 120.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 21.0, total_creatable: 0.0, total_uses_remaining: 14.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: 0.14166666666666666, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 14.0, hp_total_wasted_max: 14.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: 0.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: 0.0, total_meat_used: 840.0, total_mp_used: -1.0, total_uses_available: 21.0, total_uses_needed: 7.0}); 2 - __RestorationOptimization(name: doc galaktik's pungent unguent, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 120.0, hp_restored_per_use: 4.0, hp_starting: 200.0, hp_uses_needed_for_goal: 30.0, meat_available_to_spend: 2614.0, meat_per_use: 30.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 87.0, total_creatable: 0.0, total_uses_remaining: 57.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: 0.1322222222222222, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 1.0, hp_total_wasted_max: 1.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: 0.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: 0.0, total_meat_used: 900.0, total_mp_used: -1.0, total_uses_available: 87.0, total_uses_needed: 30.0}); 3 - __RestorationOptimization(name: tongue of the walrus, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 0.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 140.0, hp_restored_per_use: 35.0, hp_starting: 200.0, hp_uses_needed_for_goal: 4.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 0.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 60.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: 2.975, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 21.0, hp_total_wasted_max: 21.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 0.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: 40.0, total_uses_available: 64.0, total_uses_needed: 4.0}); 4 - __RestorationOptimization(name: a relaxing hot tub, vars: {blood_skill_opportunity_casts_goal: 0.0, blood_skill_opportunity_casts_max: 0.0, hard_reserve_limit: 2.0, hp_goal: 319.0, hp_max: 319.0, hp_max_restorable: 119.0, hp_restored_per_use: 119.0, hp_starting: 200.0, hp_uses_needed_for_goal: 1.0, meat_available_to_spend: 2614.0, meat_per_use: 0.0, mp_goal: 646.0, mp_max: 685.0, mp_max_restorable: 0.0, mp_restored_per_use: 0.0, mp_starting: 646.0, mp_uses_needed_for_goal: 0.0, soft_reserve_limit: 5.0, tokens_per_use: 0.0, total_buyable: 0.0, total_creatable: 0.0, total_uses_remaining: 3.0}, constraints: {have_required_resources: true, is_currently_useable: true, is_ever_useable: true, meets_hard_reserve_limit: true, restores_needed_resources: true}, objective_values: {hp_per_coinmaster_token_spent: -1.0, hp_per_meat_spent: -1.0, hp_per_mp_spent: -1.0, hp_total_restored: 119.0, hp_total_short_goal: 0.0, hp_total_short_max: 0.0, hp_total_wasted_goal: 0.0, hp_total_wasted_max: 0.0, mp_per_coinmaster_token_spent: -1.0, mp_per_meat_spent: -1.0, mp_total_restored: 0.0, mp_total_short_goal: 0.0, mp_total_short_max: 39.0, mp_total_wasted_goal: 0.0, mp_total_wasted_max: 0.0, negative_status_effects_remaining: 0.0, soft_reserve_limit_uses: 2.0, total_coinmaster_tokens_used: -1.0, total_meat_used: -1.0, total_mp_used: -1.0, total_uses_available: 4.0, total_uses_needed: 1.0})
[DEBUG] - Rank 1 optimization, prefer to... remove negative status effects
[DEBUG] - Rank 2 optimization, prefer to... maintain soft reserve limit (keep at least N on hand if possible)
[DEBUG] - Removed from consideration: (a relaxing hot tub, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 3 optimization, prefer to... try not to spend coinmaster tokens, maximizing hp/mp restored per token spent if we must spend
[DEBUG] - Rank 4 optimization, prefer to... try not to spend meat, maximizing hp/mp restored per meat spent if we must spend
[DEBUG] - Removed from consideration: (doc galaktik's pungent unguent, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 5 optimization, prefer to... try to spend less mp, maximizing hp restored per mp spent if we must spend
[DEBUG] - Removed from consideration: (tongue of the walrus, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 6 optimization, prefer to... minimize hp/mp shortage to goal and wasted hp/mp over max
[DEBUG] - Removed from consideration: (doc galaktik's homeopathic elixir, hp: 119.0, mp: 0.0, negative effects remaining: 0.0)
[DEBUG] - Rank 7 optimization, prefer to... minimize number of uses needed to reach goal
Returned: aggregate __RestorationOptimization [int]
0 => record __RestorationOptimization
  metadata => record __RestorationMetadata
    name => cannelloni cocoon
    type => skill
    hp_restored => 1000
    restores_variable_hp =>
    mp_restored => 0
    restores_variable_mp =>
    soft_reserve_limit => 0
    hard_reserve_limit => 0
    removes_beaten_up => false
    removes_effects => aggregate boolean [effect]
    gives_effects => aggregate boolean [effect]
    maxima_values => aggregate int [string]
  vars => aggregate float [string]
    blood_skill_opportunity_casts_goal => 0.0
    blood_skill_opportunity_casts_max => 0.0
    hard_reserve_limit => 0.0
    hp_goal => 319.0
    hp_max => 319.0
    hp_max_restorable => 119.0
    hp_restored_per_use => 119.0
    hp_starting => 200.0
    hp_uses_needed_for_goal => 1.0
    meat_available_to_spend => 2614.0
    meat_per_use => 0.0
    mp_goal => 646.0
    mp_max => 685.0
    mp_max_restorable => 0.0
    mp_restored_per_use => 0.0
    mp_starting => 646.0
    mp_uses_needed_for_goal => 0.0
    soft_reserve_limit => 0.0
    tokens_per_use => 0.0
    total_buyable => 0.0
    total_creatable => 0.0
    total_uses_remaining => 31.0
  objective_values => aggregate float [string]
    hp_per_coinmaster_token_spent => -1.0
    hp_per_meat_spent => -1.0
    hp_per_mp_spent => 5.95
    hp_total_restored => 119.0
    hp_total_short_goal => 0.0
    hp_total_short_max => 0.0
    hp_total_wasted_goal => 0.0
    hp_total_wasted_max => 0.0
    mp_per_coinmaster_token_spent => -1.0
    mp_per_meat_spent => -1.0
    mp_total_restored => 0.0
    mp_total_short_goal => 0.0
    mp_total_short_max => 39.0
    mp_total_wasted_goal => 0.0
    mp_total_wasted_max => 0.0
    negative_status_effects_remaining => 0.0
    soft_reserve_limit_uses => 0.0
    total_coinmaster_tokens_used => -1.0
    total_meat_used => -1.0
    total_mp_used => 20.0
    total_uses_available => 32.0
    total_uses_needed => 1.0
  constraints => aggregate boolean [string]
    have_required_resources => true
    is_currently_useable => true
    is_ever_useable => true
    meets_hard_reserve_limit => true
    restores_needed_resources => true
## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
