### PR TITLE
Fix stay in run logic for avatar paths

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1110,6 +1110,16 @@ void initializeDay(int day)
 	grey_goo_initializeDay(day);
 	jarlsberg_initializeDay(day);
 
+	// Bulk cache mall prices
+	if(!in_hardcore() && get_property("auto_day_init").to_int() < day)
+	{
+		auto_log_info("Bulk caching mall prices for consumables");
+		mall_prices("food");
+		mall_prices("booze");
+		mall_prices("hprestore");
+		mall_prices("mprestore");
+	}
+
 	if(day == 1)
 	{
 		if(get_property("auto_day_init").to_int() < 1)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1370,7 +1370,6 @@ boolean L13_towerNSFinal()
 	if(!($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class()))
 	{
 		abort("Freeing the king will result in a path change and we can barely handle The Sleazy Back Alley. Aborting, run the script again after selecting your aftercore path in order for it to clean up.");
-		return true;
 	}
 
 	visit_url("place.php?whichplace=nstower&action=ns_11_prism");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1348,29 +1348,8 @@ boolean L13_towerNSFinal()
 				set_property("auto_disableAdventureHandling", false);
 				return true;
 			}
-			if(get_property("auto_stayInRun").to_boolean())
-			{
-				set_property("auto_disableAdventureHandling", false);
-				abort("User wanted to stay in run (auto_stayInRun), we are done.");
-			}
-
-			if(!($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class()))
-			{
-				set_property("auto_disableAdventureHandling", false);
-				cli_execute("refresh quests");
-				if(internalQuestStatus("questL13Final") > 12)
-				{
-					abort("Freeing the king will result in a path change and we can barely handle The Sleazy Back Alley. Aborting, run the script again after selecting your aftercore path in order for it to clean up.");
-				}
-				return true;
-			}
-			visit_url("place.php?whichplace=nstower&action=ns_11_prism");
+			set_property("auto_disableAdventureHandling", false);
 		}
-		set_property("auto_disableAdventureHandling", false);
-	}
-	else
-	{
-		visit_url("place.php?whichplace=nstower&action=ns_11_prism");
 	}
 
 	if(get_property("auto_stayInRun").to_boolean())
@@ -1386,6 +1365,12 @@ boolean L13_towerNSFinal()
 	if(my_class() == $class[Plumber] && (0 < item_amount($item[Thwaitgold buzzy beetle statuette])))
 	{
 		abort("Freeing the king will lose your extra stomach space. Enjoy the rest of your video game.");
+	}
+
+	if(!($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class()))
+	{
+		abort("Freeing the king will result in a path change and we can barely handle The Sleazy Back Alley. Aborting, run the script again after selecting your aftercore path in order for it to clean up.");
+		return true;
 	}
 
 	visit_url("place.php?whichplace=nstower&action=ns_11_prism");


### PR DESCRIPTION
# Description

Simplify stay in run logic after beating the sorceress, as I was just in a Sneaky Pete run and autoscend automatically broke the prism.

Also precache a bunch of item prices with mall_prices() when a day starts to drastically reduce mall searches when restoring or considering consumables in a softcore run. 

## How Has This Been Tested?

Not yet but this is a pretty simple change.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
