### PR TITLE
boolean buffMaintain(effect buff)

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1121,7 +1121,7 @@ boolean doBedtime()
 		if(have_skill($skill[The Ode to Booze]))
 		{
 			shrugAT($effect[Ode to Booze]);
-			buffMaintain($effect[Ode to Booze], 0, 1, 1);
+			buffMaintain($effect[Ode to Booze]);
 		}
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -864,7 +864,7 @@ boolean auto_faceCheck(string face)
 
 	if(CanEmote)
 	{
-		buffMaintain(to_effect(face), 0, 1, 1);
+		buffMaintain(to_effect(face));
 	}
 	else
 	{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -842,6 +842,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns)
 	return buffMaintain(buff, mp_min, casts, turns, false);
 }
 
+boolean buffMaintain(effect buff)
+{
+	return buffMaintain(buff,0,1,1);
+}
+
 // Checks to see if we are already wearing a facial expression before using buffMaintain
 //	if an expression is REQUIRED force it using buffMaintain
 boolean auto_faceCheck(string face)

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -246,7 +246,7 @@ boolean auto_post_adventure()
 
 		if((my_meat() > 5000) && ((my_turncount() >= 50) || get_property("falloutShelterChronoUsed").to_boolean()))
 		{
-			buffMaintain($effect[Rad-Pro Tected], 0, 1, 1);
+			buffMaintain($effect[Rad-Pro Tected]);
 		}
 	}
 
