### PR TITLE
Break nightcap ties with mall price

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1229,7 +1229,7 @@ ConsumeAction auto_bestNightcap()
 			continue;
 		}
 
-		if(desirability(i) == desirability(best) && mall_price(actions[i].it) >= mall_price(actions[best].it))
+		if(desirability(i) == desirability(best) && historical_price(actions[i].it) >= historical_price(actions[best].it))
 		{
 			// This consumable is just as desirable as the best consumable, but it is more expensive
 			continue;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1235,7 +1235,7 @@ ConsumeAction auto_bestNightcap()
 			continue;
 		}
 
-		// This consumable is either more desirable or cheaper
+		// This consumable is either more desirable or equally desirable and cheaper
 		best = i;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1223,7 +1223,20 @@ ConsumeAction auto_bestNightcap()
 	int best = 0;
 	for(int i=1; i < count(actions); i++)
 	{
-		if(desirability(i) > desirability(best)) best = i;
+		if(desirability(i) < desirability(best))
+		{
+			// This consumable is less desirable than the best consumable found so far
+			continue;
+		}
+
+		if(desirability(i) == desirability(best) && mall_price(actions[i].it) >= mall_price(actions[best].it))
+		{
+			// This consumable is just as desirable as the best consumable, but it is more expensive
+			continue;
+		}
+
+		// This consumable is either more desirable or cheaper
+		best = i;
 	}
 
 	return actions[best];


### PR DESCRIPTION
# Description

Nightcap determination considers only desirability, picking the most desirable drink. Ties are broken by taking the drink that came first in the list. This can result in more expensive drinks being used as nightcaps, when there are equally desirable drinks that are cheaper.

This was discovered when Autoscend started recommending `corpse on the beach` as a nightcap instead of `space wine`. Both items give the same adventures and have the same desirability. However, `corpse on the beach` comes first in the list, so it was picked, despite it costing 18k while space wine costs only 5k. (Before the last holiday, it was excluded since it cost more than 20k)

Modify the algorithm to break ties in desirability by using the mall price.

## How Has This Been Tested?

I ran the modified logic and it recommended `space wine` as a nightcap instead, breaking the tie using mall price.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
