### PR TITLE
provide info on combat initialize and expand pre_adv footer info

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -7,6 +7,21 @@ void print_footer()
 	string next_line = "HP: " +my_hp()+ "/" +my_maxhp()+ ", MP: " +my_mp()+ "/" +my_maxmp()+ ", Meat: " +my_meat();
 	switch(my_class())
 	{
+		case $class[Seal Clubber]:
+			next_line += ", Fury: " +my_fury()+ "/" +my_maxfury();
+			break;
+		case $class[Turtle Tamer]:
+			foreach ttbless in $effects[Blessing of the War Snapper, Grand Blessing of the War Snapper, Glorious Blessing of the War Snapper, Blessing of She-Who-Was, Grand Blessing of She-Who-Was, Glorious Blessing of She-Who-Was, Blessing of the Storm Tortoise, Grand Blessing of the Storm Tortoise, Glorious Blessing of the Storm Tortoise]
+			{
+				if(have_effect(ttbless) > 0)
+				{
+					next_line += ", Blessing: " +ttbless;
+				}
+			}
+			break;	
+		case $class[Pastamancer]:
+			next_line += ", Thrall: [" +my_thrall()+ "]";
+			break;
 		case $class[Sauceror]:
 			next_line += ", Soulsauce: " +my_soulsauce();
 			break;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -2,7 +2,7 @@ import<autoscend.ash>
 
 void print_footer()
 {
-	auto_log_info(my_name()+ ": [" +my_class()+ "] @ path of [" +my_path()+ "]", "blue");
+	auto_log_info("[" +my_class()+ "] @ path of [" +my_path()+ "]", "blue");
 	
 	string next_line = "HP: " +my_hp()+ "/" +my_maxhp()+ ", MP: " +my_mp()+ "/" +my_maxmp()+ ", Meat: " +my_meat();
 	switch(my_class())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -5,7 +5,7 @@ void print_footer() {
 	if (my_class() == $class[Sauceror]) {
 		auto_log_info("Soulsauce: " + my_soulsauce(), "blue");
 	}
-	auto_log_info("Familiar: " + my_familiar().to_string() + " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
+	auto_log_info("Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
 	auto_log_info("ML: " + monster_level_adjustment() + " Encounter: " + combat_rate_modifier() + " Init: " + initiative_modifier(), "blue");
 	auto_log_info("Exp Bonus: " + experience_bonus() + " Meat Drop: " + meat_drop_modifier() + " Item Drop: " + item_drop_modifier(), "blue");
 	auto_log_info("Resists: " + numeric_modifier("Hot Resistance") + "/" + numeric_modifier("Cold Resistance") + "/" + numeric_modifier("Stench Resistance") + "/" + numeric_modifier("Spooky Resistance") + "/" + numeric_modifier("Sleaze Resistance"), "blue");
@@ -20,7 +20,7 @@ boolean auto_pre_adventure()
 		return true;
 	}
 	auto_log_info("Starting preadventure script...", "green");
-	auto_log_debug("Adventuring at " + place.to_string(), "green");
+	auto_log_debug("Adventuring at " +place, "green");
 	
 	preAdvUpdateFamiliar(place);
 	ed_handleAdventureServant(place);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1,14 +1,44 @@
 import<autoscend.ash>
 
-void print_footer() {
-	auto_log_info("HP: " + my_hp() + "/" + my_maxhp() + ", MP: " + my_mp() + "/" + my_maxmp() + " Meat: " + my_meat(), "blue");
-	if (my_class() == $class[Sauceror]) {
-		auto_log_info("Soulsauce: " + my_soulsauce(), "blue");
+void print_footer()
+{
+	auto_log_info(my_name()+ ": [" +my_class()+ "] @ path of [" +my_path()+ "]", "blue");
+	
+	string next_line = "HP: " +my_hp()+ "/" +my_maxhp()+ ", MP: " +my_mp()+ "/" +my_maxmp()+ ", Meat: " +my_meat();
+	switch(my_class())
+	{
+		case $class[Sauceror]:
+			next_line += ", Soulsauce: " +my_soulsauce();
+			break;
 	}
+	auto_log_info(next_line, "blue");
+	
+	int bonus_mus = my_buffedstat($stat[muscle]) - my_basestat($stat[muscle]);
+	int bonus_mys = my_buffedstat($stat[mysticality]) - my_basestat($stat[mysticality]);
+	int bonus_mox = my_buffedstat($stat[moxie]) - my_basestat($stat[moxie]);
+	auto_log_info("mus: " +my_basestat($stat[muscle])+ " + " +bonus_mus+
+	". mys: " +my_basestat($stat[mysticality])+ " + " +bonus_mys+
+	". mox: " +my_basestat($stat[moxie])+ " + " +bonus_mox, "blue");
+	
 	auto_log_info("Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
 	auto_log_info("ML: " + monster_level_adjustment() + " Encounter: " + combat_rate_modifier() + " Init: " + initiative_modifier(), "blue");
 	auto_log_info("Exp Bonus: " + experience_bonus() + " Meat Drop: " + meat_drop_modifier() + " Item Drop: " + item_drop_modifier(), "blue");
 	auto_log_info("Resists: " + numeric_modifier("Hot Resistance") + "/" + numeric_modifier("Cold Resistance") + "/" + numeric_modifier("Stench Resistance") + "/" + numeric_modifier("Spooky Resistance") + "/" + numeric_modifier("Sleaze Resistance"), "blue");
+	
+	//current equipment
+	next_line = "equipment: ";
+	foreach sl in $slots[]
+	{
+		if($slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar] contains sl)		//we always want to print the core slots
+		{
+			next_line += sl+ "=[" +equipped_item(sl)+ "]. ";
+		}
+		else if(equipped_item(sl) != $item[none])		//other slots should only be printed if they contain something
+		{
+			next_line += sl+ "=[" +equipped_item(sl)+ "]. ";
+		}
+	}
+	auto_log_info(next_line, "blue");
 }
 
 boolean auto_pre_adventure()

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -19,9 +19,6 @@ void print_footer()
 				}
 			}
 			break;	
-		case $class[Pastamancer]:
-			next_line += ", Thrall: [" +my_thrall()+ "]";
-			break;
 		case $class[Sauceror]:
 			next_line += ", Soulsauce: " +my_soulsauce();
 			break;
@@ -35,7 +32,25 @@ void print_footer()
 	". mys: " +my_basestat($stat[mysticality])+ " + " +bonus_mys+
 	". mox: " +my_basestat($stat[moxie])+ " + " +bonus_mox, "blue");
 	
-	auto_log_info("Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
+	next_line = "";
+	if(pathHasFamiliar())
+	{
+		next_line += "Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs. ";
+	}
+	if(my_class() == $class[Pastamancer])
+	{
+		next_line += "Thrall: [" +my_thrall()+ "] @ level " +my_thrall().level;
+	}
+	if(isActuallyEd())
+	{
+		next_line += "Servant: [" +my_servant()+ "] @ level " +my_servant().level;
+	}
+	if(my_class() == $class[Avatar of Jarlsberg])
+	{
+		next_line += "Companion: [" +my_companion();
+	}
+	auto_log_info(next_line, "blue");
+	
 	auto_log_info("ML: " + monster_level_adjustment() + " Encounter: " + combat_rate_modifier() + " Init: " + initiative_modifier(), "blue");
 	auto_log_info("Exp Bonus: " + experience_bonus() + " Meat Drop: " + meat_drop_modifier() + " Item Drop: " + item_drop_modifier(), "blue");
 	auto_log_info("Resists: " + numeric_modifier("Hot Resistance") + "/" + numeric_modifier("Cold Resistance") + "/" + numeric_modifier("Stench Resistance") + "/" + numeric_modifier("Spooky Resistance") + "/" + numeric_modifier("Sleaze Resistance"), "blue");

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -61,6 +61,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	//basic combat status. no need to log location as mafia does that already
 	auto_log_info("auto_combat initialized: path = [" +my_path()+
 	"]. class = [" +my_class()+
+	"]. familiar = [" +my_familiar()+
 	"]. round = " +round, "green");
 	
 	//enemy info
@@ -73,6 +74,20 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
 	". MP = " +my_mp()+ "/" +my_maxmp()+
 	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
+	
+	//current equipment
+	string wearing;
+	foreach sl in $slots[]
+	{
+		if($slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar] contains sl)		//we always want to print the core slots
+		{
+			wearing += sl+ "=[" +equipped_item(sl)+ "]. ";
+		}
+		else if(equipped_item(sl) != $item[none])		//other slots should only be printed if they contain something
+		{
+			wearing += sl+ "=[" +equipped_item(sl)+ "]. ";
+		}
+	}
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -31,12 +31,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	{
 		return;
 	}
-	
-	auto_log_info("auto_combat initializing: path = [" +my_path()+ "]. class = [" +my_class()+ "]. round = " +round, "green");
-	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+ ". MP = " +my_mp()+ "/" +my_maxmp()+
-	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
-	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". MLA = " +monster_level_adjustment(), "green");
-	
+
 	switch(enemy)
 	{
 		case $monster[Government Agent]:
@@ -61,6 +56,11 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	set_property("auto_combatHandlerThunderBird", "0");
 	set_property("auto_combatHandlerFingernailClippers", "0");
 	set_property("_auto_combatTracker_MortarRound", -1);		//tracks which round we used Stuffed Mortar Shell in.
+	
+	auto_log_info("auto_combat initialized: path = [" +my_path()+ "]. class = [" +my_class()+ "]. round = " +round, "green");
+	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+ ". MP = " +my_mp()+ "/" +my_maxmp()+
+	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
+	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". MLA = " +monster_level_adjustment(), "green");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -59,7 +59,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	
 	//log some important info.
 	//some stuff is redundant to the pre_adventure function print_footer() so it will not be logged here
-	auto_log_info("auto_combat initialized: against [" +enemy+
+	auto_log_info("auto_combat initialized fighting [" +enemy+
 	"]: atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -58,18 +58,21 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	set_property("_auto_combatTracker_MortarRound", -1);		//tracks which round we used Stuffed Mortar Shell in.
 	
 	//log some important info. it looks good and makes it much easier to figure out problems when someone just sends us the log of a single combat.
+	//basic combat status. no need to log location as mafia does that already
 	auto_log_info("auto_combat initialized: path = [" +my_path()+
 	"]. class = [" +my_class()+
 	"]. round = " +round, "green");
 	
-	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
-	". MP = " +my_mp()+ "/" +my_maxmp()+
-	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
-	
+	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+
 	". MLA = " +monster_level_adjustment(), "green");
+	
+	//player info
+	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
+	". MP = " +my_mp()+ "/" +my_maxmp()+
+	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -60,7 +60,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	auto_log_info("auto_combat initialized: path = [" +my_path()+ "]. class = [" +my_class()+ "]. round = " +round, "green");
 	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+ ". MP = " +my_mp()+ "/" +my_maxmp()+
 	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
-	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". MLA = " +monster_level_adjustment(), "green");
+	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". HP = " +monster_hp()+ ". MLA = " +monster_level_adjustment(), "green");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -61,8 +61,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	//basic combat status. no need to log location as mafia does that already
 	auto_log_info("auto_combat initialized: path = [" +my_path()+
 	"]. class = [" +my_class()+
-	"]. familiar = [" +my_familiar()+ "]. @ " +familiar_weight(my_familiar())+ " + " +weight_adjustment()+
-	"lbs. round = " +round, "blue");
+	"]. familiar = [" +my_familiar()+ "] @ " +familiar_weight(my_familiar())+weight_adjustment(), "blue");
 	
 	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -64,8 +64,6 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	"]. familiar = [" +my_familiar()+ "]. @ " +familiar_weight(my_familiar())+ " + " +weight_adjustment()+
 	"lbs. round = " +round, "blue");
 	
