### PR TITLE
Don't replace bats in robot or wildfire

### DIFF
--- a/BUILD/monsters/replace.dat
+++ b/BUILD/monsters/replace.dat
@@ -1,5 +1,5 @@
 Banshee Librarian	item:Killing Jar>0
-Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber
+Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber,!pathid:41,!path:Wildfire
 Knob Goblin Madam	item:Knob Goblin Perfume>0
 Bookbat
 Craven Carven Raven

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -53,7 +53,7 @@ banish	47	party skelteon
 banish	48	basic lihc
 
 replace	0	Banshee Librarian	item:Killing Jar>0
-replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber
+replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber,!pathid:41,!path:Wildfire
 replace	2	Knob Goblin Madam	item:Knob Goblin Perfume>0
 replace	3	Bookbat
 replace	4	Craven Carven Raven

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3970,7 +3970,7 @@ boolean auto_check_conditions(string conds)
 			// As a precaution, autoscend aborts if to_int returns 0
 			case "pathid":
 				int req_pathid = to_int(condition_data);
-				if(req_mainstat == 0)
+				if(req_pathid == 0)
 					abort('"' + condition_data + '" does not properly convert to a path id!');
 				return req_pathid == my_path_id();
 			// data: Text name of the skill, as used by to_skill()

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3965,6 +3965,14 @@ boolean auto_check_conditions(string conds)
 			// No safety checking possible here, so hopefully you don't misspell anything
 			case "path":
 				return condition_data == auto_my_path();
+			// data: The int id name of the path, as returned by my_path_id()
+			// You must be currently on that path
+			// As a precaution, autoscend aborts if to_int returns 0
+			case "pathid":
+				int req_pathid = to_int(condition_data);
+				if(req_mainstat == 0)
+					abort('"' + condition_data + '" does not properly convert to a path id!');
+				return req_pathid == my_path_id();
 			// data: Text name of the skill, as used by to_skill()
 			// You must have the given skill
 			// As a precaution, autoscend aborts if to_skill returns $skill[none]


### PR DESCRIPTION
For alternate boss bat factoids, like the other paths are already checking.

Needed to add pathid because `You, Robot` has a comma in it.