### PR TITLE
isAttackFamiliar accuracy improved for [Mini-Adventurer] & [Reagnimated Gnome]

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -53,7 +53,6 @@ boolean isAttackFamiliar(familiar fam)
 	//these familiars vary by configuration. TODO actually check their configuration
 	if($familiars[Mini-Crimbot,
 	El Vibrato Megadrone,
-	Reagnimated Gnome,
 	Reanimated Reanimator,
 	Comma Chameleon,
 	Mad Hatrack,
@@ -66,10 +65,21 @@ boolean isAttackFamiliar(familiar fam)
 	{
 		int miniAdvClass = get_property("miniAdvClass").to_int();
 		if(miniAdvClass == 1 || (miniAdvClass == 2 && my_level() >= 5) || (miniAdvClass == 3 && my_level() >= 15) ||
-		(miniAdvClass == 4 && my_level() >= 5) || (miniAdvClass == 4 && my_level() >= 10))
+		(miniAdvClass == 4 && my_level() >= 5) || (miniAdvClass == 5 && my_level() >= 10))
 		{
 			return true;
 		}
+		return false;
+	}
+	if(fam == $familiar[Reagnimated Gnome])
+	{
+		//can be an attack familiar with this part equipped
+		//todo: is it possible to know if it will be equipped after this check?
+		if(possessEquipment($item[gnomish athlete's foot]))
+		{
+			return true;
+		}
+		//but not if the part is not even owned
 		return false;
 	}
 	

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -64,8 +64,11 @@ boolean isAttackFamiliar(familiar fam)
 	if(fam == $familiar[Mini-Adventurer])
 	{
 		int miniAdvClass = get_property("miniAdvClass").to_int();
-		if(miniAdvClass == 1 || (miniAdvClass == 2 && my_level() >= 5) || (miniAdvClass == 3 && my_level() >= 15) ||
-		(miniAdvClass == 4 && my_level() >= 5) || (miniAdvClass == 5 && my_level() >= 10))
+		if(miniAdvClass == 1 ||		//seal clubber
+		(miniAdvClass == 2 && my_level() >= 5) ||		//turtle tamer
+		(miniAdvClass == 3 && my_level() >= 15) ||		//pastamancer
+		(miniAdvClass == 4 && my_level() >= 5) ||		//sauceror
+		(miniAdvClass == 5 && my_level() >= 10))		//disco bandit
 		{
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -54,7 +54,6 @@ boolean isAttackFamiliar(familiar fam)
 	if($familiars[Mini-Crimbot,
 	El Vibrato Megadrone,
 	Reagnimated Gnome,
-	Mini-Adventurer,
 	Reanimated Reanimator,
 	Comma Chameleon,
 	Mad Hatrack,
@@ -62,6 +61,16 @@ boolean isAttackFamiliar(familiar fam)
 	] contains fam)
 	{
 		return true;
+	}
+	if(fam == $familiar[Mini-Adventurer])
+	{
+		int miniAdvClass = get_property("miniAdvClass").to_int();
+		if(miniAdvClass == 1 || (miniAdvClass == 2 && my_level() >= 5) || (miniAdvClass == 3 && my_level() >= 15) ||
+		(miniAdvClass == 4 && my_level() >= 5) || (miniAdvClass == 4 && my_level() >= 10))
+		{
+			return true;
+		}
+		return false;
 	}
 	
 	if($familiars[Doppelshifter,				//random familiar every fight. can be an attack familiar


### PR DESCRIPTION
# Description

check configuration of mini-adventurer for isAttackFamiliar

## How Has This Been Tested?

tested in mafia CLI in QT

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
