### PR TITLE
auto_doGalaktik_initialize & renamed auto_alwaysGetSteelOrgan & GUI will configure setting defaults first

### DIFF
--- a/BUILD/settings/pre.dat
+++ b/BUILD/settings/pre.dat
@@ -1,1 +1,1 @@
-auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
+auto_getSteelOrgan_initialize	boolean	When we initialize an ascension this will be copied to auto_getSteelOrgan

--- a/BUILD/settings/pre.dat
+++ b/BUILD/settings/pre.dat
@@ -1,2 +1,1 @@
 auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
-auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik

--- a/BUILD/settings/pre.dat
+++ b/BUILD/settings/pre.dat
@@ -1,1 +1,2 @@
 auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
+auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik

--- a/BUILD/settings_extra/pre.dat
+++ b/BUILD/settings_extra/pre.dat
@@ -1,1 +1,1 @@
-auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
+auto_doGalaktik_initialize	boolean	When we initialize an ascension this will be copied to auto_doGalaktik

--- a/BUILD/settings_extra/pre.dat
+++ b/BUILD/settings_extra/pre.dat
@@ -1,1 +1,1 @@
-#
+auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -69,6 +69,7 @@ post	5	auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? rec
 post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
 
 pre	0	auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
+pre	1	auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 
 sharing	0	auto_disableExcavator	boolean	When set to true will disable automatically sending spading data via the Extractor script
 

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -68,7 +68,7 @@ post	4	auto_hippyInstead	boolean	Fight on the side of the hippies instead of the
 post	5	auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? recommended to set true if fighting for the hippies.
 post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
 
-pre	0	auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
+pre	0	auto_getSteelOrgan_initialize	boolean	When we initialize an ascension this will be copied to auto_getSteelOrgan
 
 sharing	0	auto_disableExcavator	boolean	When set to true will disable automatically sending spading data via the Extractor script
 

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -69,7 +69,6 @@ post	5	auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? rec
 post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
 
 pre	0	auto_alwaysGetSteelOrgan	boolean	When we next initialize settings it will be copied to auto_getSteelOrgan
-pre	1	auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 
 sharing	0	auto_disableExcavator	boolean	When set to true will disable automatically sending spading data via the Extractor script
 

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -53,7 +53,7 @@ post	29	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
 post	30	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
 post	31	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
-#
+pre	0	auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 
 #
 

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -53,7 +53,7 @@ post	29	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
 post	30	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
 post	31	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
-pre	0	auto_init_doGalaktik	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
+pre	0	auto_doGalaktik_initialize	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 
 #
 

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -163,6 +163,7 @@ void write_settings_key()
 
 void main()
 {
+	auto_settings();			//runs every time. upgrades old settings to newest format, delete obsolete settings, and configures defaults.
 	initializeSettings();		//runs once per ascension. should not handle anything other than intialising settings for this ascension.
 	
 	write_styles();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -152,12 +152,12 @@ void initializeSettings() {
 	set_property("auto_funTracker", "");
 	set_property("auto_getBoningKnife", false);
 	set_property("auto_getStarKey", true);
-	set_property("auto_getSteelOrgan", get_property("auto_alwaysGetSteelOrgan"));
+	set_property("auto_getSteelOrgan", get_property("auto_getSteelOrgan_initialize"));
 	set_property("auto_gnasirUnlocked", false);
 	set_property("auto_grimstoneFancyOilPainting", true);
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
-	set_property("auto_doGalaktik", get_property("auto_init_doGalaktik"));
+	set_property("auto_doGalaktik", get_property("auto_doGalaktik_initialize"));
 	set_property("auto_doArmory", false);
 	set_property("auto_doMeatsmith", false);
 	set_property("auto_L8_ninjaAssassinFail", false);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -157,7 +157,7 @@ void initializeSettings() {
 	set_property("auto_grimstoneFancyOilPainting", true);
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
-	set_property("auto_doGalaktik", false);
+	set_property("auto_doGalaktik", get_property("auto_init_doGalaktik"));
 	set_property("auto_doArmory", false);
 	set_property("auto_doMeatsmith", false);
 	set_property("auto_L8_ninjaAssassinFail", false);

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -130,6 +130,10 @@ void auto_settingsUpgrade()
 	{
 		set_property("auto_dontConsumeKeyLimePies", !get_property("auto_consumeKeyLimePies").to_boolean());
 	}
+	if(get_property("auto_alwaysGetSteelOrgan") != "")
+	{
+		set_property("auto_getSteelOrgan_initialize", get_property("auto_alwaysGetSteelOrgan"));
+	}
 }
 
 void auto_settingsFix()
@@ -244,6 +248,7 @@ void auto_settingsDelete()
 	remove_property("auto_mummeryChoice");
 	remove_property("auto_choice1119");
 	remove_property("auto_useTatter");				//obsolete combat directive to use [Tattered Scrap Of Paper] to escape combat
+	remove_property("auto_alwaysGetSteelOrgan");	//renamed to auto_getSteelOrgan_initialize
 }
 
 void defaultConfig(string prop, string val)


### PR DESCRIPTION
* added setting auto_doGalaktik_initialize (PRE type setting) which determines the state of auto_doGalaktik (POST type setting) when we initialize an ascension.
this allows you to set whether it should or should not do galaktik as a matter of course. By default it is set to false. Accounts lacking in IOTMs which struggle with meat might want to set it to true in the GUI.
**Note: POST type settings are used only for the current ascension and will be reset when you start a new ascension
**Note: PRE type settings are used only for the purpose of configuring POST type settings on initialization

* renamed auto_alwaysGetSteelOrgan to auto_getSteelOrgan_initialize and clarified its description. this is a pre type setting which gets copied to auto_getSteelOrgan on ascension initialization.

* GUI will now run auto_settings() before loading to configure defaults for newly added settings / delete obsolete settings / upgrade old formats to new formats.
 
## How Has This Been Tested?

tested via GUI

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
