### PR TITLE
safer reinitialize of setting on path drop. protect 100% familiar setting

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -102,21 +102,26 @@ void initializeSettings() {
 	// should not handle anything other than intialising properties etc.
 	// all paths that have extra settings should call their path specific
 	// initialise function at the end of this function (may override properties set in here).
-
-	if(my_ascensions() == get_property("auto_doneInitialize").to_int())
+	
+	//if we detected a path drop we need to reinitialize. either due to dropping a path or breaking ronin in standard.
+	boolean reinitialize = get_property("_auto_reinitialize").to_boolean();
+	if(!reinitialize && my_ascensions() == get_property("auto_doneInitialize").to_int())
 	{
 		return;		//already initialized settings this ascension
 	}
 	set_location($location[none]);
 	invalidateRestoreOptionCache();
 
-	set_property("auto_100familiar", $familiar[none]);
-	if(my_familiar() != $familiar[none] && pathAllowsChangingFamiliar()) //If we can't control familiar changes, no point setting 100% familiar data
+	if(!reinitialize)
 	{
-		boolean userAnswer = user_confirm("Familiar already set, is this a 100% familiar run? Will default to 'No' in 15 seconds.", 15000, false);
-		if(userAnswer)
+		set_property("auto_100familiar", $familiar[none]);
+		if(my_familiar() != $familiar[none] && pathAllowsChangingFamiliar()) //If we can't control familiar changes, no point setting 100% familiar data
 		{
-			set_property("auto_100familiar", my_familiar());
+			boolean userAnswer = user_confirm("Familiar already set, is this a 100% familiar run? Will default to 'No' in 15 seconds.", 15000, false);
+			if(userAnswer)
+			{
+				set_property("auto_100familiar", my_familiar());
+			}
 		}
 	}
 
@@ -243,6 +248,7 @@ void initializeSettings() {
 
 	set_property("auto_doneInitializePath", my_path());		//which path we initialized as
 	set_property("auto_doneInitialize", my_ascensions());
+	remove_property("_auto_reinitialize");
 }
 
 void initializeSession() {

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -103,7 +103,7 @@ void initializeSettings() {
 	// all paths that have extra settings should call their path specific
 	// initialise function at the end of this function (may override properties set in here).
 	
-	//if we detected a path drop we need to reinitialize. either due to dropping a path or breaking ronin in standard.
+	//if we detected a path drop we need to reinitialize. either due to dropping a path or breaking ronin in some paths.
 	boolean reinitialize = get_property("_auto_reinitialize").to_boolean();
 	if(!reinitialize && my_ascensions() == get_property("auto_doneInitialize").to_int())
 	{

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -233,7 +233,7 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 void pathDroppedCheck()
 {
 	//detect path drops and reinitialize with settings appropriate for the new path
-	//this will also trigger when standard path changes to none after ronin is broken
+	//this will also trigger when some paths break ronin
 	if(my_path() == get_property("auto_doneInitializePath"))
 	{
 		return;		//our current path is the same one we last initialized as

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -233,17 +233,18 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 void pathDroppedCheck()
 {
 	//detect path drops and reinitialize with settings appropriate for the new path
+	//this will also trigger when standard path changes to none after ronin is broken
 	if(my_path() == get_property("auto_doneInitializePath"))
 	{
 		return;		//our current path is the same one we last initialized as
 	}
 	if(get_property("auto_doneInitializePath") == "")
 	{
-		//this setting has not been set. this means the ran started with an older version of autoscend that did not have this setting
-		//a path of none would have returned "None" not "". this check can be deleted in a future PR after a week
+		//this setting has not been set. this means the run started with an older version of autoscend that did not have this setting
+		//a path of none would have returned "None" not "". This is only backwards support and can be deleted in the future.
 		return;
 	}
 	print("Path change detected. You were previously " +get_property("auto_doneInitializePath")+ " and are now a " +my_path(), "red");
-	remove_property("auto_doneInitialize");
+	set_property("_auto_reinitialize", true);
 	initializeSettings();
 }


### PR DESCRIPTION
* if path drop was detected we reinitialize settings. do not ask the user if they want a 100% familiar run during reinitialize. Instead just keep the setting from the first initialize we did that ascension.
  * this could have broken 100% familiar run if the user was doing a softcore standard. finished ronin. and was AFK while it popped up the question (for 15 seconds) on if they want to set current familiar to be 100% familiar run
* cleanup code on how reinitialize is done

## How Has This Been Tested?

hardcore standard. dropped standard

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
