### PR TITLE
Fix Tavern Cellar Refresh

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -115,7 +115,9 @@ boolean auto_tavern()
 	string tavern = get_property("tavernLayout");
 	if(tavern == "0000000000000000000000000")
 	{
+		// visit cellar then refresh layout property
 		string temp = visit_url("cellar.php");
+		tavern = get_property("tavernLayout");
 		if(tavern == "0000000000000000000000000")
 		{
 			abort("Invalid Tavern Configuration, could not visit cellar and repair. Uh oh...");


### PR DESCRIPTION
# Description

Sloon reported in Discord script aborts when tavern cellar layout is invalid. Looked at code and there is an automatic retry to fix stale data. However there's a bug where the property value isn't refreshed.

Error reported:
![image](https://user-images.githubusercontent.com/4781473/126582103-97bccf99-5d14-4890-9151-f563d9d1a78e.png)


Fixes # (issue)

## How Has This Been Tested?

gCLI. Forced invalid layout and then confirmed existing code does properly refresh the layout. Just had to add another get_property to refresh the tavern variable.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
