### PR TITLE
sonofa beach cleanup

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1526,6 +1526,8 @@ void resetState() {
 	//These settings should never persist into another turn, ever. They only track something for a single instance of the main loop.
 	//We use boolean instead of adventure count because of free combats.
 	
+	remove_property("auto_combatDirective");		//An action to execute at the start of next combat. resets every loop.
+	remove_property("auto_digitizeDirective");		//digitize a specified monster on the next combat.
 	set_property("auto_doCombatCopy", "no");
 	set_property("_auto_thisLoopHandleFamiliar", false); // have we called handleFamiliar this loop
 	set_property("auto_disableAdventureHandling", false); // used to stop auto_pre_adv and auto_post_adv from doing anything.

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -576,7 +576,7 @@ boolean LM_bond()
 					auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 					set_property("auto_digitizeDirective", $monster[Blooper]);
 					autoAdv(1, $location[8-bit Realm]);
-					set_property("auto_digitizeDirective", "");
+					remove_property("auto_digitizeDirective");
 					return true;
 				}
 			}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1191,10 +1191,11 @@ boolean L12_sonofaBeach()
 
 	if(!in_lar())
 	{
-		if(providePlusCombat(25, $location[Sonofa Beach], true, true) < 0.0)
+		float combat_bonus = providePlusCombat(25, $location[Sonofa Beach], true, true);
+		if(combat_bonus <= 0.0)
 		{
-			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
-			equipBaseline();
+			auto_log_warning("Something is keeping us from getting a suitable combat rate for [Lobsterfrogmen] in [Sonofa Beach]. we have: " +combat_bonus, "red");
+			resetState();
 			return false;
 		}
 	}
@@ -1305,32 +1306,11 @@ boolean L12_sonofaPrefix()
 
 	if(!in_lar())
 	{
-		if(equipped_item($slot[acc1]) == $item[over-the-shoulder folder holder])
+		float combat_bonus = providePlusCombat(25, $location[Sonofa Beach], true, true);
+		if(combat_bonus <= 0.0)
 		{
-			if((item_amount($item[Ass-Stompers of Violence]) > 0) && (equipped_item($slot[acc1]) != $item[Ass-Stompers of Violence]) && can_equip($item[Ass-Stompers of Violence]))
-			{
-				equip($slot[acc1], $item[Ass-Stompers of Violence]);
-			}
-			else
-			{
-				equip($slot[acc1], $item[bejeweled pledge pin]);
-			}
-		}
-		if(item_amount($item[portable cassette player]) > 0)
-		{
-			equip($slot[acc2], $item[portable cassette player]);
-		}
-		if(numeric_modifier("Combat Rate") <= 9.0)
-		{
-			if(possessEquipment($item[Carpe]))
-			{
-				equip($slot[Back], $item[Carpe]);
-			}
-		}
-		if(numeric_modifier("Combat Rate") < 0.0)
-		{
-			auto_log_warning("Something is keeping us from getting a suitable combat rate, we have: " + numeric_modifier("Combat Rate") + " and Lobsterfrogmen.", "red");
-			equipBaseline();
+			auto_log_warning("Something is keeping us from getting a suitable combat rate for [Lobsterfrogmen] in [Sonofa Beach]. we have: " +combat_bonus, "red");
+			resetState();
 			return false;
 		}
 	}
@@ -1342,7 +1322,7 @@ boolean L12_sonofaPrefix()
 
 	if((my_mp() < mp_cost($skill[Digitize])) && (auto_get_campground() contains $item[Source Terminal]) && is_unrestricted($item[Source Terminal]) && (get_property("_sourceTerminalDigitizeMonster") != $monster[Lobsterfrogman]) && (get_property("_sourceTerminalDigitizeUses").to_int() < 3))
 	{
-		equipBaseline();
+		resetState();
 		return false;
 	}
 
@@ -1365,11 +1345,12 @@ boolean L12_sonofaPrefix()
 	auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
 
 	boolean retval = autoAdv($location[Sonofa Beach]);
-	
-	set_property("auto_combatDirective", "");
-	set_property("auto_doCombatCopy", "no");
+	if(!retval)
+	{
+		auto_log_error("Failed to adventure in [Sonofa Beach]");
+		resetState();
+	}
 	edAcquireHP();
-	
 	return retval;
 }
 


### PR DESCRIPTION
* use provider instead of hardcoded list when preparing +combat for lobsterfrogman in sonofa beach
  * this fixes an error where we fail to adventure there because we try to use equip() to equip an accessory into slot 1 when that accessory is a "single" type acc and already equipped in slot 3
* some cleanup on related code. better handling of failure
* some cleanup on the combat directives

## How Has This Been Tested?

hardcore standard. i was running into this problem which is solved by this code.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
