### PR TITLE
restore code disable extra debugging

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -43,6 +43,7 @@ auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WA
 auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
 auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
 auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
+auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
 auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -54,11 +54,12 @@ any	41	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for 
 any	42	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
 any	43	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
 any	44	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
-any	45	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	46	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	47	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	48	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
-any	49	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
+any	45	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
+any	46	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	47	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	48	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	49	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	50	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1179,7 +1179,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 			else
 			{
-				auto_log_debug("Removed from consideration: " + to_string(T[Ti], true), 1);
+				auto_log_restore_debug("Removed from consideration: " + to_string(T[Ti], true), 1);
 			}
 			Ti++;
 		}
@@ -1193,7 +1193,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 			else
 			{
-				auto_log_debug("Removed from consideration: " + to_string(B[Bi], true), 1);
+				auto_log_restore_debug("Removed from consideration: " + to_string(B[Bi], true), 1);
 			}
 			Bi++;
 		}
@@ -1217,7 +1217,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 	__RestorationOptimization[int] ranked_optimization(__RestorationOptimization[int] p, int[string] value_ranks, boolean[string] maximize_keys, boolean[string] minimize_keys)
 	{
-		auto_log_debug("Beginning optimization of "+count(p)+" restoration options.", 1);
+		auto_log_restore_debug("Beginning optimization of "+count(p)+" restoration options.", 1);
 		if(count(p) == 0)
 		{
 			return p;
@@ -1225,11 +1225,11 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 		__RestorationOptimization[int] ranked = copy(p);
 		int[int] ranks = ordered_ranks(value_ranks);
-		auto_log_debug(count(ranked)+" options before optimization: " + to_string(ranked, false), 2);
+		auto_log_restore_debug(count(ranked)+" options before optimization: " + to_string(ranked, false), 2);
 		foreach _, rank in ranks
 		{
 			string desc = (__RANKED_GOAL_DESCRIPTIONS contains rank) ?  __RANKED_GOAL_DESCRIPTIONS[rank] : "whoops, someone changed things and didnt update the descriptions. Bad dev.";
-			auto_log_debug("Rank " + rank + " optimization, prefer to... " + desc, 1);
+			auto_log_restore_debug("Rank " + rank + " optimization, prefer to... " + desc, 1);
 			if(count(ranked) <= 1)
 			{
 				break;
@@ -1304,7 +1304,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 	void quick_sort_maximize(__RestorationOptimization[int] p, boolean[string] sort_keys, int[string] value_ranks)
 	{
-		auto_log_debug("Sorting "+count(p)+" options by primary objectives.", 1);
+		auto_log_restore_debug("Sorting "+count(p)+" options by primary objectives.", 1);
 		if(count(p) > 1)
 		{
 			quick_sort_maximize(p, sort_keys, value_ranks, 0, count(p)-1);
@@ -1314,7 +1314,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 	__RestorationOptimization[int] apply_constraints(__RestorationOptimization[int] p, boolean[string] constraint_keys)
 	{
 		int c = count(p);
-		auto_log_debug("Applying constraints to "+c+" objective values.", 1);
+		auto_log_restore_debug("Applying constraints to "+c+" objective values.", 1);
 
 		__RestorationOptimization[int] constrained;
 
@@ -1335,7 +1335,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 		}
 
-		auto_log_debug("Removed  "+(c-count(constrained))+" restore options from consideration.", 1);
+		auto_log_restore_debug("Removed  "+(c-count(constrained))+" restore options from consideration.", 1);
 
 		return constrained;
 	}
@@ -1344,7 +1344,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 	{
 		if(count(__restore_maximizer_cache) > 0)
 		{
-			auto_log_debug("Recalculating cached restore objective values.", 0);
+			auto_log_restore_debug("Recalculating cached restore objective values.", 0);
 			foreach i, o in __restore_maximizer_cache
 			{
 				__RestorationOptimization recalculated =
@@ -1353,7 +1353,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 		}
 		else
 		{
-			auto_log_debug("Calculating restore objective values.", 0);
+			auto_log_restore_debug("Calculating restore objective values.", 0);
 			foreach name, metadata in __restoration_methods()
 			{
 				__RestorationOptimization o = __calculate_objective_values(hp_goal, mp_goal, meat_reserve, useFreeRests, metadata);
@@ -1832,11 +1832,11 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 		cli_execute("refresh status");
 		if(initial_maxHP == my_maxhp())
 		{
-			auto_log_debug("I just refreshed status because I detected [Hand in Glove]. But it turned out to not have been necessary", 1);
+			auto_log_restore_debug("I just refreshed status because I detected [Hand in Glove]. But it turned out to not have been necessary", 1);
 		}
 		else
 		{
-			auto_log_debug("I just refreshed status because I detected [Hand in Glove] and it corrected my maxHP value. This prevented an infinite loop", 0);
+			auto_log_restore_debug("I just refreshed status because I detected [Hand in Glove] and it corrected my maxHP value. This prevented an infinite loop", 0);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -149,7 +149,7 @@ void auto_log_restore_debug(string s, int level)
 	{
 		return;		//regular debugging is off. so extra debugging is also off.
 	}
-	if(level get_property("auto_log_level_restore").to_int() >= level)
+	if(get_property("auto_log_level_restore").to_int() >= level)
 	{
 		auto_log_debug(s);
 	}

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -141,6 +141,20 @@ string to_string(__RestorationOptimization[int] optima, boolean simple)
 	return val;
 }
 
+void auto_log_restore_debug(string s, int level)
+{
+	//restore debug log is extremely girthy and usually not needed. as such it has its own custom setting for displaying it.
+	//0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump.
+	if(get_property("auto_log_level").to_int() < 3)
+	{
+		return;		//regular debugging is off. so extra debugging is also off.
+	}
+	if(level get_property("auto_log_level_restore").to_int() >= level)
+	{
+		auto_log_debug(s);
+	}
+}
+
 static boolean[effect] __all_negative_effects;
 static __RestorationMetadata[string] __known_restoration_sources;
 static __RestorationOptimization[int] __restore_maximizer_cache;
@@ -1165,7 +1179,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 			else
 			{
-				auto_log_debug("Removed from consideration: " + to_string(T[Ti], true));
+				auto_log_debug("Removed from consideration: " + to_string(T[Ti], true), 1);
 			}
 			Ti++;
 		}
@@ -1179,7 +1193,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 			else
 			{
-				auto_log_debug("Removed from consideration: " + to_string(B[Bi], true));
+				auto_log_debug("Removed from consideration: " + to_string(B[Bi], true), 1);
 			}
 			Bi++;
 		}
@@ -1203,7 +1217,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 	__RestorationOptimization[int] ranked_optimization(__RestorationOptimization[int] p, int[string] value_ranks, boolean[string] maximize_keys, boolean[string] minimize_keys)
 	{
-		auto_log_debug("Beginning optimization of "+count(p)+" restoration options.");
+		auto_log_debug("Beginning optimization of "+count(p)+" restoration options.", 1);
 		if(count(p) == 0)
 		{
 			return p;
@@ -1211,11 +1225,11 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 		__RestorationOptimization[int] ranked = copy(p);
 		int[int] ranks = ordered_ranks(value_ranks);
-		auto_log_debug(count(ranked)+" options before optimization: " + to_string(ranked, false));
+		auto_log_debug(count(ranked)+" options before optimization: " + to_string(ranked, false), 2);
 		foreach _, rank in ranks
 		{
 			string desc = (__RANKED_GOAL_DESCRIPTIONS contains rank) ?  __RANKED_GOAL_DESCRIPTIONS[rank] : "whoops, someone changed things and didnt update the descriptions. Bad dev.";
-			auto_log_debug("Rank " + rank + " optimization, prefer to... " + desc);
+			auto_log_debug("Rank " + rank + " optimization, prefer to... " + desc, 1);
 			if(count(ranked) <= 1)
 			{
 				break;
@@ -1290,7 +1304,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 
 	void quick_sort_maximize(__RestorationOptimization[int] p, boolean[string] sort_keys, int[string] value_ranks)
 	{
-		auto_log_debug("Sorting "+count(p)+" options by primary objectives.");
+		auto_log_debug("Sorting "+count(p)+" options by primary objectives.", 1);
 		if(count(p) > 1)
 		{
 			quick_sort_maximize(p, sort_keys, value_ranks, 0, count(p)-1);
@@ -1300,7 +1314,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 	__RestorationOptimization[int] apply_constraints(__RestorationOptimization[int] p, boolean[string] constraint_keys)
 	{
 		int c = count(p);
-		auto_log_debug("Applying constraints to "+c+" objective values.");
+		auto_log_debug("Applying constraints to "+c+" objective values.", 1);
 
 		__RestorationOptimization[int] constrained;
 
@@ -1321,7 +1335,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 			}
 		}
 
-		auto_log_debug("Removed  "+(c-count(constrained))+" restore options from consideration.");
+		auto_log_debug("Removed  "+(c-count(constrained))+" restore options from consideration.", 1);
 
 		return constrained;
 	}
@@ -1330,7 +1344,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 	{
 		if(count(__restore_maximizer_cache) > 0)
 		{
-			auto_log_debug("Recalculating cached restore objective values.");
+			auto_log_debug("Recalculating cached restore objective values.", 0);
 			foreach i, o in __restore_maximizer_cache
 			{
 				__RestorationOptimization recalculated =
@@ -1339,7 +1353,7 @@ __RestorationOptimization[int] __maximize_restore_options(int hp_goal, int mp_go
 		}
 		else
 		{
-			auto_log_debug("Calculating restore objective values.");
+			auto_log_debug("Calculating restore objective values.", 0);
 			foreach name, metadata in __restoration_methods()
 			{
 				__RestorationOptimization o = __calculate_objective_values(hp_goal, mp_goal, meat_reserve, useFreeRests, metadata);
@@ -1818,11 +1832,11 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 		cli_execute("refresh status");
 		if(initial_maxHP == my_maxhp())
 		{
-			auto_log_debug("I just refreshed status because I detected [Hand in Glove]. But it turned out to not have been necessary");
+			auto_log_debug("I just refreshed status because I detected [Hand in Glove]. But it turned out to not have been necessary", 1);
 		}
 		else
 		{
-			auto_log_debug("I just refreshed status because I detected [Hand in Glove] and it corrected my maxHP value. This prevented an infinite loop");
+			auto_log_debug("I just refreshed status because I detected [Hand in Glove] and it corrected my maxHP value. This prevented an infinite loop", 0);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -176,6 +176,14 @@ void auto_settingsFix()
 	{
 		set_property("auto_log_level", 3);		//values higher than 3 are not valid
 	}
+	if(get_property("auto_log_level_restore").to_int() < 0)
+	{
+		set_property("auto_log_level_restore", 0);		//values lower than 0 are not valid
+	}
+	if(get_property("auto_log_level_restore").to_int() > 2)
+	{
+		set_property("auto_log_level_restore", 2);		//values higher than 2 are not valid
+	}
 }
 
 void auto_settingsDelete()
@@ -303,7 +311,8 @@ void auto_settingsDefaults()
 	defaultConfig("auto_paranoia", "-1");
 	defaultConfig("auto_inv_paranoia", "false");
 	defaultConfig("auto_save_adv_override", "-1");
-	defaultConfig("auto_log_level", "2");	
+	defaultConfig("auto_log_level", "2");
+	defaultConfig("auto_log_level_restore", "0");
 }
 
 void auto_settings()


### PR DESCRIPTION
restore code generates exceptional amounts of debug info. limit this via auto_log_level_restore setting that is responsible for extra debug info. Allowing you to use debug level logging without having to deal with the data dumps of restore code

## How Has This Been Tested?

ash calls
QT normal run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