-	("Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
-	
 	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+
 	". def = " +monster_defense()+

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -62,18 +62,18 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	auto_log_info("auto_combat initialized: path = [" +my_path()+
 	"]. class = [" +my_class()+
 	"]. familiar = [" +my_familiar()+
-	"]. round = " +round, "green");
+	"]. round = " +round, "blue");
 	
 	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+
-	". MLA = " +monster_level_adjustment(), "green");
+	". MLA = " +monster_level_adjustment(), "blue");
 	
 	//player info
 	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
 	". MP = " +my_mp()+ "/" +my_maxmp()+
-	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
+	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "blue");
 	
 	//current equipment
 	string equip = "equipment: ";
@@ -88,7 +88,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 			equip += sl+ "=[" +equipped_item(sl)+ "]. ";
 		}
 	}
-	auto_log_info(equip, "green");
+	auto_log_info(equip, "blue");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -59,8 +59,8 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	
 	//log some important info.
 	//some stuff is redundant to the pre_adventure function print_footer() so it will not be logged here
-	auto_log_info("auto_combat initialized:", "blue");
-	auto_log_info(enemy+ ": atk = " +monster_attack()+
+	auto_log_info("auto_combat initialized: against [" +enemy+
+	"]: atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+
 	". LA = " +monster_level_adjustment(), "blue");

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -59,15 +59,17 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	
 	//log some important info. it looks good and makes it much easier to figure out problems when someone just sends us the log of a single combat.
 	//basic combat status. no need to log location as mafia does that already
-	auto_log_info("auto_combat initialized: path = [" +my_path()+
-	"]. class = [" +my_class()+
-	"]. familiar = [" +my_familiar()+ "] @ " +familiar_weight(my_familiar())+weight_adjustment(), "blue");
+	auto_log_info("auto_combat initialized: [" +my_class()+ "] at the path of [" +my_path()+
+	"]", "blue");
+	
+	int fam_lbs = familiar_weight(my_familiar())+weight_adjustment();
+	auto_log_info("familiar: [" +my_familiar()+ "] @ " +fam_lbs+ " lbs.", "blue");
 	
 	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+
-	". MLA = " +monster_level_adjustment(), "blue");
+	". LA = " +monster_level_adjustment(), "blue");
 	
 	//player info
 	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -76,18 +76,19 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
 	
 	//current equipment
