### PR TITLE
wall of skin damage accounting fixes

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1119,9 +1119,28 @@ boolean L13_towerNSTower()
 					sourcesPassive += 1;
 				}
 			}
-			else
+			else if(autoEquip($slot[back], $item[buddy bjorn]))
 			{
-				handleBjornify($familiar[Hobo Monkey]);
+				if(handleBjornify($familiar[Chocolate Lab]))
+				{
+					sourcesPassive += 1;
+				}
+				else if(handleBjornify($familiar[Restless Cow Skull]))
+				{
+					sourcesPassive += 1;
+				}
+				else if(have_familiar($familiar[Sludgepuppy]) && my_familiar() != $familiar[Sludgepuppy])
+				{	
+					//if not already chosen as damage familiar
+					if(handleBjornify($familiar[Sludgepuppy]))
+					{
+						sourcesPassive += 1;
+					}
+				}
+				else if(handleBjornify($familiar[Hobo Monkey]))
+				{
+					damageSecured += 3;	// First three rounds of combat
+				}
 			}
 			if(autoEquip($slot[acc1], $item[hippy protest button]))
 			{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -939,6 +939,7 @@ boolean L13_towerNSTower()
 			}
 			if(have_skill($skill[Belch the Rainbow]))
 			{
+				//todo: is this 5 or 6?
 				sourcesAttack = 6;
 			}
 			else if(autoEquip($item[Fourth of May Cosplay Saber]))
@@ -955,8 +956,9 @@ boolean L13_towerNSTower()
 					}
 				}
 			}
-			if(have_skill($skill[headbutt]))
+			if(have_skill($skill[headbutt]) && !have_skill($skill[Belch the Rainbow]))
 			{
+				//combat script only tries headbutt after Belch the Rainbow
 				sourcesAttack += 1;
 			}
 			
@@ -1168,16 +1170,16 @@ boolean L13_towerNSTower()
 						use_skill(1, $skill[Blessing of the War Snapper]);
 					}
 				}
-				damageSecured += 1 + sourcesFamiliar + sourcesPassive;	//reactive damage doesn't work on blocked hit
+				damageSecured += sourcesFamiliar + sourcesPassive;	//reactive damage doesn't work on blocked hit
 				if((have_effect($effect[Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Grand Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Glorious Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Blessing of She-Who-Was]) == 0) && (have_effect($effect[Grand Blessing of She-Who-Was]) == 0) && (have_effect($effect[Glorious Blessing of She-Who-Was]) == 0))
 				{
-					//Shell Up doesn't do damage with either of these blessings
-					damageSecured -= 1;
+					//Shell Up does damage if neither of these blessings is active
+					damageSecured += 1;
 				}
 			}
 			if(have_skill($skill[Sauceshell]))
 			{
-				damageSecured += 1 + sourcesFamiliar + sourcesPassive;	//reactive passive damage doesn't work on blocked hit
+				damageSecured += 1 + sourcesFamiliar + sourcesPassive;	//reactive damage doesn't work on blocked hit
 			}
 			
 			int damageMissing = damageNeed - damageSecured;
@@ -1215,7 +1217,7 @@ boolean L13_towerNSTower()
 				}
 				else
 				{
-					auto_log_warning("Need a beehive, buzz buzz. Have " + sources + " damage sources but the " + sourcesPassive + " passive sources won't work before dying on the last round", "red");
+					auto_log_warning("Need a beehive, buzz buzz. Have " + sources + " damage sources but only " + lastRoundDamage + " that would work before taking a hit on the last round", "red");
 				}
 			}
 		}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -902,7 +902,17 @@ boolean L13_towerNSTower()
 			auto_change_mcd(0);
 			acquireMP(120, 0);
 
-			int sources = 0;
+			int sources = 0;			//total damage sources
+			int sourcesAttack = 0;		//damage sources when using weapon attack or skill
+			int sourcesFamiliar = 0;	//damage sources from familiar apply before getting hit
+			int sourcesReactive = 0;	//damage in reaction to being hit. "stinging damage" doesn't work without getting hit
+			int sourcesPassive = 0;		//other passive damage sources, only work after surviving a hit, doesn't include reactive/stinging sources
+			
+			int sourceNeed = 13;	//removed inaccurate uses of this value, it is now only used in informative log message
+			int damageNeed = 50;
+			int damageSecured = 0;
+			
+			//want prismatic attack damage bonus
 			if(autoEquip($item[astral shirt]))
 			{
 				// nothing, just for else
@@ -915,6 +925,10 @@ boolean L13_towerNSTower()
 			{
 				use(1, $item[cigar box turtle]);
 			}
+			else if(item_amount($item[colorful toad]) > 0)
+			{
+				use(1, $item[colorful toad]);
+			}
 			else if(have_effect($effect[damage.enh]) == 0)
 			{
 				int enhances = auto_sourceTerminalEnhanceLeft();
@@ -923,18 +937,13 @@ boolean L13_towerNSTower()
 					auto_sourceTerminalEnhance("damage");
 				}
 			}
