### PR TITLE
plumber consume

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1659,7 +1659,6 @@ boolean doTasks()
 	awol_buySkills();
 	awol_useStuff();
 	theSource_buySkills();
-	plumber_buyStuff();
 	jarlsberg_buySkills();
 	boris_buySkills();
 	pete_buySkills();
@@ -1704,6 +1703,7 @@ boolean doTasks()
 	if(LM_kolhs()) 						return true;
 	if(LM_jarlsberg())					return true;
 	if(LM_robot())						return true;
+	if(LM_plumber())					return true;
 
 	if(!in_community())
 	{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1055,6 +1055,12 @@ boolean doBedtime()
 	auto_beachUseFreeCombs();
 	auto_drinkNightcap();
 
+	if(in_plumber() && fullness_left() > 0)
+	{
+		print("Plumber consumption is complicated. Please manually consume stuff then run me again.", "red");
+		return false;
+	}
+	
 	boolean done = (my_inebriety() > inebriety_limit()) || (my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]);
 	if(in_gnoob() || !can_drink() || out_of_blood)
 	{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1634,7 +1634,7 @@ void prepare_food_xp_multi()
 		return;
 	}
 	
-	//if you try to use shorthand it will instead give you stat % instead of stat XP %
+	//if you try to use shorthand maximizer will provide you with buffed stat % instead of stat XP % gains
 	maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
 	
 	//TODO get effect [Ready to Eat] by using a red rocket from fireworks shop in VIP clan. +400% XP on next food item

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1629,7 +1629,7 @@ boolean distill(item target)
 void prepare_food_xp_multi()
 {
 	//prepare as big an XP multi as possible for the next food item eaten
-	if(fullness_left() < 1)
+	if(fullness_left() < 1 || !can_eat())
 	{
 		return;
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1625,3 +1625,28 @@ boolean distill(item target)
 	auto_log_warning("distill(item target) mysteriously failed to create [" +target+ "]");
 	return false;
 }
+
+void prepare_food_xp_multi()
+{
+	//prepare as big an XP multi as possible for the next food item eaten
+	if(fullness_left() < 1)
+	{
+		return;
+	}
+	
+	//if you try to use shorthand it will instead give you stat % instead of stat XP %
+	maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
+	
+	//TODO get effect [Ready to Eat] by using a red rocket from fireworks shop in VIP clan. +400% XP on next food item
+	
+	//TODO get [That's Just Cloud-Talk, Man] +25% all
+	
+	pullXWhenHaveY($item[Special Seasoning], 1, 0);		//automatically consumed with food and gives extra XP
+	
+	item milk = $item[gallon of milk];
+	if(creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk))
+	{
+		acquireOrPull(milk);
+		autoEat(1, milk);
+	}
+}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1626,12 +1626,12 @@ boolean distill(item target)
 	return false;
 }
 
-void prepare_food_xp_multi()
+boolean prepare_food_xp_multi()
 {
 	//prepare as big an XP multi as possible for the next food item eaten
 	if(fullness_left() < 1 || !can_eat())
 	{
-		return;
+		return false;
 	}
 	
 	//if you try to use shorthand maximizer will provide you with buffed stat % instead of stat XP % gains
@@ -1642,11 +1642,5 @@ void prepare_food_xp_multi()
 	//TODO get [That's Just Cloud-Talk, Man] +25% all
 	
 	pullXWhenHaveY($item[Special Seasoning], 1, 0);		//automatically consumed with food and gives extra XP
-	
-	item milk = $item[gallon of milk];
-	if(creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk))
-	{
-		acquireOrPull(milk);
-		autoEat(1, milk);
-	}
+	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1354,9 +1354,8 @@ boolean auto_knapsackAutoConsume(string type, boolean simulate)
 {
 	// TODO: does not consider mime army shotglass
 
-	if(in_plumber())
+	if(in_plumber() && my_level() < 13)
 	{
-		auto_log_warning("Skipping eating, you'll have to do this manually.", "red");
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1634,12 +1634,27 @@ boolean prepare_food_xp_multi()
 		return false;
 	}
 	
-	//if you try to use shorthand maximizer will provide you with buffed stat % instead of stat XP % gains
-	maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
-	
-	//TODO get effect [Ready to Eat] by using a red rocket from fireworks shop in VIP clan. +400% XP on next food item
+	//[Ready to Eat] is gotten by using a red rocket from fireworks shop in VIP clan. it gives +400% XP on next food item
+	if(have_fireworks_shop() &&
+	have_effect($effect[Everything Looks Red]) <= 0 &&
+	have_effect($effect[Ready to Eat]) <= 0 &&
+	auto_is_valid($item[red rocket]))
+	{
+		if(item_amount($item[red rocket]) == 0 && my_meat() > npc_price($item[red rocket]))
+		{
+			//this is a more aggressive buying function than the one in pre_adv
+			retrieve_item(1, $item[red rocket]);
+		}
+		if(item_amount($item[red rocket]) > 0)
+		{
+			return false;	//go use [red rocket] in combat before eating for XP
+		}
+	}
 	
 	//TODO get [That's Just Cloud-Talk, Man] +25% all
+	
+	//if you try to use shorthand maximizer will provide you with buffed stat % instead of stat XP % gains
+	maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
 	
 	pullXWhenHaveY($item[Special Seasoning], 1, 0);		//automatically consumed with food and gives extra XP
 	return true;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -185,8 +185,7 @@ boolean auto_pre_adventure()
 	}
 
 	// be ready to use red rocket if we don't have one
