### PR TITLE
Bedtime pulling

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -20,6 +20,10 @@ auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
 auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
 auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
+auto_bedtime_pulls_skip_clover	boolean	After everything else was pulled. leftover pulls will be filled with ten-leaf clover. unless this is set to true
+auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
+auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
 auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
 auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
 auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -1,7 +1,7 @@
 auto_skipNEPOverride	boolean	If true will not use the Neverending Party even if mafia says it is available.
 auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
 auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
-auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? (Or in Ed, Even More Elemental Wards)?
+auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? Setting will situationally be ignored such as in Ed where we always delay for Even More Elemental Wards
 auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
 auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -12,7 +12,7 @@ action	4	auto_newbieOverride	boolean	If true will override newbie block once the
 any	0	auto_skipNEPOverride	boolean	If true will not use the Neverending Party even if mafia says it is available.
 any	1	auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
 any	2	auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
-any	3	auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? (Or in Ed, Even More Elemental Wards)?
+any	3	auto_delayHauntedKitchen	boolean	Should we delay the Haunted Kitchen until we have 9 resist? Setting will situationally be ignored such as in Ed where we always delay for Even More Elemental Wards
 any	4	auto_dickstab	boolean	Do you want to let the script potentially spend lots of meat just to shave off a few adventures? You probably don't.
 any	5	auto_getDinseyGarbageMoney	boolean	Spend a few turns getting the easy FunBucks during a run?
 any	6	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -31,35 +31,39 @@ any	18	auto_skipNightcap	boolean	When true will not get overdrunk at the end of 
 any	19	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
 any	20	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
 any	21	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	22	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	23	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	24	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	25	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	26	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	27	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	28	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	29	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	30	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	31	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	32	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	33	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	34	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	35	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	36	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	38	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	39	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	40	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	41	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	42	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	43	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	44	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
-any	45	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
-any	46	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	47	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	48	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	49	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
-any	50	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
+any	22	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
+any	23	auto_bedtime_pulls_skip_clover	boolean	After everything else was pulled. leftover pulls will be filled with ten-leaf clover. unless this is set to true
+any	24	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
+any	25	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
+any	26	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	27	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	28	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	29	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	30	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	31	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	32	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	33	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	34	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	35	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	36	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	37	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	38	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	39	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	40	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	41	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	42	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	43	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	44	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	45	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	46	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	47	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	48	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
+any	49	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
+any	50	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	51	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	52	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	53	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	54	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -268,7 +268,7 @@ void bedtime_pulls()
 		return rollover_value(it) - rollover_value(equipped_item(sl));
 	}
 	
-	equipRollover();
+	equipRollover(true);
 	for(int i=0; i<20; i++)
 	{
 		if(pulls_remaining() == 0)
@@ -331,7 +331,7 @@ void bedtime_pulls()
 		}
 		auto_log_info("Pulling [" +very_best+ "] which improves desireability score by " +very_best_improvement);
 		pullXWhenHaveY(very_best, 1, 0);
-		equipRollover();
+		equipRollover(true);
 	}
 }
 
@@ -594,7 +594,7 @@ boolean doBedtime()
 		}
 	}
 
-	equipRollover();
+	equipRollover(false);
 	heavy_rains_doBedtime();
 
 	while(my_daycount() == 1 && item_amount($item[resolution: be more adventurous]) > 0 && get_property("_resolutionAdv").to_int() < 10 && !can_interact())

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -238,7 +238,7 @@ void bedtime_pulls()
 	{
 		pullXWhenHaveY($item[Antique Machete], 1, 0);
 	}
-	if(item_amount($item[Wet Stunt Nut Stew]) == 0 && !possessEquipment($item[Mega Gem]))
+	if(item_amount($item[Wet Stunt Nut Stew]) == 0 && !possessEquipment($item[Mega Gem]) && !isActuallyEd())
 	{
 		pullXWhenHaveY($item[wet stew], 1, 0);
 	}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -248,8 +248,15 @@ void bedtime_pulls()
 	}
 	if(internalQuestStatus("questL11Desert") < 1)
 	{
-		pullXWhenHaveY($item[drum machine], 1, 0);
-		pullXWhenHaveY($item[killing jar], 1, 0);
+		int gnasirProgress = get_property("gnasirProgress").to_int();
+		if ((gnasirProgress & 16) == 0)
+		{
+			pullXWhenHaveY($item[drum machine], 1, 0);
+		}
+		if ((gnasirProgress & 4) == 0)
+		{
+			pullXWhenHaveY($item[killing jar], 1, 0);
+		}
 	}
 	
 	//scan through all pullable items for items that have a better rollover adv gain than currently best equipped item.

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -333,6 +333,36 @@ void bedtime_pulls()
 		pullXWhenHaveY(very_best, 1, 0);
 		equipRollover(true);
 	}
