### PR TITLE
Fix Choice 700 Handling (KOLHS)

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -293,6 +293,8 @@ boolean auto_run_choice(int choice, string page)
 			dailyDungeonChoiceHandler(choice, options);
 			break;
 		case 700: // Delirium in the Cafeterium (KOLHS 22nd adventure every day)
+			kolhsChoiceHandler(choice);
+			break;
 		case 768: // The Littlest Identity Crisis (Mini-adventurer initialization)
 			if(in_quantumTerrarium()) {
 				if (my_location() == $location[The Themthar Hills]) {


### PR DESCRIPTION
# Description

Adds back in choice 700 handling that was broken by mini-adventurer addition

## How Has This Been Tested?

Validates

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
