### PR TITLE
WOTSF path fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -309,8 +309,8 @@ boolean auto_pre_adventure()
 
 	// Latte may conflict with certain quests. Ignore latte drops for the greater good.
 	boolean[location] IgnoreLatteDrop = $locations[The Haunted Boiler Room];
-	if(auto_latteDropWanted(place) && !(IgnoreLatteDrop contains place) && !is_boris())
-	// boris has no way to equip latte mug or Kramco (no offhand or familiar)
+	if(auto_latteDropWanted(place) && !(IgnoreLatteDrop contains place) && !is_boris() && !in_wotsf())
+	// boris can't use offhands. wotsf can't use offhands without LHM, but this probably isn't best use
 	{
 		if(auto_sausageGoblin() && place == solveDelayZone())
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -785,6 +785,8 @@ boolean tcrs_maximize_with_items(string maximizerString);
 ########################################################################################################
 //Defined in autoscend/paths/way_of_the_surprising_fist.ash
 boolean in_wotsf();
+void wotsf_initializeSettings();
+boolean L11_wotsfForgedDocuments();
 
 ########################################################################################################
 //Defined in autoscend/paths/wildfire.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -365,6 +365,7 @@ int auto_powerfulGloveCharges();
 boolean auto_powerfulGloveNoncombatSkill(skill sk);
 int auto_powerfulGloveReplacesAvailable(boolean inCombat);
 int auto_powerfulGloveReplacesAvailable();
+boolean auto_powerfulGloveDelevel();
 boolean auto_powerfulGloveNoncombat();
 boolean auto_powerfulGloveStats();
 boolean auto_wantToEquipPowerfulGlove();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -785,7 +785,6 @@ boolean tcrs_maximize_with_items(string maximizerString);
 ########################################################################################################
 //Defined in autoscend/paths/way_of_the_surprising_fist.ash
 boolean in_wotsf();
-void wotsf_initializeSettings();
 boolean L11_wotsfForgedDocuments();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -175,7 +175,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 			{
 				return useSkill($skill[CHEAT CODE: Shrink Enemy]); // do it again
 			}
-			if(canUse($skill[Curse Of Weaksauce]) && my_class() == $class[Sauceror] && doWeaksauce)
+			if(canUse($skill[Curse of Weaksauce]))
 			{
 				return useSkill($skill[Curse Of Weaksauce]); // persistent deleveling
 			}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -163,6 +163,50 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		}
 	}
 	
