### PR TITLE
Combat improvements, various Avatar of Sneaky Pete changes

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -293,6 +293,9 @@ void main()
 	writeln("<h2>Banishes</h2>");
 	generateTrackingData("auto_banishes");
 
+	writeln("<h2>Free Runaways</h2>");
+	generateTrackingData("auto_freeruns");
+
 	writeln("<h2>Yellow Rays <img src=\"images/itemimages/eyes.gif\"></h2>");
 	generateTrackingData("auto_yellowRays");
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -148,6 +148,7 @@ void initializeSettings() {
 	set_property("auto_eaten", "");
 	set_property("auto_familiarChoice", "");
 	set_property("auto_forceTavern", false);
+	set_property("auto_freeruns", "");
 	set_property("auto_funTracker", "");
 	set_property("auto_getBoningKnife", false);
 	set_property("auto_getStarKey", true);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1021,7 +1021,18 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		Breathe Out: per hot jelly usage
 	*/
 
-	//Peel out with Extra-Smelly Muffler, note 10 limit, increased to 30 with Racing Slicks
+	if (auto_have_skill($skill[Peel Out]) && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out"))
+	{
+		int maxPeelOut = 10;
+		if (get_property("peteMotorbikeTires") == "Racing Slicks")
+		{
+			maxPeelOut = 30;
+		}
+		if (get_property("_petePeeledOut").to_int() < maxPeelOut)
+		{
+			return "skill " + $skill[Peel Out];
+		}
+	}
 
 	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent"))
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1021,17 +1021,9 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		Breathe Out: per hot jelly usage
 	*/
 
-	if (auto_have_skill($skill[Peel Out]) && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out"))
+	if (auto_have_skill($skill[Peel Out]) && pete_peelOutRemaining() > 0 && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out"))
 	{
-		int maxPeelOut = 10;
-		if (get_property("peteMotorbikeTires") == "Racing Slicks")
-		{
-			maxPeelOut = 30;
-		}
-		if (get_property("_petePeeledOut").to_int() < maxPeelOut)
-		{
-			return "skill " + $skill[Peel Out];
-		}
+		return "skill " + $skill[Peel Out];
 	}
 
 	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent"))

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -491,6 +491,7 @@ boolean LM_jarlsberg();
 void pete_initializeSettings();
 void pete_initializeDay(int day);
 void pete_buySkills();
+int pete_peelOutRemaining();
 boolean LM_pete();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -97,10 +97,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return "item " + $item[Short Writ Of Habeas Corpus];
 		}
 	}
-	
-	//TODO use $item[Tattered Scrap Of Paper] as a free runaway.
 
-	if(!contains_text(combatState, "banishercheck"))
+	if(!contains_text(combatState, "banishercheck") && auto_wantToBanish(enemy, my_location()))
 	{
 		string banishAction = banisherCombatString(enemy, my_location(), true);
 		if(banishAction != "")
@@ -123,6 +121,20 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		}
 		set_property("auto_combatHandler", combatState + "(banishercheck)");
 		combatState += "(banishercheck)";
+	}
+
+
+	// Free run from monsters we want to banish but are unable to
+	if(auto_wantToBanish(enemy, my_location()))
+	{
+		//TODO: Make freeRunCombatString() like banish
+		//TODO use $item[Tattered Scrap Of Paper] as a free runaway?
+		//TODO use $item[Green Smoke Bomb] as a free runaway?
+		if (canUse($skill[Peel Out]))
+		{
+			handleTracker(enemy, $skill[Peel Out], "auto_freeruns");
+			return useSkill($skill[Peel Out]);
+		}
 	}
 
 	if (!contains_text(combatState, "replacercheck") && canReplace(enemy) && auto_wantToReplace(enemy, my_location()))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -131,18 +131,10 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		//TODO use $item[Tattered Scrap Of Paper] as a free runaway?
 		//TODO use $item[Green Smoke Bomb] as a free runaway?
 
-		if (canUse($skill[Peel Out]))
+		if (canUse($skill[Peel Out]) && pete_peelOutRemaining() > 0)
 		{
-			int maxPeelOut = 10;
-			if (get_property("peteMotorbikeTires") == "Racing Slicks")
-			{
-				maxPeelOut = 30;
-			}
-			if (get_property("_petePeeledOut").to_int() < maxPeelOut)
-			{
-				handleTracker(enemy, $skill[Peel Out], "auto_freeruns");
-				return useSkill($skill[Peel Out]);
-			}
+			handleTracker(enemy, $skill[Peel Out], "auto_freeruns");
+			return useSkill($skill[Peel Out]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -130,10 +130,19 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		//TODO: Make freeRunCombatString() like banish
 		//TODO use $item[Tattered Scrap Of Paper] as a free runaway?
 		//TODO use $item[Green Smoke Bomb] as a free runaway?
+
 		if (canUse($skill[Peel Out]))
 		{
-			handleTracker(enemy, $skill[Peel Out], "auto_freeruns");
-			return useSkill($skill[Peel Out]);
+			int maxPeelOut = 10;
+			if (get_property("peteMotorbikeTires") == "Racing Slicks")
+			{
+				maxPeelOut = 30;
+			}
+			if (get_property("_petePeeledOut").to_int() < maxPeelOut)
+			{
+				handleTracker(enemy, $skill[Peel Out], "auto_freeruns");
+				return useSkill($skill[Peel Out]);
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -362,79 +362,10 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 
 	if(enemy_la <= 100 && stunnable(enemy) && !canSurvive(5.0))
 	{
-		switch(my_class())
+		skill stunner = getStunner(enemy);
+		if(stunner != $skill[none])
 		{
-		case $class[Seal Clubber]:
-			if(canUse($skill[Club Foot]) && (my_fury() > 0 || hasClubEquipped()))
-			{
-				return useSkill($skill[Club Foot]);
-			}
-			break;
-		case $class[Turtle Tamer]:
-			if(canUse($skill[Shell Up]))
-			{
-				//storm turtle blessings makes shell up a multi-round stun, otherwise it's just a (special) stagger
-				if(have_effect($effect[Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Grand Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Glorious Blessing of the Storm Tortoise]) > 0)
-				{
-					return useSkill($skill[Shell Up]);
-				}
-			}
-			break;
-		case $class[Accordion Thief]:
-			if(canUse($skill[Accordion Bash]) && (item_type(equipped_item($slot[weapon])) == "accordion"))
-			{
-				return useSkill($skill[Accordion Bash]);
-			}
-			break;
-		case $class[Pastamancer]:
-			if(canUse($skill[Entangling Noodles]))
-			{
-				return useSkill($skill[Entangling Noodles]);
-			}
-			break;
-		case $class[Sauceror]:
-			if(canUse($skill[Soul Bubble]))
-			{
-				return useSkill($skill[Soul Bubble]);
-			}
-			break;
-		case $class[Avatar of Boris]:
-			if(canUse($skill[Broadside]))
-			{
-				return useSkill($skill[Broadside]);
-			}
-			break;
-		case $class[Avatar of Sneaky Pete]:
-			if(canUse($skill[Snap Fingers]))
-			{
-				return useSkill($skill[Snap Fingers], false);
-			}
-			break;
-		case $class[Avatar of Jarlsberg]:
-			if(canUse($skill[Blend]))
-			{
-				return useSkill($skill[Blend]);
-			}
-			break;
-		case $class[Cow Puncher]:
-		case $class[Beanslinger]:
-		case $class[Snake Oiler]:
-			if(canUse($skill[Beanscreen]))
-			{
-				return useSkill($skill[Beanscreen]);
-			}
-
-			if(canUse($skill[Hogtie]) && (my_mp() >= (3 * mp_cost($skill[Hogtie]))) && hasLeg(enemy))
-			{
-				return useSkill($skill[Hogtie]);
-			}
-			break;
-		case $class[Vampyre]:
-			if(canUse($skill[Blood Chains], false) && my_hp() > 3 * hp_cost($skill[Blood Chains]))
-			{
-				return useSkill($skill[Blood Chains], false);
-			}
-			break;
+			return useSkill(stunner);
 		}
 	}
 	

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -363,7 +363,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		return useSkill($skill[Thunderstrike]);
 	}
 
-	if(enemy_la <= 100 && stunnable(enemy) && !canSurvive(5.0))
+	if(enemy_la <= 100 && stunnable(enemy) && (!canSurvive(5.0) || $monsters[Groar] contains enemy))
 	{
 		skill stunner = getStunner(enemy);
 		if(stunner != $skill[none])

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -367,7 +367,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		case $class[Seal Clubber]:
 			if(canUse($skill[Club Foot]) && (my_fury() > 0 || hasClubEquipped()))
 			{
-				return useSkill($skill[Club Foot])
+				return useSkill($skill[Club Foot]);
 			}
 			break;
 		case $class[Turtle Tamer]:

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -353,6 +353,90 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			return useSkill($skill[Spirit Snap]);
 		}
 	}
+
+	// Multi-round stuns
+	if(canUse($skill[Thunderstrike]) && enemy_la <= 150 && !canSurvive(5.0))
+	{
+		return useSkill($skill[Thunderstrike]);
+	}
+
+	if(enemy_la <= 100 && stunnable(enemy) && !canSurvive(5.0))
+	{
+		switch(my_class())
+		{
+		case $class[Seal Clubber]:
+			if(canUse($skill[Club Foot]) && (my_fury() > 0 || hasClubEquipped()))
+			{
+				return useSkill($skill[Club Foot])
+			}
+			break;
+		case $class[Turtle Tamer]:
+			if(canUse($skill[Shell Up]))
+			{
+				//storm turtle blessings makes shell up a multi-round stun, otherwise it's just a (special) stagger
+				if(have_effect($effect[Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Grand Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Glorious Blessing of the Storm Tortoise]) > 0)
+				{
+					return useSkill($skill[Shell Up]);
+				}
+			}
+			break;
+		case $class[Accordion Thief]:
+			if(canUse($skill[Accordion Bash]) && (item_type(equipped_item($slot[weapon])) == "accordion"))
+			{
+				return useSkill($skill[Accordion Bash]);
+			}
+			break;
+		case $class[Pastamancer]:
+			if(canUse($skill[Entangling Noodles]))
+			{
+				return useSkill($skill[Entangling Noodles]);
+			}
+			break;
+		case $class[Sauceror]:
+			if(canUse($skill[Soul Bubble]))
+			{
+				return useSkill($skill[Soul Bubble]);
+			}
+			break;
+		case $class[Avatar of Boris]:
+			if(canUse($skill[Broadside]))
+			{
+				return useSkill($skill[Broadside]);
+			}
+			break;
+		case $class[Avatar of Sneaky Pete]:
+			if(canUse($skill[Snap Fingers]))
+			{
+				return useSkill($skill[Snap Fingers], false);
+			}
+			break;
+		case $class[Avatar of Jarlsberg]:
+			if(canUse($skill[Blend]))
+			{
+				return useSkill($skill[Blend]);
+			}
+			break;
+		case $class[Cow Puncher]:
+		case $class[Beanslinger]:
+		case $class[Snake Oiler]:
+			if(canUse($skill[Beanscreen]))
+			{
+				return useSkill($skill[Beanscreen]);
+			}
+
+			if(canUse($skill[Hogtie]) && (my_mp() >= (3 * mp_cost($skill[Hogtie]))) && hasLeg(enemy))
+			{
+				return useSkill($skill[Hogtie]);
+			}
+			break;
+		case $class[Vampyre]:
+			if(canUse($skill[Blood Chains], false) && my_hp() > 3 * hp_cost($skill[Blood Chains]))
+			{
+				return useSkill($skill[Blood Chains], false);
+			}
+			break;
+		}
+	}
 	
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -333,9 +333,12 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			return useSkill($skill[Summon Love Gnats]);
 		}
 
-		if(canUse($skill[Summon Love Stinkbug]) && haveUsed($skill[Summon Love Gnats]) && !contains_text(text, "STUN RESIST"))
+		if(!(have_equipped($item[Protonic Accelerator Pack]) && isGhost(enemy)))
 		{
-			return useSkill($skill[Summon Love Stinkbug]);
+			if(canUse($skill[Summon Love Stinkbug]) && haveUsed($skill[Summon Love Gnats]) && !contains_text(text, "STUN RESIST"))
+			{
+				return useSkill($skill[Summon Love Stinkbug]);
+			}
 		}
 	}
 	

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -305,6 +305,12 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	{
 		return useSkill($skill[Gulp Latte]);
 	}
+
+	//stinkbug physically resistant monsters
+	if(canUse($skill[Summon Love Stinkbug]) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[stench]))
+	{
+		return useSkill($skill[Summon Love Stinkbug]);
+	}
 	
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -307,9 +307,12 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 
 	//stinkbug physically resistant monsters
