### PR TITLE
fix for spamming the DMT on day 2+ searching for a NC that won't come for 45 more adventures.

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -1172,7 +1172,7 @@ boolean adjustEdHat(string goal)
 
 boolean resolveSixthDMT()
 {
-	//every sixth machine elf tunnels visit will be a noncombat. This prepares for it and executes it.
+	// In the Deep Machine Tunnels the sixth and every 50th visit after that in a single ascension will be a noncombat. This prepares for it and executes it.
 	if(in_koe())
 	{
 		return false;
@@ -1181,7 +1181,8 @@ boolean resolveSixthDMT()
 	{
 		return false;
 	}
-	if(get_property("_machineTunnelsAdv").to_int() != 5)
+	if ($location[The Deep Machine Tunnels].turns_spent != 5)
+	// need to figure out the exact schedule for 2nd and later occurences then add it here.
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

as subject. Schedule for NCs after the first one needs verified and added but this will at least fix the issue with wasting advs in the zone on day 2+.

## How Has This Been Tested?

Hasn't.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
