### PR TITLE
hotfix sauceror MP crash due to mortar delay

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2117,10 +2117,16 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	if((my_meat() > 7500) && (item_amount($item[Seal Tooth]) == 0))
+	if(item_amount($item[Seal Tooth]) == 0)
 	{
-		acquireHermitItem($item[Seal Tooth]);
+		//saucerors want to use sealtooth to delay so that mortar shell delivers final blow for weaksauce MP explosion
+		//TODO: add delaying for mortar for other classes in combat and then remove the sauceror requirement here.
+		if( my_meat() > 7500 || (my_class() == $class[Sauceror] && canUse($skill[Stuffed Mortar Shell])) )
+		{
+			acquireHermitItem($item[Seal Tooth]);
+		}
 	}
+	
 
 	if(my_class() == $class[Turtle Tamer])
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -57,6 +57,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	remove_property("auto_funPrefix");						//ocrs specific tracker
 	set_property("auto_combatHandlerThunderBird", "0");
 	set_property("auto_combatHandlerFingernailClippers", "0");
+	set_property("_auto_combatTracker_MortarRound", -1);		//tracks which round we used Stuffed Mortar Shell in.
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -143,6 +143,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	//mortar shell is amazing. it really should not be limited to sauceror only.
 	if(canUse($skill[Stuffed Mortar Shell]) && (my_class() == $class[Sauceror]) && canSurvive(2.0) && (currentFlavour() != monster_element(enemy) || currentFlavour() == $element[none]))
 	{
+		set_property("_auto_combatTracker_MortarRound", round);
 		return useSkill($skill[Stuffed Mortar Shell]);
 	}
 
@@ -290,10 +291,16 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMinor = mp_cost($skill[Stream of Sauce]);
 			costMajor = mp_cost($skill[Stream of Sauce]);
 		}
-
-		if(!contains_text(combatState, "delaymortarshell") && canSurvive(2.0) && haveUsed($skill[Stuffed Mortar Shell]) && canUse($skill[Salsaball], false))
+		
+		#let mortar deal the killing blow so we get more MP from the exploding curse of weaksauce
+		int mortar_round = get_property("_auto_combatTracker_MortarRound").to_int();
+		if(mortar_round > -1 &&		//mortar was used this combat
+		mortar_round == round-1 &&	//mortar will hit this round
+		canSurvive(2.0) &&			//monster is not too scary to play games with
+		monster_hp() > 15 &&		//if monster has too few HP left we can accidentally kill it with salsaball and get only 2MP back
+		//TODO make sure mortar will actually kill it
+		canUse($skill[Salsaball], false))
 		{
-			set_property("auto_combatHandler", combatState + "(delaymortarshell)");
 			return useSkill($skill[Salsaball], false);
 		}
 		break;

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -296,13 +296,21 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		int mortar_round = get_property("_auto_combatTracker_MortarRound").to_int();
 		if(mortar_round > -1 &&		//mortar was used this combat
 		mortar_round == round-1 &&	//mortar will hit this round
-		canSurvive(2.0) &&			//monster is not too scary to play games with
-		monster_hp() > 15 &&		//if monster has too few HP left we can accidentally kill it with salsaball and get only 2MP back
 		//TODO make sure mortar will actually kill it
-		canUse($skill[Salsaball], false))
+		canSurvive(2.0))			//monster is not too scary.
 		{
-			return useSkill($skill[Salsaball], false);
+			if(monster_hp() > 1 &&		//avoid killing blow with seal tooth or else 0 MP will be given
+			canUse($item[Seal Tooth], false))
+			{
+				return useItem($item[Seal Tooth], false);
+			}
+			if(monster_hp() > 15 &&		//avoid killing blow with salsaball or else ~2MP will be given
+			canUse($skill[Salsaball], false))
+			{
+				return useSkill($skill[Salsaball], false);
+			}
 		}
+		
 		break;
 
 	case $class[Avatar of Boris]:


### PR DESCRIPTION
hotfix sauceror MP crash (and subsequent meat crash as it has to keep on buying galaktik consumables to fuel its crashing MP) caused by a function that was trying to get more MP from the curse of weaksauce explosion. We were trying to let mortar deal the killing blow so we get extra MP... to facilitate that we were delaying with salsaball, but accidentally killing the enemy with salsaball and only getting back 2MP. Thus losing lots of MP per combat instead of gaining MP. With the sauceror profligate spending of MP outside of combat it combined into poverty.

Now it will prefer to delay with seal tooth and will check that salsaball does not kill the monster before casting it. Exact calculation is still in the works, but this will estimate things with making sure enemy HP is higher than 15 for salsaball and 1 for seal tooth.

also better tracking on which round we used mortar in

a more comprehensive and optimal solution is still in development in #845

## How Has This Been Tested?

multiple accounts tested in QT runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
