### PR TITLE
handleBjornify if bjorn is requested familiar return true

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -50,21 +50,6 @@ boolean handleBjornify(familiar fam)
 			}
 		}
 	}
-	if(my_familiar() == $familiar[none])
-	{
-		if(my_bjorned_familiar() == $familiar[Grimstone Golem])
-		{
-			handleFamiliar("stat");
-		}
-		else if(my_bjorned_familiar() == $familiar[Grim Brother])
-		{
-			handleFamiliar("item");
-		}
-		else
-		{
-			handleFamiliar("item");
-		}
-	}
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -9,9 +9,14 @@ boolean handleBjornify(familiar fam)
 		return false;
 	}
 
-	if((equipped_item($slot[back]) != $item[buddy bjorn]) || (my_bjorned_familiar() == fam))
+	if(equipped_item($slot[back]) != $item[buddy bjorn])
 	{
 		return false;
+	}
+	
+	if(my_bjorned_familiar() == fam)
+	{
+		return true;
 	}
 
 	if(!canChangeFamiliar() && (fam == my_familiar()))


### PR DESCRIPTION
# Description

handleBjornify seems like it should return true not false if the requested familiar is already in it

## How Has This Been Tested?

the way handleBjornify is used in autoscend it also looks like it should try 
>if(!autoEquip($slot[back], $item[buddy bjorn])) 

instead of returning false if(equipped_item($slot[back]) != $item[buddy bjorn])
but I don't have buddy bjorn to test

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