-	if(canUse($skill[Summon Love Stinkbug]) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[stench]))
+	if(!(have_equipped($item[Protonic Accelerator Pack]) && isGhost(enemy)))
 	{
-		return useSkill($skill[Summon Love Stinkbug]);
+		if(canUse($skill[Summon Love Stinkbug]) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[stench]))
+		{
+			return useSkill($skill[Summon Love Stinkbug]);
+		}
 	}
 	
 	return "";

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -235,15 +235,15 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 	
 	//this completes the quest Advertise for the Mysterious Island Arena which is a sidequest which accelerates the L12 frat-hippy war quest
-	if((canUse($item[Rock Band Flyers]) || canUse($item[Jam Band Flyers])) && (my_location() != $location[The Battlefield (Frat Uniform)]) && (my_location() != $location[The Battlefield (Hippy Uniform)]) && !get_property("auto_ignoreFlyer").to_boolean())
+	if((canUse($item[Rock Band Flyers]) || canUse($item[Jam Band Flyers])) && (get_property("flyeredML").to_int() < 10000) && (my_location() != $location[The Battlefield (Frat Uniform)]) && (my_location() != $location[The Battlefield (Hippy Uniform)]) && !get_property("auto_ignoreFlyer").to_boolean())
 	{
-		string stall = getStallString(enemy);
-		if(stall != "")
+		skill stunner = getStunner(enemy);
+		if(stunner != $skill[none])
 		{
-			return stall;
+			return useSkill(stunner);
 		}
 
-		if(canUse($item[Rock Band Flyers]) && (get_property("flyeredML").to_int() < 10000))
+		if(canUse($item[Rock Band Flyers]))
 		{
 			if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
 			{
@@ -251,7 +251,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 			}
 			return useItem($item[Rock Band Flyers]);
 		}
-		if(canUse($item[Jam Band Flyers]) && (get_property("flyeredML").to_int() < 10000))
+		if(canUse($item[Jam Band Flyers]))
 		{
 			if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -321,7 +321,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			}
 		}
 