@@ -337,13 +337,13 @@ boolean auto_post_adventure()
 
 	if((my_class() == $class[Turtle Tamer]) && guild_store_available())
 	{
-		buffMaintain($effect[Eau de Tortue], 0, 1, 1);
+		buffMaintain($effect[Eau de Tortue]);
 	}
 
 	if((monster_level_adjustment() > 140) && !inAftercore())
 	{
-		buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
-		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+		buffMaintain($effect[Butt-Rock Hair]);
+		buffMaintain($effect[Go Get \'Em\, Tiger!]);
 	}
 
 	if(in_community())
@@ -1023,13 +1023,13 @@ boolean auto_post_adventure()
 			buffMaintain($effect[Purple Reign], 0, 6, 10);
 		}
 
-		buffMaintain($effect[Gummi-Grin], 0, 1, 1);
-		buffMaintain($effect[Strong Resolve], 0, 1, 1);
-		buffMaintain($effect[Irresistible Resolve], 0, 1, 1);
-		buffMaintain($effect[Brilliant Resolve], 0, 1, 1);
-		buffMaintain($effect[From Nantucket], 0, 1, 1);
-		buffMaintain($effect[Squatting and Thrusting], 0, 1, 1);
-		buffMaintain($effect[You Read the Manual], 0, 1, 1);
+		buffMaintain($effect[Gummi-Grin]);
+		buffMaintain($effect[Strong Resolve]);
+		buffMaintain($effect[Irresistible Resolve]);
+		buffMaintain($effect[Brilliant Resolve]);
+		buffMaintain($effect[From Nantucket]);
+		buffMaintain($effect[Squatting and Thrusting]);
+		buffMaintain($effect[You Read the Manual]);
 		buyableMaintain($item[Hair Spray], 1, 200, my_class() != $class[Turtle Tamer]);
 		buyableMaintain($item[Blood of the Wereseal], 1, 3500, (monster_level_adjustment() > 135));
 		buyableMaintain($item[Ben-gal&trade; Balm], 1, 200);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -181,7 +181,7 @@ boolean auto_pre_adventure()
 
 	if(get_floundry_locations() contains place)
 	{
-		buffMaintain($effect[Baited Hook], 0, 1, 1);
+		buffMaintain($effect[Baited Hook]);
 	}
 
 	// be ready to use red rocket if we don't have one
@@ -510,7 +510,7 @@ boolean auto_pre_adventure()
 	//	Casting before ML variation ensures that this, the more important buff, is cast before ML.
 	if(auto_predictAccordionTurns() >= 8)
 	{
-		buffMaintain($effect[Paul\'s Passionate Pop Song], 0, 1, 1);
+		buffMaintain($effect[Paul\'s Passionate Pop Song]);
 	}
 
 	// ML adjustment zone section

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3846,7 +3846,7 @@ boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 		{
 			if(monster_level_adjustment() + numeric_modifier(eff, "Monster Level") <= auto_convertDesiredML(ToML))
 			{
-				buffMaintain(eff, 0, 1, 1);
+				buffMaintain(eff);
 			}
 		}
 	}
@@ -4097,69 +4097,69 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//Passive damage
 	if(passive_dmg_allowed)
 	{
-		buffMaintain($effect[Spiky Shell], 0, 1, 1);					//8 MP
-		buffMaintain($effect[Jalape&ntilde;o Saucesphere], 0, 1, 1);	//5 MP
-		buffMaintain($effect[Scarysauce], 0, 1, 1);						//10 MP
+		buffMaintain($effect[Spiky Shell]);					//8 MP
+		buffMaintain($effect[Jalape&ntilde;o Saucesphere]);	//5 MP
+		buffMaintain($effect[Scarysauce]);						//10 MP
 	}
 	
 	//1MP Non-Combat skills from each class
-	buffMaintain($effect[Seal Clubbing Frenzy], 0, 1, 1);
-	buffMaintain($effect[Patience of the Tortoise], 0, 1, 1);
-	buffMaintain($effect[Pasta Oneness], 0, 1, 1);
-	buffMaintain($effect[Saucemastery], 0, 1, 1);
-	buffMaintain($effect[Disco State of Mind], 0, 1, 1);
-	buffMaintain($effect[Mariachi Mood], 0, 1, 1);
+	buffMaintain($effect[Seal Clubbing Frenzy]);
+	buffMaintain($effect[Patience of the Tortoise]);
+	buffMaintain($effect[Pasta Oneness]);
+	buffMaintain($effect[Saucemastery]);
+	buffMaintain($effect[Disco State of Mind]);
+	buffMaintain($effect[Mariachi Mood]);
 
 	//Seal clubber Non-Combat skills
-	buffMaintain($effect[Blubbered Up], 0, 1, 1);						//7 MP
-	buffMaintain($effect[Rage of the Reindeer], 0, 1, 1);				//10 MP
-	buffMaintain($effect[A Few Extra Pounds], 0, 1, 1);					//10 MP
+	buffMaintain($effect[Blubbered Up]);						//7 MP
+	buffMaintain($effect[Rage of the Reindeer]);				//10 MP
+	buffMaintain($effect[A Few Extra Pounds]);					//10 MP
 	
 	//Turtle Tamer Non-Combat skills
 	if(!hasTTBlessing())
 	{
-		buffMaintain($effect[Blessing of the War Snapper], 0, 1, 1);	//15 MP. other blessings too expensive.
+		buffMaintain($effect[Blessing of the War Snapper]);	//15 MP. other blessings too expensive.
 	}
 	
 	//Pastamancer Non-Combat skills
-	buffMaintain($effect[Springy Fusilli], 0, 1, 1);					//10 MP
-	buffMaintain($effect[Shield of the Pastalord], 0, 1, 1);			//20 MP
-	buffMaintain($effect[Leash of Linguini], 0, 1, 1);					//12 MP
+	buffMaintain($effect[Springy Fusilli]);					//10 MP
+	buffMaintain($effect[Shield of the Pastalord]);			//20 MP
+	buffMaintain($effect[Leash of Linguini]);					//12 MP
 	
 	//Sauceror Non-Combat skills
-	buffMaintain($effect[Sauce Monocle], 0, 1, 1);						//20 MP
+	buffMaintain($effect[Sauce Monocle]);						//20 MP
 
 	//Disco Bandit Non-Combat skills
-	buffMaintain($effect[Disco Fever], 0, 1, 1);						//10 MP
+	buffMaintain($effect[Disco Fever]);						//10 MP
 	
 	//Turtle Tamer Buffs
-	buffMaintain($effect[Ghostly Shell], 0, 1, 1);						//6 MP
-	buffMaintain($effect[Tenacity of the Snapper], 0, 1, 1);			//8 MP
-	buffMaintain($effect[Empathy], 0, 1, 1);							//15 MP
-	buffMaintain($effect[Reptilian Fortitude], 0, 1, 1);				//8 MP
-	buffMaintain($effect[Astral Shell], 0, 1, 1);						//10 MP
-	buffMaintain($effect[Jingle Jangle Jingle], 0, 1, 1);				//5 MP
-	buffMaintain($effect[Curiosity of Br\'er Tarrypin], 0, 1, 1);		//5 MP
+	buffMaintain($effect[Ghostly Shell]);						//6 MP
+	buffMaintain($effect[Tenacity of the Snapper]);			//8 MP
+	buffMaintain($effect[Empathy]);							//15 MP
+	buffMaintain($effect[Reptilian Fortitude]);				//8 MP
+	buffMaintain($effect[Astral Shell]);						//10 MP
+	buffMaintain($effect[Jingle Jangle Jingle]);				//5 MP
+	buffMaintain($effect[Curiosity of Br\'er Tarrypin]);		//5 MP
 	
 	//Sauceror Buffs
-	buffMaintain($effect[Elemental Saucesphere], 0, 1, 1);				//10 MP
-	buffMaintain($effect[Antibiotic Saucesphere], 0, 1, 1);				//15 MP
+	buffMaintain($effect[Elemental Saucesphere]);				//10 MP
+	buffMaintain($effect[Antibiotic Saucesphere]);				//15 MP
 	
 	//Accordion Thief Buffs. We are not shrugging so it will only apply new ones if we have space for them
-	buffMaintain($effect[The Moxious Madrigal], 0, 1, 1);				//2 MP
-	buffMaintain($effect[The Magical Mojomuscular Melody], 0, 1, 1);	//3 MP
-	buffMaintain($effect[Cletus\'s Canticle of Celerity], 0, 1, 1);		//4 MP
-	buffMaintain($effect[Power Ballad of the Arrowsmith], 0, 1, 1);		//5 MP
-	buffMaintain($effect[Polka of Plenty], 0, 1, 1);					//7 MP
+	buffMaintain($effect[The Moxious Madrigal]);				//2 MP
+	buffMaintain($effect[The Magical Mojomuscular Melody]);	//3 MP
+	buffMaintain($effect[Cletus\'s Canticle of Celerity]);		//4 MP
+	buffMaintain($effect[Power Ballad of the Arrowsmith]);		//5 MP
+	buffMaintain($effect[Polka of Plenty]);					//7 MP
 	
 	//Mutually exclusive effects
 	if(have_effect($effect[Musk of the Moose]) == 0 && have_effect($effect[Hippy Stench]) == 0)
 	{
-		buffMaintain($effect[Smooth Movements], 0, 1, 1);				//10 MP
+		buffMaintain($effect[Smooth Movements]);				//10 MP
 	}
 	if(have_effect($effect[Smooth Movements]) == 0 && have_effect($effect[Fresh Scent]) == 0)
 	{
-		buffMaintain($effect[Musk of the Moose], 0, 1, 1);				//10 MP
+		buffMaintain($effect[Musk of the Moose]);				//10 MP
 	}	
 	
 	//TODO facial expressions, need to check you are not wearing one first and which ones you have

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1159,6 +1159,7 @@ boolean buffMaintain(skill source, effect buff, int mp_min, int casts, int turns
 boolean buffMaintain(item source, effect buff, int uses, int turns, boolean speculative);
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns);
+boolean buffMaintain(effect buff);
 boolean auto_faceCheck(string face);
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -1215,7 +1215,7 @@ boolean LX_dinseylandfillFunbucks()
 		# We do this after the item check since we may have an extra bag and we should turn that in.
 		return false;
 	}
-	buffMaintain($effect[How to Scam Tourists], 0, 1, 1);
+	buffMaintain($effect[How to Scam Tourists]);
 	autoAdv(1, $location[Barf Mountain]);
 	return true;
 }

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1098,7 +1098,7 @@ boolean L1_ed_island()
 		cli_execute("auto_post_adv");
 	}
 
-	buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
+	buffMaintain($effect[Experimental Effect G-9]);
 	autoAdv($location[The Secret Government Laboratory]);
 	if(item_amount($item[Bottle-Opener Keycard]) > 0)
 	{

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -187,12 +187,12 @@ boolean LA_cs_communityService()
 		}
 
 		handleFamiliar($familiar[Galloping Grill]);
-		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
-		buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
-		buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
-		buffMaintain($effect[Phorcefullness], 0, 1, 1);
-		buffMaintain($effect[Tomato Power], 0, 1, 1);
-		buffMaintain($effect[Expert Oiliness], 0, 1, 1);
+		buffMaintain($effect[Go Get \'Em\, Tiger!]);
+		buffMaintain($effect[Glittering Eyelashes]);
+		buffMaintain($effect[Butt-Rock Hair]);
+		buffMaintain($effect[Phorcefullness]);
+		buffMaintain($effect[Tomato Power]);
+		buffMaintain($effect[Expert Oiliness]);
 		buffMaintain($effect[Ruthlessly Efficient], 130, 1, 1);
 		buffMaintain($effect[Song of Starch], 240, 1, 1);
 		buffMaintain($effect[Frostbeard], 130, 1, 1);
@@ -642,7 +642,7 @@ boolean LA_cs_communityService()
 		}
 		else if((curQuest == 7) && (item_amount($item[Emergency Margarita]) > 0))
 		{
-			buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
+			buffMaintain($effect[Sweetbreads Flamb&eacute;]);
 			if((have_effect($effect[substats.enh]) == 0) && (auto_sourceTerminalEnhanceLeft() >= 1))
 			{
 				auto_sourceTerminalEnhance("substats");
@@ -801,7 +801,7 @@ boolean LA_cs_communityService()
 			# Account for possible pixels from Snojo?
 			# Make sure for tryPowerLevel not to go too high in ML (75).
 
-			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
+			buffMaintain($effect[Glittering Eyelashes]);
 			buffMaintain($effect[Ur-Kel\'s Aria of Annoyance], 62, 1, 1);
 			buffMaintain($effect[Pride of the Puffin], 62, 1, 1);
 			buffMaintain($effect[Drescher\'s Annoying Noise], 72, 1, 1);
@@ -812,7 +812,7 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[The Magical Mojomuscular Melody], 12, 1, 1);
 			if(item_amount($item[Tomato Juice of Powerful Power]) > 4)
 			{
-				buffMaintain($effect[Tomato Power], 0, 1, 1);
+				buffMaintain($effect[Tomato Power]);
 			}
 			cs_healthMaintain();
 
@@ -882,9 +882,9 @@ boolean LA_cs_communityService()
 
 						buyUpTo(1, $item[Hair Spray]);
 						buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-						buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
-						buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
-						buffMaintain($effect[Unrunnable Face], 0, 1, 1);
+						buffMaintain($effect[Go Get \'Em\, Tiger!]);
+						buffMaintain($effect[Butt-Rock Hair]);
+						buffMaintain($effect[Unrunnable Face]);
 
 						buffMaintain($effect[Astral Shell], 42, 1, 1);
 						buffMaintain($effect[Elemental Saucesphere], 42, 1, 1);
@@ -1267,7 +1267,7 @@ boolean LA_cs_communityService()
 				{
 					abort("We have an emergency margarita but it seems really dumb to drink it right now (consider closeting the margarita and set auto_saveMargarita = true)...");
 				}
-				buffMaintain($effect[Simmering], 0, 1, 1);
+				buffMaintain($effect[Simmering]);
 				if((inebriety_left() == 0) && have_familiar($familiar[Stooper])){
 					stooperDrink();
 				}
@@ -1370,32 +1370,32 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Disdain of the War Snapper], 15, 1, 1);
 			buffMaintain($effect[A Few Extra Pounds], 10, 1, 1);
 
-			buffMaintain($effect[Lycanthropy\, Eh?], 0, 1, 1);
-			buffMaintain($effect[Expert Oiliness], 0, 1, 1);
-			buffMaintain($effect[Phorcefullness], 0, 1, 1);
-			buffMaintain($effect[Tomato Power], 0, 1, 1);
-			buffMaintain($effect[Puddingskin], 0, 1, 1);
-			buffMaintain($effect[Superheroic], 0, 1, 1);
-			buffMaintain($effect[Extra Backbone], 0, 1, 1);
-			buffMaintain($effect[Pill Power], 0, 1, 1);
-			buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+			buffMaintain($effect[Lycanthropy\, Eh?]);
+			buffMaintain($effect[Expert Oiliness]);
+			buffMaintain($effect[Phorcefullness]);
+			buffMaintain($effect[Tomato Power]);
+			buffMaintain($effect[Puddingskin]);
+			buffMaintain($effect[Superheroic]);
+			buffMaintain($effect[Extra Backbone]);
+			buffMaintain($effect[Pill Power]);
+			buffMaintain($effect[Go Get \'Em\, Tiger!]);
 
-			buffMaintain($effect[Frog in Your Throat], 0, 1, 1);
-			buffMaintain($effect[Feroci Tea], 0, 1, 1);
-			buffMaintain($effect[Vitali Tea], 0, 1, 1);
-			buffMaintain($effect[Twen Tea], 0, 1, 1);
+			buffMaintain($effect[Frog in Your Throat]);
+			buffMaintain($effect[Feroci Tea]);
+			buffMaintain($effect[Vitali Tea]);
+			buffMaintain($effect[Twen Tea]);
 			buffMaintain($effect[Peppermint Bite], 0, 1 , 1);
-			buffMaintain($effect[Barbecue Saucy], 0, 1, 1);
-			buffMaintain($effect[Graham Crackling], 0, 1, 1);
-			buffMaintain($effect[Berry Statistical], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Purity of Spirit], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Gr8ness], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Nigh-Invincible], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Phorcefullness], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Power Of LOV], 0, 1, 1);
+			buffMaintain($effect[Barbecue Saucy]);
+			buffMaintain($effect[Graham Crackling]);
+			buffMaintain($effect[Berry Statistical]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Purity of Spirit]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Human-Human Hybrid]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Gr8ness]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Nigh-Invincible]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Phorcefullness]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Power Of LOV]);
 
 			if(!get_property("_grimBuff").to_boolean() && have_familiar($familiar[Grim Brother]))
 			{
@@ -1556,33 +1556,33 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Power Ballad of the Arrowsmith], 10, 1, 1);
 			buffMaintain($effect[Disdain of the War Snapper], 15, 1, 1);
 
-			buffMaintain($effect[Expert Oiliness], 0, 1, 1);
+			buffMaintain($effect[Expert Oiliness]);
 			buffMaintain($effect[Orange Crusher], 0, 1, 50);
 			buffMaintain($effect[Orange Crusher], 0, 1, 50);
 			buffMaintain($effect[Orange Crusher], 0, 1, 50);
 			buffMaintain($effect[Orange Crusher], 0, 1, 50);
 			buffMaintain($effect[Orange Crusher], 0, 1, 50);
-			buffMaintain($effect[Phorcefullness], 0, 1, 1);
-			buffMaintain($effect[Tomato Power], 0, 1, 1);
-			buffMaintain($effect[Savage Beast Inside], 0, 1, 1);
-			buffMaintain($effect[Extra Backbone], 0, 1, 1);
+			buffMaintain($effect[Phorcefullness]);
+			buffMaintain($effect[Tomato Power]);
+			buffMaintain($effect[Savage Beast Inside]);
+			buffMaintain($effect[Extra Backbone]);
 
-			buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+			buffMaintain($effect[Go Get \'Em\, Tiger!]);
 			buffMaintain($effect[Seal Clubbing Frenzy], 1, 1, 1);
 			buffMaintain($effect[Patience of the Tortoise], 1, 1, 1);
-			buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
-			buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-			buffMaintain($effect[Frog in Your Throat], 0, 1, 1);
-			buffMaintain($effect[Twen Tea], 0, 1, 1);
-			buffMaintain($effect[Feroci Tea], 0, 1, 1);
+			buffMaintain($effect[Human-Humanoid Hybrid]);
+			buffMaintain($effect[Human-Human Hybrid]);
+			buffMaintain($effect[Frog in Your Throat]);
+			buffMaintain($effect[Twen Tea]);
+			buffMaintain($effect[Feroci Tea]);
 			buffMaintain($effect[Peppermint Bite], 0, 1 , 1);
-			buffMaintain($effect[Berry Statistical], 0, 1, 1);
+			buffMaintain($effect[Berry Statistical]);
 
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Gr8ness], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power], 0, 1, 1);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Gr8ness]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power]);
 
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power], 0, 1, 1);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Pill Power]);
 
 			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
 				tryBeachHeadBuff(curQuest);
