### PR TITLE
allow chewing spleen for adventures from familiars

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1438,14 +1438,13 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 boolean auto_chewAdventures()
 {
 	//tries to chew a size 4 familiar spleen item that gives adventures. All are IOTM derivatives with 1.875 adv/size
-	//since these items are not very good we wait until only 1 adv remains in case something better comes up for spleen.
 	if(my_inebriety() < inebriety_limit() || my_fullness() < fullness_limit() || my_adventures() > 1+auto_advToReserve())
 	{
-		return false;
+		return false;	//1.875 A/S is bad. only chew if 1 adv remains
 	}
 	if(isActuallyEd())
 	{
-		return false;	//this function should not get called in ed. just in case another check here since these are really bad for ed.
+		return false;	//these consumables are very bad for ed, who has a path specific spleen consumable shop.
 	}
 	if(spleen_left() < 4)
 	{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1438,7 +1438,8 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 boolean auto_chewAdventures()
 {
 	//tries to chew a size 4 familiar spleen item that gives adventures. All are IOTM derivatives with 1.875 adv/size
-	if(my_inebriety() < inebriety_limit() || my_fullness() < fullness_limit() || my_adventures() > 1+auto_advToReserve())
+	boolean liver_check = my_inebriety() < inebriety_limit() && !in_kolhs();	//kolhs has special drinking. liver often unfilled
+	if(liver_check || my_fullness() < fullness_limit() || my_adventures() > 1+auto_advToReserve())
 	{
 		return false;	//1.875 A/S is bad. only chew if 1 adv remains
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -596,15 +596,12 @@ void consumeStuff()
 				return;
 			}
 		}
+	}
 	
-		if (spleen_left() >= 4 && !isActuallyEd())
-		{
-			if (auto_chewAdventures())
-			{
-				return;
-			}
-
-		}
+	//if stomach and liver are full and out of adv then chew size 4 iotm derivate spleen items that give 1.875 adv/size.
+	if (auto_chewAdventures())
+	{
+		return;
 	}
 }
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -598,7 +598,7 @@ void consumeStuff()
 		}
 	}
 	
-	//if stomach and liver are full and out of adv then chew size 4 iotm derivate spleen items that give 1.875 adv/size.
+	//if stomach and liver are full and out of adv then chew size 4 iotm derivative spleen items that give 1.875 adv/size.
 	if (auto_chewAdventures())
 	{
 		return;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1441,15 +1441,7 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 boolean auto_chewAdventures()
 {
 	//tries to chew a size 4 familiar spleen item for adventures
-
-	//these items are all out of standard except in Quantum Terrarium
-	if(!is_unrestricted($item[Unconscious Collective Dream Jar]) && !is_unrestricted($item[Powdered Gold]) && !is_unrestricted($item[gooey paste]))
-	{
-		//if all these are restricted this must be standard. no point continuing if standard restrictions apply
-		return false;
-	}
-
-	//called to eat size 4 spleen items when adventures < 10 and we can't eat or drink anything
+	//called when adventures < 10 and we can't eat or drink anything
 
 	int oldSpleenUse = my_spleen_use();
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -599,7 +599,11 @@ void consumeStuff()
 	
 		if (spleen_left() >= 4 && !isActuallyEd())
 		{
-			auto_chewAdventures();
+			if (auto_chewAdventures())
+			{
+				return;
+			}
+
 		}
 	}
 }
@@ -1439,10 +1443,9 @@ boolean auto_chewAdventures()
 	//tries to chew a size 4 familiar spleen item for adventures
 
 	//these items are all out of standard except in Quantum Terrarium
-	if(!is_unrestricted($item[Unconscious Collective Dream Jar]) && !is_unrestricted($item[Powdered Gold]) && !is_unrestricted($item[beastly paste]))
+	if(!is_unrestricted($item[Unconscious Collective Dream Jar]) && !is_unrestricted($item[Powdered Gold]) && !is_unrestricted($item[gooey paste]))
 	{
-		//powdered gold is also restricted in G lover, but if all these are restricted this must be standard
-		//no point continuing if standard restrictions apply
+		//if all these are restricted this must be standard. no point continuing if standard restrictions apply
 		return false;
 	}
 
@@ -1484,10 +1487,7 @@ boolean auto_chewAdventures()
 				}
 			}
 		}
-		if(have_effect($effect[Just the Best Anapests])>0)
-		{
-			uneffect($effect[Just the Best Anapests]);
-		}
+		//text altering effect from Groose Grease should get removed by resetState
 		if(my_level() >= 4 && oldSpleenUse == my_spleen_use())
 		{
 			foreach it in $items[beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -596,6 +596,11 @@ void consumeStuff()
 				return;
 			}
 		}
+	
+		if (spleen_left() >= 4 && !isActuallyEd())
+		{
+			auto_chewAdventures();
+		}
 	}
 }
 
