### PR TITLE
Revert "hotfix inventory desync when using `boolean distill(item target)`"

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r20793;	//min mafia revision needed to run this script. Last update: Add explosive equipment to equipment.txt
+since r20870;	//min mafia revision needed to run this script. Last update: fixed inv desync on some create() command uses
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1633,7 +1633,6 @@ boolean distill(item target)
 	}
 	int start_amount = item_amount(target);
 	create(1, target);			//use the still to create target
-	cli_execute("refresh inv");		//as of r20865 distilling using create command causes inventory desync
 	if(start_amount + 1 == item_amount(target))
 	{
 		return true;


### PR DESCRIPTION
fixed upstream in mafia r20870
https://kolmafia.us/threads/inventory-desync-when-using-create-to-use-the-nash-crosby-still.26323/

## How Has This Been Tested?

ash commands

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
