### PR TITLE
fix wasting adv when tomb already found during nemesis optional quest

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1097,6 +1097,7 @@ boolean LX_fledglingPirateIsYou();
 void fcleChoiceHandler(int choice);
 boolean LX_unlockBelowdecks();
 boolean LX_pirateQuest();
+boolean tomb_already_found();
 boolean LX_acquireEpicWeapon();
 boolean LX_NemesisQuest();
 void houseUpgrade();

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1019,6 +1019,13 @@ starterWeapons[$class[Disco Bandit]] = $item[disco ball];
 starterWeapons[$class[Accordion Thief]] = $item[stolen accordion];
 // usage: item starterWeapon = starterWeapons[my_class()];
 
+boolean tomb_already_found()
+{
+	//the tomb only appears once when adv in the unquiet garves. afterwards it appears on the map instead
+	string page = visit_url("place.php?whichplace=cemetery");
+	return page.contains_text("place.php?whichplace=cemetery&action=cem_advtomb");
+}
+
 boolean LX_acquireEpicWeapon()
 {
 	if (internalQuestStatus("questG04Nemesis") > 4)
@@ -1064,6 +1071,10 @@ boolean LX_acquireEpicWeapon()
 	}
 
 	addToMaximize("-equip " + starterWeapons[my_class()].to_string());
+	if(tomb_already_found())
+	{
+		return autoAdvBypass("place.php?whichplace=cemetery&action=cem_advtomb");
+	}
 
 	return autoAdv($location[The Unquiet Garves]);
 }


### PR DESCRIPTION
during nemesis quest the tomb of the unknown YOURCLASS only appears once when adventure in the unquiet garves.
we assumed that it has not been found yet and adventured in the unquiet garves for it. however if it was already exposed or if we found it but failed to complete it for some reason (ex: not having the correct item on hand) then it will continually waste adventures in the unquiet garves looking for the tomb even though it will not appear there anymore.
this PR solves this by checking to see if the tomb has been discovered already and if it has been going there directly.

## How Has This Been Tested?

ash calls on both accounts that had the tomb discovered and had not.
also had an account stuck at wasting adventures on the unquiet garves which this code fixed and made it go to the tomb properly and get the LEW

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