@@ -1648,13 +1648,13 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Disdain of She-Who-Was], 15, 1, 1);
 
 
-			buffMaintain($effect[Mystically Oiled], 0, 1, 1);
-			buffMaintain($effect[Tomato Power], 0, 1, 1);
-			buffMaintain($effect[Pill Power], 0, 1, 1);
-			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
-			buffMaintain($effect[Liquidy Smoky], 0, 1, 1);
-			buffMaintain($effect[Gr8ness], 0, 1, 1);
-			buffMaintain($effect[OMG WTF], 0, 1, 1);
+			buffMaintain($effect[Mystically Oiled]);
+			buffMaintain($effect[Tomato Power]);
+			buffMaintain($effect[Pill Power]);
+			buffMaintain($effect[Glittering Eyelashes]);
+			buffMaintain($effect[Liquidy Smoky]);
+			buffMaintain($effect[Gr8ness]);
+			buffMaintain($effect[OMG WTF]);
 			buffMaintain($effect[Purple Reign], 0, 1, 50);
 			buffMaintain($effect[Purple Reign], 0, 1, 50);
 			buffMaintain($effect[Purple Reign], 0, 1, 50);
@@ -1662,17 +1662,17 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Purple Reign], 0, 1, 50);
 			buffMaintain($effect[Saucemastery], 1, 1, 1);
 			buffMaintain($effect[Pasta Oneness], 1, 1, 1);
-			buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
-			buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-			buffMaintain($effect[Salamander In Your Stomach], 0, 1, 1);
-			buffMaintain($effect[Twen Tea], 0, 1, 1);
-			buffMaintain($effect[Wit Tea], 0, 1, 1);
-			buffMaintain($effect[Sweet\, Nuts], 0, 1, 1);
-			buffMaintain($effect[Baconstoned], 0, 1, 1);
-			buffMaintain($effect[Berry Statistical], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Magic Of LOV], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated], 0, 1, 1);
+			buffMaintain($effect[Human-Humanoid Hybrid]);
+			buffMaintain($effect[Human-Human Hybrid]);
+			buffMaintain($effect[Salamander In Your Stomach]);
+			buffMaintain($effect[Twen Tea]);
+			buffMaintain($effect[Wit Tea]);
+			buffMaintain($effect[Sweet\, Nuts]);
+			buffMaintain($effect[Baconstoned]);
+			buffMaintain($effect[Berry Statistical]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Magic Of LOV]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated]);
 
 			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
 				tryBeachHeadBuff(curQuest);
@@ -1695,7 +1695,7 @@ boolean LA_cs_communityService()
 				}
 			}
 
-			buffMaintain($effect[Nearly All-Natural], 0, 1, 1);
+			buffMaintain($effect[Nearly All-Natural]);
 			handleFamiliar($familiar[Machine Elf]);
 			cs_giant_growth();
 
@@ -1746,17 +1746,17 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Disco Fever], 10, 1, 1);
 			buffMaintain($effect[Blubbered Up], 10, 1, 1);
 
-			buffMaintain($effect[Expert Oiliness], 0, 1, 1);
-			buffMaintain($effect[Tomato Power], 0, 1, 1);
-			buffMaintain($effect[Pulchritudinous Pressure], 0, 1, 1);
-			buffMaintain($effect[Lycanthropy\, Eh?], 0, 1, 1);
-			buffMaintain($effect[Superhuman Sarcasm], 0, 1, 1);
-			buffMaintain($effect[Notably Lovely], 0, 1, 1);
-			buffMaintain($effect[Pill Power], 0, 1, 1);
-			buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
-			buffMaintain($effect[Gr8ness], 0, 1, 1);
-			buffMaintain($effect[Liquidy Smoky], 0, 1, 1);
-			buffMaintain($effect[Barbecue Saucy], 0, 1, 1);
+			buffMaintain($effect[Expert Oiliness]);
+			buffMaintain($effect[Tomato Power]);
+			buffMaintain($effect[Pulchritudinous Pressure]);
+			buffMaintain($effect[Lycanthropy\, Eh?]);
+			buffMaintain($effect[Superhuman Sarcasm]);
+			buffMaintain($effect[Notably Lovely]);
+			buffMaintain($effect[Pill Power]);
+			buffMaintain($effect[Butt-Rock Hair]);
+			buffMaintain($effect[Gr8ness]);
+			buffMaintain($effect[Liquidy Smoky]);
+			buffMaintain($effect[Barbecue Saucy]);
 			buffMaintain($effect[Cinnamon Challenger], 0, 1, 50);
 			buffMaintain($effect[Cinnamon Challenger], 0, 1, 50);
 			buffMaintain($effect[Cinnamon Challenger], 0, 1, 50);
