### PR TITLE
check song duration of equipped accordion

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5441,7 +5441,7 @@ int auto_predictAccordionTurns()
 	foreach squeezebox in accordions
 	{
 		// Verify that we have the accordion and that it is allowed to be use in path
-		if((possessEquipment(squeezebox) > 0) && (auto_is_valid(squeezebox)))
+		if((equipmentAmount(squeezebox) > 0) && (auto_is_valid(squeezebox)))
 		{
 			expTurns = numeric_modifier(squeezebox, "Song Duration");
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5441,7 +5441,7 @@ int auto_predictAccordionTurns()
 	foreach squeezebox in accordions
 	{
 		// Verify that we have the accordion and that it is allowed to be use in path
-		if((item_amount(squeezebox) > 0) && (auto_is_valid(squeezebox)))
+		if((possessEquipment(squeezebox) > 0) && (auto_is_valid(squeezebox)))
 		{
 			expTurns = numeric_modifier(squeezebox, "Song Duration");
 


### PR DESCRIPTION
# Description

check song duration of equipped accordion too instead of only inventory accordions

## How Has This Been Tested?

tested that song duration is still 10 after antique accordion is equipped

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
