### PR TITLE
Remove Reagnimated Gnome from Heavy Rains

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -15,7 +15,7 @@ Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
 # 1.1x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
 # fairy that generates extra adventures
-Reagnimated Gnome   !path:Heavy Rains
+Reagnimated Gnome	!path:Heavy Rains
 # Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
 XO Skeleton
 # Fairy that drops bacon with no limit. 1 per combat

--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -15,7 +15,7 @@ Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
 # 1.1x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
 # fairy that generates extra adventures
-Reagnimated Gnome
+Reagnimated Gnome   !path:Heavy Rains
 # Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
 XO Skeleton
 # Fairy that drops bacon with no limit. 1 per combat

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -105,7 +105,7 @@ item	3	Steam-Powered Cheerleader	prop:_cheerleaderSteam>50
 # 1.1x multiplier fairy
 item	4	Steam-Powered Cheerleader	prop:_cheerleaderSteam>0
 # fairy that generates extra adventures
-item	5	Reagnimated Gnome
+item	5	Reagnimated Gnome	!path:Heavy Rains
 # Fairywhelp that drops x and o without limit. 1 each per 9 combats. 3 o for food. 3 x for drink, 23 x to skip half bridge.
 item	6	XO Skeleton
 # Fairy that drops bacon with no limit. 1 per combat

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -721,7 +721,7 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[over-the-shoulder folder holder], 1, 0);
 		}
-		if((my_primestat() == $stat[Muscle]) && (!in_heavyrains())
+		if((my_primestat() == $stat[Muscle]) && !in_heavyrains())
 		{
 			if((closet_amount($item[Fake Washboard]) == 0) && glover_usable($item[Fake Washboard]))
 			{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -211,7 +211,7 @@ void initializeSettings() {
 	beehiveConsider();
 
 	eudora_initializeSettings();
-	heavy_rains_initializeSettings;
+	heavy_rains_initializeSettings();
 	awol_initializeSettings();
 	theSource_initializeSettings();
 	ed_initializeSettings();
@@ -2526,7 +2526,7 @@ void print_header()
 	{
 		auto_log_info("Snow suit usage: " + get_property("_snowSuitCount") + " carrots: " + get_property("_carrotNoseDrops"), "blue");
 	}
-	if(auto_my_path() == "Heavy Rains")
+	if (in_heavyrains())
 	{
 		auto_log_info("Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -211,7 +211,7 @@ void initializeSettings() {
 	beehiveConsider();
 
 	eudora_initializeSettings();
-	hr_initializeSettings();
+	heavy_rains_initializeSettings;
 	awol_initializeSettings();
 	theSource_initializeSettings();
 	ed_initializeSettings();
@@ -1161,7 +1161,7 @@ void initializeDay(int day)
 
 			tootGetMeat();
 
-			hr_initializeDay(day);
+			heavy_rains_initializeDay(day);
 			// It's nice to have a moxie weapon for Flock of Bats form
 			if(my_class() == $class[Vampyre] && get_property("darkGyfftePoints").to_int() < 21 && !possessEquipment($item[disco ball]))
 			{
@@ -1250,7 +1250,7 @@ void initializeDay(int day)
 				use(1, $item[gym membership card]);
 			}
 
-			hr_initializeDay(day);
+			heavy_rains_initializeDay(day);
 
 			if(!in_hardcore() && (item_amount($item[Handful of Smithereens]) <= 5))
 			{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -472,7 +472,7 @@ int pullsNeeded(string data)
 		if((item_amount($item[Richard\'s Star Key]) == 0) && (item_amount($item[Star Chart]) == 0))
 		{
 			auto_log_warning("Need star chart", "red");
-			if((auto_my_path() == "Heavy Rains") && (my_rain() >= 50))
+			if(in_heavyrains() && (my_rain() >= 50))
 			{
 				auto_log_info("You should rain man a star chart", "blue");
 			}
@@ -721,7 +721,7 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[over-the-shoulder folder holder], 1, 0);
 		}
-		if((my_primestat() == $stat[Muscle]) && (auto_my_path() != "Heavy Rains"))
+		if((my_primestat() == $stat[Muscle]) && (!in_heavyrains())
 		{
 			if((closet_amount($item[Fake Washboard]) == 0) && glover_usable($item[Fake Washboard]))
 			{
@@ -771,7 +771,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 		}
 
-		if((auto_my_path() != "Heavy Rains") && (auto_my_path() != "License to Adventure") && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
+		if(!in_heavyrains() && (auto_my_path() != "License to Adventure") && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
 		{
 			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Astral Pet Sweater]) && glover_usable($item[Snow Suit]))
 			{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -329,7 +329,7 @@ boolean doBedtime()
 	}
 
 	equipRollover();
-	hr_doBedtime();
+	heavy_rains_doBedtime();
 
 	while(my_daycount() == 1 && item_amount($item[resolution: be more adventurous]) > 0 && get_property("_resolutionAdv").to_int() < 10 && !can_interact())
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -633,10 +633,11 @@ boolean LA_grey_goo_tasks();
 
 ########################################################################################################
 //Defined in autoscend/paths/heavy_rains.ash
-void hr_initializeSettings();
+boolean in_heavyrains();
+void heavy_rains_initializeSettings();
 boolean routineRainManHandler();
-void hr_initializeDay(int day);
-void hr_doBedtime();
+void heavy_rains_initializeDay(int day);
+void heavy_rains_doBedtime();
 boolean doHRSkills();
 boolean rainManSummon(monster target, boolean copy, boolean wink);
 boolean L13_towerFinalHeavyRains();

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -1,6 +1,11 @@
-void hr_initializeSettings()
+boolean in_heavyrains()
 {
-	if(my_path() == "Heavy Rains")
+	return auto_my_path() == "Heavy Rains";
+}
+
+void heavy_rains_initializeSettings()
+{
+	if(in_heavyrains())
 	{
 		#Rain Man (Heavy Rains) Related settings
 		set_property("auto_holeinthesky", false);
@@ -87,9 +92,9 @@ boolean routineRainManHandler()
 
 
 
-void hr_initializeDay(int day)
+void heavy_rains_initializeDay(int day)
 {
-	if(my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		if((day == 1) && (get_property("auto_day1_skills") != "finished"))
 		{
@@ -134,7 +139,7 @@ void hr_initializeDay(int day)
 	}
 }
 
-void hr_doBedtime()
+void heavy_rains_doBedtime()
 {
 	if(my_inebriety() > inebriety_limit())
 	{
@@ -155,7 +160,7 @@ void hr_doBedtime()
 
 boolean doHRSkills()
 {
-	if(my_path() != "Heavy Rains")
+	if(!in_heavyrains())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Removes Reagnimated Gnome from Heavy Rains as the benefit of the familiar equipment is negated by necessity for the miniature life preserver in the path.  I also made some minor code cleanup on heavy rains items for consistency and visibility.

## How Has This Been Tested?

Modified this myself on my own version of autoscend and I have run Heavy Rains.  It hasn't used the gnome once in a new run.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
