### PR TITLE
auto_mall_price() should return historical_price() if invoked in a choice adventure

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -360,7 +360,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
-			if(options contains 4 && auto_mall_price($item[Engorged Sausages and You]) > 1000) {
+			if(options contains 4) {
 				run_choice(4); // only shows up rarely. when this line was added it was worth 1.3 million in mall
 			} if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
 				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2820,6 +2820,11 @@ int auto_mall_price(item it)
 	{
 		return -1;	//speakeasy drinks are marked as tradeable but cannot be acquired as a physical item to trade.
 	}
+	if(available_choice_options() contains 0 || available_choice_options() contains 1)	//we are in a choice adventure.
+	{
+		//workaround to this issue https://kolmafia.us/threads/trying-to-use-mall_price-in-a-choice-adventure-stack-overflow.26286/
+		return historical_price(it);
+	}
 	if(is_tradeable(it))
 	{
 		int retval = mall_price(it);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2822,7 +2822,7 @@ int auto_mall_price(item it)
 	}
 	if(available_choice_options() contains 0 || available_choice_options() contains 1)	//we are in a choice adventure.
 	{
-		//workaround to this issue https://kolmafia.us/threads/trying-to-use-mall_price-in-a-choice-adventure-stack-overflow.26286/
+		//mafia returns -1 if we check mall_price() while in a choice adv. better to use historical price even if it is outdated
 		return historical_price(it);
 	}
 	if(is_tradeable(it))


### PR DESCRIPTION
* do not bother checking mall price of engorged sausages and you if you encounter it. It is rare so we might as well just grab it. Plus the check is not meaningful since we can not actually go to the mall to check at the time. And the historical price will not be meaningful there since it never gets updated for that specific item.

* workaround for mall_price() while in noncombat adv:
initially this PR was fixing stack overflow issue where it hit the server ~700 times in an infinitely nested set of calls before hitting stack overflow.
mafia r20840 fixed this upstream by returning -1 (unless the data was updated today in which case it shows todays cached price).
Still using the same workaround, only now working around the -1 by giving us a more meaningful value in that it will return historical_price() when we try to use auto_mall_price() in a choice adv. Even old historical price is better than having a -1 for the price.

## How Has This Been Tested?

ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