@@ -1764,18 +1764,18 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Cinnamon Challenger], 0, 1, 50);
 			buffMaintain($effect[Disco State of Mind], 1, 1, 1);
 			buffMaintain($effect[Mariachi Mood], 1, 1, 1);
-			buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
-			buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-			buffMaintain($effect[Newt Gets In Your Eyes], 0, 1, 1);
-			buffMaintain($effect[Twen Tea], 0, 1, 1);
-			buffMaintain($effect[Dexteri Tea], 0, 1, 1);
-			buffMaintain($effect[Busy Bein\' Delicious], 0, 1, 1);
-			buffMaintain($effect[Bandersnatched], 0, 1, 1);
-			buffMaintain($effect[Berry Statistical], 0, 1, 1);
+			buffMaintain($effect[Human-Humanoid Hybrid]);
+			buffMaintain($effect[Human-Human Hybrid]);
+			buffMaintain($effect[Newt Gets In Your Eyes]);
+			buffMaintain($effect[Twen Tea]);
+			buffMaintain($effect[Dexteri Tea]);
+			buffMaintain($effect[Busy Bein\' Delicious]);
+			buffMaintain($effect[Bandersnatched]);
+			buffMaintain($effect[Berry Statistical]);
 
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Moxie Of LOV], 0, 1, 1);
-			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated], 0, 1, 1);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Experimental Effect G-9]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[The Moxie Of LOV]);
+			if(estimate_cs_questCost(curQuest) > 1)		buffMaintain($effect[Seriously Mutated]);
 
 			if(estimate_cs_questCost(curQuest) > 1 && beachHeadTurnSavings(curQuest) > 0){
 				tryBeachHeadBuff(curQuest);
@@ -1814,7 +1814,7 @@ boolean LA_cs_communityService()
 
 			if(get_cs_questCost(curQuest) > 5)
 			{
-				buffMaintain($effect[Amazing], 0, 1, 1);
+				buffMaintain($effect[Amazing]);
 			}
 
 
@@ -1882,8 +1882,8 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
 			buffMaintain($effect[Blue Swayed], 0, 1, 50);
-			buffMaintain($effect[Loyal Tea], 0, 1, 1);
-			buffMaintain($effect[Blood Bond], 0, 1, 1);
+			buffMaintain($effect[Loyal Tea]);
+			buffMaintain($effect[Blood Bond]);
 
 			if((spleen_left() > 0) && (item_amount($item[Abstraction: Joy]) > 0) && (have_effect($effect[Joy]) == 0))
 			{
@@ -2075,18 +2075,18 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Frenzied, Bloody], 10, 1, 1);
 			songboomSetting("weapon damage");
 
