### PR TITLE
fix ca 879

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -360,12 +360,12 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
-			if(options contains 5 && auto_mall_price($item[Engorged Sausages and You]) > 1000) {
-				run_choice(5); // only shows up rarely. when this line was added it was worth 1.3 million in mall
+			if(options contains 4 && auto_mall_price($item[Engorged Sausages and You]) > 1000) {
+				run_choice(4); // only shows up rarely. when this line was added it was worth 1.3 million in mall
 			} if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
 				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror
 			} else if(item_amount($item[ghost key]) > 0 && my_primestat() == $stat[moxie] && my_buffedstat($stat[moxie]) < 150) {
-				run_choice(4); // spend 1 ghost key for primestat, get ~200 moxie XP
+				run_choice(5); // spend 1 ghost key for primestat, get ~200 moxie XP
 			} else {
 				run_choice(1); // get moxie substats
 			}


### PR DESCRIPTION
fix ca 879.
choice 4 and 5 were flipped in our handling

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
