### PR TITLE
hidden apartment cursed punch & stench jelly fix

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1310,6 +1310,21 @@ boolean L11_hiddenCity()
 			cursesNeeded = 1;
 		}
 		
+		//able to drink, enough liver?
+		if(canDrinkCursedPunch)
+		{
+			int inebrietyAllowedForPunch = inebriety_left();
+			if(in_quantumTerrarium() && my_familiar() == $familiar[Stooper])
+			{	//in QT the limit is lower or else will be overdrunk when Stooper changes
+				inebrietyAllowedForPunch -= 1;
+			}
+			
+			if(inebrietyAllowedForPunch < cursesNeeded*$item[Cursed Punch].inebriety)
+			{
+				canDrinkCursedPunch = false;
+			}
+		}
+		
 		if(!elevatorAction && $location[The Hidden Apartment Building].turns_spent <= 4 && auto_canForceNextNoncombat())
 		{
 			//should we try to force the noncombat?
@@ -1332,6 +1347,7 @@ boolean L11_hiddenCity()
 					}
 				}
 				
+				//can drink and inebriety allows it
 				if(canDrinkCursedPunch)
 				{
 					boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti());
@@ -1340,7 +1356,7 @@ boolean L11_hiddenCity()
 					{
 						L11_hiddenTavernUnlock(true);
 
-						if(my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
+						if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())
 						{
 							shouldForceElevatorAction = true;
 						}
@@ -1371,7 +1387,8 @@ boolean L11_hiddenCity()
 		{
 			if(have_effect($effect[Thrice-Cursed]) == 0)
 			{
-				if(canDrinkCursedPunch && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
+				//can drink and inebriety allows it
+				if(canDrinkCursedPunch)
 				{
 					L11_hiddenTavernUnlock(true);
 					if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1358,14 +1358,14 @@ boolean L11_hiddenCity()
 				if(canDrinkCursedPunch && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
 				{
 					L11_hiddenTavernUnlock(true);
-					while(have_effect($effect[Thrice-Cursed]) == 0 && inebriety_left() >= $item[Cursed Punch].inebriety && my_ascensions() == get_property("hiddenTavernUnlock").to_int())
+					if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())
 					{
-						buyUpTo(1, $item[Cursed Punch]);
-						if(item_amount($item[Cursed Punch]) == 0)
+						buyUpTo(cursesNeeded, $item[Cursed Punch]);
+						if(item_amount($item[Cursed Punch]) < cursesNeeded)
 						{
 							abort("Could not acquire Cursed Punch, unable to deal with Hidden Apartment Properly");
 						}
-						autoDrink(1, $item[Cursed Punch]);
+						autoDrink(cursesNeeded, $item[Cursed Punch]);
 					}
 				}
 			}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1310,9 +1310,16 @@ boolean L11_hiddenCity()
 			cursesNeeded = 1;
 		}
 		
-		if(!elevatorAction && auto_canForceNextNoncombat())
+		if(!elevatorAction && $location[The Hidden Apartment Building].turns_spent <= 4 && auto_canForceNextNoncombat())
 		{
-			if(canDrinkCursedPunch)
+			//should we try to force the noncombat?
+			boolean shouldForceElevatorAction = false;
+			
+			if(have_effect($effect[Thrice-Cursed]) > 0)
+			{
+				shouldForceElevatorAction = true;
+			}
+			else if(canDrinkCursedPunch)
 			{
 				if(get_property("auto_consumeMinAdvPerFill").to_float() != 0)
 				{
@@ -1324,28 +1331,32 @@ boolean L11_hiddenCity()
 						canDrinkCursedPunch = false;
 					}
 				}
+				
+				if(canDrinkCursedPunch)
+				{
+					boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti());
+					
+					if(canBuyCursedPunch)
+					{
+						L11_hiddenTavernUnlock(true);
+
+						if(my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
+						{
+							shouldForceElevatorAction = true;
+						}
+					}
+				}
 			}
 			
-			if(canDrinkCursedPunch)
+			if(shouldForceElevatorAction)
 			{
-				boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti());
-				
-				if(canBuyCursedPunch)
+				elevatorAction = auto_forceNextNoncombat();
+
+				if(in_pokefam())
 				{
-					L11_hiddenTavernUnlock(true);
-
-					if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
-						|| (0 != have_effect($effect[Thrice-Cursed]) && $location[The Hidden Apartment Building].turns_spent <= 4))
+					if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
 					{
-						elevatorAction = auto_forceNextNoncombat();
-
-						if(in_pokefam())
-						{
-							if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
-							{
-								return autoAdv($location[The Hidden Apartment Building]);
-							}
-						}
+						return autoAdv($location[The Hidden Apartment Building]);
 					}
 				}
 			}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1296,19 +1296,51 @@ boolean L11_hiddenCity()
 		auto_log_info("The idden [sic] apartment!", "blue");
 
 		boolean elevatorAction = ($location[The Hidden Apartment Building].turns_spent > 0 && $location[The Hidden Apartment Building].turns_spent % 8 == 0);
-
-		if(auto_canForceNextNoncombat())
+		
+		boolean canDrinkCursedPunch = canDrink($item[Cursed Punch]) && !get_property("auto_limitConsume").to_boolean() && !in_tcrs();
+		//todo: in_tcrs check quality and size of cursed punch instead of skipping? if that is possible
+		
+		int cursesNeeded = 3;
+		if(have_effect($effect[Once-Cursed]) > 0)
 		{
-			if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= 3*$item[Cursed Punch].inebriety) && !in_tcrs())
-				|| (0 != have_effect($effect[Thrice-Cursed]) && $location[The Hidden Apartment Building].turns_spent <= 4))
+			cursesNeeded = 2;
+		}
+		if(have_effect($effect[Twice-Cursed]) > 0)
+		{
+			cursesNeeded = 1;
+		}
+		
+		if(!elevatorAction && auto_canForceNextNoncombat())
+		{
+			if(canDrinkCursedPunch)
 			{
-				elevatorAction = auto_forceNextNoncombat();
-
-				if(in_pokefam())
+				if(get_property("auto_consumeMinAdvPerFill").to_float() != 0)
 				{
-					if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+					//try to respect user setting for cursed punch while there is apartment delay
+					//give it at least +1 adv that it saves fighting a pygmy shaman
+					int advPerFillFromCursedPunch = (expectedAdventuresFrom($item[Cursed Punch]) + 1) / $item[Cursed Punch].inebriety;
+					if(advPerFillFromCursedPunch < get_property("auto_consumeMinAdvPerFill").to_float())
 					{
-						return autoAdv($location[The Hidden Apartment Building]);
+						canDrinkCursedPunch = false;
+					}
+				}
+			}
+			
+			if(canDrinkCursedPunch)
+			{
+				L11_hiddenTavernUnlock(true);
+				
+				if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
+					|| (0 != have_effect($effect[Thrice-Cursed]) && $location[The Hidden Apartment Building].turns_spent <= 4))
+				{
+					elevatorAction = auto_forceNextNoncombat();
+
+					if(in_pokefam())
+					{
+						if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+						{
+							return autoAdv($location[The Hidden Apartment Building]);
+						}
 					}
 				}
 			}