-	if(item_amount($item[Clan VIP Lounge Key]) > 0 &&	// Need VIP access
-		get_property("_fireworksShop").to_boolean() &&	// in a clan that has the Underground Fireworks Shop
+	if(have_fireworks_shop() &&							// in a clan that has the Underground Fireworks Shop
 		item_amount($item[red rocket]) == 0 &&			// Don't buy if we already have one
 		auto_is_valid($item[red rocket]) &&				// or if it's not valid
 		can_eat() &&									// be in a path that can eat

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1206,7 +1206,7 @@ boolean auto_breakfastCounterVisit();
 item still_targetToOrigin(item target);
 boolean stillReachable();
 boolean distill(item target);
-void prepare_food_xp_multi();
+boolean prepare_food_xp_multi();
 
 ########################################################################################################
 //Defined in autoscend/auto_settings.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1206,6 +1206,7 @@ boolean auto_breakfastCounterVisit();
 item still_targetToOrigin(item target);
 boolean stillReachable();
 boolean distill(item target);
+void prepare_food_xp_multi();
 
 ########################################################################################################
 //Defined in autoscend/auto_settings.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -428,6 +428,7 @@ boolean batteryCombine(item battery);
 boolean batteryCombine(item battery, boolean simulate);
 boolean can_get_battery(item target);
 boolean auto_getBattery(item target);
+boolean have_fireworks_shop();
 boolean auto_haveFireExtinguisher();
 int auto_fireExtinguisherCharges();
 string auto_FireExtinguisherCombatString(location place);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -747,6 +747,8 @@ int plumber_ppCost(skill sk);
 boolean plumber_canDealScalingDamage();
 boolean plumber_skillValid(skill sk);
 boolean plumber_equipTool(stat st);
+void plumber_eat_xp();
+boolean LM_plumber();
 
 ########################################################################################################
 //Defined in autoscend/paths/picky.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -262,17 +262,20 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 
 	// use red rocket from Clan VIP Lounge to get 5x stats from next food item consumed. Does not stagger on use
-	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) &&
-		// consumeStuff fills liver first up to 10 or 15 before eating, pending if billiards room if completed. Gives confidence that we will eat within 100 turns.
-		my_inebriety() >= 10 && my_adventures() < 100)
+	// consumeStuff fills liver first up to 10 or 15 before eating, pending if billiards room if completed. Gives confidence that we will eat within 100 turns.
+	boolean billiards_check = my_inebriety() >= 10 || !can_drink() || hasSpookyravenLibraryKey();
+	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100 && billiards_check)
 	{
+		if(in_plumber())
+		{
+			return useItem($item[red rocket]);
+		}
 		//use if next food is large in size. Currently autoConsume doesn't analyze stat gain, which would be better
 		item simulationOutput = auto_autoConsumeOneSimulation("eat");
 		if (simulationOutput != $item[none] && simulationOutput.fullness > 3)
 		{
 			return useItem($item[red rocket]);
 		}
-		
 	}
 
 	// use cosmic bowling ball iotm

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -452,6 +452,19 @@ boolean auto_getBattery(item target)
 	return false;
 }
 
