### PR TITLE
Add "Just the Best Anapests" to negative status effects

### DIFF
--- a/RELEASE/data/autoscend_negative_effects.txt
+++ b/RELEASE/data/autoscend_negative_effects.txt
@@ -31,3 +31,4 @@ Skunkulated	true
 Easily Embarrassed	true
 All Covered In Whatsit	true
 Flared Nostrils	true
+Just the Best Anapests true


### PR DESCRIPTION
Added "Just the Best Anapests" to the negative status effects, as it appears to be shruggable and messes with mafia tracking. I had burned some spleen in QT to try to squeeze in some extra adventures on the last day of my run, but didn't shrug off the effect manually. I then burned 29turns in the palindome (disposable instant camera, used on turn 1 in that zone but not tracked) and 51 turns "Next to that Barrel with Something Burning in it" before getting the second abort and realizing something was up. 

Since this is shruggable, cosmetic flavor text that potentially interferes with tracking, can we shrug it off by default?


## How Has This Been Tested?

Unable to test currently, but will try next run - this does seem like a minor edge case.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
