### PR TITLE
fix restore code incorrectly storing float values as int

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -20,9 +20,9 @@
 record __RestorationMetadata{
 	string name;
 	string type;
-	int hp_restored;
+	float hp_restored;
 	string restores_variable_hp;
-	int mp_restored;
+	float mp_restored;
 	string restores_variable_mp;
 	int soft_reserve_limit;
 	int hard_reserve_limit;
@@ -189,7 +189,7 @@ void __init_restoration_metadata()
 		return parsed_effects;
 	}
 
-	int parse_restored_amount(string restored_str)
+	float parse_restored_amount(string restored_str)
 	{
 		restored_str = restored_str.to_lower_case();
 		if(restored_str == "all" || restored_str == "half" || restored_str == "scaling")
@@ -198,7 +198,7 @@ void __init_restoration_metadata()
 		}
 		else
 		{
-			return to_int(restored_str);
+			return to_float(restored_str);
 		}
 	}
 


### PR DESCRIPTION
fix restore code incorrectly storing some float values as int.
for most restorers this is not an issue. but for some it is (for example laugh it off costs 1 MP and heals 1 to 2 HP. so its value is 1.5)

## How Has This Been Tested?

ash. and also ran it in QT

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