-		if(canUse($item[Smoke Break]) && (enemy.physical_resistance >= 80))
+		if(canUse($skill[Smoke Break]) && (enemy.physical_resistance >= 80))
 		{
 			return useSkill($skill[Smoke Break]);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -322,7 +322,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			}
 
 			// Avoid apathy and cunctatitis by using a ranged attack
-			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardman, Procrastination Giants] contains enemy)
+			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardman, Procrastination Giant] contains enemy)
 			{
 				attackMinor = useSkill($skill[Throw Trusty], false);
 				attackMajor = useSkill($skill[Throw Trusty], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -66,10 +66,10 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	//iotm back item and the enemies it spawns (free fights) can be killed using special skills to get extra XP and item drops
 	if(have_equipped($item[Protonic Accelerator Pack]) && isGhost(enemy))
 	{
-		string stall = getStallString(enemy);
-		if(stall != "")
+		skill stunner = getStunner(enemy);
+		if(stunner != $skill[none])
 		{
-			return stall;
+			return useSkill(stunner);
 		}
 
 		if(canUse($skill[Shoot Ghost], false) && (my_mp() > mp_cost($skill[Shoot Ghost])) && !contains_text(combatState, "shootghost3") && !contains_text(combatState, "trapghost"))
@@ -108,7 +108,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			}
 			else
 			{
-				combatState += "(trapghost)(love stinkbug)";
+				combatState += "(trapghost)";
 				set_property("auto_combatHandler", combatState);
 			}
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -321,6 +321,10 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			}
 		}
 
+		if(canUse($item[Smoke Break]) && (enemy.physical_resistance >= 80))
+		{
+			return useSkill($skill[Smoke Break]);
+		}
 
 		if(canUse($item[Firebomb], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[hot]))
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -322,7 +322,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			}
 
 			// Avoid apathy and cunctatitis by using a ranged attack
-			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardmen, Procrastination Giants] contains enemy)
+			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardman, Procrastination Giants] contains enemy)
 			{
 				attackMinor = useSkill($skill[Throw Trusty], false);
 				attackMajor = useSkill($skill[Throw Trusty], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -303,6 +303,34 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		break;
 
 	case $class[Avatar of Boris]:
+		// Boris will have problems if Trusty isn't wielded
+		if (equipped_item($slot[Weapon]) != $item[none])
+		{
+			// Mighty axing is better than attacking as it will never fumble and has no mp cost
+			if(canUse($skill[Mighty Axing], false))
+			{
+				attackMinor = useSkill($skill[Mighty Axing], false);
+				attackMajor = useSkill($skill[Mighty Axing], false);
+				costMinor = mp_cost($skill[Mighty Axing]);
+				costMajor = mp_cost($skill[Mighty Axing]);
+			}
+
+			if(canUse($skill[Cleave], false) && (equipped_item($slot[Weapon]) != $item[none]))
+			{
+				attackMajor = useSkill($skill[Cleave], false);
+				costMajor = mp_cost($skill[Cleave]);
+			}
+
+			// Avoid apathy and cunctatitis by using a ranged attack
+			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardmen, Procrastination Giants] contains enemy)
+			{
+				attackMinor = useSkill($skill[Throw Trusty], false);
+				attackMajor = useSkill($skill[Throw Trusty], false);
+				costMinor = mp_cost($skill[Throw Trusty]);
+				costMajor = mp_cost($skill[Throw Trusty]);
+			}
+		}
+
 		if(canUse($skill[Heroic Belch], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[stench]) && (my_fullness() >= 5))
 		{
 			attackMinor = useSkill($skill[Heroic Belch], false);
@@ -313,32 +341,38 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		break;
 
 	case $class[Avatar of Sneaky Pete]:
-		if(canUse($skill[Peel Out]))
+		// TODO: Move to stage 2, make generic free run handler
+		if (canUse($skill[Peel Out] && auto_wantToBanish(enemy, my_location()))
 		{
-			if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, Tomb Asp, Tomb Servant,  W imp] contains enemy)
-			{
-				return useSkill($skill[Peel Out]);
-			}
+			return useSkill($skill[Peel Out]);
+		}
+
+		if(canUse($skill[Pop Wheelie], false))
+		{
+			attackMajor = useSkill($skill[Pop Wheelie], false);
+			costMajor = mp_cost($skill[Pop Wheelie]);
 		}
 
 		if(canUse($skill[Smoke Break]) && (enemy.physical_resistance >= 80))
 		{
-			return useSkill($skill[Smoke Break]);
+			attackMinor = useSkill($skill[Smoke Break]);
+			attackMajor = useSkill($skill[Smoke Break]);
+			costMinor = mp_cost($skill[Smoke Break]);
+			costMajor = mp_cost($skill[Smoke Break]);
 		}
-
-		if(canUse($skill[Flash Headlight]) && (enemy.physical_resistance >= 80) && (get_property("peteMotorbikeHeadlight") == "Party Bulb" || (get_property("peteMotorbikeHeadlight") == "Blacklight Bulb" && monster_element(enemy) != $element[sleaze])))
+		else if(canUse($skill[Flash Headlight]) && (enemy.physical_resistance >= 80) && (get_property("peteMotorbikeHeadlight") == "Party Bulb" || (get_property("peteMotorbikeHeadlight") == "Blacklight Bulb" && monster_element(enemy) != $element[sleaze])))
 		{
-			return useSkill($skill[Flash Headlight]);
+			attackMinor = useSkill($skill[Flash Headlight]);
+			attackMajor = useSkill($skill[Flash Headlight]);
+			costMinor = mp_cost($skill[Flash Headlight]);
+			costMajor = mp_cost($skill[Flash Headlight]);
 		}
-
-		if(canUse($item[Firebomb], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[hot]))
+		else if(canUse($item[Firebomb], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[hot]))
 		{
-			return useItem($item[Firebomb], false);
-		}
-
-		if(canUse($skill[Pop Wheelie]) && (my_mp() > 40))
-		{
-			return useSkill($skill[Pop Wheelie]);
+			attackMinor = useItem($item[Firebomb], false);
+			attackMajor = useItem($item[Firebomb], false);
+			costMinor = 0;
+			costMajor = 0;
 		}
 		break;
 
@@ -567,18 +601,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	if((monster_level_adjustment() > 150) && (my_mp() >= 45) && canUse($skill[Shell Up]) && (my_class() == $class[Turtle Tamer]))
 	{
 		return useSkill($skill[Shell Up]);
-	}
-
-	if(attackMinor == "attack with weapon")
-	{
-		if(canUse($skill[Summon Love Stinkbug]))
-		{
-			return useSkill($skill[Summon Love Stinkbug]);
-		}
-		if(canUse($skill[Mighty Axing], false) && (equipped_item($slot[Weapon]) != $item[none]))
-		{
-			return useSkill($skill[Mighty Axing], false);
-		}
 	}
 
 	if((enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[cold]) && canUse($skill[Throat Refrigerant], false))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -326,6 +326,11 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			return useSkill($skill[Smoke Break]);
 		}
 