-	string wearing;
+	string equip = "equipment: ";
 	foreach sl in $slots[]
 	{
 		if($slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar] contains sl)		//we always want to print the core slots
 		{
-			wearing += sl+ "=[" +equipped_item(sl)+ "]. ";
+			equip += sl+ "=[" +equipped_item(sl)+ "]. ";
 		}
 		else if(equipped_item(sl) != $item[none])		//other slots should only be printed if they contain something
 		{
-			wearing += sl+ "=[" +equipped_item(sl)+ "]. ";
+			equip += sl+ "=[" +equipped_item(sl)+ "]. ";
 		}
 	}
+	auto_log_info(equip, "green");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -61,8 +61,10 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	//basic combat status. no need to log location as mafia does that already
 	auto_log_info("auto_combat initialized: path = [" +my_path()+
 	"]. class = [" +my_class()+
-	"]. familiar = [" +my_familiar()+
-	"]. round = " +round, "blue");
+	"]. familiar = [" +my_familiar()+ "]. @ " +familiar_weight(my_familiar())+ " + " +weight_adjustment()+
+	"lbs. round = " +round, "blue");
+	
+	("Familiar: " +my_familiar()+ " @ " + familiar_weight(my_familiar()) + " + " + weight_adjustment() + "lbs.", "blue");
 	
 	//enemy info
 	auto_log_info(enemy+ ": atk = " +monster_attack()+

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -57,39 +57,13 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	set_property("auto_combatHandlerFingernailClippers", "0");
 	set_property("_auto_combatTracker_MortarRound", -1);		//tracks which round we used Stuffed Mortar Shell in.
 	
-	//log some important info. it looks good and makes it much easier to figure out problems when someone just sends us the log of a single combat.
-	//basic combat status. no need to log location as mafia does that already
-	auto_log_info("auto_combat initialized: [" +my_class()+ "] at the path of [" +my_path()+
-	"]", "blue");
-	
-	int fam_lbs = familiar_weight(my_familiar())+weight_adjustment();
-	auto_log_info("familiar: [" +my_familiar()+ "] @ " +fam_lbs+ " lbs.", "blue");
-	
-	//enemy info
+	//log some important info.
+	//some stuff is redundant to the pre_adventure function print_footer() so it will not be logged here
+	auto_log_info("auto_combat initialized:", "blue");
 	auto_log_info(enemy+ ": atk = " +monster_attack()+
 	". def = " +monster_defense()+
 	". HP = " +monster_hp()+
 	". LA = " +monster_level_adjustment(), "blue");
-	
-	//player info
-	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
-	". MP = " +my_mp()+ "/" +my_maxmp()+
-	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "blue");
-	
-	//current equipment
-	string equip = "equipment: ";
-	foreach sl in $slots[]
-	{
-		if($slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar] contains sl)		//we always want to print the core slots
-		{
-			equip += sl+ "=[" +equipped_item(sl)+ "]. ";
-		}
-		else if(equipped_item(sl) != $item[none])		//other slots should only be printed if they contain something
-		{
-			equip += sl+ "=[" +equipped_item(sl)+ "]. ";
-		}
-	}
-	auto_log_info(equip, "blue");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -32,7 +32,10 @@ void auto_combatInitialize(int round, monster enemy, string text)
 		return;
 	}
 	