-
-			if(my_class() == $class[Turtle Tamer])
-			{
-				autoEquip($slot[shirt], $item[Shocked Shell]);
-			}
 			if(have_skill($skill[Belch the Rainbow]))
 			{
-				sources = 6;
+				sourcesAttack = 6;
 			}
 			else if(autoEquip($item[Fourth of May Cosplay Saber]))
 			{
-				sources = 6;
+				sourcesAttack = 6;
 			}
 			else
 			{
@@ -942,32 +951,34 @@ boolean L13_towerNSTower()
 				{
 					if(numeric_modifier(damage) > 0)
 					{
-						sources += 1;
+						sourcesAttack += 1;
 					}
 				}
 			}
 			if(have_skill($skill[headbutt]))
 			{
-				sources = sources + 1;
+				sourcesAttack += 1;
 			}
+			
+			boolean familiarEquipped = false;
 			if(canChangeToFamiliar($familiar[Shorter-Order Cook]) || qt_currentFamiliar($familiar[Shorter-Order Cook]))
 			{
 				handleFamiliar($familiar[Shorter-Order Cook]);
-				sources = sources + 6;
+				sourcesFamiliar += 6;
 			}		
 			else if(canChangeToFamiliar($familiar[Mu]) || qt_currentFamiliar($familiar[Mu]))
 			{
 				handleFamiliar($familiar[Mu]);
-				sources = sources + 5;
+				sourcesFamiliar += 5;
 			}
 			else if(canChangeToFamiliar($familiar[Imitation Crab]) || qt_currentFamiliar($familiar[Imitation Crab]))
 			{
 				handleFamiliar($familiar[Imitation Crab]);
-				sources = sources + 4;
+				sourcesFamiliar += 4;
 			}
 			else if(canChangeToFamiliar($familiar[warbear drone]) || qt_currentFamiliar($familiar[warbear drone]))
 			{
-				sources = sources + 2;
+				sourcesFamiliar += 2;
 				handleFamiliar($familiar[Warbear Drone]);
 				use_familiar($familiar[Warbear Drone]);
 				cli_execute("auto_pre_adv"); // TODO: can we remove this?
@@ -977,87 +988,215 @@ boolean L13_towerNSTower()
 				}
 				if(possessEquipment($item[warbear drone codes]))
 				{
-					autoEquip($item[warbear drone codes]);
-					sources = sources + 2;
+					if(autoEquip($item[warbear drone codes]))
+					{
+						sourcesFamiliar += 2;
+						familiarEquipped = true;
+					}
 				}
 			}
 			else if(canChangeToFamiliar($familiar[Sludgepuppy]) || qt_currentFamiliar($familiar[Sludgepuppy]))
 			{
 				handleFamiliar($familiar[Sludgepuppy]);
-				sources = sources + 3;
+				sourcesFamiliar += 3;
+			}
+			else if(canChangeToFamiliar($familiar[Feral Kobold]) || qt_currentFamiliar($familiar[Feral Kobold]))
+			{
+				handleFamiliar($familiar[Feral Kobold]);
+				sourcesFamiliar += 1;
+			}
+			else if(canChangeToFamiliar($familiar[Topiary Skunk]) || qt_currentFamiliar($familiar[Topiary Skunk]))
+			{
+				//100% first round, then 20% chance of attack
+				handleFamiliar($familiar[Topiary Skunk]);
+				damageSecured += 1;
+			}
+			//no guaranteed damage familiar, try to use better than nothing
+			else
+			{
+				boolean attackFamiliarPicked = false;
+				foreach fam in $familiars[BRICKO chick,Clockwork Grapefruit,Pair of Ragged Claws]
+				{
+					//50% chance of attack
+					if(canChangeToFamiliar(fam))
+					{
+						handleFamiliar(fam);
+						attackFamiliarPicked = true;
+						break;
+					}
+				}
+				if(!attackFamiliarPicked)
+				{
+					foreach fam in $familiars[Star Starfish,Animated Macaroni Duck,Killer Bee,Flaming Gravy Fairy,Frozen Gravy Fairy,Stinky Gravy Fairy]
+					{
+						//33% chance of attack
+						if(canChangeToFamiliar(fam))
+						{
+							handleFamiliar(fam);
+							attackFamiliarPicked = true;
+							break;
+						}
+					}
+				}
+				if(!attackFamiliarPicked)
+				{
+					foreach fam in $familiars[]
+					{
+						if(isAttackFamiliar(fam))
+						{
+							if(canChangeToFamiliar(fam))
+							{
+								handleFamiliar(fam);
+								attackFamiliarPicked = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			if(!familiarEquipped)
+			{
+				if(autoEquip($item[tiny bowler]))
+				{
+					sourcesPassive += 1;	//todo: confirm this damage only counts after getting hit, not with familiar damage
+					familiarEquipped = true;
+				}
+				if(!familiarEquipped)
+				{
+					foreach it in $items[ant hoe,ant pick,ant pitchfork,ant rake,ant sickle]
+					{
+						if(autoEquip(it))
+						{
+							//attacks ~40% of the time?
+							familiarEquipped = true;
+							break;
+						}
+					}
+				}
+				if(!familiarEquipped)
+				{
+					if(autoEquip($item[plastic pumpkin bucket]))
+					{
+						//attacks ~35% of the time?
+						familiarEquipped = true;
+					}
+				}
+			}
+			
+			if(my_class() == $class[Turtle Tamer])
+			{
+				if (autoEquip($slot[back], $item[Shocked Shell]))
+				{
+					sourcesPassive += 1;
+				}
 			}
 			if(autoEquip($slot[acc1], $item[hippy protest button]))
 			{
-				sources = sources + 1;
+				sourcesReactive += 1;
+			}
+			if(autoEquip($item[smirking shrunken head]))
+			{
+				sourcesPassive += 1;
+			}
+			else if(autoEquip($item[hot plate]))
+			{
+				sourcesReactive += 1;
 			}
 			if(item_amount($item[glob of spoiled mayo]) > 0)
 			{
 				buffMaintain($effect[Mayeaugh], 0, 1, 1);
-				sources = sources + 1;
-			}
-			if(autoEquip($item[smirking shrunken head]))
-			{
-				sources = sources + 1;
-			}
-			else if(autoEquip($item[hot plate]))
-			{
-				sources = sources + 1;
+				sourcesPassive += 1;
 			}
 			if(have_skill($skill[Scarysauce]))
 			{
 				buffMaintain($effect[Scarysauce], 0, 1, 1);
-				sources = sources + 1;
+				sourcesReactive += 1;
 			}
 			if(have_skill($skill[Spiky Shell]))
 			{
 				buffMaintain($effect[Spiky Shell], 0, 1, 1);
-				sources = sources + 1;
+				sourcesReactive += 1;
 			}
 			if(have_skill($skill[Jalape&ntilde;o Saucesphere]))
 			{
-				sources = sources + 1;
 				buffMaintain($effect[Jalape&ntilde;o Saucesphere], 0, 1, 1);
+				sourcesReactive += 1;
 			}
 			if(have_skill($skill[The Psalm of Pointiness]))
 			{
 				buffMaintain($effect[Psalm of Pointiness], 0, 1, 1);
-				sources = sources + 1;
+				sourcesReactive += 1;
 			}
 			handleBjornify($familiar[Hobo Monkey]);
 			autoEquip($slot[acc2], $item[world\'s best adventurer sash]);
 			autoEquip($slot[acc3], $item[Groll Doll]);
 			autoEquip($slot[acc3], $item[old school calculator watch]);
 			autoEquip($slot[acc3], $item[Bottle Opener Belt Buckle]);
-			autoEquip($slot[acc3], $item[acid-squirting flower]);
+			if(autoEquip($slot[acc3], $item[acid-squirting flower]))
+			{
+				sourcesReactive += 1;
+			}
 			if(have_skill($skill[Frigidalmatian]) && (my_mp() > 300))
 			{
-				sources = sources + 1;
+				sourcesPassive += 1;
 			}
-			int sourceNeed = 13;
+			
+			
+			sources = sourcesAttack + sourcesFamiliar + sourcesReactive + sourcesPassive;
+			int firstRoundDamage = sources;
+			boolean firstHitBlocked = false;
+			if(have_effect($effect[Blood Bubble]) > 0)
+			{
+				firstHitBlocked = true;					//will try to remove it if needed after counting all damage
+				//what else can block the first hit?
+			}
+			if(firstHitBlocked)
+			{
+				firstRoundDamage -= sourcesReactive;	//reactive damage doesn't work on blocked hit
+			}
+			int lastRoundDamage = sources - sourcesReactive - sourcesPassive;	//passive sources only work after surviving a hit
+			//expect to survive 3 hits, hit damage still increases if the first hit is blocked
+			damageSecured = firstRoundDamage + 2*sources + lastRoundDamage;	
+
 			if(have_skill($skill[Shell Up]))
 			{
-				if((have_effect($effect[Blessing of the Storm Tortoise]) > 0) || (have_effect($effect[Grand Blessing of the Storm Tortoise]) > 0) || (have_effect($effect[Glorious Blessing of the Storm Tortoise]) > 0))
+				if((have_effect($effect[Blessing of the Storm Tortoise]) > 0) || (have_effect($effect[Grand Blessing of the Storm Tortoise]) > 0) || (have_effect($effect[Glorious Blessing of the Storm Tortoise]) > 0) || (have_effect($effect[Blessing of She-Who-Was]) > 0) || (have_effect($effect[Grand Blessing of She-Who-Was]) > 0) || (have_effect($effect[Glorious Blessing of She-Who-Was]) > 0))
 				{
 					if(have_skill($skill[Blessing of the War Snapper]) && (my_mp() > (2 * mp_cost($skill[Blessing of the War Snapper]))))
 					{
 						use_skill(1, $skill[Blessing of the War Snapper]);
 					}
 				}
-				if((have_effect($effect[Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Grand Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Glorious Blessing of the Storm Tortoise]) == 0))
+				damageSecured += 1 + sourcesFamiliar + sourcesPassive;	//reactive damage doesn't work on blocked hit
+				if((have_effect($effect[Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Grand Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Glorious Blessing of the Storm Tortoise]) == 0) && (have_effect($effect[Blessing of She-Who-Was]) == 0) && (have_effect($effect[Grand Blessing of She-Who-Was]) == 0) && (have_effect($effect[Glorious Blessing of She-Who-Was]) == 0))
 				{
-					sourceNeed -= 2;
+					//Shell Up doesn't do damage with either of these blessings
+					damageSecured -= 1;
 				}
 			}
 			if(have_skill($skill[Sauceshell]))
 			{
-				sourceNeed -= 2;
+				damageSecured += 1 + sourcesFamiliar + sourcesPassive;	//reactive passive damage doesn't work on blocked hit
 			}
+			
+			int damageMissing = damageNeed - damageSecured;
+			if(damageMissing <= sourcesReactive && have_effect($effect[Blood Bubble]) > 0)
+			{	//try to remove blocking effect to enable reactive sources
+				if(uneffect($effect[Blood Bubble]))
+				{
+					firstHitBlocked = false;
+					//what else can block the first hit?
+					damageSecured += sourcesReactive;
+				}
+			}
+			
 			auto_log_info("I think I have " + sources + " sources of damage, let's do this!", "blue");
 			if(in_pokefam())
 			{
-				sources = 9999;
+				damageSecured = 9999;
 			}
-			if(sources > sourceNeed)
+			if(damageSecured > damageNeed)
 			{
 				acquireHP();
 				autoAdvBypass("place.php?whichplace=nstower&action=ns_05_monster1", $location[Tower Level 1]);
@@ -1070,7 +1209,14 @@ boolean L13_towerNSTower()
 			else
 			{
 				set_property("auto_getBeehive", true);
-				auto_log_warning("Need a beehive, buzz buzz. Only have " + sources + " damage sources and we want " + sourceNeed, "red");
+				if(sources < sourceNeed)
+				{
+					auto_log_warning("Need a beehive, buzz buzz. Only have " + sources + " damage sources and we want " + sourceNeed, "red");
+				}
+				else
+				{
+					auto_log_warning("Need a beehive, buzz buzz. Have " + sources + " damage sources but the " + sourcesPassive + " passive sources won't work before dying on the last round", "red");
+				}
 			}
 		}
 		return true;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1066,7 +1066,7 @@ boolean L13_towerNSTower()
 					{
 						if(isAttackFamiliar(fam))
 						{
-							if(canChangeToFamiliar(fam) || qt_currentFamiliar(fam))
+							if(canChangeToFamiliar(fam))
 							{
 								handleFamiliar(fam);
 								attackFamiliarPicked = true;
@@ -1112,12 +1112,16 @@ boolean L13_towerNSTower()
 				}
 			}
 			
-			if(my_class() == $class[Turtle Tamer])
+			if(my_class() == $class[Turtle Tamer] && possessEquipment($item[Shocked Shell]))
 			{
 				if (autoEquip($slot[back], $item[Shocked Shell]))
 				{
 					sourcesPassive += 1;
 				}
+			}
+			else
+			{
+				handleBjornify($familiar[Hobo Monkey]);
 			}
 			if(autoEquip($slot[acc1], $item[hippy protest button]))
 			{
@@ -1156,7 +1160,6 @@ boolean L13_towerNSTower()
 				buffMaintain($effect[Psalm of Pointiness], 0, 1, 1);
 				sourcesReactive += 1;
 			}
-			handleBjornify($familiar[Hobo Monkey]);
 			autoEquip($slot[acc2], $item[world\'s best adventurer sash]);
 			autoEquip($slot[acc3], $item[Groll Doll]);
 			autoEquip($slot[acc3], $item[old school calculator watch]);
@@ -1209,7 +1212,7 @@ boolean L13_towerNSTower()
 			}
 			
 			int damageMissing = damageNeed - damageSecured;
-			if(damageMissing <= sourcesReactive && have_effect($effect[Blood Bubble]) > 0)
+			if(damageMissing <= sourcesReactive && damageMissing > 0 && have_effect($effect[Blood Bubble]) > 0)
 			{	//try to remove blocking effect to enable reactive sources
 				if(uneffect($effect[Blood Bubble]))
 				{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -906,7 +906,7 @@ boolean L13_towerNSTower()
 			int sourcesAttack = 0;		//damage sources when using weapon attack or skill
 			int sourcesFamiliar = 0;	//damage sources from familiar apply before getting hit
 			int sourcesReactive = 0;	//damage in reaction to being hit. "stinging damage" doesn't work without getting hit
-			int sourcesPassive = 0;		//other passive damage sources, only work after surviving a hit, doesn't include reactive/stinging sources
+			int sourcesPassive = 0;		//other passive damage sources, only work after surviving to end of round, doesn't include reactive/stinging sources
 			
 			int sourceNeed = 13;	//removed inaccurate uses of this value, it is now only used in informative log message
 			int damageNeed = 50;
@@ -1198,9 +1198,12 @@ boolean L13_towerNSTower()
 			{
 				sourcesReactive += 1;
 			}
-			if(have_skill($skill[Frigidalmatian]) && (my_mp() > 300))
+			if(have_skill($skill[Frigidalmatian]))	//1 turn, doesn't need remover
 			{
-				sourcesPassive += 1;
+				if(buffMaintain($effect[Frigidalmatian], 300, 1, 1))
+				{
+					sourcesPassive += 1;
+				}
 			}
 			
 			

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -963,6 +963,11 @@ boolean L13_towerNSTower()
 			}
 			
 			boolean familiarEquipped = false;
+			boolean haveFamiliarWillAlwaysActEffect = false;
+			if(have_effect($effect[Shortly Stacked]) > 0 || have_effect($effect[Shortly Buttered]) > 0 || have_effect($effect[Shortly Hydrated]) > 0 || have_effect($effect[Shortly Wired]) > 0 || have_effect($effect[Shortly Drunk]) > 0)
+			{
+				haveFamiliarWillAlwaysActEffect = true;
+			}
 			if(canChangeToFamiliar($familiar[Shorter-Order Cook]) || qt_currentFamiliar($familiar[Shorter-Order Cook]))
 			{
 				handleFamiliar($familiar[Shorter-Order Cook]);
@@ -983,7 +988,7 @@ boolean L13_towerNSTower()
 				sourcesFamiliar += 2;
 				handleFamiliar($familiar[Warbear Drone]);
 				use_familiar($familiar[Warbear Drone]);
-				cli_execute("auto_pre_adv"); // TODO: can we remove this?
+				cli_execute("auto_pre_adv"); // TODO: can we remove this? //could probably instead call preAdvUpdateFamiliar(loc)
 				if(!possessEquipment($item[Warbear Drone Codes]))
 				{
 					pullXWhenHaveY($item[warbear drone codes], 1, 0);
@@ -1011,7 +1016,14 @@ boolean L13_towerNSTower()
 			{
 				//100% first round, then 20% chance of attack
 				handleFamiliar($familiar[Topiary Skunk]);
-				damageSecured += 1;
+				if(haveFamiliarWillAlwaysActEffect)
+				{
+					sourcesFamiliar += 1;
+				}
+				else
+				{
+					damageSecured += 1;
+				}
 			}
 			//no guaranteed damage familiar, try to use better than nothing
 			else
@@ -1020,9 +1032,13 @@ boolean L13_towerNSTower()
 				foreach fam in $familiars[BRICKO chick,Clockwork Grapefruit,Pair of Ragged Claws]
 				{
 					//50% chance of attack
-					if(canChangeToFamiliar(fam))
+					if(canChangeToFamiliar(fam) || qt_currentFamiliar(fam))
 					{
 						handleFamiliar(fam);
+						if(haveFamiliarWillAlwaysActEffect)
+						{
+							sourcesFamiliar += 1;
+						}
 						attackFamiliarPicked = true;
 						break;
 					}
@@ -1032,9 +1048,13 @@ boolean L13_towerNSTower()
 					foreach fam in $familiars[Star Starfish,Animated Macaroni Duck,Killer Bee,Flaming Gravy Fairy,Frozen Gravy Fairy,Stinky Gravy Fairy]
 					{
 						//33% chance of attack
-						if(canChangeToFamiliar(fam))
+						if(canChangeToFamiliar(fam) || qt_currentFamiliar(fam))
 						{
 							handleFamiliar(fam);
+							if(haveFamiliarWillAlwaysActEffect)
+							{
+								sourcesFamiliar += 1;
+							}
 							attackFamiliarPicked = true;
 							break;
 						}
@@ -1046,7 +1066,7 @@ boolean L13_towerNSTower()
 					{
 						if(isAttackFamiliar(fam))
 						{
-							if(canChangeToFamiliar(fam))
+							if(canChangeToFamiliar(fam) || qt_currentFamiliar(fam))
 							{
 								handleFamiliar(fam);
 								attackFamiliarPicked = true;
@@ -1055,6 +1075,12 @@ boolean L13_towerNSTower()
 						}
 					}
 				}
+			}
+
+			if(have_effect($effect[Shortly Wired]) > 0)
+			{
+				//familiar will act twice per round
+				sourcesFamiliar = sourcesFamiliar*2;
 			}
 
 			if(!familiarEquipped)
@@ -1159,7 +1185,7 @@ boolean L13_towerNSTower()
 			}
 			int lastRoundDamage = sources - sourcesReactive - sourcesPassive;	//passive sources only work after surviving a hit
 			//expect to survive 3 hits, hit damage still increases if the first hit is blocked
-			damageSecured = firstRoundDamage + 2*sources + lastRoundDamage;	
+			damageSecured += firstRoundDamage + 2*sources + lastRoundDamage;	
 
 			if(have_skill($skill[Shell Up]))
 			{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1288,7 +1288,7 @@ boolean L13_towerNSTower()
 							{
 								sourcesReactive += 1;
 								damageSecured += 3;
-								if(have_effect($effect[Blood Bubble]) > 0)
+								if(firstHitBlocked)
 								{
 									damageSecured -= 1;
 								}


### PR DESCRIPTION
# Description

count wall of skin damage instead of sources to fix some errors
L13_towerNSTower thought it needed 2 less damage sources with each Shell blocking skills but these skills don't do 2 damage every round
it counted 13 sources to do 50 damage in 4 rounds but passive sources don't work on the last round
count that reactive sources don't work without getting hit

and added familiar equipment sources. and some better than nothing familiars.

## How Has This Been Tested?

run in QT

todo: didn't fix that it doesn't verify hit chance or attack skills to force hit chance or MP or improve the combat code for any of that. is Belch the Rainbow only 5 damage and not 6?
didn't make it try to pull or edit what it pulls, only 1 familiar equipment without knowing if it needs to.
didn't try to use buffs that make familiar act more often or twice item[short white].
didn't check Doctor Big Chungus or Floating Big Chungus. they will just fail and then get beehive.
are there other things with the same effect as Blood Bubble?

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
