### PR TITLE
int auto_mall_price(item it) fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -120,7 +120,6 @@ int auto_mall_price(item it)
 			//-1 could be due to tradeable item not found in the mall. Or due to an IO error during lookup
 			//-1 is non trivial to fix due to mafia anti abuse code
 			//historical price can never be -1. only 0 or a positive number
-			
 			//just use the historical price. It will be good enough. it never returns -1. and if it returns 0 it is because this mafia install never happened to look up that item before. which suggests an extreme edge case or that the item is really unavailable
 			return historical_price(it);
 		}

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -121,28 +121,8 @@ int auto_mall_price(item it)
 			//-1 is non trivial to fix due to mafia anti abuse code
 			//historical price can never be -1. only 0 or a positive number
 			
-			if(historical_price(it) > 0)
-			{
-				auto_log_warning("Failed getting mall price for [" +it+ "]. We have historical price and that is good enough.");
-				return historical_price(it);	//just use the historical price. It will be good enough
-			}
-			
-			if(get_property("_auto_mallprice_error_list").contains_text(it))
-			{
-				return 0;
-			}
-			if(get_property("_auto_mallprice_skip_next_error").to_int() == my_adventures())
-			{
-				auto_log_debug("Failed getting mall price for [" +it+ "]. Per setting we will ignore it as unbuyable today");
-				set_property("_auto_mallprice_error_list", get_property("_auto_mallprice_error_list")+ "," +it);
-				return 0;
-			}
-			
-			print("Failed getting mall price for [" +it+ "].", "red");
-			print("If this is a critical item for the run manually buy it and run me again", "red");
-			print("Otherwise use the CLI command below then run me again to skip it:", "blue");
-			print(`ash set_property("_auto_mallprice_skip_next_error", my_adventures());`, "blue");
-			abort();
+			//just use the historical price. It will be good enough. it never returns -1. and if it returns 0 it is because this mafia install never happened to look up that item before. which suggests an extreme edge case or that the item is really unavailable
+			return historical_price(it);
 		}
 		return retval;
 	}


### PR DESCRIPTION
auto_mall_price has an issue if mall_price returns -1 for a tradeable item. this is usually caused by an IO error during mall search.
It results in an abort. in some situations (where we look at the price even for an item we already have) then autoscend will continue to abort the entire day and nothing you can do can make it run.

this PR will prevent the abort by using historical price instead, which is close enough in terms of value.
if this is the first time your mafia install tries to look up that item then historical price will return 0 even if it is available in the mall, which results in the item not being bought. potentially wasting some adventures. Although it is very much an edge case. As it requires a new mafia instance or your first time doing a new path and a path specific item to buy. As well as an IO error on that item's price lookup.

## How Has This Been Tested?

tested in wildfire. need input from other devs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
