### PR TITLE
fix warning that we should change "Ed" to "Ed the Undying"

### DIFF
--- a/BUILD/monsters/banish.dat
+++ b/BUILD/monsters/banish.dat
@@ -2,28 +2,28 @@ A.M.C. Gremlin
 Animated Mahogany Nightstand
 Animated Possessions
 Animated Rustic Nightstand	!path:Bees Hate You
-Bubblemint Twins	!class:Ed
+Bubblemint Twins	!class:Ed the Undying
 Bullet Bill
 Burly Sidekick	item:Mohawk Wig>0;!familiar:Red-Nosed Snapper
 Coaltergeist
 Doughbat
 Drunk Goat
-Eagle	class:Ed
+Eagle	class:Ed the Undying
 Evil Olive
-Empty suit of armor	class:Ed
+Empty suit of armor	class:Ed the Undying
 Flock Of Stab-Bats
 Gluttonous Ghuol	class:Vampyre
 Knob Goblin Harem Guard
 Knob Goblin Madam	item:Knob Goblin Perfume>0
-Mad Wino	!class:Ed
-MagiMechTech MechaMech	class:Ed
-Mob Penguin Capo	class:Ed
+Mad Wino	!class:Ed the Undying
+MagiMechTech MechaMech	class:Ed the Undying
+Mob Penguin Capo	class:Ed the Undying
 Mismatched Twins
 Natural Spider
 Plaid Ghost
 Possessed Laundry Press
 Procrastination Giant
-Protagonist	!class:Ed;!familiar:Red-Nosed Snapper
+Protagonist	!class:Ed the Undying;!familiar:Red-Nosed Snapper
 Pygmy Headhunter
 Pygmy Janitor	tavern:true
 Pygmy Orderlies
@@ -35,14 +35,14 @@ Sabre-Toothed Goat
 Senile Lihc	loc:The Defiled Niche
 Slick Lihc	loc:The Defiled Niche
 Skeletal Sommelier
-Spooky mummy	class:Ed
-Spooky vampire	class:Ed
+Spooky mummy	class:Ed the Undying
+Spooky vampire	class:Ed the Undying
 Steam Elemental
 Taco Cat
 Tan Gnat
 Tomb Asp
 Tomb Servant
-Triffid	class:Ed
+Triffid	class:Ed the Undying
 Wardr&ouml;b Nightstand
 Warehouse Janitor
 party skelteon

--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -13,7 +13,7 @@ Tomb Rat
 Blooper	loc:8-Bit Realm
 Bob Racecar	!sniffed:Racecar Bob
 Racecar Bob	!sniffed:Bob Racecar
-Government Scientist	class:Ed
+Government Scientist	class:Ed the Undying
 Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath

--- a/BUILD/monsters/yellowray.dat
+++ b/BUILD/monsters/yellowray.dat
@@ -27,23 +27,23 @@ War Frat Wartender	!outfit:Frat Warrior Fatigues
 War Pledge	!outfit:Frat Warrior Fatigues
 # We also want to dress up like a filthy hippy to get frat warrior fatigues
 business hippy	!outfit:Filthy Hippy Disguise
-crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
-dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
-filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
 zombie hippy	!outfit:Filthy Hippy Disguise
 # Want hippy war outfit if fighting for hippies. TODO: add monsters for Frat Boy Ensemble and War Hippy Fatigues outfits. Issue #900
 War Hippy Spy	!outfit:War Hippy Fatigues
 # And we want filthworm glands, but not if we're gonna hugpocket them
-larval filthworm	!familiar:XO Skeleton;!class:Ed
-filthworm drone	!familiar:XO Skeleton;!class:Ed
-filthworm royal guard	!familiar:XO Skeleton;!class:Ed
-Knight (Snake)	class:Ed
+larval filthworm	!familiar:XO Skeleton;!class:Ed the Undying
+filthworm drone	!familiar:XO Skeleton;!class:Ed the Undying
+filthworm royal guard	!familiar:XO Skeleton;!class:Ed the Undying
+Knight (Snake)	class:Ed the Undying
 bearpig topiary animal	familiar:Melodramedary
 elephant (meatcar?) topiary animal	familiar:Melodramedary
 spider (duck?) topiary animal	familiar:Melodramedary

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -6,28 +6,28 @@ banish	0	A.M.C. Gremlin
 banish	1	Animated Mahogany Nightstand
 banish	2	Animated Possessions
 banish	3	Animated Rustic Nightstand	!path:Bees Hate You