@@ -1323,15 +1355,18 @@ boolean L11_hiddenCity()
 		{
 			if(have_effect($effect[Thrice-Cursed]) == 0)
 			{
-				L11_hiddenTavernUnlock(true);
-				while(have_effect($effect[Thrice-Cursed]) == 0 && inebriety_left() >= $item[Cursed Punch].inebriety && canDrink($item[Cursed Punch]) && my_ascensions() == get_property("hiddenTavernUnlock").to_int() && !in_tcrs())
+				if(canDrinkCursedPunch && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
 				{
-					buyUpTo(1, $item[Cursed Punch]);
-					if(item_amount($item[Cursed Punch]) == 0)
+					L11_hiddenTavernUnlock(true);
+					while(have_effect($effect[Thrice-Cursed]) == 0 && inebriety_left() >= $item[Cursed Punch].inebriety && my_ascensions() == get_property("hiddenTavernUnlock").to_int())
 					{
-						abort("Could not acquire Cursed Punch, unable to deal with Hidden Apartment Properly");
+						buyUpTo(1, $item[Cursed Punch]);
+						if(item_amount($item[Cursed Punch]) == 0)
+						{
+							abort("Could not acquire Cursed Punch, unable to deal with Hidden Apartment Properly");
+						}
+						autoDrink(1, $item[Cursed Punch]);
 					}
-					autoDrink(1, $item[Cursed Punch]);
 				}
 			}
 			auto_log_info("Hidden Apartment Progress: " + get_property("hiddenApartmentProgress"), "blue");

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1328,18 +1328,23 @@ boolean L11_hiddenCity()
 			
 			if(canDrinkCursedPunch)
 			{
-				L11_hiddenTavernUnlock(true);
+				boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti());
 				
-				if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
-					|| (0 != have_effect($effect[Thrice-Cursed]) && $location[The Hidden Apartment Building].turns_spent <= 4))
+				if(canBuyCursedPunch)
 				{
-					elevatorAction = auto_forceNextNoncombat();
+					L11_hiddenTavernUnlock(true);
 
-					if(in_pokefam())
+					if((my_ascensions() == get_property("hiddenTavernUnlock").to_int() && (inebriety_left() >= cursesNeeded*$item[Cursed Punch].inebriety))
+						|| (0 != have_effect($effect[Thrice-Cursed]) && $location[The Hidden Apartment Building].turns_spent <= 4))
 					{
-						if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+						elevatorAction = auto_forceNextNoncombat();
+
+						if(in_pokefam())
 						{
-							return autoAdv($location[The Hidden Apartment Building]);
+							if(get_property("relocatePygmyLawyer").to_int() != my_ascensions())
+							{
+								return autoAdv($location[The Hidden Apartment Building]);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
# Description

do hiddenTavernUnlock before looking at the availability of the tavern to force noncombat
try to respect user setting auto_consumeMinAdvPerFill for cursed punch while there is apartment delay, that's when autoscend didn't try cursed punch on its own before because it looked for the tavern before unlocking it
respect user setting auto_limitConsume for cursed punch
count amount of inebriety needed for Thrice-Cursed instead of 3
verify that Cursed Punch can be drunk before doing hiddenTavernUnlock for the apartment
verify that elevatorAction is not already going to happen before using forced noncombat
todo: in_tcrs check quality and size of cursed punch instead of skipping? if that is possible

## How Has This Been Tested?

QT run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
