### PR TITLE
Stop adventuring in NEP until you run out of turns

### DIFF
--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -1167,7 +1167,8 @@ boolean LA_cs_communityService()
 				//Consider checking for all Snojo debuffs.
 				uneffect($effect[Hypnotized]);
 
-				if(neverendingPartyAvailable() && (my_adventures() > 0))
+				if(neverendingPartyAvailable() && (get_property("_neverendingPartyFreeTurns").to_int() > 0))
+				//if this isn't only the freeturns, it will run forever based on current coding. TOFIX in future maybe?
 				{
 					familiar oldFam = my_familiar();
 					if(have_familiar($familiar[Rockin\' Robin]) && (item_amount($item[Robin\'s Egg]) == 0))


### PR DESCRIPTION
# Description

Only use familiars for hopeful drops in NEP whilst freeturns are available

Fixes # (issue)

## How Has This Been Tested?

It hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
