### PR TITLE
hotfix inventory desync when using `boolean distill(item target)`

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1633,6 +1633,7 @@ boolean distill(item target)
 	}
 	int start_amount = item_amount(target);
 	create(1, target);			//use the still to create target
+	cli_execute("refresh inv");		//as of r20865 distilling using create command causes inventory desync
 	if(start_amount + 1 == item_amount(target))
 	{
 		return true;


### PR DESCRIPTION
workaround for https://kolmafia.us/threads/inventory-desync-when-using-create-to-use-the-nash-crosby-still.26323/

as of r20865 distilling using create() command inventory desync which in turn causes errors when trying to use the still.
fixed via `cli_execute("refresh inv");`

## How Has This Been Tested?

during bedtime `void bedtime_still()` was doing
buy 1 soda water
distill it to tonic water
attempt to distill it again to tonic water without buying a replacement soda water and fail.

with this code this no longer happened.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