-banish	4	Bubblemint Twins	!class:Ed
+banish	4	Bubblemint Twins	!class:Ed the Undying
 banish	5	Bullet Bill
 banish	6	Burly Sidekick	item:Mohawk Wig>0;!familiar:Red-Nosed Snapper
 banish	7	Coaltergeist
 banish	8	Doughbat
 banish	9	Drunk Goat
-banish	10	Eagle	class:Ed
+banish	10	Eagle	class:Ed the Undying
 banish	11	Evil Olive
-banish	12	Empty suit of armor	class:Ed
+banish	12	Empty suit of armor	class:Ed the Undying
 banish	13	Flock Of Stab-Bats
 banish	14	Gluttonous Ghuol	class:Vampyre
 banish	15	Knob Goblin Harem Guard
 banish	16	Knob Goblin Madam	item:Knob Goblin Perfume>0
-banish	17	Mad Wino	!class:Ed
-banish	18	MagiMechTech MechaMech	class:Ed
-banish	19	Mob Penguin Capo	class:Ed
+banish	17	Mad Wino	!class:Ed the Undying
+banish	18	MagiMechTech MechaMech	class:Ed the Undying
+banish	19	Mob Penguin Capo	class:Ed the Undying
 banish	20	Mismatched Twins
 banish	21	Natural Spider
 banish	22	Plaid Ghost
 banish	23	Possessed Laundry Press
 banish	24	Procrastination Giant
-banish	25	Protagonist	!class:Ed;!familiar:Red-Nosed Snapper
+banish	25	Protagonist	!class:Ed the Undying;!familiar:Red-Nosed Snapper
 banish	26	Pygmy Headhunter
 banish	27	Pygmy Janitor	tavern:true
 banish	28	Pygmy Orderlies
@@ -39,14 +39,14 @@ banish	33	Sabre-Toothed Goat
 banish	34	Senile Lihc	loc:The Defiled Niche
 banish	35	Slick Lihc	loc:The Defiled Niche
 banish	36	Skeletal Sommelier
-banish	37	Spooky mummy	class:Ed
-banish	38	Spooky vampire	class:Ed
+banish	37	Spooky mummy	class:Ed the Undying
+banish	38	Spooky vampire	class:Ed the Undying
 banish	39	Steam Elemental
 banish	40	Taco Cat
 banish	41	Tan Gnat
 banish	42	Tomb Asp
 banish	43	Tomb Servant
-banish	44	Triffid	class:Ed
+banish	44	Triffid	class:Ed the Undying
 banish	45	Wardr&ouml;b Nightstand
 banish	46	Warehouse Janitor
 banish	47	party skelteon
@@ -110,7 +110,7 @@ sniff	11	Tomb Rat
 sniff	12	Blooper	loc:8-Bit Realm
 sniff	13	Bob Racecar	!sniffed:Racecar Bob
 sniff	14	Racecar Bob	!sniffed:Bob Racecar
-sniff	15	Government Scientist	class:Ed
+sniff	15	Government Scientist	class:Ed the Undying
 sniff	16	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 sniff	17	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
 sniff	18	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
@@ -153,23 +153,23 @@ yellowray	19	War Frat Wartender	!outfit:Frat Warrior Fatigues
 yellowray	20	War Pledge	!outfit:Frat Warrior Fatigues
 # We also want to dress up like a filthy hippy to get frat warrior fatigues
 yellowray	21	business hippy	!outfit:Filthy Hippy Disguise