+		if(canUse($skill[Flash Headlight]) && (enemy.physical_resistance >= 80) && (get_property("peteMotorbikeHeadlight") == "Party Bulb" || (get_property("peteMotorbikeHeadlight") == "Blacklight Bulb" && monster_element(enemy) != $element[sleaze])))
+		{
+			return useSkill($skill[Flash Headlight]);
+		}
+
 		if(canUse($item[Firebomb], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[hot]))
 		{
 			return useItem($item[Firebomb], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -342,7 +342,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 
 	case $class[Avatar of Sneaky Pete]:
 		// TODO: Move to stage 2, make generic free run handler
-		if (canUse($skill[Peel Out] && auto_wantToBanish(enemy, my_location()))
+		if (canUse($skill[Peel Out]) && auto_wantToBanish(enemy, my_location()))
 		{
 			return useSkill($skill[Peel Out]);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -303,32 +303,28 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		break;
 
 	case $class[Avatar of Boris]:
-		// Boris will have problems if Trusty isn't wielded
-		if (equipped_item($slot[Weapon]) != $item[none])
+		// Mighty axing is better than attacking as it will never fumble and has no mp cost
+		if(canUse($skill[Mighty Axing], false))
 		{
-			// Mighty axing is better than attacking as it will never fumble and has no mp cost
-			if(canUse($skill[Mighty Axing], false))
-			{
-				attackMinor = useSkill($skill[Mighty Axing], false);
-				attackMajor = useSkill($skill[Mighty Axing], false);
-				costMinor = mp_cost($skill[Mighty Axing]);
-				costMajor = mp_cost($skill[Mighty Axing]);
-			}
+			attackMinor = useSkill($skill[Mighty Axing], false);
+			attackMajor = useSkill($skill[Mighty Axing], false);
+			costMinor = mp_cost($skill[Mighty Axing]);
+			costMajor = mp_cost($skill[Mighty Axing]);
+		}
 
-			if(canUse($skill[Cleave], false))
-			{
-				attackMajor = useSkill($skill[Cleave], false);
-				costMajor = mp_cost($skill[Cleave]);
-			}
+		if(canUse($skill[Cleave], false))
+		{
+			attackMajor = useSkill($skill[Cleave], false);
+			costMajor = mp_cost($skill[Cleave]);
+		}
 
-			// Avoid apathy and cunctatitis by using a ranged attack
-			if (canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardman, Procrastination Giant] contains enemy)
-			{
-				attackMinor = useSkill($skill[Throw Trusty], false);
-				attackMajor = useSkill($skill[Throw Trusty], false);
-				costMinor = mp_cost($skill[Throw Trusty]);
-				costMajor = mp_cost($skill[Throw Trusty]);
-			}
+		// Avoid apathy and cunctatitis by using a ranged attack
+		if (equipped_item($slot[Weapon]) == $item[Trusty] && canUse($skill[Throw Trusty], false) && $monsters[Apathetic Lizardman, Procrastination Giant] contains enemy)
+		{
+			attackMinor = useSkill($skill[Throw Trusty], false);
+			attackMajor = useSkill($skill[Throw Trusty], false);
+			costMinor = mp_cost($skill[Throw Trusty]);
+			costMajor = mp_cost($skill[Throw Trusty]);
 		}
 
 		if(canUse($skill[Heroic Belch], false) && (enemy.physical_resistance >= 100) && (monster_element(enemy) != $element[stench]) && (my_fullness() >= 5))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -315,7 +315,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				costMajor = mp_cost($skill[Mighty Axing]);
 			}
 
-			if(canUse($skill[Cleave], false) && (equipped_item($slot[Weapon]) != $item[none]))
+			if(canUse($skill[Cleave], false))
 			{
 				attackMajor = useSkill($skill[Cleave], false);
 				costMajor = mp_cost($skill[Cleave]);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -341,12 +341,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		break;
 
 	case $class[Avatar of Sneaky Pete]:
-		// TODO: Move to stage 2, make generic free run handler
-		if (canUse($skill[Peel Out]) && auto_wantToBanish(enemy, my_location()))
-		{
-			return useSkill($skill[Peel Out]);
-		}
-
 		if(canUse($skill[Pop Wheelie], false))
 		{
 			attackMajor = useSkill($skill[Pop Wheelie], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -29,8 +29,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	string attackMajor = "attack with weapon";
 	int costMinor = 0;
 	int costMajor = 0;
-	string stunner = "";
-	int costStunner = 0;
 	int damageReceived = 0;
 	if(round != 0)
 	{
@@ -167,13 +165,8 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			attackMajor = useSkill($skill[Lunging Thrust-Smack], false);
 			costMajor = mp_cost($skill[Lunging Thrust-Smack]);
 		}
-		if(canUse($skill[Club Foot], false))
-		{
-			stunner = useSkill($skill[Club Foot], false);
-			costStunner = mp_cost($skill[Club Foot]);
-		}
-        
-        if((buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false) && !hasClubEquipped())
+
+		if((buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false) && !hasClubEquipped())
 		{
 			attackMajor = useSkill($skill[Saucestorm], false);
 			costMajor = mp_cost($skill[Saucestorm]);
@@ -223,11 +216,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			attackMajor = useSkill($skill[Shieldbutt], false);
 			costMajor = mp_cost($skill[Shieldbutt]);
 		}
-		if(canUse($skill[Shell Up], false)) // can't mark it when using it as the generic stunner
-		{
-			stunner = useSkill($skill[Shell Up], false);
-			costStunner = mp_cost($skill[Shell Up]);
-		}
 
 		if((buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false))
 		{
@@ -269,11 +257,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				costMinor = mp_cost($skill[Utensil Twist]);
 			}
 		}
-		if(canUse($skill[Entangling Noodles], false))
-		{
-			stunner = useSkill($skill[Entangling Noodles], false);
-			costStunner = mp_cost($skill[Entangling Noodles]);
-		}
 		break;
 	case $class[Sauceror]:
 		if(canUse($skill[Saucegeyser], false))
@@ -312,18 +295,11 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Stream of Sauce]);
 		}
 
-		if(canUse($skill[Soul Bubble], false) && my_soulsauce() >= 5)
-		{
-			stunner = useSkill($skill[Soul Bubble]);
-			costStunner = mp_cost($skill[Soul Bubble]);
-		}
-
 		if(!contains_text(combatState, "delaymortarshell") && canSurvive(2.0) && haveUsed($skill[Stuffed Mortar Shell]) && canUse($skill[Salsaball], false))
 		{
 			set_property("auto_combatHandler", combatState + "(delaymortarshell)");
 			return useSkill($skill[Salsaball], false);
 		}
-
 		break;
 
 	case $class[Avatar of Boris]:
@@ -333,12 +309,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			attackMajor = useSkill($skill[Heroic Belch], false);
 			costMinor = mp_cost($skill[Heroic Belch]);
 			costMajor = mp_cost($skill[Heroic Belch]);
-		}
-
-		if(canUse($skill[Broadside], false))
-		{
-			stunner = useSkill($skill[Broadside], false);
-			costStunner = mp_cost($skill[Broadside]);
 		}
 		break;
 
@@ -361,13 +331,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Pop Wheelie]);
 		}
-
-		if(canUse($skill[Snap Fingers], false))
-		{
-			stunner = useSkill($skill[Snap Fingers], false);
-			costStunner = mp_cost($skill[Snap Fingers]);
-		}
-
 		break;
 
 	case $class[Accordion Thief]:
@@ -378,12 +341,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			{
 				return useSkill($skill[Cadenza]);
 			}
-		}
-
-		if(canUse($skill[Accordion Bash], false) && (item_type(equipped_item($slot[weapon])) == "accordion"))
-		{
-			stunner = useSkill($skill[Accordion Bash], false);
-			costStunner = mp_cost($skill[Accordion Bash]);
 		}
 
 		if((buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false))
@@ -462,11 +419,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			return useSkill($skill[Good Medicine]);
 		}
 