-	auto_log_info("auto_combatHandler: " + round, "brown");
+	auto_log_info("auto_combat initializing: path = [" +my_path()+ "]. class = [" +my_class()+ "]. round = " +round, "green");
+	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+ ". MP = " +my_mp()+ "/" +my_maxmp()+
+	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
+	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". MLA = " +monster_level_adjustment(), "green");
 	
 	switch(enemy)
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -57,10 +57,19 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	set_property("auto_combatHandlerFingernailClippers", "0");
 	set_property("_auto_combatTracker_MortarRound", -1);		//tracks which round we used Stuffed Mortar Shell in.
 	
-	auto_log_info("auto_combat initialized: path = [" +my_path()+ "]. class = [" +my_class()+ "]. round = " +round, "green");
-	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+ ". MP = " +my_mp()+ "/" +my_maxmp()+
+	//log some important info. it looks good and makes it much easier to figure out problems when someone just sends us the log of a single combat.
+	auto_log_info("auto_combat initialized: path = [" +my_path()+
+	"]. class = [" +my_class()+
+	"]. round = " +round, "green");
+	
+	auto_log_info(my_name()+ ": HP = " +my_hp()+ "/" +my_maxhp()+
+	". MP = " +my_mp()+ "/" +my_maxmp()+
 	". mus:mys:mox = " +my_buffedstat($stat[muscle])+ ":" +my_buffedstat($stat[mysticality])+ ":" +my_buffedstat($stat[moxie]), "green");
