### PR TITLE
Added choctopus to fairywhelps in item fams

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -29,6 +29,7 @@ God Lobster	item:God Lobster's Crown>0
 Pocket Professor
 Garbage Fire
 Dandy Lion
+Choctopus
 # Fairychauns
 Fist Turkey
 Cat Burglar

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -119,50 +119,51 @@ item	11	God Lobster	item:God Lobster's Crown>0
 item	12	Pocket Professor
 item	13	Garbage Fire
 item	14	Dandy Lion
+item	15	Choctopus
 # Fairychauns
-item	15	Fist Turkey
-item	16	Cat Burglar
-item	17	Angry Jung Man
-item	18	Grimstone Golem
-item	19	Adventurous Spelunker
-item	20	Blavious Kloop
-item	21	Hippo Ballerina
-item	22	Dancing Frog
-item	23	Coffee Pixie
-item	24	Attention-Deficit Demon
-item	25	Jitterbug
-item	26	Casagnova Gnome
-item	27	Psychedelic Bear
-item	28	Piano Cat
+item	16	Fist Turkey
+item	17	Cat Burglar
+item	18	Angry Jung Man
+item	19	Grimstone Golem
+item	20	Adventurous Spelunker
+item	21	Blavious Kloop
+item	22	Hippo Ballerina
+item	23	Dancing Frog
+item	24	Coffee Pixie
+item	25	Attention-Deficit Demon
+item	26	Jitterbug
+item	27	Casagnova Gnome
+item	28	Psychedelic Bear
+item	29	Piano Cat
 # Slightly special fairies
-item	29	Ghost of Crimbo Carols
-item	30	Red-Nosed Snapper
-item	31	Pair of Stomping Boots	!path:G-Lover
-item	32	Gelatinous Cubeling
-item	33	Steam-Powered Cheerleader
-item	34	Obtuse Angel
-item	35	Green Pixie
+item	30	Ghost of Crimbo Carols
+item	31	Red-Nosed Snapper
+item	32	Pair of Stomping Boots	!path:G-Lover
+item	33	Gelatinous Cubeling
+item	34	Steam-Powered Cheerleader
+item	35	Obtuse Angel
+item	36	Green Pixie
 # Elemental fairies
-item	36	Sleazy Gravy Fairy
-item	37	Stinky Gravy Fairy
-item	38	Flaming Gravy Fairy
-item	39	Frozen Gravy Fairy
-item	40	Spooky Gravy Fairy
+item	37	Sleazy Gravy Fairy
+item	38	Stinky Gravy Fairy
+item	39	Flaming Gravy Fairy
+item	40	Frozen Gravy Fairy
+item	41	Spooky Gravy Fairy
 # Physical damage fairy
-item	41	Bowlet
+item	42	Bowlet
 # Barely special fairies
-item	42	Mechanical Songbird
-item	43	Grouper Groupie
-item	44	Peppermint Rhino
+item	43	Mechanical Songbird
+item	44	Grouper Groupie
+item	45	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	45	Slimeling
+item	46	Slimeling
 # Turtles are cute
-item	46	Syncopated Turtle
+item	47	Syncopated Turtle
 # The original
-item	47	Baby Gravy Fairy
+item	48	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	48	Mutant Fire Ant
+item	49	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1


### PR DESCRIPTION
# Description

Reported in discord that choctopus wasn't being used when gelatinous cubeling was. We already had choctopus in familiars/regen, but missing in familiars/item. 

## How Has This Been Tested?

None. Don't have fam to test with

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