-yellowray	22	crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	23	crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	24	crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	25	dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	26	dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	27	dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	28	filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	29	filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed
-yellowray	30	filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed
+yellowray	22	crusty hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	23	crusty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	24	crusty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	25	dirty hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	26	dirty hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	27	dirty hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	28	filthy hippy	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	29	filthy hippy Vegan chef	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
+yellowray	30	filthy hippy jewelry maker	!outfit:Filthy Hippy Disguise;!class:Ed the Undying
 yellowray	31	zombie hippy	!outfit:Filthy Hippy Disguise
 # Want hippy war outfit if fighting for hippies. TODO: add monsters for Frat Boy Ensemble and War Hippy Fatigues outfits. Issue #900
 yellowray	32	War Hippy Spy	!outfit:War Hippy Fatigues
 # And we want filthworm glands, but not if we're gonna hugpocket them
-yellowray	33	larval filthworm	!familiar:XO Skeleton;!class:Ed
-yellowray	34	filthworm drone	!familiar:XO Skeleton;!class:Ed
-yellowray	35	filthworm royal guard	!familiar:XO Skeleton;!class:Ed
-yellowray	36	Knight (Snake)	class:Ed
+yellowray	33	larval filthworm	!familiar:XO Skeleton;!class:Ed the Undying
+yellowray	34	filthworm drone	!familiar:XO Skeleton;!class:Ed the Undying
+yellowray	35	filthworm royal guard	!familiar:XO Skeleton;!class:Ed the Undying
+yellowray	36	Knight (Snake)	class:Ed the Undying
 yellowray	37	bearpig topiary animal	familiar:Melodramedary
 yellowray	38	elephant (meatcar?) topiary animal	familiar:Melodramedary
 yellowray	39	spider (duck?) topiary animal	familiar:Melodramedary

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r25791;	//You Robot tracking fixes
+since r25863;	//fix my_class() to work with Ed the Undying again
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1322,7 +1322,7 @@ item whatHiMein()
 			return $item[Cold Hi Mein];
 		case $class[Sauceror]:
 		case $class[Pastamancer]:
-		case $class[Ed]:
+		case $class[Ed the Undying]:
 			return $item[Spooky Hi Mein];
 		case $class[Disco Bandit]:
 		case $class[Accordion Thief]:

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -230,7 +230,7 @@ void oldPeoplePlantStuff()
 		cli_execute("florist plant rabid dogwood");
 		cli_execute("florist plant artichoker");
 	}
-	else if((my_location() == $location[Barrrney\'s Barrr]) && (my_class() != $class[Ed]))
+	else if((my_location() == $location[Barrrney\'s Barrr]) && (my_class() != $class[Ed the Undying]))
 	{
 		cli_execute("florist plant spider plant");
 		cli_execute("florist plant red fern");

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -982,7 +982,7 @@ boolean deck_useScheme(string action)
 			case 3:				cards["1952 Mickey Mantle"] = true;						break;
 			}
 			break;
-		case $class[Ed]:
+		case $class[Ed the Undying]:
 			switch(my_daycount())
 			{
 			case 1:				cards["ore"] = true;						break;

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1295,7 +1295,7 @@ boolean asdonAutoFeed()
 
 boolean asdonAutoFeed(int goal)
 {
-	if(my_class() == $class[Ed])
+	if(my_class() == $class[Ed the Undying])
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -207,7 +207,7 @@ boolean LX_steelOrgan()
 	{
 		return false;
 	}
-	if($classes[Ed, Gelatinous Noob, Vampyre] contains my_class())
+	if($classes[Ed the Undying, Gelatinous Noob, Vampyre] contains my_class())
 	{
 		auto_log_info(my_class() + " can not use a Steel Organ, turning off setting.", "blue");
 		set_property("auto_getSteelOrgan", false);


### PR DESCRIPTION
if I understanding things correctly kol changed something which made my_class() break for ed the undying. which was fixed in r25863 but now gives this warning. So I fixed this in autoscend and also updated the since command to ensure we do not use mafia older than this fix, as older versions of mafia won't work with ed anymore.

## How Has This Been Tested?

validates.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