-		if(canUse($skill[Hogtie]) && (my_mp() >= (6 * mp_cost($skill[Hogtie]))) && hasLeg(enemy))
-		{
-			return useSkill($skill[Hogtie]);
-		}
-
 		if(canUse($skill[Lavafava], false) && (enemy.defense_element != $element[hot]))
 		{
 			attackMajor = useSkill($skill[Lavafava], false);
@@ -512,18 +464,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Cowcall]);
 			costMinor = mp_cost($skill[Cowcall]);
 		}
-
-		if(canUse($skill[Beanscreen]) && !canSurvive(5.0))
-		{
-			stunner = useSkill($skill[Beanscreen]);
-			costStunner = mp_cost($skill[Beanscreen]);
-		}
-
-		if(canUse($skill[Hogtie], false) && (my_mp() >= (3 * mp_cost($skill[Hogtie]))) && hasLeg(enemy))
-		{
-			stunner = useSkill($skill[Hogtie], false);
-			costStunner = mp_cost($skill[Hogtie]);
-		}
 		break;
 
 	case $class[Vampyre]:
@@ -547,8 +487,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Dark Feast]);
 		}
-		if(canUse($skill[Blood Chains], false) && my_hp() > 3 * hp_cost($skill[Blood Chains]))
-			stunner = useSkill($skill[Blood Chains], false);
 		// intentionally not setting costMinor or costMajor since they don't cost mp...
 
 		// If we're in a form or something, a beehive is probably better than just attacking
@@ -565,12 +503,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		if(canUse($skill[Thunderstrike]) && (monster_level_adjustment() <= 150))
 		{
 			return useSkill($skill[Thunderstrike]);
-		}
-
-		if(!contains_text(combatState, "stunner") && (stunner != "") && (monster_level_adjustment() <= 100) && (my_mp() >= costStunner) && stunnable(enemy))
-		{
-			set_property("auto_combatHandler", combatState + "(stunner)");
-			return stunner;
 		}
 
 		if(canUse($skill[Unleash The Greash]) && (monster_element(enemy) != $element[sleaze]) && (have_effect($effect[Takin\' It Greasy]) > 100))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -409,7 +409,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			{
 				return useSkill($skill[Extract Oil]);
 			}
-			else if(($phylums[undead] contains type) && (item_amount($item[Skin Oil]) < 5))
+			else if(($phylums[undead] contains type) && (item_amount($item[Eldritch Oil]) < 5))
 			{
 				return useSkill($skill[Extract Oil]);
 			}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -550,7 +550,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Thousand-Yard Stare]);
 		}
-		if($monsters[Aquagoblin, Lord Soggyraven] contains enemy)
+		if($monsters[Aquagoblin, Lord Soggyraven, Groar] contains enemy && (my_mp() >= costMajor))
 		{
 			return attackMajor;
 		}
@@ -631,6 +631,12 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	{
 		return attackMajor;
 	}
+
+	if($monsters[Aquagoblin, Lord Soggyraven, Groar] contains enemy && (my_mp() >= costMajor))
+	{
+		return attackMajor;
+	}
+
 	if(canUse($skill[Lunge Smack], false) && (attackMinor != "attack with weapon") && (weapon_type(equipped_item($slot[weapon])) == $stat[Muscle]))
 	{
 		return attackMinor;

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -25,7 +25,7 @@ string useItem(item it, boolean mark);
 string useItem(item it);							
 string useItems(item it1, item it2, boolean mark);	
 string useItems(item it1, item it2);				
-string getStallString(monster enemy);				
+skill getStunner(monster enemy);				
 boolean enemyCanBlocksSkills();						
 boolean canSurvive(float mult, int add);			
 boolean canSurvive(float mult);						

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -164,51 +164,96 @@ string useItems(item it1, item it2)
 	return useItems(it1, it2, true);
 }
 
-string getStallString(monster enemy)
+skill getStunner(monster enemy)
 {
-	// if you call this without actually doing what it returns it'll make me sad :(
+	// Class specific
+	switch(my_class())
+	{
+	case $class[Seal Clubber]:
+		if(canUse($skill[Club Foot]) && (my_fury() > 0 || hasClubEquipped()))
+		{
+			return $skill[Club Foot];
+		}
+		break;
+	case $class[Turtle Tamer]:
+		if(canUse($skill[Shell Up]))
+		{
+			//storm turtle blessings makes shell up a multi-round stun, otherwise it's just a (special) stagger
+			if(have_effect($effect[Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Grand Blessing of the Storm Tortoise]) > 0 || have_effect($effect[Glorious Blessing of the Storm Tortoise]) > 0)
+			{
+				return $skill[Shell Up];
+			}
+		}
+		break;
+	case $class[Accordion Thief]:
+		if(canUse($skill[Accordion Bash]) && (item_type(equipped_item($slot[weapon])) == "accordion"))
+		{
+			return $skill[Accordion Bash];
+		}
+		break;
+	case $class[Pastamancer]:
+		if(canUse($skill[Entangling Noodles]))
+		{
+			return $skill[Entangling Noodles];
+		}
+		break;
+	case $class[Sauceror]:
+		if(canUse($skill[Soul Bubble]))
+		{
+			return $skill[Soul Bubble];
+		}
+		break;
+	case $class[Avatar of Boris]:
+		if(canUse($skill[Broadside]))
+		{
+			return $skill[Broadside];
+		}
+		break;
+	case $class[Avatar of Sneaky Pete]:
+		if(canUse($skill[Snap Fingers]))
+		{
+			return $skill[Snap Fingers];
+		}
+		break;
+	case $class[Avatar of Jarlsberg]:
+		if(canUse($skill[Blend]))
+		{
+			return $skill[Blend];
+		}
+		break;
+	case $class[Cow Puncher]:
+	case $class[Beanslinger]:
+	case $class[Snake Oiler]:
+		if(canUse($skill[Beanscreen]))
+		{
+			return $skill[Beanscreen];
+		}
+		if(canUse($skill[Hogtie]) && !hasUsed($skill[Beanscreen]) && hasLeg(enemy))
+		{
+			return $skill[Hogtie];
+		}
+		break;
+	case $class[Vampyre]:
+		if(canUse($skill[Blood Chains]) && my_hp() > 3 * hp_cost($skill[Blood Chains]))
+		{
+			return $skill[Blood Chains];
+		}
+		break;
+	}
 	
+	// Decreases in stun duration the more it's used
 	if(canUse($skill[Summon Love Gnats]))
 	{
-		return useSkill($skill[Summon Love Gnats]);
+		return $skill[Summon Love Gnats];
 	}
 
-	if(canUse($skill[Beanscreen]))
-	{
-		return useSkill($skill[Beanscreen]);
-	}
-
-	if(canUse($skill[Broadside]))
-	{
-		return useSkill($skill[Broadside]);
-	}
-
+	// Nuclear Autum
 	if(canUse($skill[Mind Bullets]))
 	{
-		return useSkill($skill[Mind Bullets]);
+		return $skill[Mind Bullets];
 	}
 
-	if(canUse($skill[Snap Fingers]))
-	{
-		return useSkill($skill[Snap Fingers]);
-	}
-
-	if(canUse($skill[Soul Bubble]))
-	{
-		return useSkill($skill[Soul Bubble]);
-	}
-
-	if(canUse($skill[Blood Chains]))
-	{
-		return useSkill($skill[Blood Chains]);
-	}
-
-	if(canUse($skill[Hogtie]) && !haveUsed($skill[Beanscreen]) && (my_mp() >= (6 * mp_cost($skill[Hogtie]))) && hasLeg(enemy))
-	{
-		return useSkill($skill[Hogtie]);
-	}
-
-	return "";
+	return $skill[none];
 }
 
 boolean enemyCanBlocksSkills()

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -228,7 +228,7 @@ skill getStunner(monster enemy)
 		{
 			return $skill[Beanscreen];
 		}
