### PR TITLE
path restriction on pulls for familiar equip

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -627,7 +627,7 @@ int handlePulls(int day)
 				put_closet(1, $item[empty rain-doh can]);
 			}
 		}
-		if((storage_amount($item[Buddy Bjorn]) > 0) && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
+		if(storage_amount($item[Buddy Bjorn]) > 0 && pathHasFamiliar())
 		{
 			pullXWhenHaveY($item[Buddy Bjorn], 1, 0);
 		}
@@ -745,7 +745,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 		}
 
-		if(!in_heavyrains() && !in_lta() && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
+		if(!in_heavyrains() && pathHasFamiliar())
 		{
 			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Astral Pet Sweater]) && glover_usable($item[Snow Suit]))
 			{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -300,6 +300,14 @@ void bedtime_pulls_rollover_equip()
 			if(!possessEquipment(it) && !canPull(it,true)) continue;		//do not have it and can not pull it.
 			if(!auto_can_equip(it)) continue;		//we can not equip it
 			
+			if($slot[familiar] == sl && !pathHasFamiliar())
+			{
+				//in paths without familiar do not pull familiar equip.
+				if(!in_robot())
+				{
+					continue;
+				}
+			}
 			if($slot[acc1] == sl)
 			{
 				//all accessories always return acc1 from to_slot() function.


### PR DESCRIPTION
* don't pull familiar equip at bedtime if you are in a path that does not allow familiar
* buddy bjorn and snow suit were pulled on turn 0. unless an outdated list said we are in a path that does not allow familiar. replaced that list with the function `pathHasFamiliar()`. this will both fix the issue of pulling those items in newer paths that forbid familiar (such as dark gyffte) and also help in the future as more such paths are added

fixes #954

## How Has This Been Tested?

it does not break standard.
need to actually go into dark gyfte to test it

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
