### PR TITLE
uneffect Psalm of Pointiness for wall of bones

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1153,8 +1153,10 @@ boolean L13_towerNSTower()
 		//if we reached this spot we decided that we do not need a boning knife and intend to try to towerkill the wall of bones.
 		uneffect($effect[Scarysauce]);
 		uneffect($effect[Jalape&ntilde;o Saucesphere]);
-		uneffect($effect[Mayeaugh]);
 		uneffect($effect[Spiky Shell]);
+		uneffect($effect[Psalm of Pointiness]);
+		uneffect($effect[Mayeaugh]);
+		uneffect($effect[Feeling Nervous]);
 		buffMaintain($effect[Tomato Power], 0, 1, 1);
 		buffMaintain($effect[Seeing Colors], 0, 1, 1);
 		buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);


### PR DESCRIPTION
Psalm of Pointiness should be removed too when trying to kill wall of bones without boning knife

and Feeling Nervous. that one is not used now but I add it in #875

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
