### PR TITLE
restore abort or continue on failure based on setting

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -46,5 +46,5 @@ auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets 
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -46,3 +46,4 @@ auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets 
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing

--- a/BUILD/settings_extra/any.dat
+++ b/BUILD/settings_extra/any.dat
@@ -9,3 +9,4 @@ auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (d
 auto_hccsNoConcludeDay	boolean	Community Service: When true reduce how many daily end-of-day things we do.
 auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -57,8 +57,8 @@ any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace
 any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	48	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
-any	49	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	48	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	49	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -57,6 +57,7 @@ any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace
 any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	48	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -18,6 +18,7 @@ any	7	auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Ca
 any	8	auto_hccsNoConcludeDay	boolean	Community Service: When true reduce how many daily end-of-day things we do.
 any	9	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 any	10	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	11	_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
 
 post	0	auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
 post	1	auto_cookie	integer	HCCS Only: Tracks fortune cookie.

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1570,8 +1570,15 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		__RestorationOptimization[int] options = __maximize_restore_options(hp_target(), mp_target(), meat_reserve, useFreeRests);
 		if(count(options) == 0)
 		{
-			auto_log_warning("Target "+resource_type+" => " + goal + " - Uh, couldnt determine an effective restoration mechanism. Sorry.", "red");
-			return false;
+			auto_log_critical("Target "+resource_type+" => " + goal + " - couldnt determine an effective restoration mechanism", "red");
+			if(get_property("auto_ignoreRestoreFailure").to_boolean() || get_property("_auto_ignoreRestoreFailureToday").to_boolean())
+			{
+				auto_log_critical("Ignoring the error as per user instructions", "red");
+ 				return false;
+			}
+			print("Aborting due to restore failure... you can override this setting for today by entering in gCLI:");
+			print("set _auto_ignoreRestoreFailureToday = true");
+			abort();
 		}
 
 		boolean success = false;


### PR DESCRIPTION
instead of always ignoring a failure to restore MP or HP, it should now handle it based on settings (which were added to GUI). Either aborting or continuing as desired by the user. By default we will now abort on failure to restore.

## How Has This Been Tested?

tested in QT softcore

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
