### PR TITLE
update outdated conditions for nightmare fuel

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1437,7 +1437,7 @@ int auto_spleenFamiliarAdvItemsPossessed()
 	
 	foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease, beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]
 	{
-		if(auto_is_valid(it))
+		if(auto_is_valid(it) && mall_price(it) < get_property("autoBuyPriceLimit").to_int())	//even when not mallbuying them we do not want to use exceptionally expensive items
 		{
 			spleenFamiliarAdvItemsCount += item_amount(it);
 		}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1429,6 +1429,23 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 	return true;
 }
 
+int auto_spleenFamiliarAdvItemsPossessed() 
+{
+	//returns how many size 4 items from spleen familiars in possession
+	
+	int spleenFamiliarAdvItemsCount = 0;
+	
+	foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease, beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]
+	{
+		if(auto_is_valid(it))
+		{
+			spleenFamiliarAdvItemsCount += item_amount(it);
+		}
+	}
+	
+	return spleenFamiliarAdvItemsCount;
+}
+
 boolean auto_breakfastCounterVisit() {
 	if (item_amount($item[earthenware muffin tin]) > 0 ||
 	    (!get_property("_muffinOrderedToday").to_boolean() && 

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -492,22 +492,7 @@ boolean autoChooseFamiliar(location place)
 	//Should take around 10 combats to grab enough on day 1 and on subsequent days you should already have them from previous days.
 	if(famChoice == $familiar[none])
 	{
-		int available_spleen_items_size = 0;
-		foreach it in $items[Agua De Vida, Grim Fairy Tale, Groose Grease, Powdered Gold, Unconscious Collective Dream Jar]
-		{
-			if (auto_is_valid(it))
-			{
-				available_spleen_items_size += 4 * item_amount(it);
-			}
-		}
-		foreach it in $items[beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste]
-		{
-			//count pastes from fairy-worn boots. excepting excessively expensive pastes.
-			if (auto_is_valid(it) && auto_mall_price(it) < 10000 + auto_mall_price($item[gooey paste]))
-			{
-				available_spleen_items_size += 4 * item_amount(it);
-			}
-		}
+		int available_spleen_items_size = 4 * auto_spleenFamiliarAdvItemsPossessed();
 		
 		if(spleen_left() >= (4 + available_spleen_items_size) && haveSpleenFamiliar())
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1058,6 +1058,7 @@ void auto_printNightcap();
 void auto_drinkNightcap();
 boolean auto_autoConsumeOne(string type, boolean simulate);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
+int auto_spleenFamiliarAdvItemsPossessed();
 boolean auto_breakfastCounterVisit();
 item still_targetToOrigin(item target);
 boolean stillReachable();

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -417,7 +417,7 @@ void auto_setSongboom()
 	}
 	else if (!isActuallyEd() && internalQuestStatus("questL07Cyrptic") < 1 && 
 	!(auto_havePillKeeper() && spleen_left() >= 3) && 
-	!(haveSpleenFamiliar() && spleen_left() >= 4) && 
+	(spleen_left() > 4*min(auto_spleenFamiliarAdvItemsPossessed(),floor(spleen_left()/4))) &&	//only uses space than can't be filled with adv item
 	get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
 	{
 		songboomSetting("nightmare");

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -415,7 +415,10 @@ void auto_setSongboom()
 		// Once we've started the war, we want to be able to micromanage songs
 		// for Gremlins and Nuns. Don't break this for them.
 	}
-	else if (!isActuallyEd() && !auto_havePillKeeper() && internalQuestStatus("questL07Cyrptic") < 1 && get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
+	else if (!isActuallyEd() && internalQuestStatus("questL07Cyrptic") < 1 && 
+	!(auto_havePillKeeper() && spleen_left() >= 3) && 
+	!(haveSpleenFamiliar() && spleen_left() >= 4) && 
+	get_property("_boomBoxFights").to_int() == 10 && get_property("_boomBoxSongsLeft").to_int() > 3)
 	{
 		songboomSetting("nightmare");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -35,7 +35,7 @@ boolean L7_crypt()
 		//chews this when there are no guaranteed uses for spleen 
 		if((spleen_left() > 0) && (item_amount($item[Nightmare Fuel]) > 0) && !isActuallyEd() && 
 		!(auto_havePillKeeper() && spleen_left() >= 3) && 
-		!(haveSpleenFamiliar() && spleen_left() >= 4))
+		(spleen_left() > 4*min(auto_spleenFamiliarAdvItemsPossessed(),floor(spleen_left()/4))))	//only uses space than can't be filled with adv item
 		{
 			autoChew(1, $item[Nightmare Fuel]);
 		}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -32,7 +32,10 @@ boolean L7_crypt()
 
 	void useNightmareFuelIfPossible()
 	{
-		if((spleen_left() > 0) && (item_amount($item[Nightmare Fuel]) > 0) && !is_unrestricted($item[Powdered Gold]))
+		//chews this when there are no guaranteed uses for spleen 
+		if((spleen_left() > 0) && (item_amount($item[Nightmare Fuel]) > 0) && !isActuallyEd() && 
+		!(auto_havePillKeeper() && spleen_left() >= 3) && 
+		!(haveSpleenFamiliar() && spleen_left() >= 4))
 		{
 			autoChew(1, $item[Nightmare Fuel]);
 		}


### PR DESCRIPTION
# Description

I saw an outdated condition that tries to use a spleen item if Powdered Gold is restricted. Now both that item and Powdered Gold are restricted together except in G lover. so autoscend produces the item but never uses it
I think it was trying to use it only in standard when there were no other uses for spleen. it makes more sense to use the same conditions to produce and use that item

## How Has This Been Tested?

not tested

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