+	
+	//grab clovers with remaining pulls
+	void batch_pull(item it)		//pull from storage without buying any extras
+	{
+		int amt = min(storage_amount(it), pulls_remaining());
+		if(amt > 0)
+		{
+			pullXWhenHaveY(it, amt, item_amount(it));
+		}
+	}
+	if(!get_property("auto_bedtime_pulls_skip_clover").to_boolean() && pulls_remaining() > 0)
+	{
+		boolean pieces_forbidden = in_glover() || in_bhy();
+		if(!pieces_forbidden)
+		{
+			batch_pull($item[Disassembled Clover]);
+		}
+		batch_pull($item[Ten-Leaf Clover]);
+		
+		//buy and pull clovers if we still need any
+		item cheaper = $item[Disassembled Clover];
+		if(pieces_forbidden || mall_price($item[Disassembled Clover]) > mall_price($item[Ten-Leaf Clover]))
+		{
+			cheaper = $item[Ten-Leaf Clover];
+		}
+		if(pulls_remaining() > 0)
+		{
+			pullXWhenHaveY(cheaper, pulls_remaining() + item_amount(cheaper), item_amount(cheaper));
+		}
+	}
 }
 
 boolean doBedtime()

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -585,8 +585,10 @@ void equipRollover()
 	auto_log_info("Putting on pajamas...", "blue");
 
 	string to_max = "-tie,adv";
-	if(hippy_stone_broken())
-		to_max += ",0.3fites";
+	if(hippy_stone_broken() && get_property("auto_bedtime_pulls_pvp_multi").to_float() > 0)
+	{
+		to_max += "," +get_property("auto_bedtime_pulls_pvp_multi")+ "fites";
+	}
 	if(auto_have_familiar($familiar[Trick-or-Treating Tot]))
 		to_max += ",switch Trick-or-Treating Tot";
 	if(auto_have_familiar($familiar[Left-Hand Man]))

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -570,7 +570,7 @@ void ensureSealClubs()
 	}
 }
 
-void equipRollover()
+void equipRollover(boolean silent)
 {
 	if(in_gnoob())
 	{
@@ -582,7 +582,10 @@ void equipRollover()
 		cli_execute("buy Li'l Unicorn Costume");
 	}
 
-	auto_log_info("Putting on pajamas...", "blue");
+	if(!silent)
+	{
+		auto_log_info("Putting on pajamas...", "blue");
+	}
 
 	string to_max = "-tie,adv";
 	if(hippy_stone_broken() && get_property("auto_bedtime_pulls_pvp_multi").to_float() > 0)
@@ -598,7 +601,7 @@ void equipRollover()
 
 	maximize(to_max, false);
 
-	if(!in_hardcore())
+	if(!in_hardcore() && !silent)
 	{
 		auto_log_info("Done putting on jammies, if you pulled anything with a rollover effect you might want to make sure it's equipped before you log out.", "red");
 	}

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -313,7 +313,7 @@ void auto_settingsDefaults()
 	defaultConfig("auto_save_adv_override", "-1");
 	defaultConfig("auto_log_level", "2");
 	defaultConfig("auto_log_level_restore", "0");
-	defaultConfig("auto_bedtime_pulls_skip", "false");
+	defaultConfig("auto_bedtime_pulls_skip", "true");
 	defaultConfig("auto_bedtime_pulls_skip_clover", "false");
 	defaultConfig("auto_bedtime_pulls_pvp_multi", "0.3");
 	defaultConfig("auto_bedtime_pulls_min_desirability", "1.0");

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -313,7 +313,7 @@ void auto_settingsDefaults()
 	defaultConfig("auto_save_adv_override", "-1");
 	defaultConfig("auto_log_level", "2");
 	defaultConfig("auto_log_level_restore", "0");
-	defaultConfig("auto_bedtime_pulls_skip", "true");
+	defaultConfig("auto_bedtime_pulls_skip", "false");
 	defaultConfig("auto_bedtime_pulls_skip_clover", "false");
 	defaultConfig("auto_bedtime_pulls_pvp_multi", "0.3");
 	defaultConfig("auto_bedtime_pulls_min_desirability", "1.0");

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -313,6 +313,10 @@ void auto_settingsDefaults()
 	defaultConfig("auto_save_adv_override", "-1");
 	defaultConfig("auto_log_level", "2");
 	defaultConfig("auto_log_level_restore", "0");
+	defaultConfig("auto_bedtime_pulls_skip", "false");
+	defaultConfig("auto_bedtime_pulls_skip_clover", "false");
+	defaultConfig("auto_bedtime_pulls_pvp_multi", "0.3");
+	defaultConfig("auto_bedtime_pulls_min_desirability", "1.0");
 }
 
 void auto_settings()

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1171,7 +1171,7 @@ boolean possessOutfit(string outfit, boolean checkCanEquip);
 boolean possessOutfit(string outfit);
 void equipBaseline();
 void ensureSealClubs();
-void equipRollover();
+void equipRollover(boolean silent);
 boolean auto_forceEquipSword();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1084,6 +1084,7 @@ boolean autoAdvBypass(string url, string option);
 //Defined in autoscend/auto_bedtime.ash
 void bedtime_still();
 int pullsNeeded(string data);
+void bedtime_pulls();
 boolean doBedtime();
 
 ########################################################################################################


### PR DESCRIPTION
bedtime improvements
* add settings for various bedtime pull related stuff.
* instead of printing a suggestion of items to pull. make sure they are really needed and if so pull them automatically during bedtime
* automatically pull in bedtime equipment that improves your rollover adv and pvp gains.
  * does not pull weapon, off-hand, or accessories yet due to those require more complex code to handle conflicts. This is currently being worked on in a followup PR
* fill remaining pulls with clovers
* printout the estimated number of pulls needed to finish the entire ascension after we perform automatic pulls instead of before. That function also printsout other info about what remains todo this ascension beyond just pulls

## How Has This Been Tested?

tested many times during standard and wildfire.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
