### PR TITLE
check for super-advanced meatsmithing skill for day 1 bedtime chrome sword

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -761,7 +761,7 @@ boolean doBedtime()
 			need = 4;
 		}
 		if (!haveAdvSmithing) {
-			print('No Super-Advanced Meatsmithing for chrome sword crafting!');
+			auto_log_info('No Super-Advanced Meatsmithing for chrome sword crafting!');
 		}
 		if((item_amount($item[Chrome Ore]) >= need) && !possessEquipment($item[Chrome Sword]) && isArmoryAvailable() && haveAdvSmithing)
 		{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -769,7 +769,7 @@ boolean doBedtime()
 		}
 		else
 		{
-			print('Did not make chrome sword');
+			auto_log_info('Did not make chrome sword');
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -755,13 +755,21 @@ boolean doBedtime()
 	{
 		item oreGoal = to_item(get_property("trapperOre"));
 		int need = 1;
+		boolean haveAdvSmithing = have_skill($skill[Super-Advanced Meatsmithing]);
 		if(oreGoal == $item[Chrome Ore])
 		{
 			need = 4;
 		}
-		if((item_amount($item[Chrome Ore]) >= need) && !possessEquipment($item[Chrome Sword]) && isArmoryAvailable())
+		if (!haveAdvSmithing) {
+			print('No Super-Advanced Meatsmithing for chrome sword crafting!');
+		}
+		if((item_amount($item[Chrome Ore]) >= need) && !possessEquipment($item[Chrome Sword]) && isArmoryAvailable() && haveAdvSmithing)
 		{
 			cli_execute("make " + $item[Chrome Sword]);
+		}
+		else
+		{
+			print('Did not make chrome sword');
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes #965 by adding a `have_skill($skill[Super-Advanced Meatsmithing])` in the `craft Chrome Sword` step of `auto_bedtime.ash`

## How Has This Been Tested?

Fortunately, this happens consistently if:
1. It is day one of the run
2. Account has free crafts at the time
3. Account does not have Chrome Sword
4. Account has enough ores
5. Account does **NOT** have `Super-Advanced Meatsmithing`

Prior to this change:
Bedtime will terminate with an exception, and will not proceed with the rest of bedtime.

After this change:
If `have_skill($skill[Super-Advanced Meatsmithing])`, (i.e. 1-4 conditions above are all true), then it should still proceed with creating the chrome sword. However, it should no longer terminate unexpectedly if Super-Advanced Meatsmithing is unavailable.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
