### PR TITLE
confirm extinguisher is equipped before using skill

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -11,7 +11,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 
 	//use industrial fire extinguisher zone specific skills
 	string extinguisherSkill = auto_FireExtinguisherCombatString(my_location());
-	if(extinguisherSkill != "")
+	if(extinguisherSkill != "" && have_equipped($item[industrial fire extinguisher]))
 	{
 		handleTracker(enemy, to_skill(substring(extinguisherSkill, 6)), "auto_otherstuff");
 		return extinguisherSkill;

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -168,7 +168,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	//use industrial fire extinguisher zone specific skills
 	string extinguisherSkill = auto_FireExtinguisherCombatString(my_location());
-	if(extinguisherSkill != "")
+	if(extinguisherSkill != "" && have_equipped($item[industrial fire extinguisher]))
 	{
 		handleTracker(enemy, to_skill(substring(extinguisherSkill, 6)), "auto_otherstuff");
 		return extinguisherSkill;


### PR DESCRIPTION
# Description

Reported in discord that extinguisher skill is attempted to be used, even if not equipped. Happened when user had a weapon in the override setting. Added check that extinguisher is equipped before using the zone specific skills. Polar vortex already check by confirming the skill could be used, which indirectly checks that extinguisher is equipped.

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