-	auto_log_info(enemy+ ": atk = " +monster_attack()+ ". def = " +monster_defense()+ ". HP = " +monster_hp()+ ". MLA = " +monster_level_adjustment(), "green");
+	
+	auto_log_info(enemy+ ": atk = " +monster_attack()+
+	". def = " +monster_defense()+
+	". HP = " +monster_hp()+
+	". MLA = " +monster_level_adjustment(), "green");
 }
 
 string auto_combatHandler(int round, monster enemy, string text)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -11,7 +11,6 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	if (round == 0)
 	{
-		auto_log_info("auto_combatHandler: " + round, "brown");
 		set_property("auto_combatHandler", "");
 		if (get_property("_edDefeats").to_int() == 0)
 		{
@@ -25,6 +24,13 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		{
 			set_property("auto_edStatus", "UNDYING!"); //  Undying means ressurect until it's not free any more
 		}
+		//log some important info.
+		//some stuff is redundant to the pre_adventure function print_footer() so it will not be logged here
+		auto_log_info("auto_combat initialized fighting [" +enemy+
+		"]: atk = " +monster_attack()+
+		". def = " +monster_defense()+
+		". HP = " +monster_hp()+
+		". LA = " +monster_level_adjustment(), "blue");
 	}
 	else
 	{


### PR DESCRIPTION
* expanded pre_adv footer info with class, path, mus, mox, mys, current equipment, turtle blessing, pasta thrall, seal clubber fury, actuallyed servant,  jarlsberg companion.
* added combat info about enemy when initializing combat

## How Has This Been Tested?

ash calls
normal quantum terrarium run
normal ed run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