+	if(in_wotsf())
+	{
+		if(enemy == $monster[Wu Tang the Betrayer]) // puzzle boss in WOTSF
+		{
+			if(canUse($skill[CHEAT CODE: Shrink Enemy]))
+			{
+				return useSkill($skill[CHEAT CODE: Shrink Enemy]); // delevel and hit HP by ~50%
+			}
+			if(canUse($skill[CHEAT CODE: Shrink Enemy]))
+			{
+				return useSkill($skill[CHEAT CODE: Shrink Enemy]); // do it again
+			}
+			if(canUse($skill[Curse Of Weaksauce]) && my_class() == $class[Sauceror] && doWeaksauce)
+			{
+				return useSkill($skill[Curse Of Weaksauce]); // persistent deleveling
+			}
+			if(canUse($skill[Micrometeorite]))
+			{
+				return useSkill($skill[Micrometeorite]); // delevel by ~25%
+			}
+			if(canUse($item[Rain-Doh indigo cup]))
+			{
+				return useItem($item[Rain-Doh Indigo Cup]); // delevel and restore HP
+			}
+			if(canUse($skill[Summon Love Mosquito]))
+			{
+				return useSkill($skill[Summon Love Mosquito]); // one-time deals damage
+			}
+			if(canUse($skill[Summon Love Stinkbug]))
+			{
+				return useSkill($skill[Summon Love Stinkbug]); // persistent damage
+			}
+			if(canUse($skill[Unleash The Greash]) && (have_effect($effect[Takin\' It Greasy]) > 100))
+			{
+				return useSkill($skill[Unleash The Greash]); // if available, strong sleaze damage
+			}
+			if(canUse($skill[Tango of Terror]))
+			{
+				return useSkill($skill[Tango of Terror]); // delevel and damage
+			}
+			return attackMinor;
+		}
+	}
+
 	//nanorhino familiar buff acquisition. Must be the first action taken in combat.
 	//done after puzzle bosses. if puzzle bosses get a random buff that is ok, we would rather beat the puzzle boss.
 	retval = auto_combat_nanorhinoBuff(round, enemy, text);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -203,7 +203,10 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 			{
 				return useSkill($skill[Tango of Terror]); // delevel and damage
 			}
-			return attackMinor;
+			if(canUse($skill[Saucestorm]))
+			{
+				return useSkill($skill[Saucestorm]); // default attacking
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -3,6 +3,10 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	// stage 1 = 1st round actions: puzzle boss, pickpocket, duplicate, things that are only allowed if they are the first action you take.
 	string retval;
 	
+	// Path = Way of the Surprising Fist
+	retval = auto_combatWOTSFStage1(round, enemy, text);
+	if(retval != "") return retval;
+	
 	// Path = Heavy Rains
 	retval = auto_combatHeavyRainsStage1(round, enemy, text);
 	if(retval != "") return retval;
@@ -27,7 +31,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	retval = auto_combatDisguisesStage1(round, enemy, text);
 	if(retval != "") return retval;
 	
-	// Path = wildfire
+	// Path = Wildfire
 	retval = auto_combatWildfireStage1(round, enemy, text);
 	if(retval != "") return retval;
 	
@@ -163,53 +167,6 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		}
 	}
 	
-	if(in_wotsf())
-	{
-		if(enemy == $monster[Wu Tang the Betrayer]) // puzzle boss in WOTSF
-		{
-			if(canUse($skill[CHEAT CODE: Shrink Enemy]))
-			{
-				return useSkill($skill[CHEAT CODE: Shrink Enemy]); // delevel and hit HP by ~50%
-			}
-			if(canUse($skill[CHEAT CODE: Shrink Enemy]))
-			{
-				return useSkill($skill[CHEAT CODE: Shrink Enemy]); // do it again
-			}
-			if(canUse($skill[Curse of Weaksauce]))
-			{
-				return useSkill($skill[Curse Of Weaksauce]); // persistent deleveling
-			}
-			if(canUse($skill[Micrometeorite]))
-			{
-				return useSkill($skill[Micrometeorite]); // delevel by ~25%
-			}
-			if(canUse($item[Rain-Doh indigo cup]))
-			{
-				return useItem($item[Rain-Doh Indigo Cup]); // delevel and restore HP
-			}
-			if(canUse($skill[Summon Love Mosquito]))
-			{
-				return useSkill($skill[Summon Love Mosquito]); // one-time deals damage
-			}
-			if(canUse($skill[Summon Love Stinkbug]))
-			{
-				return useSkill($skill[Summon Love Stinkbug]); // persistent damage
-			}
-			if(canUse($skill[Unleash The Greash]) && (have_effect($effect[Takin\' It Greasy]) > 100))
-			{
-				return useSkill($skill[Unleash The Greash]); // if available, strong sleaze damage
-			}
-			if(canUse($skill[Tango of Terror]))
-			{
-				return useSkill($skill[Tango of Terror]); // delevel and damage
-			}
-			if(canUse($skill[Saucestorm]))
-			{
-				return useSkill($skill[Saucestorm]); // default attacking
-			}
-		}
-	}
-
 	//nanorhino familiar buff acquisition. Must be the first action taken in combat.
 	//done after puzzle bosses. if puzzle bosses get a random buff that is ok, we would rather beat the puzzle boss.
 	retval = auto_combat_nanorhinoBuff(round, enemy, text);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -146,6 +146,10 @@ string auto_combatBHYStage1(int round, monster enemy, string text);
 string auto_combatWildfireStage1(int round, monster enemy, string text);
 
 #####################################################
+//defined in /autoscend/combat/auto_combat_wotsf.ash
+string auto_combatWOTSFStage1(int round, monster enemy, string text);
+
+#####################################################
 //defined in /autoscend/combat/auto_combat_you_robot.ash
 string auto_combat_robot_stage5(int round, monster enemy, string text);
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wotsf.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wotsf.ash
@@ -1,0 +1,57 @@
+//Path specific combat handling for Way of the Surprising Fist
+
+string auto_combatWOTSFStage1(int round, monster enemy, string text)
+{
+	// stage 1 = 1st round actions: puzzle boss, pickpocket, duplicate, things that are only allowed if they are the first action you take.
+	if(!in_wotsf())
+	{
+		return "";
+	}
+    
+    // handling for Wu Tang the Betrayer at Black Market
+	if(enemy == $monster[Wu Tang the Betrayer]) // puzzle boss in WOTSF
+	{
+		if(canUse($skill[CHEAT CODE: Shrink Enemy]))
+		{
+			return useSkill($skill[CHEAT CODE: Shrink Enemy]); // delevel and hit HP by ~50%
+		}
+		if(canUse($skill[Curse of Vichyssoise]))
+		{
+			return useSkill($skill[Curse Of Vichyssoise]); // persistent cold damage
+		}
+		if(canUse($skill[CHEAT CODE: Shrink Enemy]))
+		{
+			return useSkill($skill[CHEAT CODE: Shrink Enemy]); // hit them again with big HP knock
+		}
+		if(canUse($skill[Micrometeorite]))
+		{
+			return useSkill($skill[Micrometeorite]); // delevel by ~25%
+		}
+		if(canUse($item[Rain-Doh indigo cup]))
+		{
+			return useItem($item[Rain-Doh Indigo Cup]); // delevel and restore HP
+		}
+		if(canUse($skill[Summon Love Mosquito]))
+		{
+			return useSkill($skill[Summon Love Mosquito]); // one-time deals damage
+		}
+		if(canUse($skill[Summon Love Stinkbug]))
+		{
+			return useSkill($skill[Summon Love Stinkbug]); // persistent damage
+		}
+		if(canUse($skill[Unleash The Greash]) && (have_effect($effect[Takin\' It Greasy]) > 100))
+		{
+			return useSkill($skill[Unleash The Greash]); // if available, strong sleaze damage
+		}
+		if(canUse($skill[Tango of Terror]))
+		{
+			return useSkill($skill[Tango of Terror]); // delevel and damage
+		}
+		if(canUse($skill[Saucestorm]))
+		{
+			return useSkill($skill[Saucestorm]); // default attacking
+		}
+	}
+	
+	return "";
+}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wotsf.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wotsf.ash
@@ -19,6 +19,10 @@ string auto_combatWOTSFStage1(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Curse Of Vichyssoise]); // persistent cold damage
 		}
+		else if(canUse($skill[Curse of Marinara]))
+		{
+			return useSkill($skill[Curse Of Marinara ]); // persistent regular damage
+		}
 		if(canUse($skill[CHEAT CODE: Shrink Enemy]))
 		{
 			return useSkill($skill[CHEAT CODE: Shrink Enemy]); // hit them again with big HP knock
@@ -47,9 +51,13 @@ string auto_combatWOTSFStage1(int round, monster enemy, string text)
 		{
 			return useSkill($skill[Tango of Terror]); // delevel and damage
 		}
-		if(canUse($skill[Saucestorm]))
+		if(canUse($skill[Stringozzi Serpent]))
 		{
-			return useSkill($skill[Saucestorm]); // default attacking
+			return useSkill($skill[Stringozzi Serpent]); // damage and add persistent damage
+		}
+		if(canUse($skill[Sing]))
+		{
+			return useSkill($skill[Sing]); // damage and add persistent damage
 		}
 	}
 	

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -151,6 +151,11 @@ int auto_powerfulGloveReplacesAvailable()
 	return auto_powerfulGloveReplacesAvailable(false);
 }
 
+boolean auto_powerfulGloveDelevel()
+{
+	return auto_powerfulGloveNoncombatSkill($skill[CHEAT CODE: Shrink Enemy]);
+}
+
 boolean auto_powerfulGloveNoncombat()
 {
 	if (0 < have_effect($effect[Invisible Avatar])) return false;

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -3,14 +3,6 @@ boolean in_wotsf()
 	return my_path() == "Way of the Surprising Fist";
 }
 
-void wotsf_initializeSettings()
-{
-	if(in_wotsf())
-	{
-		set_property("auto_wandOfNagamar", false);
-	}
-}
-
 boolean L11_wotsfForgedDocuments()
 {
 	if(!in_wotsf())

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -2,3 +2,24 @@ boolean in_wotsf()
 {
 	return my_path() == "Way of the Surprising Fist";
 }
+
+void wotsf_initializeSettings()
+{
+	if(in_wotsf())
+	{
+		set_property("auto_wandOfNagamar", false);
+	}
+}
+
+boolean L11_wotsfForgedDocuments()
+{
+	if(!in_wotsf())
+	{
+		return false;
+	}
+
+	string[int] pages;
+	pages[0] = "shop.php?whichshop=blackmarket";
+	pages[1] = "shop.php?whichshop=blackmarket&action=fightbmguy";
+	return autoAdvBypass(0, pages, $location[Noob Cave], "");
+}

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -10,11 +10,28 @@ boolean L11_wotsfForgedDocuments()
 		return false;
 	}
 
-	handleFamiliar("boss");
+	if(canChangeToFamiliar($familiar[warbear drone])) // old event item. still farmable. up to 6 attacks per round
+	{
+		use_familiar($familiar[Warbear Drone]);
+	}
+	else if(canChangeToFamiliar($familiar[Sludgepuppy])) // IOTM derivative, infinitely farmable. attacks 3 times per round
+	{
+		use_familiar($familiar[Sludgepuppy]);
+	}
+	else if(canChangeToFamiliar($familiar[Imitation Crab])) // cheap, easily acquired. attacks 2 times per round
+	{
+		use_familiar($familiar[Imitation Crab]);
+	}
+	else if(canChangeToFamiliar($familiar[Angry Goat]))	 // super cheap. high chance to attack each round.
+	{
+		use_familiar($familiar[Angry Goat]);
+	}
+
 	if(possessEquipment($item[Powerful Glove]) && !have_equipped($item[Powerful Glove]))
 	{
 		return autoEquip($slot[acc3], $item[Powerful Glove]);
 	}
+
 	string[int] pages;
 	pages[0] = "shop.php?whichshop=blackmarket";
 	pages[1] = "shop.php?whichshop=blackmarket&action=fightbmguy";

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -10,6 +10,11 @@ boolean L11_wotsfForgedDocuments()
 		return false;
 	}
 
+	handleFamiliar("boss");
+	if(possessEquipment($item[Powerful Glove]) && !have_equipped($item[Powerful Glove]))
+	{
+		return autoEquip($slot[acc3], $item[Powerful Glove]);
+	}
 	string[int] pages;
 	pages[0] = "shop.php?whichshop=blackmarket";
 	pages[1] = "shop.php?whichshop=blackmarket&action=fightbmguy";

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -121,8 +121,8 @@ boolean L10_basement()
 		return false;
 	}
 
-	if(possessEquipment($item[Titanium Assault Umbrella]) && !auto_can_equip($item[Titanium Assault Umbrella]))
-	{
+	if(possessEquipment($item[Titanium Assault Umbrella]) && (!auto_can_equip($item[Titanium Assault Umbrella]) && (!in_wotsf() || !is_boris())))
+	{ // can't hold umbrella in WOTSF (without disembodied hand) or Boris
 		return false;
 	}
 
@@ -160,7 +160,10 @@ boolean L10_basement()
 	}
 
 	auto_forceNextNoncombat();
-	autoEquip($item[Titanium Assault Umbrella]);
+	if(!in_wotsf() || !is_boris()) // can't hold umbrella in WOTSF (without disembodied hand) or Boris
+	{
+		autoEquip($item[Titanium Assault Umbrella]);
+	}
 	autoEquip($item[Amulet of Extreme Plot Significance]);
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 	

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -121,7 +121,7 @@ boolean L10_basement()
 		return false;
 	}
 
-	if(possessEquipment($item[Titanium Assault Umbrella]) && (!auto_can_equip($item[Titanium Assault Umbrella]) && (!in_wotsf() && !is_boris())))
+	if(possessEquipment($item[Titanium Assault Umbrella]) && !auto_can_equip($item[Titanium Assault Umbrella]) && !in_wotsf() && !is_boris())
 	{ // can't hold umbrella in WOTSF (without disembodied hand) or Boris
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -121,7 +121,7 @@ boolean L10_basement()
 		return false;
 	}
 
-	if(possessEquipment($item[Titanium Assault Umbrella]) && (!auto_can_equip($item[Titanium Assault Umbrella]) && (!in_wotsf() || !is_boris())))
+	if(possessEquipment($item[Titanium Assault Umbrella]) && (!auto_can_equip($item[Titanium Assault Umbrella]) && (!in_wotsf() && !is_boris())))
 	{ // can't hold umbrella in WOTSF (without disembodied hand) or Boris
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -628,7 +628,7 @@ boolean L11_blackMarket()
 
 boolean L11_getBeehive()
 {
-	if (!black_market_available() || !get_property("auto_getBeehive").to_boolean())
+	if(!black_market_available() || !get_property("auto_getBeehive").to_boolean())
 	{
 		return false;
 	}
@@ -652,15 +652,19 @@ boolean L11_getBeehive()
 
 boolean L11_forgedDocuments()
 {
-	if (internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 2 || !black_market_available())
+	if(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 2 || !black_market_available())
 	{
 		return false;
 	}
-	if (item_amount($item[Forged Identification Documents]) > 0)
+	if(item_amount($item[Forged Identification Documents]) > 0)
 	{
 		return false;
 	}
-	if (my_meat() < npc_price($item[Forged Identification Documents]))
+	if(in_wotsf())
+	{
+		return L11_wotsfForgedDocuments();
+	}
+	if(my_meat() < npc_price($item[Forged Identification Documents]))
 	{
 		if(isAboutToPowerlevel())
 		{
@@ -670,14 +674,6 @@ boolean L11_forgedDocuments()
 	}
 
 	auto_log_info("Getting the McMuffin Book", "blue");
-	if(in_wotsf())
-	{
-		// TODO: move this to WotSF path file if one is ever created.
-		string[int] pages;
-		pages[0] = "shop.php?whichshop=blackmarket";
-		pages[1] = "shop.php?whichshop=blackmarket&action=fightbmguy";
-		return autoAdvBypass(0, pages, $location[Noob Cave], "");
-	}
 	buyUpTo(1, $item[Forged Identification Documents]);
 	if(item_amount($item[Forged Identification Documents]) > 0)
 	{
@@ -689,7 +685,7 @@ boolean L11_forgedDocuments()
 
 boolean L11_mcmuffinDiary()
 {
-	if (internalQuestStatus("questL11MacGuffin") != 1 || internalQuestStatus("questL11Black") < 2)
+	if(internalQuestStatus("questL11MacGuffin") != 1 || internalQuestStatus("questL11Black") < 2)
 	{
 		return false;
 	}
@@ -707,7 +703,7 @@ boolean L11_mcmuffinDiary()
 		use(item_amount($item[Copy of a Jerk Adventurer\'s Father\'s Diary]), $item[Copy of a Jerk Adventurer\'s Father\'s Diary]);
 		return true;
 	}
-	if (my_adventures() < 4 || my_meat() < 500 || item_amount($item[Forged Identification Documents]) == 0)
+	if(my_adventures() < 4 || my_meat() < 500 || item_amount($item[Forged Identification Documents]) == 0)
 	{
 		if(isAboutToPowerlevel())
 		{


### PR DESCRIPTION
# Description

Adds handler for fighting Wu Tang instead of buying forged documents.
Removes L10 quest stop for not being able to equip titanium umbrella after airship.

Fixes #202

## How Has This Been Tested?

Run WOTSF and it works

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