-		if(canUse($skill[Hogtie]) && !hasUsed($skill[Beanscreen]) && hasLeg(enemy))
+		if(canUse($skill[Hogtie]) && !haveUsed($skill[Beanscreen]) && hasLeg(enemy))
 		{
 			return $skill[Hogtie];
 		}

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -76,7 +76,7 @@ void pete_buySkills()
 	}
 
 	//if you have those 3 skills then you have all skills.
-	if (!have_skill($skill[Natural Dancer]) || !have_skill($skill[Flash Headlight]) || !have_skill($skill[Walk Away From Explosion])
+	if (!have_skill($skill[Natural Dancer]) || !have_skill($skill[Flash Headlight]) || !have_skill($skill[Walk Away From Explosion]))
 	{
 		string page = visit_url("da.php?place=gate3");
 		matcher my_skillPoints = create_matcher("<b>(\\d\+)</b> skill point", page);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -70,217 +70,218 @@ void pete_buySkills()
 	{
 		return;
 	}
+
 	if(my_level() <= get_property("auto_peteSkills").to_int())
 	{
 		return;
 	}
 
-	//if you have those 3 skills then you have all skills.
-	if (!have_skill($skill[Natural Dancer]) || !have_skill($skill[Flash Headlight]) || !have_skill($skill[Walk Away From Explosion]))
+	// if you have all the skills and the motorcycle is fully upgraded, we're done.
+	if (have_skill($skill[Natural Dancer]) && have_skill($skill[Flash Headlight]) && have_skill($skill[Walk Away From Explosion]) &&
+		get_property("peteMotorbikeCowling") != "" &&
+		get_property("peteMotorbikeTires") != "" &&
+		get_property("peteMotorbikeMuffler") != "" &&
+		get_property("peteMotorbikeGasTank") != "" &&
+		get_property("peteMotorbikeHeadlight") != "" &&
+		get_property("peteMotorbikeSeat") != "")
 	{
-		string page = visit_url("da.php?place=gate3");
-		matcher my_skillPoints = create_matcher("<b>(\\d\+)</b> skill point", page);
-		if(my_skillPoints.find())
+		return;
+	}
+
+	string page = visit_url("da.php?place=gate3");
+	matcher my_skillPoints = create_matcher("<b>(\\d\+)</b> skill point", page);
+	if(my_skillPoints.find())
+	{
+		int skillPoints = to_int(my_skillPoints.group(1));
+		auto_log_info("Skill points found: " + skillPoints);
+
+		while(skillPoints > 0)
 		{
-			int skillPoints = to_int(my_skillPoints.group(1));
-			auto_log_info("Skill points found: " + skillPoints);
+			//skills are listed in inverse order. The first listed skill is the last skill to buy.
+			skillPoints = skillPoints - 1;
+			int tree = 1;
 
-			while(skillPoints > 0)
+			if(!have_skill($skill[Flash Headlight]))
 			{
-				//skills are listed in inverse order. The first listed skill is the last skill to buy.
-				skillPoints = skillPoints - 1;
-				int tree = 1;
-
-				if(!have_skill($skill[Flash Headlight]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Biker Swagger]))
-				{
-					tree = 2;
-				}
-
-				if(!have_skill($skill[Walk Away From Explosion]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Brood]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Unrepentant Thief]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[[15025]Hard Drinker]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Smoke Break]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Animal Magnetism]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Jump Shark]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Incite Riot]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Live Fast]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Insult]))
-				{
-					tree = 3;
-				}
-				if(!have_skill($skill[Natural Dancer]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Make Friends]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Cocktail Magic]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Check Hair]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Shake It Off]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Snap Fingers]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Fix Jukebox]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Throw Party]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Mixologist]))
-				{
-					tree = 1;
-				}
-				if(!have_skill($skill[Catchphrase]))
-				{
-					tree = 1;
-				}
-
-				if(!have_skill($skill[Riding Tall]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Check Mirror]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Easy Riding]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Peel Out]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Rowdy Drinker]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Pop Wheelie]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Born Showman]))
-				{
-					tree = 2;
-				}
-				if(!have_skill($skill[Rev Engine]))
-				{
-					tree = 2;
-				}
-				visit_url("choice.php?option=" + tree + "&whichchoice=867&pwd=");
+				tree = 2;
 			}
+			if(!have_skill($skill[Biker Swagger]))
+			{
+				tree = 2;
+			}
+
+			if(!have_skill($skill[Walk Away From Explosion]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Brood]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Unrepentant Thief]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[[15025]Hard Drinker]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Smoke Break]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Animal Magnetism]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Jump Shark]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Incite Riot]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Live Fast]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Insult]))
+			{
+				tree = 3;
+			}
+			if(!have_skill($skill[Natural Dancer]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Make Friends]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Cocktail Magic]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Check Hair]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Shake It Off]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Snap Fingers]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Fix Jukebox]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Throw Party]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Mixologist]))
+			{
+				tree = 1;
+			}
+			if(!have_skill($skill[Catchphrase]))
+			{
+				tree = 1;
+			}
+
+			if(!have_skill($skill[Riding Tall]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Check Mirror]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Easy Riding]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Peel Out]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Rowdy Drinker]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Pop Wheelie]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Born Showman]))
+			{
+				tree = 2;
+			}
+			if(!have_skill($skill[Rev Engine]))
+			{
+				tree = 2;
+			}
+			visit_url("choice.php?option=" + tree + "&whichchoice=867&pwd=");
 		}
 	}
 
 	// Skip if the motorcycle is fully upgraded
