### PR TITLE
Olfaction/SGEEA fix(es)

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -1,7 +1,5 @@
 pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
-Gurgle the Turgle
 Writing Desk	!prop:writingDesksDefeated=5
-Smoke Monster	item:Pack of Smokes>0
 cabinet of Dr. Limpieza
 Dairy Goat	loc:The Goatlet
 Morbid Skull
@@ -17,14 +15,14 @@ Bob Racecar	!sniffed:Racecar Bob
 Racecar Bob	!sniffed:Bob Racecar
 Government Scientist	class:Ed
 Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
-War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
-War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
+War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
+War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
 Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>28
 Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
 Serialbus	item:bus pass<5
 CH Imp	item:imp air<5
-Camel Toe
-Skinflute
+Camel Toe	!sniffed:Skinflute
+Skinflute	!sniffed:Camel Toe
 Red Butler

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -96,35 +96,33 @@ replace	38	Ferocious Bugbear	path:Community Service;loc:The Haiku Dungeon
 replace	39	Gelatinous Cube	path:Community Service;loc:The Haiku Dungeon
 
 sniff	0	pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
-sniff	1	Gurgle the Turgle
-sniff	2	Writing Desk	!prop:writingDesksDefeated=5
-sniff	3	Smoke Monster	item:Pack of Smokes>0
-sniff	4	cabinet of Dr. Limpieza
-sniff	5	Dairy Goat	loc:The Goatlet
-sniff	6	Morbid Skull
-sniff	7	Pygmy Bowler
-sniff	8	Pygmy Witch Surgeon
-sniff	9	pygmy witch accountant	loc:The Hidden Office Building
-sniff	10	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
-sniff	11	Pygmy Janitor	loc:The Hidden Park;!tavern:true
-sniff	12	Quiet Healer
-sniff	13	Tomb Rat
-sniff	14	Blooper	loc:8-Bit Realm
-sniff	15	Bob Racecar	!sniffed:Racecar Bob
-sniff	16	Racecar Bob	!sniffed:Bob Racecar
-sniff	17	Government Scientist	class:Ed
-sniff	18	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
-sniff	19	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
-sniff	20	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5
-sniff	21	Possessed Wine Rack
-sniff	22	Blue Oyster cultist
-sniff	23	Dirty Old Lihc	prop:cyrptNicheEvilness>28
-sniff	24	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
-sniff	25	Serialbus	item:bus pass<5
-sniff	26	CH Imp	item:imp air<5
-sniff	27	Camel Toe
-sniff	28	Skinflute
-sniff	29	Red Butler
+sniff	1	Writing Desk	!prop:writingDesksDefeated=5
+sniff	2	cabinet of Dr. Limpieza
+sniff	3	Dairy Goat	loc:The Goatlet
+sniff	4	Morbid Skull
+sniff	5	Pygmy Bowler
+sniff	6	Pygmy Witch Surgeon
+sniff	7	pygmy witch accountant	loc:The Hidden Office Building
+sniff	8	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
+sniff	9	Pygmy Janitor	loc:The Hidden Park;!tavern:true
+sniff	10	Quiet Healer
+sniff	11	Tomb Rat
+sniff	12	Blooper	loc:8-Bit Realm
+sniff	13	Bob Racecar	!sniffed:Racecar Bob
+sniff	14	Racecar Bob	!sniffed:Bob Racecar
+sniff	15	Government Scientist	class:Ed
+sniff	16	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
+sniff	17	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
+sniff	18	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
+sniff	19	Possessed Wine Rack
+sniff	20	Blue Oyster cultist
+sniff	21	Dirty Old Lihc	prop:cyrptNicheEvilness>28
+sniff	22	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+sniff	23	Serialbus	item:bus pass<5
+sniff	24	CH Imp	item:imp air<5
+sniff	25	Camel Toe	!sniffed:Skinflute
+sniff	26	Skinflute	!sniffed:Camel Toe
+sniff	27	Red Butler
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography


### PR DESCRIPTION
# Description

Issue raised in Discord by @HippoKingKoL

- fix SGEEA removing On the Trail for Camel Toe/Skinflute unnecessarily
- same fix for War Hippies in KoE
- clean up some old redundant crap from cc_ascend days.

## How Has This Been Tested?

Hasn't but the changes are a copy of the Bob Racecar/Racecar Bob entries which works as expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
