### PR TITLE
Release lock on snake zones once we are actively looking for that zone's snake.

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -845,7 +845,7 @@ boolean L10_rainOnThePlains();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_11.ash
-int shenItemsReturned();
+int shenItemsReturnedOrInProgress();
 boolean[location] shenSnakeLocations(int day, int n_items_returned);
 boolean[location] shenZonesToAvoidBecauseMaybeSnake();
 boolean shenShouldDelayZone(location loc);

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -337,8 +337,7 @@ boolean L10_holeInTheSkyUnlock()
 		return false;
 	}
 	int day = get_property("shenInitiationDay").to_int();
-	int items_returned = shenItemsReturned();
-	boolean[location] shenLocs = shenSnakeLocations(day, items_returned);
+	boolean[location] shenLocs = shenSnakeLocations(day, 0);
 	if (!needStarKey() && !(shenLocs contains $location[The Hole in the Sky]))
 	{
 		// we force auto_holeinthesky to true in L11_shenCopperhead() as Ed if Shen sends us to the Hole in the Sky

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -104,12 +104,12 @@ desert_buff_record desertBuffs()
     return dbr;
 }
 
-int shenItemsReturned()
+int shenItemsReturnedOrInProgress()
 {
 	int progress = internalQuestStatus("questL11Shen");
-	if (progress < 3) return 0;
-	if (progress < 5) return 1;
-	else if (progress < 7) return 2;
+	if (progress < 1) return 0;
+	if (progress < 3) return 1;
+	else if (progress < 5) return 2;
 	else return 3;
 }
 
@@ -172,7 +172,7 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 	if (get_property("shenInitiationDay").to_int() > 0)
 	{
 		int day = get_property("shenInitiationDay").to_int();
-		int items_returned = shenItemsReturned();
+		int items_returned = shenItemsReturnedOrInProgress();
 		return shenSnakeLocations(day, items_returned);
 	}
 	else


### PR DESCRIPTION
# Description

Currently, the L11 shen snake handler attempts to delegate quest zones to the appropriate quest handler, notably Smut Orc Camp and Top Floor of the Castle in the sky. Unfortunately, the first check these handlers perform is whether a soft lock is in place on these zones because we may potentially find a snake there later- which will always be the case if we are in this situation- leading to the delegation failing and us autoadventuring in the snake zone instead, leading to inefficiencies and aborts.

This PR fixes the above issue by releasing the shen soft lock on zones where we are actively looking for the snake, instead of only releasing the lock once the snake for that zone has been found.

## How Has This Been Tested?

Tested in failing case and appears to be functioning in regular ascension. Not yet tested under SCP conditions.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
