### PR TITLE
Workaround for yet more spaghetti code in KoL.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20782;	//min mafia revision needed to run this script. Last update: Initial support for July IotM
+since r20793;	//min mafia revision needed to run this script. Last update: Add explosive equipment to equipment.txt
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -1329,6 +1329,11 @@ void initializeDay(int day)
 	}
 
 	set_property("auto_forceNonCombatSource", "");
+
+	// Until KoL fix the utterly stupid bug that requires a manual visit to the fireworks shop
+	// before you can even buy anything from it, we will have to do this.
+	// Why is this so hard? Also why is this even a Clan VIP room item? It's just a shop which charges meat.
+	visit_url("clan_viplounge.php?action=fwshop");
 
 	set_property("auto_day_init", day);
 }


### PR DESCRIPTION
# Description

Add a visit_url to the fireworks shop because apparently implementing a shop as a clan VIP item which has no business being a clan VIP item since there's literally no group interaction is hard or something.

Also update min mafia version to last change which affected the firework shop.

## How Has This Been Tested?

I added this manually to my aftercore "breakfast" script which fixed the issue. Haven't tested it in an actual run and also don't care.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