-	if (get_property("peteMotorbikeCowling") == "" ||
-		get_property("peteMotorbikeTires") == "" ||
-		get_property("peteMotorbikeMuffler") == "" ||
-		get_property("peteMotorbikeGasTank") == "" ||
-		get_property("peteMotorbikeHeadlight") == "" ||
-		get_property("peteMotorbikeSeat") == "")
+	string page = visit_url("main.php?action=motorcycle");
+	matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
+	while(my_cyclePoints.find())
 	{
-		string page = visit_url("main.php?action=motorcycle");
-		matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
-		while(my_cyclePoints.find())
+		auto_log_info("Found Upping Your Grade", "blue");
+		int firstChoice = -1;
+		int secondChoice = -1;
+		if(get_property("peteMotorbikeCowling") == "")
 		{
-			auto_log_info("Found Upping Your Grade", "blue");
-			int firstChoice = -1;
-			int secondChoice = -1;
-			if(get_property("peteMotorbikeCowling") == "")
-			{
-				firstChoice = 4;
-				secondChoice = 3;
-			}
-			else if(get_property("peteMotorbikeTires") == "")
-			{
-				firstChoice = 1;
-				secondChoice = 1;
-			}
-			else if(get_property("peteMotorbikeMuffler") == "")
-			{
-				firstChoice = 5;
-				secondChoice = 2;
-			}
-			else if(get_property("peteMotorbikeGasTank") == "")
-			{
-				firstChoice = 2;
-				secondChoice = 2;
-			}
-			else if(get_property("peteMotorbikeHeadlight") == "")
-			{
-				firstChoice = 3;
-				secondChoice = 3;
-			}
-			else if(get_property("peteMotorbikeSeat") == "")
-			{
-				firstChoice = 6;
-				secondChoice = 1;
-				run_choice(6);
-			}
-
-			if(firstChoice == -1)
-			{
-				break;
-			}
-
-			page = visit_url("choice.php?pwd=&whichchoice=859&option=" + firstChoice);
-
-			if(last_choice() == 859)
-			{
-				abort("Mafia is not handling this correctly, sorry");
-			}
-			page = visit_url("choice.php?pwd=&whichchoice=" + last_choice() + "&option=" + secondChoice);
-
-			page = visit_url("main.php?action=motorcycle");
-			my_cyclePoints = create_matcher("Upping Your Grade", page);
+			firstChoice = 4;
+			secondChoice = 3;
 		}
+		else if(get_property("peteMotorbikeTires") == "")
+		{
+			firstChoice = 1;
+			secondChoice = 1;
+		}
+		else if(get_property("peteMotorbikeMuffler") == "")
+		{
+			firstChoice = 5;
+			secondChoice = 2;
+		}
+		else if(get_property("peteMotorbikeGasTank") == "")
+		{
+			firstChoice = 2;
+			secondChoice = 2;
+		}
+		else if(get_property("peteMotorbikeHeadlight") == "")
+		{
+			firstChoice = 3;
+			secondChoice = 3;
+		}
+		else if(get_property("peteMotorbikeSeat") == "")
+		{
+			firstChoice = 6;
+			secondChoice = 1;
+			run_choice(6);
+		}
+
+		if(firstChoice == -1)
+		{
+			break;
+		}
+
+		page = visit_url("choice.php?pwd=&whichchoice=859&option=" + firstChoice);
+
+		if(last_choice() == 859)
+		{
+			abort("Mafia is not handling this correctly, sorry");
+		}
+		page = visit_url("choice.php?pwd=&whichchoice=" + last_choice() + "&option=" + secondChoice);
+
+		page = visit_url("main.php?action=motorcycle");
+		my_cyclePoints = create_matcher("Upping Your Grade", page);
 	}
 
 	set_property("auto_peteSkills", my_level());

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -221,7 +221,7 @@ void pete_buySkills()
 	// Skip if the motorcycle is fully upgraded
 	if (get_property("peteMotorbikeCowling") == "" ||
 		get_property("peteMotorbikeTires") == "" ||
-		get_property("peteMotorbikeMuffler") == ""||&&
+		get_property("peteMotorbikeMuffler") == "" ||
 		get_property("peteMotorbikeGasTank") == "" ||
 		get_property("peteMotorbikeHeadlight") == "" ||
 		get_property("peteMotorbikeSeat") == "")

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -74,221 +74,216 @@ void pete_buySkills()
 	{
 		return;
 	}
+
 	//if you have those 3 skills then you have all skills.
-	if(have_skill($skill[Natural Dancer]) && have_skill($skill[Flash Headlight]) && have_skill($skill[Walk Away From Explosion]))
+	if (!have_skill($skill[Natural Dancer]) || !have_skill($skill[Flash Headlight]) || !have_skill($skill[Walk Away From Explosion])
 	{
-		return;
+		string page = visit_url("da.php?place=gate3");
+		matcher my_skillPoints = create_matcher("<b>(\\d\+)</b> skill point", page);
+		if(my_skillPoints.find())
+		{
+			int skillPoints = to_int(my_skillPoints.group(1));
+			auto_log_info("Skill points found: " + skillPoints);
+
+			while(skillPoints > 0)
+			{
+				//skills are listed in inverse order. The first listed skill is the last skill to buy.
+				skillPoints = skillPoints - 1;
+				int tree = 1;
+
+				if(!have_skill($skill[Flash Headlight]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Biker Swagger]))
+				{
+					tree = 2;
+				}
+
+				if(!have_skill($skill[Walk Away From Explosion]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Brood]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Unrepentant Thief]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[[15025]Hard Drinker]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Smoke Break]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Animal Magnetism]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Jump Shark]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Incite Riot]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Live Fast]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Insult]))
+				{
+					tree = 3;
+				}
+				if(!have_skill($skill[Natural Dancer]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Make Friends]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Cocktail Magic]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Check Hair]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Shake It Off]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Snap Fingers]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Fix Jukebox]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Throw Party]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Mixologist]))
+				{
+					tree = 1;
+				}
+				if(!have_skill($skill[Catchphrase]))
+				{
+					tree = 1;
+				}
+
+				if(!have_skill($skill[Riding Tall]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Check Mirror]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Easy Riding]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Peel Out]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Rowdy Drinker]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Pop Wheelie]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Born Showman]))
+				{
+					tree = 2;
+				}
+				if(!have_skill($skill[Rev Engine]))
+				{
+					tree = 2;
+				}
+				visit_url("choice.php?option=" + tree + "&whichchoice=867&pwd=");
+			}
+		}
 	}
 
-	string page = visit_url("da.php?place=gate3");
-	matcher my_skillPoints = create_matcher("<b>(\\d\+)</b> skill point", page);
-	if(my_skillPoints.find())
+	// Skip if the motorcycle is fully upgraded
+	if (get_property("peteMotorbikeCowling") == "" ||
+		get_property("peteMotorbikeTires") == "" ||
+		get_property("peteMotorbikeMuffler") == ""||&&
+		get_property("peteMotorbikeGasTank") == "" ||
+		get_property("peteMotorbikeHeadlight") == "" ||
+		get_property("peteMotorbikeSeat") == "")
 	{
-		int skillPoints = to_int(my_skillPoints.group(1));
-		auto_log_info("Skill points found: " + skillPoints);
-
-		while(skillPoints > 0)
+		string page = visit_url("main.php?action=motorcycle");
+		matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
+		while(my_cyclePoints.find())
 		{
-			//skills are listed in inverse order. The first listed skill is the last skill to buy.
-			skillPoints = skillPoints - 1;
-			int tree = 1;
-
-			if(!have_skill($skill[Flash Headlight]))
+			auto_log_info("Found Upping Your Grade", "blue");
+			int firstChoice = -1;
+			int secondChoice = -1;
+			if(get_property("peteMotorbikeCowling") == "")
 			{
-				tree = 2;
+				firstChoice = 4;
+				secondChoice = 3;
 			}
-			if(!have_skill($skill[Biker Swagger]))
+			else if(get_property("peteMotorbikeTires") == "")
 			{
-				tree = 2;
+				firstChoice = 1;
+				secondChoice = 1;
 			}
-
-			if(!have_skill($skill[Walk Away From Explosion]))
+			else if(get_property("peteMotorbikeMuffler") == "")
 			{
-				tree = 3;
+				firstChoice = 5;
+				secondChoice = 2;
 			}
-			if(!have_skill($skill[Brood]))
+			else if(get_property("peteMotorbikeGasTank") == "")
 			{
-				tree = 3;
+				firstChoice = 2;
+				secondChoice = 2;
 			}
-			if(!have_skill($skill[Unrepentant Thief]))
+			else if(get_property("peteMotorbikeHeadlight") == "")
 			{
-				tree = 3;
+				firstChoice = 3;
+				secondChoice = 3;
 			}
-			if(!have_skill($skill[[15025]Hard Drinker]))
+			else if(get_property("peteMotorbikeSeat") == "")
 			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Smoke Break]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Animal Magnetism]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Jump Shark]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Incite Riot]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Live Fast]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Insult]))