-			buffMaintain($effect[The Power Of LOV], 0, 1, 1);
+			buffMaintain($effect[The Power Of LOV]);
 
 			if((item_amount($item[Wasabi Marble Soda]) == 0) && (have_effect($effect[Wasabi With You]) == 0) && (item_amount($item[Ye Wizard\'s Shack snack voucher]) > 0))
 			{
 				cli_execute("make " + $item[Wasabi Marble Soda]);
-				buffMaintain($effect[Wasabi With You], 0, 1, 1);
+				buffMaintain($effect[Wasabi With You]);
 			}
 
-			buffMaintain($effect[Human-Beast Hybrid], 0, 1, 1);
-			buffMaintain($effect[Twinkly Weapon], 0, 1, 1);
-			buffMaintain($effect[This Is Where You\'re a Viking], 0, 1, 1);
-			buffMaintain($effect[Feeling Punchy], 0, 1, 1);
+			buffMaintain($effect[Human-Beast Hybrid]);
+			buffMaintain($effect[Twinkly Weapon]);
+			buffMaintain($effect[This Is Where You\'re a Viking]);
+			buffMaintain($effect[Feeling Punchy]);
 			if(is_unrestricted($item[Clan Pool Table]) && (have_effect($effect[Billiards Belligerence]) == 0))
 			{
 				visit_url("clan_viplounge.php?preaction=poolgame&stance=1");
@@ -2263,10 +2263,10 @@ boolean LA_cs_communityService()
 				buffMaintain($effect[Bendin\' Hell], 100, 1, 1);
 				buffMaintain($effect[Arched Eyebrow of the Archmage], 10, 1, 1);
 				buffMaintain($effect[Jackasses\' Symphony of Destruction], 8, 1, 1);
-				buffMaintain($effect[Puzzle Fury], 0, 1, 1);
-				buffMaintain($effect[Be A Mind Master], 0, 1, 1);
-				buffMaintain($effect[Paging Betty], 0, 1, 1);
-				buffMaintain($effect[The Magic Of LOV], 0, 1, 1);
+				buffMaintain($effect[Puzzle Fury]);
+				buffMaintain($effect[Be A Mind Master]);
+				buffMaintain($effect[Paging Betty]);
+				buffMaintain($effect[The Magic Of LOV]);
 
 				if(is_unrestricted($item[Clan Pool Table]) && (have_effect($effect[Mental A-cue-ity]) == 0))
 				{
@@ -2276,7 +2276,7 @@ boolean LA_cs_communityService()
 				if((item_amount($item[Tobiko Marble Soda]) == 0) && (have_effect($effect[Pisces in the Skyces]) == 0) && (item_amount($item[Ye Wizard\'s Shack snack voucher]) > 0))
 				{
 					cli_execute("make " + $item[Tobiko Marble Soda]);
-					buffMaintain($effect[Pisces in the Skyces], 0, 1, 1);
+					buffMaintain($effect[Pisces in the Skyces]);
 				}
 
 				if(have_familiar($familiar[Disembodied Hand]))
@@ -2361,10 +2361,10 @@ boolean LA_cs_communityService()
 				}
 			}
 
-			buffMaintain($effect[Snow Shoes], 0, 1, 1);
-			buffMaintain($effect[Obscuri Tea], 0, 1, 1);
-			buffMaintain($effect[Gummed Shoes], 0, 1, 1);
-			buffMaintain($effect[Become Superficially Interested], 0, 1, 1);
+			buffMaintain($effect[Snow Shoes]);
+			buffMaintain($effect[Obscuri Tea]);
+			buffMaintain($effect[Gummed Shoes]);
+			buffMaintain($effect[Become Superficially Interested]);
 			if(is_unrestricted($item[Olympic-sized Clan Crate]) && !get_property("_olympicSwimmingPool").to_boolean())
 			{
 				cli_execute("swim noncombat");
@@ -2402,20 +2402,20 @@ boolean LA_cs_communityService()
 			int questCost = get_cs_questCost(curQuest);
 			if(my_adventures() < questCost)
 			{
-				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
+				buffMaintain($effect[A Rose by Any Other Material]);
 				questCost = questCost - 12;
 			}
 			if(my_adventures() < questCost)
 			{
-				buffMaintain($effect[Throwing Some Shade], 0, 1, 1);
+				buffMaintain($effect[Throwing Some Shade]);
 			}
 			if((auto_mall_price($item[Shady Shades]) < 20000) && (questCost > 12))
 			{
-				buffMaintain($effect[Throwing Some Shade], 0, 1, 1);
+				buffMaintain($effect[Throwing Some Shade]);
 			}
 			if((auto_mall_price($item[Squeaky Toy Rose]) < 20000) && (questCost > 12))
 			{
-				buffMaintain($effect[A Rose by Any Other Material], 0, 1, 1);
+				buffMaintain($effect[A Rose by Any Other Material]);
 			}
 			getHorse("non-combat");
 
@@ -2520,7 +2520,7 @@ boolean LA_cs_communityService()
 			buffMaintain($effect[Leash of Linguini], 12, 1, 1);
 			buffMaintain($effect[Fat Leon\'s Phat Loot Lyric], 11, 1, 1);
 			buffMaintain($effect[Steely-Eyed Squint], 101, 1, 1);
-			buffMaintain($effect[Heightened Senses], 0, 1, 1);
+			buffMaintain($effect[Heightened Senses]);
 			asdonBuff($effect[Driving Observantly]);
 
 			buffMaintain($effect[Spice Haze], 250, 1, 1);
@@ -2533,10 +2533,10 @@ boolean LA_cs_communityService()
 				}
 			}
 
-			buffMaintain($effect[Human-Pirate Hybrid], 0, 1, 1);
-			buffMaintain($effect[One Very Clear Eye], 0, 1, 1);
-			buffMaintain($effect[Sour Softshoe], 0, 1, 1);
-			buffMaintain($effect[Serendipi Tea], 0, 1, 1);
+			buffMaintain($effect[Human-Pirate Hybrid]);
+			buffMaintain($effect[One Very Clear Eye]);
+			buffMaintain($effect[Sour Softshoe]);
+			buffMaintain($effect[Serendipi Tea]);
 
 			if(have_effect($effect[Uncucumbered]) == 0)
 			{
@@ -2742,8 +2742,8 @@ boolean LA_cs_communityService()
 				string temp = visit_url("shop.php?action=bacta&whichshop=mayoclinic");
 			}
 
-			buffMaintain($effect[Protection from Bad Stuff], 0, 1, 1);
-			buffMaintain($effect[Human-Elemental Hybrid], 0, 1, 1);
+			buffMaintain($effect[Protection from Bad Stuff]);
+			buffMaintain($effect[Human-Elemental Hybrid]);
 			buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
 			if((my_familiar() == $familiar[Exotic Parrot]) || (my_familiar() == $familiar[Mu]))
 			{
@@ -2751,14 +2751,14 @@ boolean LA_cs_communityService()
 				buffMaintain($effect[Empathy], 15, 1, 1);
 			}
 			buffMaintain($effect[Astral Shell], 10, 1, 1);
-			buffMaintain($effect[Sleazy Hands], 0, 1, 1);
-			buffMaintain($effect[Egged On], 0, 1, 1);
-			buffMaintain($effect[Flame-Retardant Trousers], 0, 1, 1);
-			buffMaintain($effect[Stinky Hands], 0, 1, 1);
-			buffMaintain($effect[Human-Machine Hybrid], 0, 1, 1);
-			buffMaintain($effect[Frost Tea], 0, 1, 1);
-			buffMaintain($effect[Berry Elemental], 0, 1, 1);
-			buffMaintain($effect[Amazing], 0, 1, 1);
+			buffMaintain($effect[Sleazy Hands]);
+			buffMaintain($effect[Egged On]);
+			buffMaintain($effect[Flame-Retardant Trousers]);
+			buffMaintain($effect[Stinky Hands]);
+			buffMaintain($effect[Human-Machine Hybrid]);
+			buffMaintain($effect[Frost Tea]);
+			buffMaintain($effect[Berry Elemental]);
+			buffMaintain($effect[Amazing]);
 
 			spacegateVaccine($effect[Rainbow Vaccine]);
 
@@ -2776,7 +2776,7 @@ boolean LA_cs_communityService()
 
 			if(curCost >= 3)
 			{
-				buffMaintain($effect[Spiro Gyro], 0, 1, 1);
+				buffMaintain($effect[Spiro Gyro]);
 			}
 
 

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -463,10 +463,10 @@ boolean L13_heavyrains_towerFinal()
 	}
 	
 	//buff up before the boss
-	buffMaintain($effect[Benetton's Medley of Diversity], 0, 1, 1);			//15 prismatic weapon dmg.
-	buffMaintain($effect[Dirge of Dreadfulness], 0, 1, 1);					//12 spooky weapon dmg
-	buffMaintain($effect[Boner Battalion], 0, 1, 1);						//32-33 sleaze and spooky passive dmg
-	buffMaintain($effect[Frigidalmatian], 0, 1, 1);							//40 (due to cap) cold passive dmg
+	buffMaintain($effect[Benetton's Medley of Diversity]);			//15 prismatic weapon dmg.
+	buffMaintain($effect[Dirge of Dreadfulness]);					//12 spooky weapon dmg
+	buffMaintain($effect[Boner Battalion]);						//32-33 sleaze and spooky passive dmg
+	buffMaintain($effect[Frigidalmatian]);							//40 (due to cap) cold passive dmg
 	effectAblativeArmor(true);					//Unimportant effects protect your important one from being removed.
 	
 	//Calculate melee/ranged damage. Each element is capped at 40. assume you will be able to deal 40 physical damage.

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -106,7 +106,7 @@ boolean LX_koeInvaderHandler()
 			setFlavour($element[cold]);
 			buffMaintain($effect[Carol of the Hells], 50, 1, 1);
 			buffMaintain($effect[Song of Sauce], 150, 1, 1);
-			buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
+			buffMaintain($effect[Glittering Eyelashes]);
 			acquireMP(100, 0);
 
 			// Use maximizer now that we are for sure fighting the Invader

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -11,7 +11,7 @@ boolean L4_batCave()
 	{
 		handleBjornify($familiar[Grimstone Golem]);
 	}
-	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
+	buffMaintain($effect[Fishy Whiskers]);
 
 	int batStatus = internalQuestStatus("questL04Bat");
 	if (batStatus < 3)

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -79,7 +79,7 @@ boolean L5_haremOutfit()
 
 	if(in_heavyrains())
 	{
-		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
+		buffMaintain($effect[Fishy Whiskers]);
 	}
 	bat_formBats();
 
@@ -122,7 +122,7 @@ boolean L5_goblinKing()
 	{
 		abort("Could not put on Knob Goblin Harem Girl Disguise, aborting");
 	}
-	buffMaintain($effect[Knob Goblin Perfume], 0, 1, 1);
+	buffMaintain($effect[Knob Goblin Perfume]);
 	if(have_effect($effect[Knob Goblin Perfume]) == 0)
 	{
 		boolean advSpent = autoAdv($location[Cobb\'s Knob Harem]);
@@ -136,15 +136,15 @@ boolean L5_goblinKing()
 	if(my_primestat() == $stat[Muscle])
 	{
 		buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+		buffMaintain($effect[Go Get \'Em\, Tiger!]);
 	}
 	buyUpTo(1, $item[Hair Spray]);
-	buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
+	buffMaintain($effect[Butt-Rock Hair]);
 
 	if((my_class() == $class[Seal Clubber]) || (my_class() == $class[Turtle Tamer]))
 	{
 		buyUpTo(1, $item[Blood of the Wereseal]);
-		buffMaintain($effect[Temporary Lycanthropy], 0, 1, 1);
+		buffMaintain($effect[Temporary Lycanthropy]);
 	}
 
 	// TODO: I died here, maybe we should heal a bit?

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -86,8 +86,8 @@ boolean L7_crypt()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 
-	buffMaintain($effect[Browbeaten], 0, 1, 1);
-	buffMaintain($effect[Rosewater Mark], 0, 1, 1);
+	buffMaintain($effect[Browbeaten]);
+	buffMaintain($effect[Rosewater Mark]);
 
 	boolean edAlcove = true;
 	if(isActuallyEd())
@@ -160,7 +160,7 @@ boolean L7_crypt()
 	if((get_property("cyrptNookEvilness").to_int() > 0) && lar_repeat($location[The Defiled Nook]) && !skip_in_koe)
 	{
 		auto_log_info("The Nook!", "blue");
-		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
+		buffMaintain($effect[Joyful Resolve]);
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
 
@@ -245,9 +245,9 @@ boolean L7_crypt()
 		if(my_primestat() == $stat[Muscle])
 		{
 			buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-			buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+			buffMaintain($effect[Go Get \'Em\, Tiger!]);
 			buyUpTo(1, $item[Blood of the Wereseal]);
-			buffMaintain($effect[Temporary Lycanthropy], 0, 1, 1);
+			buffMaintain($effect[Temporary Lycanthropy]);
 		}
 
 		acquireHP();

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -533,7 +533,7 @@ boolean L9_aBooPeak()
 
 		if(doThisBoo)
 		{
-			buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+			buffMaintain($effect[Go Get \'Em\, Tiger!]);
 			bat_formMist();
 			if(0 == have_effect($effect[Mist Form]))
 			{
@@ -545,12 +545,12 @@ boolean L9_aBooPeak()
 			buffMaintain($effect[Astral Shell], 10, 1, 1);
 			buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
 			buffMaintain($effect[Scarysauce], 10, 1, 1);
-			buffMaintain($effect[Spookypants], 0, 1, 1);
-			buffMaintain($effect[Hyphemariffic], 0, 1, 1);
-			buffMaintain($effect[Insulated Trousers], 0, 1, 1);
-			buffMaintain($effect[Balls of Ectoplasm], 0, 1, 1);
-			buffMaintain($effect[Red Door Syndrome], 0, 1, 1);
-			buffMaintain($effect[Well-Oiled], 0, 1, 1);
+			buffMaintain($effect[Spookypants]);
+			buffMaintain($effect[Hyphemariffic]);
+			buffMaintain($effect[Insulated Trousers]);
+			buffMaintain($effect[Balls of Ectoplasm]);
+			buffMaintain($effect[Red Door Syndrome]);
+			buffMaintain($effect[Well-Oiled]);
 
 			auto_beachCombHead("cold");
 			auto_beachCombHead("spooky");
@@ -648,9 +648,9 @@ boolean L9_twinPeak()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 	
-	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);		//heavy rains specific reduce item drop penalty by 10%
+	buffMaintain($effect[Fishy Whiskers]);		//heavy rains specific reduce item drop penalty by 10%
 	//BHY specific prevent wandering bees from skipping the burning the hotel down choice and wasting turns
-	buffMaintain($effect[Float Like a Butterfly, Smell Like a Bee], 0, 1, 1);
+	buffMaintain($effect[Float Like a Butterfly, Smell Like a Bee]);
 	
 	if(in_bhy())
 	{
@@ -715,7 +715,7 @@ boolean L9_twinPeak()
 		}
 		if((food_drop < 50.0) && (item_amount($item[resolution: be happier]) > 0) && (have_effect($effect[Joyful Resolve]) == 0))
 		{
-			buffMaintain($effect[Joyful Resolve], 0, 1, 1);
+			buffMaintain($effect[Joyful Resolve]);
 			food_drop = food_drop + 15;
 		}
 		if(food_drop >= 50.0)
@@ -834,17 +834,17 @@ boolean L9_oilPeak()
 		auto_log_info("Oil Peak is finished but we need more crude!", "blue");
 	}
 
-	buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
+	buffMaintain($effect[Fishy Whiskers]);
 
 	auto_MaxMLToCap(auto_convertDesiredML(100), true);
 
 	if (isActuallyEd() && get_property("auto_dickstab").to_boolean())
 	{
-		buffMaintain($effect[The Dinsey Look], 0, 1, 1);
+		buffMaintain($effect[The Dinsey Look]);
 	}
 	if(monster_level_adjustment() < 50)
 	{
-		buffMaintain($effect[The Dinsey Look], 0, 1, 1);
+		buffMaintain($effect[The Dinsey Look]);
 	}
 	if((monster_level_adjustment() < 60))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -146,10 +146,10 @@ boolean L10_basement()
 	if(my_primestat() == $stat[Muscle])
 	{
 		buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
+		buffMaintain($effect[Go Get \'Em\, Tiger!]);
 	}
 	buyUpTo(1, $item[Hair Spray]);
-	buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
+	buffMaintain($effect[Butt-Rock Hair]);
 	
 	if(in_gnoob() && auto_have_familiar($familiar[Robortender]))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -404,7 +404,7 @@ boolean LX_unlockHauntedLibrary()
 	}
 	
 	//+3 pool skill & +1 training gains. speculative_pool_skill() already assumed we would use it if we can.
-	buffMaintain($effect[Chalky Hand], 0, 1, 1);
+	buffMaintain($effect[Chalky Hand]);
 
 	if (internalQuestStatus("questM20Necklace") == 2)
 	{
@@ -994,13 +994,13 @@ boolean L11_aridDesert()
 		}
 
 		buyUpTo(1, $item[hair spray]);
-		buffMaintain($effect[Butt-Rock Hair], 0, 1, 1);
+		buffMaintain($effect[Butt-Rock Hair]);
 		if(my_primestat() == $stat[Muscle])
 		{
 			buyUpTo(1, $item[Ben-Gal&trade; Balm]);
-			buffMaintain($effect[Go Get \'Em, Tiger!], 0, 1, 1);
+			buffMaintain($effect[Go Get \'Em, Tiger!]);
 			buyUpTo(1, $item[Blood of the Wereseal]);
-			buffMaintain($effect[Temporary Lycanthropy], 0, 1, 1);
+			buffMaintain($effect[Temporary Lycanthropy]);
 		}
 
 		if(my_mp() > 30 && my_hp() < (my_maxhp()*0.5))
@@ -1316,7 +1316,7 @@ boolean L11_unlockHiddenCity() {
 			L11_wishForBaaBaaBuran();
 			pullXWhenHaveY($item[Stone Wool], 1, 0);
 		}
-		buffMaintain($effect[Stone-Faced], 0, 1, 1);
+		buffMaintain($effect[Stone-Faced]);
 		if (have_effect($effect[Stone-Faced]) == 0)
 		{
 			if(isAboutToPowerlevel())	//we ran out of other quests to do. stop waiting for optimal conditions
@@ -1757,7 +1757,7 @@ boolean L11_hiddenCity()
 			}
 		}
 
-		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
+		buffMaintain($effect[Fishy Whiskers]);
 		auto_log_info("Hidden Bowling Alley Progress: " + get_property("hiddenBowlingAlleyProgress"), "blue");
 		if (canSniff($monster[Pygmy Bowler], $location[The Hidden Bowling Alley]) && item_amount($item[bowling ball]) < 1 && auto_mapTheMonsters())
 		{
@@ -2106,7 +2106,7 @@ boolean L11_mauriceSpookyraven()
 		
 		if(monster_level_adjustment() < 57)
 		{
-			buffMaintain($effect[Sweetbreads Flamb&eacute;], 0, 1, 1);
+			buffMaintain($effect[Sweetbreads Flamb&eacute;]);
 		}
 		
 		if(!autoForceEquip($slot[off-hand], $item[Unstable Fulminate]))
@@ -2142,9 +2142,9 @@ boolean L11_redZeppelin()
 	set_property("choiceAdventure856", 1);
 	set_property("choiceAdventure857", 1);
 	set_property("choiceAdventure858", 1);
-	buffMaintain($effect[Greasy Peasy], 0, 1, 1);
-	buffMaintain($effect[Musky], 0, 1, 1);
-	buffMaintain($effect[Blood-Gorged], 0, 1, 1);
+	buffMaintain($effect[Greasy Peasy]);
+	buffMaintain($effect[Musky]);
+	buffMaintain($effect[Blood-Gorged]);
 	if(!in_wotsf())
 	{
 		pullXWhenHaveY($item[deck of lewd playing cards], 1, 0);
@@ -2842,25 +2842,25 @@ boolean L11_unlockEd()
 	}
 	if(total < 10)
 	{
-		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
-		buffMaintain($effect[One Very Clear Eye], 0, 1, 1);
-		buffMaintain($effect[Fishy Whiskers], 0, 1, 1);
-		buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
-		buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-		buffMaintain($effect[Unusual Perspective], 0, 1, 1);
+		buffMaintain($effect[Joyful Resolve]);
+		buffMaintain($effect[One Very Clear Eye]);
+		buffMaintain($effect[Fishy Whiskers]);
+		buffMaintain($effect[Human-Fish Hybrid]);
+		buffMaintain($effect[Human-Human Hybrid]);
+		buffMaintain($effect[Unusual Perspective]);
 		if(!bat_wantHowl($location[The Middle Chamber]))
 		{
 			bat_formBats();
 		}
 		if(get_property("auto_dickstab").to_boolean())
 		{
-			buffMaintain($effect[Wet and Greedy], 0, 1, 1);
-			buffMaintain($effect[Frosty], 0, 1, 1);
+			buffMaintain($effect[Wet and Greedy]);
+			buffMaintain($effect[Frosty]);
 		}
 		if((item_amount($item[possessed sugar cube]) > 0) && (have_effect($effect[Dance of the Sugar Fairy]) == 0))
 		{
 			cli_execute("make sugar fairy");
-			buffMaintain($effect[Dance of the Sugar Fairy], 0, 1, 1);
+			buffMaintain($effect[Dance of the Sugar Fairy]);
 		}
 		if(have_effect($effect[items.enh]) == 0)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -895,24 +895,24 @@ boolean L12_filthworms()
 	}
 	else		//could not guarentee stealing. buff item drops instead
 	{
-		buffMaintain($effect[Joyful Resolve], 0, 1, 1);
-		buffMaintain($effect[Kindly Resolve], 0, 1, 1);
-		buffMaintain($effect[Fortunate Resolve], 0, 1, 1);
-		buffMaintain($effect[One Very Clear Eye], 0, 1, 1);
-		buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
-		buffMaintain($effect[Human-Human Hybrid], 0, 1, 1);
-		buffMaintain($effect[Human-Machine Hybrid], 0, 1, 1);
-		buffMaintain($effect[Unusual Perspective], 0, 1, 1);
-		buffMaintain($effect[Eagle Eyes], 0, 1, 1);
-		buffMaintain($effect[Heart of Lavender], 0, 1, 1);
+		buffMaintain($effect[Joyful Resolve]);
+		buffMaintain($effect[Kindly Resolve]);
+		buffMaintain($effect[Fortunate Resolve]);
+		buffMaintain($effect[One Very Clear Eye]);
+		buffMaintain($effect[Human-Fish Hybrid]);
+		buffMaintain($effect[Human-Human Hybrid]);
+		buffMaintain($effect[Human-Machine Hybrid]);
+		buffMaintain($effect[Unusual Perspective]);
+		buffMaintain($effect[Eagle Eyes]);
+		buffMaintain($effect[Heart of Lavender]);
 		asdonBuff($effect[Driving Observantly]);
 		bat_formBats();
 
 		if(get_property("auto_dickstab").to_boolean())
 		{
-			buffMaintain($effect[Wet and Greedy], 0, 1, 1);
+			buffMaintain($effect[Wet and Greedy]);
 		}
-		buffMaintain($effect[Frosty], 0, 1, 1);
+		buffMaintain($effect[Frosty]);
 		
 		//craft IOTM derivative that gives high item bonus
 		if((!possessEquipment($item[A Light That Never Goes Out])) && (item_amount($item[Lump of Brituminous Coal]) > 0))
@@ -1613,21 +1613,21 @@ boolean L12_themtharHills()
 	{
 		makeGenieWish($effect[Frosty]);
 	}
-	buffMaintain($effect[Greedy Resolve], 0, 1, 1);
+	buffMaintain($effect[Greedy Resolve]);
 	buffMaintain($effect[Disco Leer], 10, 1, 1);
 	buffMaintain($effect[Polka of Plenty], 8, 1, 1);
 	#Handle for familiar weight change.
-	buffMaintain($effect[Kindly Resolve], 0, 1, 1);
-	buffMaintain($effect[Heightened Senses], 0, 1, 1);
-	buffMaintain($effect[Big Meat Big Prizes], 0, 1, 1);
-	buffMaintain($effect[Human-Machine Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Constellation Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
-	buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
-	buffMaintain($effect[Patent Avarice], 0, 1, 1);
-	buffMaintain($effect[Car-Charged], 0, 1, 1);
-	buffMaintain($effect[Heart of Pink], 0, 1, 1);
+	buffMaintain($effect[Kindly Resolve]);
+	buffMaintain($effect[Heightened Senses]);
+	buffMaintain($effect[Big Meat Big Prizes]);
+	buffMaintain($effect[Human-Machine Hybrid]);
+	buffMaintain($effect[Human-Constellation Hybrid]);
+	buffMaintain($effect[Human-Humanoid Hybrid]);
+	buffMaintain($effect[Human-Fish Hybrid]);
+	buffMaintain($effect[Cranberry Cordiality]);
+	buffMaintain($effect[Patent Avarice]);
+	buffMaintain($effect[Car-Charged]);
+	buffMaintain($effect[Heart of Pink]);
 	buffMaintain($effect[Sweet Heart], 0, 1, 20);
 		
 	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
@@ -1656,7 +1656,7 @@ boolean L12_themtharHills()
 
 	if(in_heavyrains())
 	{
-		buffMaintain($effect[Sinuses For Miles], 0, 1, 1);
+		buffMaintain($effect[Sinuses For Miles]);
 	}
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
@@ -1726,19 +1726,19 @@ boolean L12_themtharHills()
 
 	buffMaintain($effect[Disco Leer], 10, 1, 1);
 	buffMaintain($effect[Polka of Plenty], 8, 1, 1);
-	buffMaintain($effect[Sinuses For Miles], 0, 1, 1);
-	buffMaintain($effect[Greedy Resolve], 0, 1, 1);
-	buffMaintain($effect[Kindly Resolve], 0, 1, 1);
-	buffMaintain($effect[Heightened Senses], 0, 1, 1);
-	buffMaintain($effect[Big Meat Big Prizes], 0, 1, 1);
-	buffMaintain($effect[Fortunate Resolve], 0, 1, 1);
-	buffMaintain($effect[Human-Machine Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Constellation Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Humanoid Hybrid], 0, 1, 1);
-	buffMaintain($effect[Human-Fish Hybrid], 0, 1, 1);
-	buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
-	buffMaintain($effect[Car-Charged], 0, 1, 1);
-	buffMaintain($effect[Heart of Pink], 0, 1, 1);
+	buffMaintain($effect[Sinuses For Miles]);
+	buffMaintain($effect[Greedy Resolve]);
+	buffMaintain($effect[Kindly Resolve]);
+	buffMaintain($effect[Heightened Senses]);
+	buffMaintain($effect[Big Meat Big Prizes]);
+	buffMaintain($effect[Fortunate Resolve]);
+	buffMaintain($effect[Human-Machine Hybrid]);
+	buffMaintain($effect[Human-Constellation Hybrid]);
+	buffMaintain($effect[Human-Humanoid Hybrid]);
+	buffMaintain($effect[Human-Fish Hybrid]);
+	buffMaintain($effect[Cranberry Cordiality]);
+	buffMaintain($effect[Car-Charged]);
+	buffMaintain($effect[Heart of Pink]);
 	buffMaintain($effect[Sweet Heart], 0, 1, 20);
 	bat_formWolf();
 	zataraSeaside("meat");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -474,13 +474,13 @@ boolean L13_towerNSContests()
 				autoMaximize(challenge + " dmg, " + challenge + " spell dmg -equip snow suit", 1500, 0, false);
 			}
 
-			if(crowd3Insufficient()) buffMaintain($effect[All Glory To the Toad], 0, 1, 1);
+			if(crowd3Insufficient()) buffMaintain($effect[All Glory To the Toad]);
 			if(crowd3Insufficient()) buffMaintain($effect[Bendin\' Hell], 120, 1, 1);
 			switch(challenge)
 			{
 			case $element[cold]:
 				if(crowd3Insufficient()) auto_beachCombHead("cold");
-				if(crowd3Insufficient()) buffMaintain($effect[Cold Hard Skin], 0, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Cold Hard Skin]);
 				if(crowd3Insufficient()) buffMaintain($effect[Frostbeard], 15, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Icy Glare], 10, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Song of the North], 100, 1, 1);
@@ -488,32 +488,32 @@ boolean L13_towerNSContests()
 			case $element[hot]:
 				if(crowd3Insufficient()) auto_beachCombHead("hot");
 				if(crowd3Insufficient()) buffMaintain($effect[Song of Sauce], 100, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Flamibili Tea], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Flaming Weapon], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Human-Demon Hybrid], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Lit Up], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Fire Inside], 0, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Flamibili Tea]);
+				if(crowd3Insufficient()) buffMaintain($effect[Flaming Weapon]);
+				if(crowd3Insufficient()) buffMaintain($effect[Human-Demon Hybrid]);
+				if(crowd3Insufficient()) buffMaintain($effect[Lit Up]);
+				if(crowd3Insufficient()) buffMaintain($effect[Fire Inside]);
 				if(crowd3Insufficient()) buffMaintain($effect[Pyromania], 15, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Your Fifteen Minutes], 50, 1, 1);
 				break;
 			case $element[sleaze]:
 				if(crowd3Insufficient()) auto_beachCombHead("sleaze");
 				if(crowd3Insufficient()) buffMaintain($effect[Takin\' It Greasy], 15, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Blood-Gorged], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Greasy Peasy], 0, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Blood-Gorged]);
+				if(crowd3Insufficient()) buffMaintain($effect[Greasy Peasy]);
 				break;
 			case $element[stench]:
 				if(crowd3Insufficient()) auto_beachCombHead("stench");
-				if(crowd3Insufficient()) buffMaintain($effect[Drenched With Filth], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Musky], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Stinky Hands], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Stinky Weapon], 0, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Drenched With Filth]);
+				if(crowd3Insufficient()) buffMaintain($effect[Musky]);
+				if(crowd3Insufficient()) buffMaintain($effect[Stinky Hands]);
+				if(crowd3Insufficient()) buffMaintain($effect[Stinky Weapon]);
 				if(crowd3Insufficient()) buffMaintain($effect[Rotten Memories], 15, 1, 1);
 				break;
 			case $element[spooky]:
 				if(crowd3Insufficient()) auto_beachCombHead("spooky");
-				if(crowd3Insufficient()) buffMaintain($effect[Spooky Hands], 0, 1, 1);
-				if(crowd3Insufficient()) buffMaintain($effect[Spooky Weapon], 0, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Spooky Hands]);
+				if(crowd3Insufficient()) buffMaintain($effect[Spooky Weapon]);
 				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness], 10, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Intimidating Mien], 15, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Snarl of the Timberwolf], 10, 1, 1);
@@ -1171,7 +1171,7 @@ boolean L13_towerNSTower()
 			}
 			else if(!willNeedToRemoveEffects && item_amount($item[glob of spoiled mayo]) > 0)
 			{
-				if(buffMaintain($effect[Mayeaugh], 0, 1, 1))
+				if(buffMaintain($effect[Mayeaugh]))
 				{
 					sourcesPassive += 1;
 				}
@@ -1182,7 +1182,7 @@ boolean L13_towerNSTower()
 			}
 			else if(!willNeedToRemoveEffects && auto_canFeelNervous())
 			{
-				if(buffMaintain($effect[Feeling Nervous], 0, 1, 1))
+				if(buffMaintain($effect[Feeling Nervous]))
 				{
 					sourcesReactive += 1;
 				}
@@ -1190,22 +1190,22 @@ boolean L13_towerNSTower()
 			
 			if(have_skill($skill[Scarysauce]))
 			{
-				buffMaintain($effect[Scarysauce], 0, 1, 1);
+				buffMaintain($effect[Scarysauce]);
 				sourcesReactive += 1;
 			}
 			if(have_skill($skill[Spiky Shell]))
 			{
-				buffMaintain($effect[Spiky Shell], 0, 1, 1);
+				buffMaintain($effect[Spiky Shell]);
 				sourcesReactive += 1;
 			}
 			if(have_skill($skill[Jalape&ntilde;o Saucesphere]))
 			{
-				buffMaintain($effect[Jalape&ntilde;o Saucesphere], 0, 1, 1);
+				buffMaintain($effect[Jalape&ntilde;o Saucesphere]);
 				sourcesReactive += 1;
 			}
 			if(have_skill($skill[The Psalm of Pointiness]))
 			{
-				buffMaintain($effect[Psalm of Pointiness], 0, 1, 1);
+				buffMaintain($effect[Psalm of Pointiness]);
 				sourcesReactive += 1;
 			}
 			autoEquip($slot[acc2], $item[world\'s best adventurer sash]);
@@ -1274,7 +1274,7 @@ boolean L13_towerNSTower()
 					{
 						if(ef == $effect[Mayeaugh] && item_amount($item[glob of spoiled mayo]) > 0)
 						{
-							if(buffMaintain(ef, 0, 1, 1))
+							if(buffMaintain(ef))
 							{
 								sourcesPassive += 1;
 								damageSecured += 3 + extraRoundsFromBlocking;
@@ -1283,7 +1283,7 @@ boolean L13_towerNSTower()
 						}
 						else if(ef == $effect[Feeling Nervous] && auto_canFeelNervous())
 						{
-							if(buffMaintain(ef, 0, 1, 1))
+							if(buffMaintain(ef))
 							{
 								sourcesReactive += 1;
 								damageSecured += 3;
@@ -1350,19 +1350,19 @@ boolean L13_towerNSTower()
 		}
 		equipBaseline();
 		shrugAT($effect[Polka of Plenty]);
-		buffMaintain($effect[Disco Leer], 0, 1, 1);
-		buffMaintain($effect[Polka of Plenty], 0, 1, 1);
-		buffMaintain($effect[Cranberry Cordiality], 0, 1, 1);
-		buffMaintain($effect[Big Meat Big Prizes], 0, 1, 1);
-		buffMaintain($effect[Patent Avarice], 0, 1, 1);
+		buffMaintain($effect[Disco Leer]);
+		buffMaintain($effect[Polka of Plenty]);
+		buffMaintain($effect[Cranberry Cordiality]);
+		buffMaintain($effect[Big Meat Big Prizes]);
+		buffMaintain($effect[Patent Avarice]);
 		bat_formWolf();
 		if(auto_birdModifier("Meat Drop") > 0)
 		{
-			buffMaintain($effect[Blessing of the Bird], 0, 1, 1);
+			buffMaintain($effect[Blessing of the Bird]);
 		}
 		if(auto_favoriteBirdModifier("Meat Drop") > 0)
 		{
-			buffMaintain($effect[Blessing of Your Favorite Bird], 0, 1, 1);
+			buffMaintain($effect[Blessing of Your Favorite Bird]);
 		}
 		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 		{
@@ -1423,13 +1423,13 @@ boolean L13_towerNSTower()
 		uneffect($effect[Psalm of Pointiness]);
 		uneffect($effect[Mayeaugh]);
 		uneffect($effect[Feeling Nervous]);
-		buffMaintain($effect[Tomato Power], 0, 1, 1);
-		buffMaintain($effect[Seeing Colors], 0, 1, 1);
-		buffMaintain($effect[Glittering Eyelashes], 0, 1, 1);
-		buffMaintain($effect[OMG WTF], 0, 1, 1);
-		buffMaintain($effect[There is a Spoon], 0, 1, 1);
-		buffMaintain($effect[Song of Sauce], 0, 1, 1);
-		buffMaintain($effect[Carol of the Hells], 0, 1, 1);
+		buffMaintain($effect[Tomato Power]);
+		buffMaintain($effect[Seeing Colors]);
+		buffMaintain($effect[Glittering Eyelashes]);
+		buffMaintain($effect[OMG WTF]);
+		buffMaintain($effect[There is a Spoon]);
+		buffMaintain($effect[Song of Sauce]);
+		buffMaintain($effect[Carol of the Hells]);
 		
 		// Maximizer tries to force familiar equipment. and prefers passive dmg a that. Avoid dealing damage from familiar and losing
 		if(canChangeFamiliar())
@@ -1493,11 +1493,11 @@ boolean L13_towerNSTower()
 		}
 		if(my_maxhp() < 800)
 		{
-			buffMaintain($effect[Industrial Strength Starch], 0, 1, 1);
-			buffMaintain($effect[Truly Gritty], 0, 1, 1);
-			buffMaintain($effect[Superheroic], 0, 1, 1);
-			buffMaintain($effect[Strong Grip], 0, 1, 1);
-			buffMaintain($effect[Spiky Hair], 0, 1, 1);
+			buffMaintain($effect[Industrial Strength Starch]);
+			buffMaintain($effect[Truly Gritty]);
+			buffMaintain($effect[Superheroic]);
+			buffMaintain($effect[Strong Grip]);
+			buffMaintain($effect[Spiky Hair]);
 		}
 		cli_execute("scripts/autoscend/auto_post_adv.ash");
 		acquireHP();


### PR DESCRIPTION
* boolean buffMaintain(effect buff) created
* used the above new function via find `, 0, 1, 1)` and replace `)` then going over the results and making sure no problems were introduced.

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
