### PR TITLE
settings upgrade cleanup

### DIFF
--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -32,6 +32,40 @@ boolean trackingSplitterFixer(string oldSetting, int day, string newSetting)
 	return true;
 }
 
+void cleanup_property(string target)
+{
+	//we need to clear out empty property that exist with an empty value.
+	//aside from being messy they also cause problems such as rename_property refusing to work.
+	if(get_property(target) == "" && property_exists(target))
+	{
+		remove_property(target);
+	}
+}
+
+void auto_rename_property(string oldprop, string newprop)
+{
+	cleanup_property(oldprop);
+	cleanup_property(newprop);
+	if(!property_exists(oldprop) || property_exists(newprop))
+	{
+		return;
+	}
+	rename_property(oldprop,newprop);
+}
+
+void boolFix(string p)
+{
+	string p_val = get_property(p);
+	if(p_val == "need" || p_val == "yes")
+	{
+		set_property(p, true);
+	}
+	if(p_val == "no")
+	{
+		set_property(p, false);
+	}
+}
+
 void auto_settingsUpgrade()
 {
 	//upgrade settings from old format to new format.
@@ -71,43 +105,11 @@ void auto_settingsUpgrade()
 		set_property("auto_killingjar", "finished");
 	}
 	
-	if(get_property("auto_wandOfNagamar") == "yes")
-	{
-		set_property("auto_wandOfNagamar", true);
-	}
-	if(get_property("auto_wandOfNagamar") == "no")
-	{
-		set_property("auto_wandOfNagamar", false);
-	}
-	if(get_property("auto_chasmBusted") == "yes")
-	{
-		set_property("auto_chasmBusted", true);
-	}
-	if(get_property("auto_chasmBusted") == "no")
-	{
-		set_property("auto_chasmBusted", false);
-	}
-
-	if(property_exists("auto_edDelayTimer"))
-	{
-		set_property("auto_delayTimer", get_property("auto_edDelayTimer"));
-	}
-	if(get_property("auto_grimstoneFancyOilPainting") == "need")
-	{
-		set_property("auto_grimstoneFancyOilPainting", true);
-	}
-	if(get_property("auto_grimstoneFancyOilPainting") == "no")
-	{
-		set_property("auto_grimstoneFancyOilPainting", false);
-	}
-	if(get_property("auto_grimstoneOrnateDowsingRod") == "need")
-	{
-		set_property("auto_grimstoneOrnateDowsingRod", true);
-	}
-	if(get_property("auto_grimstoneOrnateDowsingRod") == "no")
-	{
-		set_property("auto_grimstoneOrnateDowsingRod", false);
-	}
+	boolFix("auto_wandOfNagamar");
+	boolFix("auto_chasmBusted");
+	auto_rename_property("auto_delayTimer", "auto_edDelayTimer");
+	boolFix("auto_grimstoneFancyOilPainting");
+	boolFix("auto_grimstoneOrnateDowsingRod");
 
 	if(get_property("auto_abooclover") == "used")
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1204,6 +1204,9 @@ boolean distill(item target);
 ########################################################################################################
 //Defined in autoscend/auto_settings.ash
 boolean trackingSplitterFixer(string oldSetting, int day, string newSetting);
+void cleanup_property(string target);
+void auto_rename_property(string oldprop, string newprop);
+void boolFix(string p);
 void auto_settingsUpgrade();
 void auto_settingsFix();
 void auto_settingsDelete();


### PR DESCRIPTION
some code cleanup on auto_setting and added some related tools.
* void cleanup_property(string target);
  * necessary for rename_property to work property. maybe should use it on all properties?
* void auto_rename_property(string oldprop, string newprop);
  * I was sure we had a whole bunch of these. but when I was done writing this and went to apply it I only found a single case.
* void boolFix(string p);
  * cleaner and easier for a human to read

## How Has This Been Tested?

tested via ash commands
also validation

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
