### PR TITLE
.ash file and header/autoscend.ash imports

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -71,6 +71,7 @@ import <autoscend/paths/pocket_familiars.ash>
 import <autoscend/paths/quantum_terrarium.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
+import <autoscend/paths/wildfire.ash>
 
 
 import <autoscend/quests/level_01.ash>

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -776,6 +776,10 @@ float tcrs_expectedAdvPerFill(string quality);
 boolean tcrs_maximize_with_items(string maximizerString);
 
 ########################################################################################################
+//Defined in autoscend/paths/wildfire.ash
+boolean in_wildfire();
+
+########################################################################################################
 //Defined in autoscend/quests/level_01.ash
 void tootOriole();
 void tootGetMeat();

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -1,0 +1,4 @@
+boolean in_wildfire()
+{
+	return auto_my_path() == "Wildfire";
+}


### PR DESCRIPTION
# Description

Built out the wildfire.ash file and added a spot to import it in autoscend and define it in header.

## How Has This Been Tested?

It didn't break anything for me.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
