### PR TITLE
Code Cleanup for a Few Paths

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -337,7 +337,7 @@ void main()
 		generateTrackingData("auto_renenutet");
 	}
 
-	if(my_path() == "One Crazy Random Summer")
+	if(in_ocrs())
 	{
 		writeln("<h2>One Crazy Random Summer Fun-o-meter!</h2>");
 		generateTrackingData("auto_funTracker");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -523,7 +523,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[Camp Scout Backpack], 1, 0);
 		}
 
-		if(my_path() == "Way of the Surprising Fist")
+		if(in_wotsf())
 		{
 			pullXWhenHaveY($item[Bittycar Meatcar], 1, 0);
 		}
@@ -562,7 +562,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(((in_picky()) || !canChangeFamiliar()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
+		if((in_picky() || !canChangeFamiliar()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{
@@ -716,7 +716,7 @@ boolean LX_doVacation()
 	int meat_needed = 500;
 	int adv_needed = 3;
 	int adv_budget = my_adventures() - auto_advToReserve();
-	if(my_path() == "Way of the Surprising Fist")
+	if(in_wotsf())
 	{
 		meat_needed = 5;
 		adv_needed = 5;
@@ -2049,7 +2049,7 @@ boolean LX_craftAcquireItems()
 		//Demonskin Jacket, requires an adventure, knoll available doesn\'t matter here...
 	}
 
-	if (in_koe())
+	if(in_koe())
 	{
 		if ((creatable_amount($item[Antique Accordion]) > 0 && !possessEquipment($item[Antique Accordion])) && auto_predictAccordionTurns() < 10)
 		{
@@ -2300,7 +2300,7 @@ boolean autosellCrap()
 	{
 		return false;		//do not autosell stuff in casual or postronin unless you are very poor
 	}
-	if(my_path() == "Way of the Surprising Fist") 
+	if(in_wotsf()) 
 	{
 		return false;		//selling things in the way of the suprising fist only donates the money to charity, so we should not autosell anything automatically
 	}
@@ -2393,15 +2393,15 @@ void print_header()
 	{
 		auto_log_info("Snow suit usage: " + get_property("_snowSuitCount") + " carrots: " + get_property("_carrotNoseDrops"), "blue");
 	}
-	if (in_heavyrains())
+	if(in_heavyrains())
 	{
 		auto_log_info("Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}
-	if (isActuallyEd())
+	if(isActuallyEd())
 	{
 		auto_log_info("Ka Coins: " + item_amount($item[Ka Coin]) + " Lashes used: " + get_property("_edLashCount"), "green");
 	}
-	if (in_plumber())
+	if(in_plumber())
 	{
 		auto_log_info("Coins: " + item_amount($item[Coin]), "green");
 	}
@@ -2526,7 +2526,7 @@ boolean doTasks()
 		auto_log_warning("I am in aftercore", "red");
 		return false;
 	}
-	if (in_casual() && get_property("_casualAscension").to_int() != -1)
+	if(in_casual() && get_property("_casualAscension").to_int() != -1)
 	{
 		set_property("_casualAscension", my_ascensions());
 		auto_log_warning("I think I'm in a casual ascension and should not run. To override: set _casualAscension = -1", "red");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -213,7 +213,7 @@ void initializeSettings() {
 	beehiveConsider();
 
 	eudora_initializeSettings();
-	heavy_rains_initializeSettings();
+	heavyrains_initializeSettings();
 	awol_initializeSettings();
 	theSource_initializeSettings();
 	ed_initializeSettings();
@@ -1022,7 +1022,7 @@ void initializeDay(int day)
 
 			tootGetMeat();
 
-			heavy_rains_initializeDay(day);
+			heavyrains_initializeDay(day);
 			// It's nice to have a moxie weapon for Flock of Bats form
 			if(my_class() == $class[Vampyre] && get_property("darkGyfftePoints").to_int() < 21 && !possessEquipment($item[disco ball]))
 			{
@@ -1111,7 +1111,7 @@ void initializeDay(int day)
 				use(1, $item[gym membership card]);
 			}
 
-			heavy_rains_initializeDay(day);
+			heavyrains_initializeDay(day);
 
 			if(!in_hardcore() && (item_amount($item[Handful of Smithereens]) <= 5))
 			{
@@ -2618,11 +2618,11 @@ boolean doTasks()
 	if(dna_startAcquire())				return true;
 	if(LM_boris())						return true;
 	if(LM_pete())						return true;
-	if(LM_jello())						return true;
+	if(LM_gnoob())						return true;
 	if(LM_fallout())					return true;
 	if(LM_groundhog())					return true;
 	if(LM_batpath()) 					return true;
-	if(doHRSkills())					return true;
+	if(heavyrains_buySkills())			return true;
 	if(LM_canInteract()) 				return true;
 	if(LM_kolhs()) 						return true;
 	if(LM_jarlsberg())					return true;
@@ -2715,7 +2715,7 @@ void auto_begin()
 	}
 	else if(contains_text(page, "Welcome to the Kingdom, Gelatinous Noob"))
 	{
-		jello_startAscension(page);
+		gnoob_startAscension(page);
 	}
 	else if(contains_text(page, "it appears that a stray bat has accidentally flown right through you") || (get_property("lastAdventure") == "Intro: View of a Vampire"))
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -74,7 +74,7 @@ import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
 import <autoscend/paths/way_of_the_surprising_fist.ash>
 import <autoscend/paths/wildfire.ash>
-
+import <autoscend/paths/you_robot.ash>
 
 import <autoscend/quests/level_01.ash>
 import <autoscend/quests/level_02.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -562,7 +562,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(((auto_my_path() == "Picky") || !canChangeFamiliar()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
+		if(((in_picky()) || !canChangeFamiliar()) && (item_amount($item[Deck of Every Card]) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{
@@ -623,7 +623,7 @@ int handlePulls(int day)
 			}
 		}
 
-		if(auto_my_path() == "Picky")
+		if(in_picky())
 		{
 			pullXWhenHaveY($item[gumshoes], 1, 0);
 		}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -72,6 +72,7 @@ import <autoscend/paths/pocket_familiars.ash>
 import <autoscend/paths/quantum_terrarium.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
+import <autoscend/paths/way_of_the_surprising_fist.ash>
 import <autoscend/paths/wildfire.ash>
 
 
@@ -219,7 +220,7 @@ void initializeSettings() {
 	ed_initializeSettings();
 	boris_initializeSettings();
 	bond_initializeSettings();
-	fallout_initializeSettings();
+	nuclear_initializeSettings();
 	pete_initializeSettings();
 	pokefam_initializeSettings();
 	disguises_initializeSettings();
@@ -964,7 +965,7 @@ void initializeDay(int day)
 
 	ed_initializeDay(day);
 	boris_initializeDay(day);
-	fallout_initializeDay(day);
+	nuclear_initializeDay(day);
 	pete_initializeDay(day);
 	cs_initializeDay(day);
 	bond_initializeDay(day);
@@ -2619,7 +2620,7 @@ boolean doTasks()
 	if(LM_boris())						return true;
 	if(LM_pete())						return true;
 	if(LM_gnoob())						return true;
-	if(LM_fallout())					return true;
+	if(LM_nuclear())					return true;
 	if(LM_groundhog())					return true;
 	if(LM_batpath()) 					return true;
 	if(heavyrains_buySkills())			return true;

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -289,7 +289,7 @@ boolean buyableMaintain(item toMaintain, int howMany, int meatMin)
 
 boolean buyableMaintain(item toMaintain, int howMany, int meatMin, boolean condition)
 {
-	if((!condition) || (my_meat() < meatMin) || (my_path() == "Way of the Surprising Fist"))
+	if((!condition) || (my_meat() < meatMin) || in_wotsf())
 	{
 		return false;
 	}
@@ -519,7 +519,7 @@ boolean pull_meat(int target)
 	{
 		return false;	//can not pull
 	}
-	if(my_path() == "Way of the Surprising Fist")
+	if(in_wotsf())
 	{
 		return false;	//can not pull meat & autoselling items just donates them
 	}

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -113,7 +113,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 
 	// handle the initial combat or choice the easy way.
 	string combatPage = "<b>Combat";
-	if (in_pokefam()) {
+	if(in_pokefam()) {
 		combatPage = "<b>Fight!";
 	}
 	if (contains_text(page, combatPage)) {

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -640,7 +640,7 @@ boolean doBedtime()
 	}
 
 	// If in TCRS skip using freecrafts but alert user of how many they can manually use.
-	if((in_tcrs()) && (freeCrafts() > 0))
+	if(in_tcrs() && (freeCrafts() > 0))
 	{
 		auto_log_warning("In TCRS: Items are variable, skipping End Of Day crafting", "red");
 		auto_log_warning("Consider manually using your "+freeCrafts()+" free crafts", "red");

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -567,7 +567,7 @@ boolean doBedtime()
 		string temp = visit_url("shop.php?action=bacta&whichshop=mayoclinic");
 	}
 
-	if((auto_my_path() == "Nuclear Autumn") && (get_property("falloutShelterLevel").to_int() >= 3) && !get_property("_falloutShelterSpaUsed").to_boolean())
+	if(in_nuclear() && (get_property("falloutShelterLevel").to_int() >= 3) && !get_property("_falloutShelterSpaUsed").to_boolean())
 	{
 		string temp = visit_url("place.php?whichplace=falloutshelter&action=vault3");
 	}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -632,7 +632,7 @@ boolean doBedtime()
 	}
 
 	equipRollover(false);
-	heavy_rains_doBedtime();
+	heavyrains_doBedtime();
 
 	while(my_daycount() == 1 && item_amount($item[resolution: be more adventurous]) > 0 && get_property("_resolutionAdv").to_int() < 10 && !can_interact())
 	{

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -193,7 +193,7 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 700: // Delirium in the Cafeterium (KOLHS 22nd adventure every day)
 		case 768: // The Littlest Identity Crisis (Mini-adventurer initialization)
-			if (in_quantumTerrarium()) {
+			if(in_quantumTerrarium()) {
 				if (my_location() == $location[The Themthar Hills]) {
 					run_choice(4); // Sauceror is a lep and starfish
 				}
@@ -212,7 +212,7 @@ boolean auto_run_choice(int choice, string page)
 			kolhsChoiceHandler(choice);
 			break;
 		case 780: // Action Elevator (The Hidden Apartment Building)
-			if (in_pokefam() && get_property("relocatePygmyLawyer").to_int() != my_ascensions()) {
+			if(in_pokefam() && get_property("relocatePygmyLawyer").to_int() != my_ascensions()) {
 				run_choice(3); // relocate lawyers to park
 			} else if (have_effect($effect[Thrice-Cursed]) > 0) {
 				run_choice(1); // fight the spirit

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -326,7 +326,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 876: // One Simple Nightstand (The Haunted Bedroom)
-			if(my_meat() < 1000 + meatReserve() && auto_is_valid($item[old leather wallet]) && auto_my_path() != "Way of the Surprising Fist")
+			if(my_meat() < 1000 + meatReserve() && auto_is_valid($item[old leather wallet]) && !in_wotsf())
 			{
 				run_choice(1); //get old leather wallet worth ~500 meat
 			}
@@ -344,7 +344,7 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 878: // One Ornate Nightstand (The Haunted Bedroom)
 			boolean needSpectacles = (item_amount($item[Lord Spookyraven\'s Spectacles]) == 0 && internalQuestStatus("questL11Manor") < 2);
-			if (is_boris() || auto_my_path() == "Way of the Surprising Fist" || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
+			if (is_boris() || in_wotsf() || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
 				needSpectacles = false;
 			}
 			if (needSpectacles) {
@@ -362,7 +362,7 @@ boolean auto_run_choice(int choice, string page)
 		case 879: // One Rustic Nightstand (The Haunted Bedroom)
 			if(options contains 4) {
 				run_choice(4); // only shows up rarely. when this line was added it was worth 1.3 million in mall
-			} if (in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
+			} if(in_bhy() && item_amount($item[Antique Hand Mirror]) < 1) {
 				run_choice(3); // fight the remains of a jilted mistress for the antique hand mirror
 			} else if(item_amount($item[ghost key]) > 0 && my_primestat() == $stat[moxie] && my_buffedstat($stat[moxie]) < 150) {
 				run_choice(5); // spend 1 ghost key for primestat, get ~200 moxie XP

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -344,7 +344,7 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 878: // One Ornate Nightstand (The Haunted Bedroom)
 			boolean needSpectacles = (item_amount($item[Lord Spookyraven\'s Spectacles]) == 0 && internalQuestStatus("questL11Manor") < 2);
-			if (is_boris() || in_wotsf() || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
+			if (is_boris() || in_wotsf() || (in_nuclear() && in_hardcore())) {
 				needSpectacles = false;
 			}
 			if (needSpectacles) {

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1322,7 +1322,7 @@ ConsumeAction auto_findBestConsumeAction(string type)
 		if (type == "eat") return fullness_left();
 		if (type == "drink") 
 		{
-			if (in_quantumTerrarium() && my_familiar() == $familiar[Stooper])
+			if(in_quantumTerrarium() && my_familiar() == $familiar[Stooper])
 			{
 				// we can't change familiars so don't drink to full liver as we'll be overdrunk when it changes familiar.
 				return (my_inebriety() < inebriety_limit() ? inebriety_left() - 1 : 0);

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -412,7 +412,7 @@ boolean canDrink(item toDrink, boolean checkValidity)
 	{
 		return contains_text(craft_type(toDrink), "Jarlsberg's Kitchen");
 	}
-	if((auto_my_path() == "Nuclear Autumn") && (toDrink.inebriety != 1))
+	if(in_nuclear() && (toDrink.inebriety != 1))
 	{
 		return false;
 	}
@@ -476,7 +476,7 @@ boolean canEat(item toEat, boolean checkValidity)
 	{
 		return contains_text(craft_type(toEat), "Jarlsberg's Kitchen");
 	}
-	if((auto_my_path() == "Nuclear Autumn") && (toEat.fullness != 1))
+	if(in_nuclear() && (toEat.fullness != 1))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -226,7 +226,7 @@ string defaultMaximizeStatement()
 	{
 		res += ",water,hot res";
 	}
-	if (in_plumber())
+	if(in_plumber())
 	{
 		res += ",plumber,-ml";
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -681,7 +681,7 @@ void preAdvUpdateFamiliar(location place)
 	}
 	
 	//familiar equipment overrides
-	if(my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		if(famChoice != $familiar[Left-Hand Man])
 		{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -738,7 +738,7 @@ boolean checkTerrarium()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Nuclear Autumn" || auto_my_path() == "You, Robot")
+	if(in_nuclear() || auto_my_path() == "You, Robot")
 	{
 		return true;	//these paths use an alternative form of terrarium
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -738,7 +738,7 @@ boolean checkTerrarium()
 	{
 		return false;
 	}
-	if(in_nuclear() || auto_my_path() == "You, Robot")
+	if(in_nuclear() || in_youRobot())
 	{
 		return true;	//these paths use an alternative form of terrarium
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -124,13 +124,13 @@ boolean pathHasFamiliar()
 
 boolean pathAllowsChangingFamiliar()
 {
-		if (!pathHasFamiliar())
+		if(!pathHasFamiliar())
 		{
 			return false;
 		}
 
 		// path check for case(s) where Path has familiars but forces you to use one of its choice
-		if (in_quantumTerrarium())
+		if(in_quantumTerrarium())
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -979,7 +979,7 @@ boolean auto_post_adventure()
 		}
 	}
 
-	if(my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		auto_log_info("Post adventure done: Thunder: " + my_thunder() + " Rain: " + my_rain() + " Lightning: " + my_lightning(), "green");
 	}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -235,7 +235,7 @@ boolean auto_post_adventure()
 		}
 	}
 
-	if(my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		buffMaintain($effect[Juiced and Loose], 35, 1, 1);
 		buffMaintain($effect[Hardened Sweatshirt], 35, 1, 1);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -208,7 +208,7 @@ boolean auto_pre_adventure()
 		}
 	}
 
-	if (in_koe() && possessEquipment($item[low-pressure oxygen tank]))
+	if(in_koe() && possessEquipment($item[low-pressure oxygen tank]))
 	{
 		autoEquip($item[low-pressure oxygen tank]);
 	}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -294,7 +294,7 @@ float providePlusNonCombat(int amt, boolean doEquips, boolean speculative) {
 
 	//blooper ink costs 15 coins without which it will error when trying to buy it, so that is the bare minimum we need to check for
 	//However we don't want to waste our early coins on it as they are precious. So require at least 400 coins before buying it.
-	if (in_plumber() && 0 == have_effect($effect[Blooper Inked]) && item_amount($item[coin]) > 400) {
+	if(in_plumber() && 0 == have_effect($effect[Blooper Inked]) && item_amount($item[coin]) > 400) {
 		if (!speculative) {
 			retrieve_item(1, $item[blooper ink]);
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2018,7 +2018,7 @@ boolean acquireCombatMods(int amt, boolean doEquips)
 boolean basicAdjustML()
 {
 	if(is_boris()) return borisAdjustML();
-	if (in_plumber())
+	if(in_plumber())
 	{
 		// We don't get many stats from combat - no point running ML.
 		auto_change_mcd(0);
@@ -2054,7 +2054,7 @@ boolean auto_change_mcd(int mcd)
 
 boolean auto_change_mcd(int mcd, boolean immediately)
 {
-	if (in_koe()) return false;
+	if(in_koe()) return false;
 
 	int best = 10;
 	if(knoll_available())
@@ -2355,7 +2355,7 @@ boolean auto_autosell(int quantity, item toSell)
 		return false;
 	}
 
-	if(my_path() != "Way of the Surprising Fist")
+	if(!in_wotsf())
 	{
 		return autosell(quantity, toSell);
 	}
@@ -2916,7 +2916,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if((item_amount(source) < uses) && (my_path() != "Way of the Surprising Fist"))
+	if((item_amount(source) < uses) && (!in_wotsf()))
 	{
 		if(historical_price(source) < 2000)
 		{
@@ -5099,7 +5099,7 @@ int meatReserve()
 	//how much do we reserve for [your father's MacGuffin diary]?
 	if(item_amount($item[your father\'s MacGuffin diary]) == 0 &&		//you do not yet have diary
 	!in_koe() &&														//diary is given by council for free in kingdom of exploathing
-	my_path() != "Way of the Surprising Fist")							//costs 5 meat total in way of the surprising fist. no need to track that
+	!in_wotsf()															//costs 5 meat total in way of the surprising fist. no need to track that
 	{
 		reserve_diary += 500;		//1 vacation. no need to count script. we don't pull it or get it prematurely.
 		
@@ -5130,7 +5130,7 @@ int meatReserve()
 	if(get_property("lastIslandUnlock").to_int() < my_ascensions())		//need to unlock island
 	{
 		int price_vacation = 500;
-		if(my_path() == "Way of the Surprising Fist")
+		if(in_wotsf())
 		{
 		price_vacation = 5;  //yes really. just 5 meat each
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1461,7 +1461,7 @@ boolean cloverUsageFinish()
 
 boolean isHermitAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -1478,7 +1478,7 @@ boolean isHermitAvailable()
 
 boolean isGalaktikAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -1495,7 +1495,7 @@ boolean isGalaktikAvailable()
 
 boolean isGeneralStoreAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -1508,7 +1508,7 @@ boolean isGeneralStoreAvailable()
 
 boolean isArmoryAndLeggeryStoreAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -1548,7 +1548,7 @@ boolean isMystGuildStoreAvailable() {
 
 boolean isArmoryAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -1565,7 +1565,7 @@ boolean isArmoryAvailable()
 
 boolean isUnclePAvailable()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return false;
 	}
@@ -2828,7 +2828,7 @@ int [item] auto_get_campground()
 	}
 
 	static boolean didCheck = false;
-	if((auto_my_path() == "Nuclear Autumn") && !didCheck)
+	if(in_nuclear() && !didCheck)
 	{
 		didCheck = true;
 		string temp = visit_url("place.php?whichplace=falloutshelter&action=vault_term");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5099,7 +5099,7 @@ int meatReserve()
 	//how much do we reserve for [your father's MacGuffin diary]?
 	if(item_amount($item[your father\'s MacGuffin diary]) == 0 &&		//you do not yet have diary
 	!in_koe() &&														//diary is given by council for free in kingdom of exploathing
-	!in_wotsf()															//costs 5 meat total in way of the surprising fist. no need to track that
+	!in_wotsf())															//costs 5 meat total in way of the surprising fist. no need to track that
 	{
 		reserve_diary += 500;		//1 vacation. no need to count script. we don't pull it or get it prematurely.
 		

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4352,7 +4352,7 @@ boolean autoFlavour(location place)
 			return setFlavour($element[none]);
 	}
 
-	if(auto_my_path() == "One Crazy Random Summer")
+	if(in_ocrs())
 	{
 		// monsters can randomly be any element in OCRS
 		setFlavour($element[none]);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -730,7 +730,7 @@ boolean summonMonster(string option)
 			bootyCalls++;
 		}
 	}
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		int rain = my_rain() + (turns_left * 0.85);
 		rainCalls = rain / 50;
@@ -3107,13 +3107,13 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Fireproof Lips]:					useItem = $item[SPF 451 lip balm];			break;
 	case $effect[Fire Inside]:					useItem = $item[Hot Coal];						break;
 	case $effect[Fishy\, Oily]:
-		if(auto_my_path() == "Heavy Rains")
+		if(in_heavyrains())
 		{
 			useItem = $item[Gourmet Gourami Oil];
 		}																						break;
 	case $effect[Fishy Fortification]:			useItem = $item[Fish-Liver Oil];				break;
 	case $effect[Fishy Whiskers]:
-		if(auto_my_path() == "Heavy Rains")
+		if(in_heavyrains())
 		{
 			useItem = $item[Catfish Whiskers];
 		}																						break;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1761,7 +1761,7 @@ boolean is_ghost_in_zone(location loc)
 	}
 
 	// Special-case for King Boo.
-	if (in_plumber() && loc == $location[Summoning Chamber])
+	if(in_plumber() && loc == $location[Summoning Chamber])
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -743,6 +743,7 @@ boolean plumber_equipTool(stat st);
 
 ########################################################################################################
 //Defined in autoscend/paths/picky.ash
+boolean in_picky();
 void picky_pulls();
 void picky_startAscension();
 boolean picky_buyskills();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -709,10 +709,11 @@ boolean LX_lowkeySummer();
 
 ########################################################################################################
 //Defined in autoscend/paths/nuclear_autumn.ash
-void fallout_initializeSettings();
-void fallout_initializeDay(int day);
-boolean fallout_buySkills();
-boolean LM_fallout();
+boolean in_nuclear();
+void nuclear_initializeSettings();
+void nuclear_initializeDay(int day);
+boolean nuclear_buySkills();
+boolean LM_nuclear();
 
 ########################################################################################################
 //Defined in autoscend/paths/one_crazy_random_summer.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -811,6 +811,10 @@ boolean LX_wildfire_spookyravenManorFirstFloor();
 boolean LA_wildfire();
 
 ########################################################################################################
+//Defined in autoscend/paths/you_robot.ash
+boolean in_youRobot();
+
+########################################################################################################
 //Defined in autoscend/quests/level_01.ash
 void tootOriole();
 void tootGetMeat();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -508,6 +508,7 @@ boolean LM_pete();
 
 ########################################################################################################
 //Defined in autoscend/paths/avatar_of_west_of_loathing.ash
+boolean in_awol();
 boolean awol_initializeSettings();
 void awol_useStuff();
 effect awol_walkBuff();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -716,6 +716,7 @@ boolean LM_fallout();
 
 ########################################################################################################
 //Defined in autoscend/paths/one_crazy_random_summer.ash
+boolean in_ocrs();
 boolean ocrs_postHelper();
 boolean ocrs_postCombatResolve();
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -784,6 +784,10 @@ float tcrs_expectedAdvPerFill(string quality);
 boolean tcrs_maximize_with_items(string maximizerString);
 
 ########################################################################################################
+//Defined in autoscend/paths/way_of_the_surprising_fist.ash
+boolean in_wotsf();
+
+########################################################################################################
 //Defined in autoscend/paths/wildfire.ash
 boolean in_wildfire();
 void wildfire_initializeSettings();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -620,13 +620,13 @@ boolean LM_glover();
 ########################################################################################################
 //Defined in autoscend/paths/gelatinous_noob.ash
 boolean in_gnoob();
-void jello_startAscension(string page);
+void gnoob_startAscension(string page);
 int gnoobAbsorbCost(item it);
-void jello_buySkills();
-string[item] jello_lister(string goal);
-int jello_absorbsLeft();
-string[item] jello_lister();
-boolean LM_jello();
+void gnoob_buySkills();
+string[item] gnoob_lister(string goal);
+int gnoob_absorbsLeft();
+string[item] gnoob_lister();
+boolean LM_gnoob();
 
 ########################################################################################################
 //Defined in autoscend/paths/grey_goo.ash
@@ -638,13 +638,13 @@ boolean LA_grey_goo_tasks();
 ########################################################################################################
 //Defined in autoscend/paths/heavy_rains.ash
 boolean in_heavyrains();
-void heavy_rains_initializeSettings();
+void heavyrains_initializeSettings();
 boolean routineRainManHandler();
-void heavy_rains_initializeDay(int day);
-void heavy_rains_doBedtime();
-boolean doHRSkills();
+void heavyrains_initializeDay(int day);
+void heavyrains_doBedtime();
+boolean heavyrains_buySkills();
 boolean rainManSummon(monster target, boolean copy, boolean wink);
-boolean L13_towerFinalHeavyRains();
+boolean L13_heavyrains_towerFinal();
 
 ########################################################################################################
 //Defined in autoscend/paths/kingdom_of_exploathing.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -89,10 +89,12 @@ string auto_combatHandler(int round, monster enemy, string text)
 		enemy = ocrs_combat_helper(text);
 		enemy = last_monster();
 	}
+
 	if(in_awol())
 	{
 		awol_combat_helper(text);
 	}
+	
 	if(in_pokefam())
 	{
 		if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -89,7 +89,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 		enemy = ocrs_combat_helper(text);
 		enemy = last_monster();
 	}
-	if(my_path() == "Avatar of West of Loathing")
+	if(in_awol())
 	{
 		awol_combat_helper(text);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -84,7 +84,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 	set_property("auto_combatHP", my_hp());
 	set_property("auto_diag_round", round);
 
-	if(my_path() == "One Crazy Random Summer")
+	if(in_ocrs())
 	{
 		enemy = ocrs_combat_helper(text);
 		enemy = last_monster();
@@ -94,7 +94,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 	{
 		awol_combat_helper(text);
 	}
-	
+
 	if(in_pokefam())
 	{
 		if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -205,7 +205,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	}
 	
 	//duplicate turns the enemy from a single enemy into a mob containing 2 copies of this enemy. Doubling their stats and doubling their drops
-	if(canUse($skill[Duplicate]) && (get_property("_sourceTerminalDuplicateUses").to_int() == 0) && !inAftercore() && (auto_my_path() != "Nuclear Autumn"))
+	if(canUse($skill[Duplicate]) && (get_property("_sourceTerminalDuplicateUses").to_int() == 0) && !inAftercore() && !in_nuclear())
 	{
 		if($monsters[Dairy Goat] contains enemy)
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -383,7 +383,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		
 			//this is for increasing meat income. gain +25 meat per monster, at the cost of letting it act once. If healing is too costly this can be a net loss of meat. until a full cost calculator is made, limit to under 10 HP damage and no more than 20% of your remaining HP.
 			
-			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (auto_my_path() != "Way of the Surprising Fist"))
+			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (!in_wotsf()))
 			{
 				return useSkill($skill[Sing Along]);
 			}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -54,7 +54,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 	
 	//TODO auto_doCombatCopy property is silly. get rid of it
-	if(!haveUsed($item[Rain-Doh black box]) && (my_path() != "Heavy Rains") && (get_property("_raindohCopiesMade").to_int() < 5))
+	if(!haveUsed($item[Rain-Doh black box]) && (!in_heavyrains()) && (get_property("_raindohCopiesMade").to_int() < 5))
 	{
 		if((enemy == $monster[Modern Zmobie]) && (get_property("auto_modernzmobiecount").to_int() < 3))
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -11,7 +11,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	retval = auto_combatPlumberStage5(round, enemy, text);
 	if(retval != "") return retval;
 	
-	// Path = disguises deliimt
+	// Path = disguises delimit
 	retval = auto_combatDisguisesStage5(round, enemy, text);
 	if(retval != "") return retval;
 	

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ocrs.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ocrs.ash
@@ -2,7 +2,7 @@
 
 monster ocrs_combat_helper(string page)
 {
-	if(my_path() != "One Crazy Random Summer")
+	if(!in_ocrs())
 	{
 		auto_log_error("Should not be in ocrs_combat_helper if not on the path!");
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -168,7 +168,7 @@ boolean dna_generic()
 
 	boolean[phylum] potion;
 
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		switch(my_daycount())
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -575,7 +575,7 @@ boolean chateaumantegna_nightstandSet()
 boolean chateauPainting()
 {
 	int paintingLevel = 8;
-	if(auto_my_path() == "One Crazy Random Summer")
+	if(in_ocrs())
 	{
 		paintingLevel = 9;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -55,7 +55,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Protection, Glamour, Vigor];		break;
 		}
 	}
-	else if(my_path() == "Nuclear Autumn")
+	else if(in_nuclear())
 	{
 		switch(my_daycount())
 		{
@@ -991,7 +991,7 @@ boolean deck_useScheme(string action)
 			break;
 		}
 
-		if(my_path() == "Nuclear Autumn")
+		if(in_nuclear())
 		{
 			cards["key"] = true;
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -125,7 +125,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Protection, Glamour, Vigor];		break;
 		}
 	}
-	else if(my_path() == "Way of the Surprising Fist")
+	else if(in_wotsf())
 	{
 		switch(my_daycount())
 		{
@@ -1069,15 +1069,15 @@ boolean deck_useScheme(string action)
 				continue;
 			}
 		}
-		if((in_theSource()) && (card == (my_primestat() + " stat")))
+		if(in_theSource() && (card == (my_primestat() + " stat")))
 		{
 			continue;
 		}
-		if((my_path() == "Way of the Surprising Fist") && ($strings[Candlestick, Knife, Lead Pipe, Revolver, Rope, Wrench] contains card))
+		if(in_wotsf() && ($strings[Candlestick, Knife, Lead Pipe, Revolver, Rope, Wrench] contains card))
 		{
 			continue;
 		}
-		if((card == "1952 Mickey Mantle") && ((my_meat() >= 20000) || (my_path() == "Way of the Surprising Fist")))
+		if((card == "1952 Mickey Mantle") && ((my_meat() >= 20000) || in_wotsf()))
 		{
 			continue;
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -75,7 +75,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Protection, Glamour, Vigor];		break;
 		}
 	}
-	else if(my_path() == "Avatar of West of Loathing")
+	else if(in_awol())
 	{
 		switch(my_daycount())
 		{
@@ -135,7 +135,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Glamour, Vigor];					break;
 		}
 	}
-	else if(my_path() == "Heavy Rains")
+	else if(in_heavyrains())
 	{
 		switch(my_daycount())
 		{
@@ -246,7 +246,7 @@ boolean auto_mayoItems()
 		case 4:				mayos = $items[none];								break;
 		}
 	}
-	else if(my_path() == "Heavy Rains" && !in_hardcore())
+	else if(in_heavyrains() && !in_hardcore())
 	{
 		switch(my_daycount())
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -105,7 +105,7 @@ boolean auto_haveSourceTerminal()
 		return false;
 	}
 	static boolean didCheck = false;
-	if((auto_my_path() == "Nuclear Autumn") && !didCheck)
+	if(in_nuclear() && !didCheck)
 	{
 		didCheck = true;
 		string temp = visit_url("place.php?whichplace=falloutshelter&action=vault_term");
@@ -152,7 +152,7 @@ boolean auto_sourceTerminalRequest(string request)
 	//"campground.php?action=terminal&hack=enhance items.enh"
 	if(auto_haveSourceTerminal())
 	{
-		if(auto_my_path() == "Nuclear Autumn")
+		if(in_nuclear())
 		{
 			string temp = visit_url("place.php?whichplace=falloutshelter&action=vault_term");
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -739,7 +739,7 @@ int neverendingPartyRemainingFreeFights()
 		return 0;
 	}
 	//if path randomizes names then the free fights are not free
-	if(in_disguises() || auto_my_path() == "One Crazy Random Summer")
+	if(in_disguises() || in_ocrs())
 	{
 		return 0;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -739,7 +739,7 @@ int neverendingPartyRemainingFreeFights()
 		return 0;
 	}
 	//if path randomizes names then the free fights are not free
-	if(auto_my_path() == "Disguises Delimit" || auto_my_path() == "One Crazy Random Summer")
+	if(in_disguises() || auto_my_path() == "One Crazy Random Summer")
 	{
 		return 0;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -104,7 +104,7 @@ boolean januaryToteAcquire(item it)
 
 	if(choice == 2)
 	{
-		if((auto_my_path() == "Way of the Surprising Fist") || is_boris())
+		if(in_wotsf() || is_boris())
 		{
 			return false;
 		}
@@ -1291,7 +1291,7 @@ boolean fightClubSpa()
 {
 	int option = 4;
 	stat st = my_primestat();
-	if (in_plumber())
+	if(in_plumber())
 	{
 		// We deal 250% of our Moxie, so if our Muscle is too high we... die.
 		st = $stat[moxie];

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -389,13 +389,13 @@ boolean auto_saberChoice(string choice)
 
 boolean auto_saberDailyUpgrade(int day)
 {
-	if (isActuallyEd())
+	if(isActuallyEd())
 	{
 		return auto_saberChoice("mp");
 	}
 
 	// Maybe famweight is better, I don't know.
-	if (in_plumber())
+	if(in_plumber())
 	{
 		return auto_saberChoice("res");
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -167,7 +167,7 @@ boolean auto_wantToEquipPowerfulGlove()
 {
 	if (!auto_hasPowerfulGlove()) return false;
 
-	if (in_plumber() && !plumber_nothingToBuy()) return true;
+	if(in_plumber() && !plumber_nothingToBuy()) return true;
 
 	int pixels = whitePixelCount();
 	if (contains_text(get_property("nsTowerDoorKeysUsed"), "digital key"))

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -110,7 +110,7 @@ void auto_enableBackupCameraReverser()
 
 int auto_backupUsesLeft()
 {
-	return 11 + (my_path() == "You, Robot" ? 5 : 0) - get_property("_backUpUses").to_int();
+	return 11 + (in_youRobot() ? 5 : 0) - get_property("_backUpUses").to_int();
 }
 
 boolean auto_havePowerPlant()

--- a/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
@@ -1,6 +1,11 @@
+boolean in_awol()
+{
+	return (auto_my_path() == "Avatar of West of Loathing");
+}
+
 boolean awol_initializeSettings()
 {
-	if(my_path() == "Avatar of West of Loathing")
+	if(in_awol())
 	{
 		set_property("auto_awolLastSkill", 0);
 		set_property("auto_getBeehive", true);
@@ -10,7 +15,7 @@ boolean awol_initializeSettings()
 
 void awol_useStuff()
 {
-	if(my_path() == "Avatar of West of Loathing")
+	if(in_awol())
 	{
 		if(have_skill($skill[Patent Medicine]))
 		{
@@ -58,7 +63,6 @@ void awol_useStuff()
 		}
 	}
 }
-
 
 effect awol_walkBuff()
 {

--- a/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
+++ b/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
@@ -3,11 +3,11 @@ boolean in_gnoob()
 	return my_class() == $class[Gelatinous Noob];
 }
 
-void jello_startAscension(string page)
+void gnoob_startAscension(string page)
 {
 	if(contains_text(page, "Welcome to the Kingdom, Gelatinous Noob"))
 	{
-		auto_log_info("In starting Jello Adventure", "blue");
+		auto_log_info("Starting a new run as Gelatinous Noob", "blue");
 		matcher my_skillPoints = create_matcher("You can pick <span class=\"num\">(\\d\+)</span> more skill", page);
 		if(my_skillPoints.find())
 		{
@@ -83,7 +83,7 @@ int gnoobAbsorbCost(item it)
 	return retval;
 }
 
-void jello_buySkills()
+void gnoob_buySkills()
 {
 	//Need to consider skill orders, how to handle when we have starting skills.
 
@@ -98,7 +98,7 @@ void jello_buySkills()
 		blacklist[$item[Enchanted Bean]] = true;	//need to keep our only enchanted bean to be planted
 	}
 
-	string[item] available = jello_lister();
+	string[item] available = gnoob_lister();
 	int starting_absorb_count = my_absorbs();
 	int earlyTerm = max(5, get_property("_noobSkillCount").to_int() + ((my_daycount() - 1) * min(my_level()+2, 15))) + get_property("noobPoints").to_int() + 2;
 
@@ -111,10 +111,10 @@ void jello_buySkills()
 		earlyTerm --;
 		if(earlyTerm <= 0)
 		{
-			auto_log_debug("jello_buySkills checked too many skills without getting any. terminating loop early");
+			auto_log_debug("gnoob_buySkills checked too many skills without getting any. terminating loop early");
 			break;
 		}
-		if(jello_absorbsLeft() <= 0)
+		if(gnoob_absorbsLeft() <= 0)
 		{
 			break;
 		}
@@ -150,7 +150,7 @@ void jello_buySkills()
 				retrieve_item(1,possible[i]);
 				if(item_amount(possible[i]) == 0)
 				{
-					auto_log_info("Failed to acquire [" + possible[i] + "] for jello_buySkills");
+					auto_log_info("Failed to acquire [" + possible[i] + "] for gnoob_buySkills");
 					continue;
 				}
 			}
@@ -161,13 +161,13 @@ void jello_buySkills()
 			}
 			else
 			{
-				available = jello_lister();		//recheck item availability now that one was consumed. necessary for tome handling and NPC stores.
+				available = gnoob_lister();		//recheck item availability now that one was consumed. necessary for tome handling and NPC stores.
 			}
 		}
 	}
 	
 	//absorb potted cactus for adventures
-	if(jello_absorbsLeft() > 0 && my_adventures() <= 1 + auto_advToReserve() && my_level() >= 12)
+	if(gnoob_absorbsLeft() > 0 && my_adventures() <= 1 + auto_advToReserve() && my_level() >= 12)
 	{
 		buyUpTo(1, $item[Potted Cactus]);
 		if(item_amount($item[Potted Cactus]) > 0)
@@ -178,7 +178,7 @@ void jello_buySkills()
 }
 
 
-string[item] jello_lister(string goal)
+string[item] gnoob_lister(string goal)
 {
 	string[item] retval;
 	foreach it in $items[]
@@ -208,7 +208,7 @@ string[item] jello_lister(string goal)
 	return retval;
 }
 
-int jello_absorbsLeft()
+int gnoob_absorbsLeft()
 {
 	if(!in_gnoob())
 	{
@@ -218,17 +218,17 @@ int jello_absorbsLeft()
 	return absorbs - my_absorbs();
 }
 
-string[item] jello_lister()
+string[item] gnoob_lister()
 {
-	return jello_lister("");
+	return gnoob_lister("");
 }
 
-boolean LM_jello()
+boolean LM_gnoob()
 {
 	if(!in_gnoob())
 	{
 		return false;
 	}
-	jello_buySkills();
+	gnoob_buySkills();
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -3,7 +3,7 @@ boolean in_heavyrains()
 	return auto_my_path() == "Heavy Rains";
 }
 
-void heavy_rains_initializeSettings()
+void heavyrains_initializeSettings()
 {
 	if(in_heavyrains())
 	{
@@ -92,7 +92,7 @@ boolean routineRainManHandler()
 
 
 
-void heavy_rains_initializeDay(int day)
+void heavyrains_initializeDay(int day)
 {
 	if(in_heavyrains())
 	{
@@ -139,7 +139,7 @@ void heavy_rains_initializeDay(int day)
 	}
 }
 
-void heavy_rains_doBedtime()
+void heavyrains_doBedtime()
 {
 	if(my_inebriety() > inebriety_limit())
 	{
@@ -158,7 +158,7 @@ void heavy_rains_doBedtime()
 	}
 }
 
-boolean doHRSkills()
+boolean heavyrains_buySkills()
 {
 	if(!in_heavyrains())
 	{

--- a/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
+++ b/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
@@ -1,15 +1,20 @@
-void fallout_initializeSettings()
+boolean in_nuclear()
 {
-	if(my_path() == "Nuclear Autumn")
+	return my_path() == "Nuclear Autumn";
+}
+
+void nuclear_initializeSettings()
+{
+	if(in_nuclear())
 	{
 		set_property("auto_getBeehive", true);
 	}
 }
 
 
-void fallout_initializeDay(int day)
+void nuclear_initializeDay(int day)
 {
-	if(my_path() != "Nuclear Autumn")
+	if(!in_nuclear())
 	{
 		return;
 	}
@@ -83,9 +88,9 @@ void fallout_initializeDay(int day)
 	}
 }
 
-boolean fallout_buySkills()
+boolean nuclear_buySkills()
 {
-	if(my_path() != "Nuclear Autumn")
+	if(!in_nuclear())
 	{
 		return false;
 	}
@@ -325,14 +330,14 @@ Missing: 858, 866
 }
 
 
-boolean LM_fallout()
+boolean LM_nuclear()
 {
-	if(my_path() != "Nuclear Autumn")
+	if(!in_nuclear())
 	{
 		return false;
 	}
 
-	fallout_buySkills();
+	nuclear_buySkills();
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
@@ -16,7 +16,7 @@ boolean ocrs_postHelper()
 
 boolean ocrs_postCombatResolve()
 {
-	if((have_effect($effect[Beaten Up]) > 0) && (in_ocrs()))
+	if((have_effect($effect[Beaten Up]) > 0) && in_ocrs())
 	{
 		if(contains_text(get_property("auto_funPrefix"), "annoying") ||
 			contains_text(get_property("auto_funPrefix"), "phase-shifting") ||

--- a/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
@@ -1,6 +1,11 @@
+boolean in_ocrs()
+{
+	return (auto_my_path() == "One Crazy Random Summer");
+}
+
 boolean ocrs_postHelper()
 {
-	if(my_path() != "One Crazy Random Summer")
+	if(in_ocrs())
 	{
 		return false;
 	}
@@ -11,7 +16,7 @@ boolean ocrs_postHelper()
 
 boolean ocrs_postCombatResolve()
 {
-	if((have_effect($effect[Beaten Up]) > 0) && (auto_my_path() == "One Crazy Random Summer"))
+	if((have_effect($effect[Beaten Up]) > 0) && (in_ocrs()))
 	{
 		if(contains_text(get_property("auto_funPrefix"), "annoying") ||
 			contains_text(get_property("auto_funPrefix"), "phase-shifting") ||

--- a/RELEASE/scripts/autoscend/paths/picky.ash
+++ b/RELEASE/scripts/autoscend/paths/picky.ash
@@ -1,8 +1,13 @@
 # Code here is supplementary handlers and specialized handlers
 
+boolean in_picky()
+{
+	return my_path() == "Picky";
+}
+
 void picky_pulls()
 {
-	if(my_path() == "Picky")
+	if(in_picky())
 	{
 		if(my_daycount() == 3)
 		{

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -66,7 +66,7 @@ boolean LX_quantumTerrarium()
 
 void qt_initializeSettings()
 {
-	if (in_quantumTerrarium())
+	if(in_quantumTerrarium())
 	{
 		set_property("auto_skipNuns", true);	//Remove when leprechaun swapping is supported at nuns.
 	}

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -1,0 +1,4 @@
+boolean in_wotsf()
+{
+	return auto_my_path() == "Way of the Surprising Fist";
+}

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -1,0 +1,4 @@
+boolean in_youRobot()
+{
+	return auto_my_path() == "You, Robot";
+}

--- a/RELEASE/scripts/autoscend/quests/level_02.ash
+++ b/RELEASE/scripts/autoscend/quests/level_02.ash
@@ -14,7 +14,7 @@ boolean L2_mosquito()
 		if (internalQuestStatus("questL02Larva") > 0 || item_amount($item[mosquito larva]) > 0)
 		{
 			council();
-			if (in_koe())
+			if(in_koe())
 			{
 				cli_execute("refresh quests");
 			}

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -48,7 +48,7 @@ boolean L4_batCave()
 			return autoAdv($location[The Beanbat Chamber]);
 		}
 		council();
-		if (in_koe())
+		if(in_koe())
 		{
 			cli_execute("refresh quests");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -77,7 +77,7 @@ boolean L5_haremOutfit()
 		}
 	}
 
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -304,7 +304,7 @@ boolean L8_getMineOres()
 			numCloversKeep = 0;
 		}
 	}
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		if(cloversAvailable() <= numCloversKeep)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -254,7 +254,7 @@ boolean L8_getMineOres()
 	}
 
 	//heavy rain copy handling.
-	if(auto_my_path() == "Heavy Rains" && have_skill($skill[Rain Man]))
+	if(in_heavyrains() && have_skill($skill[Rain Man]))
 	{
 		if(my_rain() < 50)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -238,7 +238,7 @@ boolean L9_chasmBuild()
 		return true;
 	}
 
-	if (in_plumber() && possessEquipment($item[frosty button]))
+	if(in_plumber() && possessEquipment($item[frosty button]))
 	{
 		autoEquip($item[frosty button]);
 	}
@@ -817,7 +817,7 @@ boolean L9_oilPeak()
 		}
 		else if (item_amount($item[Bubblin' Crude]) >= 12)
 		{
-			if (in_glover())
+			if(in_glover())
 			{
 				if (item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 2)
 				{

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -311,7 +311,7 @@ boolean L10_topFloor()
 	if (internalQuestStatus("questL10Garbage") > 9)
 	{
 		council();
-		if (in_koe())
+		if(in_koe())
 		{
 			cli_execute("refresh quests");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -495,7 +495,7 @@ boolean LX_getLadySpookyravensFinestGown() {
 		// of the macguffin quest if we got unlucky
 		boolean needSpectacles = (item_amount($item[Lord Spookyraven\'s Spectacles]) == 0 && internalQuestStatus("questL11Manor") < 2);
 		boolean needCamera = (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1);
-		if (is_boris() || in_wotsf() || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
+		if (is_boris() || in_wotsf() || (in_nuclear() && in_hardcore())) {
 			needSpectacles = false;
 		}
 
@@ -938,7 +938,7 @@ boolean L11_aridDesert()
 		if(get_property("auto_gnasirUnlocked").to_boolean() && ((get_property("gnasirProgress").to_int() & 2) != 2))
 		{
 			boolean canBuyPaint = true;
-			if(in_wotsf() || (auto_my_path() == "Nuclear Autumn"))
+			if(in_wotsf() || in_nuclear())
 			{
 				canBuyPaint = false;
 			}
@@ -1675,7 +1675,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_wotsf() || in_bhy() || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_wotsf() || in_bhy() || (in_nuclear() && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.
@@ -1728,7 +1728,7 @@ boolean L11_mauriceSpookyraven()
 			autoCraft("cook", 1, $item[bottle of Chateau de Vinegar], $item[blasting soda]);
 			if(item_amount($item[Unstable Fulminate]) == 0)
 			{
-				if(auto_my_path() == "Nuclear Autumn")
+				if(in_nuclear())
 				{
 					auto_log_warning("Could not make an Unstable Fulminate, assuming we have no oven for realz...", "red");
 					return true;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1778,7 +1778,7 @@ boolean L11_mauriceSpookyraven()
 		auto_MaxMLToCap(auto_convertDesiredML(82), true);
 		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
 
-		if((auto_my_path() == "Picky") && (item_amount($item[gumshoes]) > 0))
+		if((in_picky()) && (item_amount($item[gumshoes]) > 0))
 		{
 			auto_change_mcd(0);
 			autoEquip($slot[acc2], $item[gumshoes]);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -140,7 +140,7 @@ boolean[location] shenSnakeLocations(int day, int n_items_returned)
 	boolean[location] frattle   = $locations[The Smut Orc Logging Camp];
 	boolean[location] snakleton = $locations[The Unquiet Garves, The VERY Unquiet Garves];
 
-	if (in_koe())
+	if(in_koe())
 	{
 		return union(ten_heads, frattle, frozen);
 	}
@@ -228,7 +228,7 @@ int[location] getShenZonesTurnsSpent()
 boolean LX_unlockHiddenTemple() {
 	// replaces L2_treeCoin(),  L2_spookyMap(),  L2_spookyFertilizer() & L2_spookySapling()
 
-	if (in_glover()) {
+	if(in_glover()) {
 		// Spooky Temple map ain't nuthin' but a 'G' Thang.
 		return false;
 	}
@@ -495,7 +495,7 @@ boolean LX_getLadySpookyravensFinestGown() {
 		// of the macguffin quest if we got unlucky
 		boolean needSpectacles = (item_amount($item[Lord Spookyraven\'s Spectacles]) == 0 && internalQuestStatus("questL11Manor") < 2);
 		boolean needCamera = (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1);
-		if (is_boris() || auto_my_path() == "Way of the Surprising Fist" || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
+		if (is_boris() || in_wotsf() || (auto_my_path() == "Nuclear Autumn" && in_hardcore())) {
 			needSpectacles = false;
 		}
 
@@ -675,7 +675,7 @@ boolean L11_forgedDocuments()
 	}
 
 	auto_log_info("Getting the McMuffin Book", "blue");
-	if(auto_my_path() == "Way of the Surprising Fist")
+	if(in_wotsf())
 	{
 		// TODO: move this to WotSF path file if one is ever created.
 		string[int] pages;
@@ -698,7 +698,7 @@ boolean L11_mcmuffinDiary()
 	{
 		return false;
 	}
-	if (in_koe() && item_amount($item[Forged Identification Documents]) > 0)
+	if(in_koe() && item_amount($item[Forged Identification Documents]) > 0)
 	{
 		council(); // Shore doesn't exist in Exploathing so we acquire diary from the council
 	}
@@ -737,7 +737,7 @@ boolean L11_mcmuffinDiary()
 void auto_visit_gnasir()
 {
 	//Visits gnasir, can change based on path
-	if (in_koe())
+	if(in_koe())
 	{
 		visit_url("place.php?whichplace=exploathing_beach&action=expl_gnasir");
 	}
@@ -938,7 +938,7 @@ boolean L11_aridDesert()
 		if(get_property("auto_gnasirUnlocked").to_boolean() && ((get_property("gnasirProgress").to_int() & 2) != 2))
 		{
 			boolean canBuyPaint = true;
-			if((auto_my_path() == "Way of the Surprising Fist") || (auto_my_path() == "Nuclear Autumn"))
+			if(in_wotsf() || (auto_my_path() == "Nuclear Autumn"))
 			{
 				canBuyPaint = false;
 			}
@@ -1540,7 +1540,7 @@ boolean L11_hiddenCityZones()
 
 	L11_hiddenTavernUnlock();
 
-	boolean canUseMachete = !is_boris() && auto_my_path() != "Way of the Surprising Fist" && !in_pokefam();
+	boolean canUseMachete = !is_boris() && !in_wotsf() && !in_pokefam();
 	boolean needMachete = canUseMachete && !possessEquipment($item[Antique Machete]) && in_hardcore();
 	boolean needRelocate = (get_property("relocatePygmyJanitor").to_int() != my_ascensions());
 
@@ -1675,7 +1675,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || (auto_my_path() == "Way of the Surprising Fist") || in_bhy() || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_wotsf() || in_bhy() || ((auto_my_path() == "Nuclear Autumn") && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.
@@ -1778,7 +1778,7 @@ boolean L11_mauriceSpookyraven()
 		auto_MaxMLToCap(auto_convertDesiredML(82), true);
 		addToMaximize("500ml " + auto_convertDesiredML(82) + "max");
 
-		if((in_picky()) && (item_amount($item[gumshoes]) > 0))
+		if(in_picky() && (item_amount($item[gumshoes]) > 0))
 		{
 			auto_change_mcd(0);
 			autoEquip($slot[acc2], $item[gumshoes]);
@@ -2411,7 +2411,7 @@ boolean L11_unlockPyramid()
 	}
 	
 	auto_log_info("Reveal the pyramid", "blue");
-	if (in_koe())
+	if(in_koe())
 	{
 		visit_url("place.php?whichplace=exploathing_beach&action=expl_pyramidpre");
 		cli_execute("refresh quests");

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -826,7 +826,7 @@ boolean L11_aridDesert()
 	if((have_effect($effect[Ultrahydrated]) > 0) || (get_property("desertExploration").to_int() == 0))
 	{
 		auto_log_info("Searching for the pyramid", "blue");
-		if(auto_my_path() == "Heavy Rains")
+		if(in_heavyrains())
 		{
 			autoEquip($item[Thor\'s Pliers]);
 		}
@@ -2586,7 +2586,7 @@ boolean L11_defeatEd()
 	}
 
 	int baseML = monster_level_adjustment();
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		baseML = baseML + 60;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1434,7 +1434,7 @@ boolean L11_hiddenCity()
 			if(item_amount($item[Bowl Of Scorpions]) == 0)
 			{
 				buyUpTo(1, $item[Bowl Of Scorpions]);
-				if(auto_my_path() == "One Crazy Random Summer")
+				if(in_ocrs())
 				{
 					buyUpTo(3, $item[Bowl Of Scorpions]);
 				}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -474,7 +474,7 @@ boolean LX_danceWithLadySpookyraven() {
 
 	auto_log_info("Finished Spookyraven, just dancing with the lady.", "blue");
 	if (autoAdv($location[The Haunted Ballroom])) {
-		if (in_lowkeysummer()) {
+		if(in_lowkeysummer()) {
 			// need to open the Haunted Nursery for the music box key.
 			visit_url("place.php?whichplace=manor3&action=manor3_ladys");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1042,7 +1042,7 @@ boolean L12_gremlins()
 		else return true;
 	}
 
-	if(auto_my_path() == "Disguises Delimit")
+	if(in_disguises())
 	{
 		abort("Do gremlins manually, sorry. Or set sidequestJunkyardCompleted=fratboy and we will just skip them");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -549,7 +549,7 @@ boolean L12_getOutfit()
 	}
 	
 	//heavy rains softcore pull handling
-	if(!in_hardcore() && (auto_my_path() == "Heavy Rains"))
+	if(!in_hardcore() && (in_heavyrains()))
 	{
 		// auto_warhippyspy indicates rainman was already used to copy a war hippy spy in heavy rains. if it failed to YR pull missing items
 		if(get_property("auto_warhippyspy") == "done" && get_property("auto_hippyInstead").to_boolean())
@@ -568,7 +568,7 @@ boolean L12_getOutfit()
 	}
 
 	//softcore pull handling for all other paths
-	if(!in_hardcore() && (auto_my_path() != "Heavy Rains"))
+	if(!in_hardcore() && (!in_heavyrains()))
 	{
 		if(get_property("auto_hippyInstead").to_boolean())
 		{
@@ -1553,7 +1553,7 @@ boolean L12_themtharHills()
 	}
 
 	autoEquip($item[Half a Purse]);
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		autoEquip($item[Thor\'s Pliers]);
 	}
@@ -1614,14 +1614,14 @@ boolean L12_themtharHills()
 	}
 	asdonBuff($effect[Driving Observantly]);
 
-	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (auto_my_path() != "Heavy Rains"))
+	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (!in_heavyrains()))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
 		autoEquip($item[Li\'l Pirate Costume]);
 		handleFamiliar($familiar[Trick-or-Treating Tot]);
 	}
 
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
 		buffMaintain($effect[Sinuses For Miles], 0, 1, 1);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -274,7 +274,7 @@ WarPlan auto_bestWarPlan()
 		considerArena = false;
 		considerJunkyard = false;
 	}
-	if(auto_my_path() == "Way of the Surprising Fist")
+	if(in_wotsf())
 	{
 		considerNuns = false;
 	}
@@ -283,7 +283,7 @@ WarPlan auto_bestWarPlan()
 		considerNuns = false;
 		considerOrchard = false;
 	}
-	if (in_glover())
+	if(in_glover())
 	{
 		considerArena = false;
 	}
@@ -549,7 +549,7 @@ boolean L12_getOutfit()
 	}
 	
 	//heavy rains softcore pull handling
-	if(!in_hardcore() && (in_heavyrains()))
+	if(!in_hardcore() && in_heavyrains())
 	{
 		// auto_warhippyspy indicates rainman was already used to copy a war hippy spy in heavy rains. if it failed to YR pull missing items
 		if(get_property("auto_warhippyspy") == "done" && get_property("auto_hippyInstead").to_boolean())
@@ -731,7 +731,7 @@ boolean L12_startWar()
 		return false;
 	}
 
-	if (in_koe())
+	if(in_koe())
 	{
 		return false;
 	}
@@ -789,7 +789,7 @@ boolean L12_filthworms()
 	{
 		return false;
 	}
-	if (in_tcrs() || in_koe())
+	if(in_tcrs() || in_koe())
 	{
 		return false;
 	}
@@ -985,7 +985,7 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
-	if (in_koe() || in_pokefam() || in_bhy())
+	if(in_koe() || in_pokefam() || in_bhy())
 	{
 		return false;
 	}
@@ -1092,7 +1092,7 @@ boolean L12_sonofaBeach()
 	{
 		return false;
 	}
-	if (in_koe())
+	if(in_koe())
 	{
 		return false;
 	}
@@ -1341,7 +1341,7 @@ boolean L12_sonofaFinish()
 	{
 		return false;
 	}
-	if (in_koe())
+	if(in_koe())
 	{
 		return false;
 	}
@@ -1525,7 +1525,7 @@ boolean L12_themtharHills()
 		return false;
 	}
 
-	if (in_tcrs() || in_koe() || auto_my_path() == "Way of the Surprising Fist")
+	if(in_tcrs() || in_koe() || in_wotsf())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1694,7 +1694,7 @@ boolean L13_towerNSNagamar()
 		return false;
 	}
 	
-	if(auto_my_path() == "Disguises Delimit" && internalQuestStatus("questL13Final") == 12)
+	if(in_disguises() && internalQuestStatus("questL13Final") == 12)
 	{
 		cli_execute("refresh quests");
 		if(internalQuestStatus("questL13Final") != 12)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -86,7 +86,7 @@ boolean LX_getDigitalKey()
 		}
 		return false;
 	}
-	if (in_koe())
+	if in_koe())
 	{
 		if(item_amount($item[Digital Key]) == 0 && internalQuestStatus("questL13Final") == 5)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -763,7 +763,7 @@ boolean L13_sorceressDoor()
 	}
 
 	// Low Key Summer has an entirely different door.
-	if (in_lowkeysummer())
+	if(in_lowkeysummer())
 	{
 		return L13_sorceressDoorLowKey();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1559,9 +1559,9 @@ boolean L13_towerNSFinal()
 		auto_log_warning("We do not have a Wand of Nagamar but appear to need one. We must lose to the Sausage first...", "red");
 	}
 
-	if(auto_my_path() == "Heavy Rains")
+	if(in_heavyrains())
 	{
-		return L13_towerFinalHeavyRains();
+		return L13_heavyrains_towerFinal();
 	}
 	
 	if(in_bhy())

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -86,7 +86,7 @@ boolean LX_getDigitalKey()
 		}
 		return false;
 	}
-	if in_koe())
+	if(in_koe())
 	{
 		if(item_amount($item[Digital Key]) == 0 && internalQuestStatus("questL13Final") == 5)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -170,7 +170,8 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if (in_lowkeysummer()) {
+	if(in_lowkeysummer())
+	{
 		return LX_hippyBoatman();
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -92,7 +92,7 @@ boolean LX_unlockDesert()
 		return false;
 	}
 	
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		if(isAboutToPowerlevel())
 		{
@@ -140,7 +140,7 @@ boolean LX_unlockDesert()
 
 boolean LX_desertAlternate()
 {
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		return LX_hippyBoatman();
 	}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -213,7 +213,7 @@ boolean LX_steelOrgan()
 		set_property("auto_getSteelOrgan", false);
 		return false;
 	}
-	if((auto_my_path() == "Nuclear Autumn") || (auto_my_path() == "License to Adventure"))
+	if(in_nuclear() || (auto_my_path() == "License to Adventure"))
 	{
 		auto_log_info("You could get a Steel Organ for aftercore, but why? We won't help with this deviant and perverse behavior. Turning off setting.", "blue");
 		set_property("auto_getSteelOrgan", false);
@@ -391,7 +391,7 @@ boolean LX_guildUnlock()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Nuclear Autumn" || in_pokefam())
+	if(in_nuclear() || in_pokefam())
 	{
 		return false;
 	}
@@ -475,7 +475,7 @@ boolean LX_guildUnlock()
 
 boolean startArmorySubQuest()
 {
-	if(in_koe() || auto_my_path() == "Nuclear Autumn")
+	if(in_koe() || in_nuclear())
 	{
 		//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
 		if(item_amount($item[Hypnotic Breadcrumbs]) > 0)
@@ -540,7 +540,7 @@ boolean startMeatsmithSubQuest()
 	{
 		return false;	//quest already started
 	}
-	if(auto_my_path() == "Nuclear Autumn")
+	if(in_nuclear())
 	{
 		if(item_amount($item[Bone With a Price Tag On It]) > 0)
 		{
@@ -647,7 +647,7 @@ boolean startGalaktikSubQuest()
 	{
 		return false;	//quest already started
 	}
-	if(auto_my_path() == "Nuclear Autumn" || in_koe())
+	if(in_nuclear() || in_koe())
 	{
 		//will unlock the zone but does not actually start the quest. also currently not tracked by mafia so we will think the zone is unavailable.
 		if(item_amount($item[Map to a Hidden Booze Cache]) > 0)
@@ -1098,7 +1098,7 @@ boolean LX_NemesisQuest()
 void houseUpgrade()
 {
 	//function for upgrading your dwelling.
-	if(isActuallyEd() || my_class() == $class[Vampyre] || auto_my_path() == "Nuclear Autumn")
+	if(isActuallyEd() || my_class() == $class[Vampyre] || in_nuclear())
 	{
 		return;		//paths where dwelling is locked
 	}


### PR DESCRIPTION
Change all references for Nuclear Autumn, Heavy Rains, AWOL, DD, OCRS, Picky, You Robot, and Gelatinous Noob for consistency

# Description

Changed all references for NA, HR, AWOL, DD, OCRS, Picky, YR, and GNoob to be consistent with other paths and code style

## How Has This Been Tested?

Name edits only

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
