### PR TITLE
forbid Dance Police store

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2769,6 +2769,9 @@ void auto_begin()
 	backupSetting("logPreferenceChange", "true");
 	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
+
+	string userForbidden = get_property("forbiddenStores");
+	backupSetting("forbiddenStores", userForbidden + ",3408540"); // forbid Dance Police
 	
 	backupSetting("choiceAdventure1107", 1);
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2771,7 +2771,9 @@ void auto_begin()
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 
 	string userForbidden = get_property("forbiddenStores");
-	backupSetting("forbiddenStores", userForbidden + ",3408540"); // forbid Dance Police
+	if (!userForbidden.contains_text("3408540")) {
+		backupSetting("forbiddenStores", userForbidden + ",3408540"); // forbid Dance Police
+	}
 	
 	backupSetting("choiceAdventure1107", 1);
 


### PR DESCRIPTION
# Description

As subject. More important now that Dance Police is stocking more ascension relevant stuff like key lime pies and possible nightcaps like emergency margaritas/vintage smart drinks.

## How Has This Been Tested?

Works fine from what I can see. I ran with `auto_dontConsumeKeyLimePies` disabled in a Normal run & it skipped purchasing from Dance Police during consumption.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
