### PR TITLE
do not autosell in way of the surprising fist

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2430,6 +2430,10 @@ boolean autosellCrap()
 	{
 		return false;		//do not autosell stuff in casual or postronin unless you are very poor
 	}
+	if(my_path() == "Way of the Surprising Fist") 
+	{
+		return false;		//selling things in the way of the suprising fist only donates the money to charity, so we should not autosell anything automatically
+	}
 	foreach it in $items[dense meat stack, meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
 	{
 		if(item_amount(it) > 0)


### PR DESCRIPTION
# Description
If we are currently in the Way of the Surprising Fist challenge path, items should not be autosold as all the acquired meat will be donated to charity. If the player wants to donate to charity, they can do that manually.

## How Has This Been Tested?
Added my section of code with a print() function to confirm that we exited the autosell crap function automatically. Reaffirmed by watching as it acquired a Gathered Meat-Clip and then printed my statement, leaving the meat clip in the inventory. Print statement removed for this PR, but the functionality remains.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
