### PR TITLE
Fix divide by zero in Spleen familiar handling

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -510,12 +510,11 @@ boolean autoChooseFamiliar(location place)
 					spleenFamiliarsAvailable++;
 				}
 			}
-
-			int spleen_drops_need = (spleen_left() + 3)/4;
-			int bound = (spleen_drops_need + spleenFamiliarsAvailable - 1) / spleenFamiliarsAvailable;
 			
 			if(spleenFamiliarsAvailable > 0)
 			{
+				int spleen_drops_need = (spleen_left() + 3)/4;
+				int bound = (spleen_drops_need + spleenFamiliarsAvailable - 1) / spleenFamiliarsAvailable;
 				foreach fam in $familiars[Baby Sandworm, Rogue Program, Pair of Stomping Boots, Bloovian Groose, Unconscious Collective, Grim Brother, Golden Monkey]
 				{
 					if((fam.drops_today < bound) && canChangeToFamiliar(fam))


### PR DESCRIPTION
# Description

Discord reported abort due to spleen familiar handling dividing by zero. Issue was golden monkey was in bjorn. haveSpleenFamiliar() returned non-zero, but couldn't change to it. So line 515 (before this change) in auto_familiar attempted to divide by zero and aborted

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