@@ -1427,6 +1432,78 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 
 	auto_log_info("Expected " + total_adv + " adventures, got " + (my_adventures() - pre_adventures), "blue");
 	return true;
+}
+
+boolean auto_chewAdventures()
+{
+	//tries to chew a size 4 familiar spleen item for adventures
+
+	//these items are all out of standard except in Quantum Terrarium
+	if(!is_unrestricted($item[Unconscious Collective Dream Jar]) && !is_unrestricted($item[Powdered Gold]) && !is_unrestricted($item[beastly paste]))
+	{
+		//powdered gold is also restricted in G lover, but if all these are restricted this must be standard
+		//no point continuing if standard restrictions apply
+		return false;
+	}
+
+	//called to eat size 4 spleen items when adventures < 10 and we can't eat or drink anything
+
+	int oldSpleenUse = my_spleen_use();
+
+	//do we wait until the last adventure to chew spleen?
+	boolean waitUntilLastAdventure = false;
+	if(item_amount($item[stench jelly]) >= 2)
+	{
+		int spleenForStenchJelly = min(my_adventures(),item_amount($item[stench jelly]));
+		//wait if chewing 4 spleen would take away the chance to use 2 or more stench jellies
+		if (oldSpleenUse - spleenForStenchJelly <= 2)
+		{
+			waitUntilLastAdventure = true;
+		}
+	}
+	if(auto_havePillKeeper() && spleen_left() == 6)
+	{
+		//if you have pill keeper maybe two force noncombat is better than chewing for adventures?
+		waitUntilLastAdventure = true;
+	}
+	if(waitUntilLastAdventure && my_adventures() > 1+auto_advToReserve())
+	{
+		return false;
+	}
+
+	if(spleen_left() >= 4)
+	{
+		//first the ones without the level 4 requirement because they give more stats
+		foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease]
+		{
+			if(item_amount(it) > 0)
+			{
+				if(autoChew(1, it))
+				{
+					break;
+				}
+			}
+		}
+		if(have_effect($effect[Just the Best Anapests])>0)
+		{
+			uneffect($effect[Just the Best Anapests]);
+		}
+		if(my_level() >= 4 && oldSpleenUse == my_spleen_use())
+		{
+			foreach it in $items[beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]
+			{
+				if(item_amount(it) > 0)
+				{
+					if (autoChew(1, it))
+					{
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	return oldSpleenUse != my_spleen_use();
 }
 
 boolean auto_breakfastCounterVisit() {

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1458,8 +1458,7 @@ boolean auto_chewAdventures()
 	item target = $item[none];
 	int target_value = 0;
 	
-	//first the ones without the level 4 requirement because they give more stats
-	foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease]
+	void chooseCheapestTarget(item it)
 	{
 		if(item_amount(it) > 0 && auto_is_valid(it) &&
 		mall_price(it) < get_property("autoBuyPriceLimit").to_int())	//do not chew very expensive items even if already in inv
@@ -1471,19 +1470,17 @@ boolean auto_chewAdventures()
 			}
 		}
 	}
+	
+	//first the ones without the level 4 requirement because they give more stats
+	foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease]
+	{
+		chooseCheapestTarget(it);
+	}
 	if(my_level() >= 4 && target == $item[none])
 	{
 		foreach it in $items[beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]
 		{
-			if(item_amount(it) > 0 && auto_is_valid(it) &&
-			mall_price(it) < get_property("autoBuyPriceLimit").to_int())	//do not chew very expensive items even if already in inv
-			{
-				if(target == $item[none] || mall_price(it) < target_value)
-				{
-					target = it;
-					target_value = mall_price(it);
-				}
-			}
+			chooseCheapestTarget(it);
 		}
 	}
 	

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1058,6 +1058,7 @@ void auto_printNightcap();
 void auto_drinkNightcap();
 boolean auto_autoConsumeOne(string type, boolean simulate);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
+boolean auto_chewAdventures();
 boolean auto_breakfastCounterVisit();
 item still_targetToOrigin(item target);
 boolean stillReachable();

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -113,6 +113,12 @@ void kolhs_consume()
 		auto_autoConsumeOne("drink", false);
 		return;
 	}
+	
+	//if stomach and liver are full and out of adv then chew size 4 iotm derivate spleen items that give 1.875 adv/size.
+	if (auto_chewAdventures())
+	{
+		return;
+	}
 }
 
 void kolhs_preadv(location place)


### PR DESCRIPTION
redoing #840

# Description

chew spleen items that provide adventures if we do not have something better to chew.
relevant to QT because those old familiars can appear there and can drop those chewables. and they are not standard restricted in QT

## How Has This Been Tested?

normal QT runs with 0 iotms. one chewed 3 Powdered Gold, another account chewed 1 aqua de vida.
that is all they chewed at all, most of their spleen was still empty.
2 more runs did not have anything to chew

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
