### PR TITLE
WOTSF clean-up

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1411,7 +1411,7 @@ boolean autosellCrap()
 	}
 	if(in_wotsf()) 
 	{
-		return false;		//selling things in the way of the suprising fist only donates the money to charity, so we should not autosell anything automatically
+		return false;		//selling things in the way of the surprising fist only donates the money to charity, so we should not autosell anything automatically
 	}
 	foreach it in $items[dense meat stack, meat stack, Blue Money Bag, Red Money Bag, White Money Bag]
 	{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -695,7 +695,7 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[over-the-shoulder folder holder], 1, 0);
 		}
-		if((my_primestat() == $stat[Muscle]) && !in_heavyrains())
+		if((my_primestat() == $stat[Muscle]) && !in_heavyrains() && !in_wotsf()) // no need for shields in way of the surprising fist
 		{
 			if((closet_amount($item[Fake Washboard]) == 0) && glover_usable($item[Fake Washboard]))
 			{
@@ -724,7 +724,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[Eleven-Foot Pole], 1, 0);
 		}
 
-		if((my_class() == $class[Sauceror]) || (my_class() == $class[Pastamancer]))
+		if(((my_class() == $class[Sauceror]) || (my_class() == $class[Pastamancer])) && !in_wotsf()) // no need for offhands in way of the surprising fist
 		{
 			if((item_amount($item[Deck of Every Card]) == 0) && !auto_have_skill($skill[Summon Smithsness]))
 			{
@@ -772,7 +772,7 @@ int handlePulls(int day)
 			string temp = visit_url("storage.php?action=pull&whichitem1=" + to_int($item[Bastille Battalion Control Rig]) + "&howmany1=1&pwd");
 		}
 
-		if(!in_pokefam() && !in_glover())
+		if(!in_pokefam())
 		{
 			pullXWhenHaveY($item[Replica Bat-oomerang], 1, 0);
 		}
@@ -915,7 +915,7 @@ boolean LX_craftAcquireItems()
 	}
 	
 
-	if(my_class() == $class[Turtle Tamer])
+	if(my_class() == $class[Turtle Tamer] && !in_wotsf()) // no need for shields in way of the surprising fist
 	{
 		if(!possessEquipment($item[Turtle Wax Shield]) && (item_amount($item[Turtle Wax]) > 0))
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2902,7 +2902,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if((item_amount(source) < uses) && (!in_wotsf()))
+	if((item_amount(source) < uses) && !in_wotsf())
 	{
 		if(historical_price(source) < 2000)
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -383,7 +383,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		
 			//this is for increasing meat income. gain +25 meat per monster, at the cost of letting it act once. If healing is too costly this can be a net loss of meat. until a full cost calculator is made, limit to under 10 HP damage and no more than 20% of your remaining HP.
 			
-			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && (!in_wotsf()))
+			if(canSurvive(5.0) && (get_property("boomBoxSong") == "Total Eclipse of Your Meat") && (expected_damage() < 10) && !in_wotsf())
 			{
 				return useSkill($skill[Sing Along]);
 			}

--- a/RELEASE/scripts/autoscend/quests/level_01.ash
+++ b/RELEASE/scripts/autoscend/quests/level_01.ash
@@ -29,7 +29,7 @@ void tootOriole()
 
 void tootGetMeat()
 {
-	if(can_interact())		//avoid selling gems in casual
+	if(can_interact() || in_wotsf()) // avoid selling gems in casual and way of the surprising fist
 	{
 		return;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1847,7 +1847,10 @@ boolean L11_redZeppelin()
 	buffMaintain($effect[Greasy Peasy], 0, 1, 1);
 	buffMaintain($effect[Musky], 0, 1, 1);
 	buffMaintain($effect[Blood-Gorged], 0, 1, 1);
-	pullXWhenHaveY($item[deck of lewd playing cards], 1, 0);
+	if(!in_wotsf())
+	{
+		pullXWhenHaveY($item[deck of lewd playing cards], 1, 0);
+	}
 
 	if(item_amount($item[Flamin\' Whatshisname]) > 0)
 	{
@@ -1971,7 +1974,7 @@ boolean L11_ronCopperhead()
 
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
 	{
-		if (item_amount($item[Red Zeppelin Ticket]) < 1)
+		if (item_amount($item[Red Zeppelin Ticket]) < 1 && !in_wotsf()) // no black market in wotsf
 		{
 			// use the priceless diamond since we go to the effort of trying to get one in the Copperhead Club
 			// and it saves us 4.5k meat.


### PR DESCRIPTION
# Description

Cleans up some WOTSF items: still autoselling pork gems, pulling offhand items, and general code consistency.

## How Has This Been Tested?

A few WOTSF runs

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