+boolean have_fireworks_shop()
+{
+	if(item_amount($item[Clan VIP Lounge Key]) == 0)
+	{
+		return false;
+	}
+	if(!auto_is_valid($item[clan underground fireworks shop]))
+	{
+		return false;
+	}
+	return get_property("_fireworksShop").to_boolean();
+}
+
 boolean auto_haveFireExtinguisher()
 {
 	return possessEquipment($item[industrial fire extinguisher]) && auto_is_valid($item[industrial fire extinguisher]);

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -429,31 +429,12 @@ boolean plumber_equipTool(stat st)
 void plumber_eat_xp()
 {
 	//eat stuff for XP.
-	if(!in_plumber() || fullness_left() == 0)
+	if(!in_plumber() || fullness_left() < 1)
 	{
 		return;
 	}
 	
-	void prepare_xp_multi()
-	{
-		//prepare as big an XP multi as possible for the next food item eaten
-		//if you try to use shorthand it will instead give you stat % instead of stat XP %
-		maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
-		
-		//TODO get effect [Ready to Eat] by using a red rocket from fireworks shop in VIP clan. +400% XP on next food item
-		
-		//TODO get [That's Just Cloud-Talk, Man] +25% all
-		
-		pullXWhenHaveY($item[Special Seasoning], 1, 0);		//automatically consumed with food and gives extra XP
-	}
-	
-	item milk = $item[gallon of milk];
-	if(15 <= fullness_left() && (creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk)))
-	{
-		acquireOrPull(milk);
-		prepare_xp_multi();
-		autoEat(1, milk);
-	}
+	prepare_food_xp_multi();
 	
 	//TODO diabolic pizza oven with pie man was not meant to eat
 }

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -437,6 +437,13 @@ void plumber_eat_xp()
 	prepare_food_xp_multi();
 	
 	//TODO diabolic pizza oven with pie man was not meant to eat
+	
+	item milk = $item[gallon of milk];
+	if(creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk))
+	{
+		acquireOrPull(milk);
+		autoEat(1, milk);
+	}
 }
 
 boolean LM_plumber()

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -433,8 +433,10 @@ void plumber_eat_xp()
 	{
 		return;
 	}
-	
-	prepare_food_xp_multi();
+	if(!prepare_food_xp_multi())
+	{
+		return;		//we are not prepared.
+	}
 	
 	//TODO diabolic pizza oven with pie man was not meant to eat
 	

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -441,7 +441,8 @@ void plumber_eat_xp()
 	//TODO diabolic pizza oven with pie man was not meant to eat
 	
 	item milk = $item[gallon of milk];
-	if(creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk))
+	boolean got_milk = creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk);
+	if(got_milk && fullness_left() >= 15)
 	{
 		acquireOrPull(milk);
 		autoEat(1, milk);

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -425,3 +425,52 @@ boolean plumber_equipTool(stat st)
 	}
 	return false;
 }
+
+void plumber_eat_xp()
+{
+	//eat stuff for XP.
+	if(!in_plumber() || fullness_left() == 0)
+	{
+		return;
+	}
+	
+	void prepare_xp_multi()
+	{
+		//prepare as big an XP multi as possible for the next food item eaten
+		//if you try to use shorthand it will instead give you stat % instead of stat XP %
+		maximize("muscle experience percent, mysticality experience percent, moxie experience percent", false);
+		
+		//TODO get effect [Ready to Eat] by using a red rocket from fireworks shop in VIP clan. +400% XP on next food item
+		
+		//TODO get [That's Just Cloud-Talk, Man] +25% all
+		
+		pullXWhenHaveY($item[Special Seasoning], 1, 0);		//automatically consumed with food and gives extra XP
+	}
+	
+	item milk = $item[gallon of milk];
+	if(15 <= fullness_left() && (creatable_amount(milk) > 0 || item_amount(milk) > 0 || canPull(milk)))
+	{
+		acquireOrPull(milk);
+		prepare_xp_multi();
+		autoEat(1, milk);
+	}
+	
+	//TODO diabolic pizza oven with pie man was not meant to eat
+}
+
+boolean LM_plumber()
+{
+	//this function is called early once every loop of doTasks() in autoscend.ash
+	//if something in this function returns true then it will restart the loop and get called again.
+	if(!in_plumber())
+	{
+		return false;
+	}
+	plumber_buyStuff();
+	if(my_level() < 13)
+	{
+		plumber_eat_xp();
+	}
+	
+	return false;
+}


### PR DESCRIPTION
* automatically consume in plumber once we reach level 13 and no longer care about the XP
* only warn about manual consumption during bedtime instead of every loop. and be clearer with it as well. Also always display the instruction of "eat then run me again" regardless of log settings.
* started adding some measure of consumption for XP to plumber

## How Has This Been Tested?

standard plumber run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
