### PR TITLE
boolean canPull(item it) fixed & misc

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2202,12 +2202,18 @@ boolean adventureFailureHandler()
 		{
 			tooManyAdventures = false;		//if we do not have iotm powerlevel zones then we are forced to use haunted gallery or bedroom
 		}
+		
+		if(my_adventures() < get_property("_auto_override_tooManyAdv").to_int())
+		{
+			tooManyAdventures = false;		//currently in override for too many adv
+		}
 
 		if(tooManyAdventures)
 		{
 			if(get_property("auto_newbieOverride").to_boolean())
 			{
 				set_property("auto_newbieOverride", false);
+				set_property("_auto_override_tooManyAdv", my_adventures()+5);		//override 5 adv at a time
 				auto_log_warning("We have spent " + place.turns_spent + " turns at '" + place + "' and that is bad... override accepted.", "red");
 			}
 			else

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -40,7 +40,7 @@ boolean acquireOrPull(item it)
 	return false;
 }
 
-boolean canPull(item it)
+boolean canPull(item it, boolean historical)
 {
 	if(in_hardcore())
 	{
@@ -61,7 +61,11 @@ boolean canPull(item it)
 	
 	if(storage_amount(it) > 0)
 	{
-		return true;
+		return true;	//we have it in storage so we can pull it
+	}
+	else if(!is_tradeable(it))
+	{
+		return false;	//we do not have it in storage and we can not trade for it. gifts currently not handled
 	}
 
 	int meat = my_storage_meat();
@@ -69,7 +73,15 @@ boolean canPull(item it)
 	{
 		meat = max(meat, my_meat() - 5000);
 	}
-	int curPrice = auto_mall_price(it);
+	int curPrice = historical_price(it);
+	if(!historical)
+	{
+		curPrice = auto_mall_price(it);
+	}
+	if(curPrice < 1)
+	{
+		return false;	//a 0 or a -1 indicates the item is not available.
+	}
 	if (curPrice > get_property("autoBuyPriceLimit").to_int())
 	{
 		return false;
@@ -80,6 +92,11 @@ boolean canPull(item it)
 	}
 	
 	return false;
+}
+
+boolean canPull(item it)
+{
+	return canPull(it, false);
 }
 
 void pullAll(item it)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1596,8 +1596,8 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 				auto_log_error("Ignoring the error as per user instructions");
  				return false;
 			}
-			print("Aborting due to restore failure... you can override this setting for today by entering in gCLI:");
-			print("set _auto_ignoreRestoreFailureToday = true");
+			print("Aborting due to restore failure... you can override this setting for today by entering in gCLI:" ,"blue");
+			print("set _auto_ignoreRestoreFailureToday = true" ,"blue");
 			abort();
 		}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1045,6 +1045,7 @@ void houseUpgrade();
 //Defined in autoscend/auto_acquire.ash
 boolean haveAny(boolean[item] array);
 boolean acquireOrPull(item it);
+boolean canPull(item it, boolean update);
 boolean canPull(item it);
 void pullAll(item it);
 void pullAndUse(item it, int uses);


### PR DESCRIPTION
* boolean canPull(item it) fixed. it did not account for mallprice returning 0 or -1
* make the instructions on how to bypass aborting due to MP restore fail more visible (and in line with other similar cases) by making the text blue
* make auto_newbieOverride last for 5 adv instead of 1
* boolean canPull(item it) modified into  boolean canPull(item it, boolean update)
  * allows canPull to use historical instead of current pricing

## How Has This Been Tested?

tested in wildfire

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
