### PR TITLE
don't consider excess HP from healing skills as "wasted".

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -760,7 +760,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		}
 
 		float price = get_value("meat_per_use");
-		if(price < 0.001)
+		if (price < 0.0)
 		{
 			return -1.0;
 		}

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -457,7 +457,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			restored_amount += numeric_modifier("Bonus Resting HP");
 		}
 
-		if (metadata.name == "Disco Nap" && auto_have_skill($skill[Adventurer of Leisure]))
+		if (metadata.name == "disco nap" && auto_have_skill($skill[Adventurer of Leisure]))
 		{
 			restored_amount = 40;
 		}
@@ -680,7 +680,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if (resource_type == "hp" && metadata.type == "skill")
 		{
 			// don't consider excess healing from spells as "waste".
-			// It would be better to cost this in meat teams across all healing but that's not easy to do right now.
+			// It would be better to price this in meat terms across all healing but that's not easy to do right now.
 			return 0.0;
 		}
 		return max(0.0, get_value(resource_type, "starting") + get_value(resource_type, "max_restorable") - goal);

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -677,6 +677,12 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		{
 			return 0.0;
 		}
+		if (resource_type == "hp" && metadata.type == "skill")
+		{
+			// don't consider excess healing from spells as "waste".
+			// It would be better to cost this in meat teams across all healing but that's not easy to do right now.
+			return 0.0;
+		}
 		return max(0.0, get_value(resource_type, "starting") + get_value(resource_type, "max_restorable") - goal);
 	}
 


### PR DESCRIPTION
# Description

as title. Should result in not removing Cannelloni Cocoon/Disco Nap/Tongue of the Walrus in Rank 6 optimization any more.

## How Has This Been Tested?

~Hasn't yet (in progress).~ Looks fine in Casual. Should probably run a Standard or QT too just to verify it's fine in-run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
