### PR TITLE
auto_towerBreak setting

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -46,4 +46,4 @@ auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets 
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
+auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -46,3 +46,4 @@ auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets 
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+auto_towerBreak string  Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -46,4 +46,4 @@ auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets 
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-auto_towerBreak string  Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
+auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)

--- a/BUILD/settings_extra/any.dat
+++ b/BUILD/settings_extra/any.dat
@@ -9,3 +9,4 @@ auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (d
 auto_hccsNoConcludeDay	boolean	Community Service: When true reduce how many daily end-of-day things we do.
 auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+auto_towerBreak string Where should we break in the tower (e.g. wall of skin, wall of bones, shadow, ns). Disabled by default.

--- a/BUILD/settings_extra/any.dat
+++ b/BUILD/settings_extra/any.dat
@@ -9,4 +9,3 @@ auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (d
 auto_hccsNoConcludeDay	boolean	Community Service: When true reduce how many daily end-of-day things we do.
 auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-auto_towerBreak string Where should we break in the tower (e.g. wall of skin, wall of bones, shadow, ns). Disabled by default.

--- a/RELEASE/data/autoscend_properties.txt
+++ b/RELEASE/data/autoscend_properties.txt
@@ -226,3 +226,4 @@
 223	auto_paranoia_counter
 224	auto_wishes
 225	auto_restoreUseBloodBond
+226 auto_towerBreak

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -57,7 +57,7 @@ any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace
 any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	48	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
+any	48	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -57,6 +57,7 @@ any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace
 any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	48	auto_towerBreak string  Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -57,7 +57,7 @@ any	44	auto_logLevel	string	One of: critical, error, warning, info, debug, trace
 any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	48	auto_towerBreak string  Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
+any	48	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns)
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -891,7 +891,7 @@ boolean L13_towerNSTower()
 		auto_log_info("Time to fight the Wall of Skins!", "blue");
 		if (get_property("auto_towerBreak").to_lower_case() == "wall of skin" || get_property("auto_towerBreak").to_lower_case() == "wallofskin" || get_property("auto_towerBreak").to_lower_case() == "skin" || get_property("auto_towerBreak").to_lower_case() == "level 1")
 		{
-			abort("auto_towerBreak set to abort here.")
+			abort("auto_towerBreak set to abort here.");
 		}
 		if (item_amount($item[Beehive]) > 0)
 		{
@@ -1080,7 +1080,7 @@ boolean L13_towerNSTower()
 	{
 		if (get_property("auto_towerBreak").to_lower_case() == "wall of meat" || get_property("auto_towerBreak").to_lower_case() == "wallofmeat" || get_property("auto_towerBreak").to_lower_case() == "meat" || get_property("auto_towerBreak").to_lower_case() == "level 2")
 		{
-			abort("auto_towerBreak set to abort here.")
+			abort("auto_towerBreak set to abort here.");
 		}
 		equipBaseline();
 		shrugAT($effect[Polka of Plenty]);
@@ -1120,7 +1120,7 @@ boolean L13_towerNSTower()
 	{
 		if (get_property("auto_towerBreak").to_lower_case() == "wall of bones" || get_property("auto_towerBreak").to_lower_case() == "wallofbones" || get_property("auto_towerBreak").to_lower_case() == "bones" || get_property("auto_towerBreak").to_lower_case() == "level 3")
 		{
-			abort("auto_towerBreak set to abort here.")
+			abort("auto_towerBreak set to abort here.");
 		}
 		familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
 		boolean has_boning_knife = item_amount($item[Electric Boning Knife]) > 0;
@@ -1200,7 +1200,7 @@ boolean L13_towerNSTower()
 	{
 		if (get_property("auto_towerBreak").to_lower_case() == "mirror" || get_property("auto_towerBreak").to_lower_case() == "level 4")
 		{
-			abort("auto_towerBreak set to abort here.")
+			abort("auto_towerBreak set to abort here.");
 		}
 		boolean confidence = get_property("auto_confidence").to_boolean();
 		// confidence really just means take the first choice, so it's necessary in vampyre
@@ -1217,7 +1217,7 @@ boolean L13_towerNSTower()
 	{
 		if (get_property("auto_towerBreak").to_lower_case() == "shadow" || get_property("auto_towerBreak").to_lower_case() == "the shadow" || get_property("auto_towerBreak").to_lower_case() == "level 5")
 		{
-			abort("auto_towerBreak set to abort here.")
+			abort("auto_towerBreak set to abort here.");
 		}
 		if(my_maxhp() < 800)
 		{
@@ -1275,7 +1275,7 @@ boolean L13_towerNSFinal()
 {
 	if (get_property("auto_towerBreak").to_lower_case() == "naughty soreceress" || get_property("auto_towerBreak").to_lower_case() == "the naughty soreceress" || get_property("auto_towerBreak").to_lower_case() == "ns" || get_property("auto_towerBreak").to_lower_case() == "sorceress" || get_property("auto_towerBreak").to_lower_case() == "level 6" || get_property("auto_towerBreak").to_lower_case() == "chamber")
 	{
-		abort("auto_towerBreak set to abort here.")
+		abort("auto_towerBreak set to abort here.");
 	}
 	//state 11 means ready to fight sorceress. state 12 means lost to her due to lack of wand thus unlocking bear verb orgy
 	if (internalQuestStatus("questL13Final") < 11 || internalQuestStatus("questL13Final") > 12)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -889,6 +889,10 @@ boolean L13_towerNSTower()
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_05_monster1"))
 	{
 		auto_log_info("Time to fight the Wall of Skins!", "blue");
+		if (get_property("auto_towerBreak").to_lower_case() == "wall of skin" || get_property("auto_towerBreak").to_lower_case() == "wallofskin" || get_property("auto_towerBreak").to_lower_case() == "skin" || get_property("auto_towerBreak").to_lower_case() == "level 1")
+		{
+			abort("auto_towerBreak set to abort here.")
+		}
 		if (item_amount($item[Beehive]) > 0)
 		{
 			autoAdvBypass("place.php?whichplace=nstower&action=ns_05_monster1", $location[Tower Level 1]);
@@ -1074,6 +1078,10 @@ boolean L13_towerNSTower()
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_06_monster2"))
 	{
+		if (get_property("auto_towerBreak").to_lower_case() == "wall of meat" || get_property("auto_towerBreak").to_lower_case() == "wallofmeat" || get_property("auto_towerBreak").to_lower_case() == "meat" || get_property("auto_towerBreak").to_lower_case() == "level 2")
+		{
+			abort("auto_towerBreak set to abort here.")
+		}
 		equipBaseline();
 		shrugAT($effect[Polka of Plenty]);
 		buffMaintain($effect[Disco Leer], 0, 1, 1);
@@ -1110,6 +1118,10 @@ boolean L13_towerNSTower()
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_07_monster3"))		//need to kill wall of bones
 	{
+		if (get_property("auto_towerBreak").to_lower_case() == "wall of bones" || get_property("auto_towerBreak").to_lower_case() == "wallofbones" || get_property("auto_towerBreak").to_lower_case() == "bones" || get_property("auto_towerBreak").to_lower_case() == "level 3")
+		{
+			abort("auto_towerBreak set to abort here.")
+		}
 		familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
 		boolean has_boning_knife = item_amount($item[Electric Boning Knife]) > 0;
 		
@@ -1186,6 +1198,10 @@ boolean L13_towerNSTower()
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_08_monster4"))
 	{
+		if (get_property("auto_towerBreak").to_lower_case() == "mirror" || get_property("auto_towerBreak").to_lower_case() == "level 4")
+		{
+			abort("auto_towerBreak set to abort here.")
+		}
 		boolean confidence = get_property("auto_confidence").to_boolean();
 		// confidence really just means take the first choice, so it's necessary in vampyre
 		if(my_class() == $class[Vampyre])
@@ -1199,6 +1215,10 @@ boolean L13_towerNSTower()
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_09_monster5"))
 	{
+		if (get_property("auto_towerBreak").to_lower_case() == "shadow" || get_property("auto_towerBreak").to_lower_case() == "the shadow" || get_property("auto_towerBreak").to_lower_case() == "level 5")
+		{
+			abort("auto_towerBreak set to abort here.")
+		}
 		if(my_maxhp() < 800)
 		{
 			buffMaintain($effect[Industrial Strength Starch], 0, 1, 1);
@@ -1253,6 +1273,10 @@ boolean L13_towerNSTower()
 
 boolean L13_towerNSFinal()
 {
+	if (get_property("auto_towerBreak").to_lower_case() == "naughty soreceress" || get_property("auto_towerBreak").to_lower_case() == "the naughty soreceress" || get_property("auto_towerBreak").to_lower_case() == "ns" || get_property("auto_towerBreak").to_lower_case() == "sorceress" || get_property("auto_towerBreak").to_lower_case() == "level 6" || get_property("auto_towerBreak").to_lower_case() == "chamber")
+	{
+		abort("auto_towerBreak set to abort here.")
+	}
 	//state 11 means ready to fight sorceress. state 12 means lost to her due to lack of wand thus unlocking bear verb orgy
 	if (internalQuestStatus("questL13Final") < 11 || internalQuestStatus("questL13Final") > 12)
 	{


### PR DESCRIPTION
# Description

Added a setting to break at a particular level of the tower, after a bunch of comments about the bear verb orgy pvp mini. Useful for manual towerkilling when autoscend might otherwise not towerkill. Disabled by default.

## How Has This Been Tested?

This has been tested in the relay script and cli.
```
> ash get_property("auto_towerBreak")

Returned: ns

> ash import <autoscend.ash> L13_towerNSFinal()

auto_towerBreak set to abort here.
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
