### PR TITLE
avoid warnings that it fails to buy Platinum Yendorian Express Card

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -485,6 +485,14 @@ boolean LX_dailyDungeonToken()
 	{
 		pullXWhenHaveY($item[Ring of Detect Boring Doors], 1, 0);
 	}
+	if(item_amount($item[Pick-O-Matic Lockpicks]) == 0 && storage_amount($item[Platinum Yendorian Express Card]) > 0)
+	{
+		pullXWhenHaveY($item[Platinum Yendorian Express Card], 1, 0);
+	}
+	if(item_amount($item[Platinum Yendorian Express Card]) == 0)
+	{
+		pullXWhenHaveY($item[Pick-O-Matic Lockpicks], 1, 0);
+	}
 	
 	//if you do not have an unlimited lockpick then handle skeleton keys and verify primary stat
 	if(item_amount($item[Platinum Yendorian Express Card]) == 0 && item_amount($item[Pick-O-Matic Lockpicks]) == 0)
@@ -502,29 +510,12 @@ boolean LX_dailyDungeonToken()
 			create(skeleton_key_amt_to_create, $item[Skeleton Key]);
 		}
 		
-		//if you do not have enough skeleton keys pull an unlimited lockpick if possible
-		if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed)
+		//make sure we have the means to handle choice adventure 692 [I Wanna Be a Door]
+		if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed && my_basestat(my_primestat()) < 30)
 		{
-			if(item_amount($item[Pick-O-Matic Lockpicks]) == 0 && storage_amount($item[Platinum Yendorian Express Card]) > 0)
-			{
-				pullXWhenHaveY($item[Platinum Yendorian Express Card], 1, 0);
-			}
-			if(item_amount($item[Platinum Yendorian Express Card]) == 0)
-			{
-				pullXWhenHaveY($item[Pick-O-Matic Lockpicks], 1, 0);
-			}
-		}
-		
-		//if still no unlimited lockpick
-		if(item_amount($item[Platinum Yendorian Express Card]) == 0 && item_amount($item[Pick-O-Matic Lockpicks]) == 0)
-		{
-			//make sure we have the means to handle choice adventure 692 [I Wanna Be a Door]
-			if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed && my_basestat(my_primestat()) < 30)
-			{
-				//no lockpick, not enough skeleton key, and not enough primestat.
-				//checking basestat because buffed can become lower based on equipment worn. and also if mainstat is under 30 and you got no lockpicks then you should probably delay daily dungeon
-				return false;
-			}
+			//no lockpick, not enough skeleton key, and not enough primestat.
+			//checking basestat because buffed can become lower based on equipment worn. and also if mainstat is under 30 and you got no lockpicks then you should probably delay daily dungeon
+			return false;
 		}
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -485,14 +485,6 @@ boolean LX_dailyDungeonToken()
 	{
 		pullXWhenHaveY($item[Ring of Detect Boring Doors], 1, 0);
 	}
-	if(item_amount($item[Pick-O-Matic Lockpicks]) == 0)
-	{
-		pullXWhenHaveY($item[Platinum Yendorian Express Card], 1, 0);
-	}
-	if(item_amount($item[Platinum Yendorian Express Card]) == 0)
-	{
-		pullXWhenHaveY($item[Pick-O-Matic Lockpicks], 1, 0);
-	}
 	
 	//if you do not have an unlimited lockpick then handle skeleton keys and verify primary stat
 	if(item_amount($item[Platinum Yendorian Express Card]) == 0 && item_amount($item[Pick-O-Matic Lockpicks]) == 0)
@@ -510,12 +502,29 @@ boolean LX_dailyDungeonToken()
 			create(skeleton_key_amt_to_create, $item[Skeleton Key]);
 		}
 		
-		//make sure we have the means to handle choice adventure 692 [I Wanna Be a Door]
-		if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed && my_basestat(my_primestat()) < 30)
+		//if you do not have enough skeleton keys pull an unlimited lockpick if possible
+		if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed)
 		{
-			//no lockpick, not enough skeleton key, and not enough primestat.
-			//checking basestat because buffed can become lower based on equipment worn. and also if mainstat is under 30 and you got no lockpicks then you should probably delay daily dungeon
-			return false;
+			if(item_amount($item[Pick-O-Matic Lockpicks]) == 0 && storage_amount($item[Platinum Yendorian Express Card]) > 0)
+			{
+				pullXWhenHaveY($item[Platinum Yendorian Express Card], 1, 0);
+			}
+			if(item_amount($item[Platinum Yendorian Express Card]) == 0)
+			{
+				pullXWhenHaveY($item[Pick-O-Matic Lockpicks], 1, 0);
+			}
+		}
+		
+		//if still no unlimited lockpick
+		if(item_amount($item[Platinum Yendorian Express Card]) == 0 && item_amount($item[Pick-O-Matic Lockpicks]) == 0)
+		{
+			//make sure we have the means to handle choice adventure 692 [I Wanna Be a Door]
+			if(item_amount($item[Skeleton Key]) < skeleton_key_amt_needed && my_basestat(my_primestat()) < 30)
+			{
+				//no lockpick, not enough skeleton key, and not enough primestat.
+				//checking basestat because buffed can become lower based on equipment worn. and also if mainstat is under 30 and you got no lockpicks then you should probably delay daily dungeon
+				return false;
+			}
 		}
 	}
 	


### PR DESCRIPTION
# Description

lockpicks still get pulled if all extra keys get destroyed.
autoscend doesn't wait for keys to start daily dungeon, so this could end up wasting a meat paste or two instead of saving the pull but only when you get bones manually in a no cubeling path.

also avoid warnings that it fails to buy Platinum Yendorian Express Card if you don't have one in storage because you shouldn't try to autobuy that anyway?

## How Has This Been Tested?
only loaded in QT

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