-			{
-				tree = 3;
-			}
-			if(!have_skill($skill[Natural Dancer]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Make Friends]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Cocktail Magic]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Check Hair]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Shake It Off]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Snap Fingers]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Fix Jukebox]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Throw Party]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Mixologist]))
-			{
-				tree = 1;
-			}
-			if(!have_skill($skill[Catchphrase]))
-			{
-				tree = 1;
+				firstChoice = 6;
+				secondChoice = 1;
+				run_choice(6);
 			}
 
-			if(!have_skill($skill[Riding Tall]))
+			if(firstChoice == -1)
 			{
-				tree = 2;
+				break;
 			}
-			if(!have_skill($skill[Check Mirror]))
+
+			page = visit_url("choice.php?pwd=&whichchoice=859&option=" + firstChoice);
+
+			if(last_choice() == 859)
 			{
-				tree = 2;
+				abort("Mafia is not handling this correctly, sorry");
 			}
-			if(!have_skill($skill[Easy Riding]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Peel Out]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Rowdy Drinker]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Pop Wheelie]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Born Showman]))
-			{
-				tree = 2;
-			}
-			if(!have_skill($skill[Rev Engine]))
-			{
-				tree = 2;
-			}
-			visit_url("choice.php?option=" + tree + "&whichchoice=867&pwd=");
+			page = visit_url("choice.php?pwd=&whichchoice=" + last_choice() + "&option=" + secondChoice);
+
+			page = visit_url("main.php?action=motorcycle");
+			my_cyclePoints = create_matcher("Upping Your Grade", page);
 		}
 	}
 
 	set_property("auto_peteSkills", my_level());
-}
-void pete_upgradeMotorcycle()
-{
-	if (get_property("peteMotorbikeCowling") != "" &&
-		get_property("peteMotorbikeTires") != "" &&
-		get_property("peteMotorbikeMuffler") != "" &&
-		get_property("peteMotorbikeGasTank") != "" &&
-		get_property("peteMotorbikeHeadlight") != "" &&
-		get_property("peteMotorbikeSeat") != "")
-	{
-		return;
-	}
-	string page = visit_url("main.php?action=motorcycle");
-	matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
-	while(my_cyclePoints.find())
-	{
-		auto_log_info("Found Upping Your Grade", "blue");
-		int firstChoice = -1;
-		int secondChoice = -1;
-		if(get_property("peteMotorbikeCowling") == "")
-		{
-			firstChoice = 4;
-			secondChoice = 3;
-		}
-		else if(get_property("peteMotorbikeTires") == "")
-		{
-			firstChoice = 1;
-			secondChoice = 1;
-		}
-		else if(get_property("peteMotorbikeMuffler") == "")
-		{
-			firstChoice = 5;
-			secondChoice = 2;
-		}
-		else if(get_property("peteMotorbikeGasTank") == "")
-		{
-			firstChoice = 2;
-			secondChoice = 2;
-		}
-		else if(get_property("peteMotorbikeHeadlight") == "")
-		{
-			firstChoice = 3;
-			secondChoice = 3;
-		}
-		else if(get_property("peteMotorbikeSeat") == "")
-		{
-			firstChoice = 6;
-			secondChoice = 1;
-		}
-
-		if(firstChoice == -1)
-		{
-			break;
-		}
-
-		run_choice(firstChoice);
-		if(last_choice() == 859)
-		{
-			abort("Mafia is not handling this correctly, sorry");
-		}
-		run_choice(secondChoice);
-		if(last_choice() == 859)
-		{
-			abort("Mafia is not handling this correctly, sorry");
-		}
-
-		page = visit_url("main.php?action=motorcycle");
-		my_cyclePoints = create_matcher("Upping Your Grade", page);
-	}
 }
 
 boolean LM_pete()
@@ -299,7 +294,6 @@ boolean LM_pete()
 	}
 
 	pete_buySkills();
-	pete_upgradeMotorcycle();
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -286,6 +286,16 @@ void pete_buySkills()
 	set_property("auto_peteSkills", my_level());
 }
 
+int pete_peelOutRemaining()
+{
+	if (get_property("peteMotorbikeTires") == "Racing Slicks")
+	{
+		return 30 - get_property("_petePeeledOut").to_int();
+	}
+
+	return 10 - get_property("_petePeeledOut").to_int();
+}
+
 boolean LM_pete()
 {
 	if(my_path() != "Avatar of Sneaky Pete")

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -228,7 +228,7 @@ void pete_buySkills()
 	}
 
 	// Skip if the motorcycle is fully upgraded
-	string page = visit_url("main.php?action=motorcycle");
+	page = visit_url("main.php?action=motorcycle");
 	matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
 	while(my_cyclePoints.find())
 	{

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -219,7 +219,20 @@ void pete_buySkills()
 		}
 	}
 
-	page = visit_url("main.php?action=motorcycle");
+	set_property("auto_peteSkills", my_level());
+}
+void pete_upgradeMotorcycle()
+{
+	if (get_property("peteMotorbikeCowling") != "" &&
+		get_property("peteMotorbikeTires") != "" &&
+		get_property("peteMotorbikeMuffler") != "" &&
+		get_property("peteMotorbikeGasTank") != "" &&
+		get_property("peteMotorbikeHeadlight") != "" &&
+		get_property("peteMotorbikeSeat") != "")
+	{
+		return;
+	}
+	string page = visit_url("main.php?action=motorcycle");
 	matcher my_cyclePoints = create_matcher("Upping Your Grade", page);
 	while(my_cyclePoints.find())
 	{
@@ -255,7 +268,6 @@ void pete_buySkills()
 		{
 			firstChoice = 6;
 			secondChoice = 1;
-			run_choice(6);
 		}
 
 		if(firstChoice == -1)
@@ -263,19 +275,20 @@ void pete_buySkills()
 			break;
 		}
 
-		page = visit_url("choice.php?pwd=&whichchoice=859&option=" + firstChoice);
-
+		run_choice(firstChoice);
 		if(last_choice() == 859)
 		{
 			abort("Mafia is not handling this correctly, sorry");
 		}
-		page = visit_url("choice.php?pwd=&whichchoice=" + last_choice() + "&option=" + secondChoice);
+		run_choice(secondChoice);
+		if(last_choice() == 859)
+		{
+			abort("Mafia is not handling this correctly, sorry");
+		}
 
 		page = visit_url("main.php?action=motorcycle");
 		my_cyclePoints = create_matcher("Upping Your Grade", page);
 	}
-
-	set_property("auto_peteSkills", my_level());
 }
 
 boolean LM_pete()
@@ -286,6 +299,7 @@ boolean LM_pete()
 	}
 
 	pete_buySkills();
+	pete_upgradeMotorcycle();
 
 	return false;
 }


### PR DESCRIPTION
# Description

- Move multi-round stun handling from step5 to step3 of combat
- Improve Avatar of Sneaky Pete combat
- Improve Avatar of Boris combat
- Always use majorAttack on Groar
- Fix not upgrading Sneaky Pete motorcycle if all skills have been learned
- Peel out can be a banish (unused by autoscend as we don't upgrade the motorcycle that way)
- Peel out is also a free run, use it to run away from monsters we would have banished but can't (we should probably use free runs to burn delay)
- Track free runs and show them on the relay page (currently just peel out)

## How Has This Been Tested?

Two sneaky pete softcore runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
