### PR TITLE
velour buffs

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -890,9 +890,9 @@ boolean LX_craftAcquireItems()
 	{
 		boolean buyAntiqueAccordion = false;
 
-	foreach SongCheck in ATSongList()
+		foreach SongCheck in ATSongList()
 		{
-			if(have_skill(SongCheck))
+			if(have_skill(SongCheck.to_skill()))
 			{
 				buyAntiqueAccordion = true;
 			}

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -84,6 +84,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 {
 	skill useSkill = $skill[none];
 	item useItem = $item[none];
+	item mustEquip = $item[none];
 
 	if(buff == $effect[none])
 	{
@@ -212,6 +213,10 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Digitally Converted]:			useItem = $item[Digital Underground Potion];	break;
 	case $effect[The Dinsey Look]:				useItem = $item[Dinsey Face Paint];				break;
 	case $effect[Dirge of Dreadfulness]:		useSkill = $skill[Dirge of Dreadfulness];		break;
+	case $effect[Dirge of Dreadfulness (Remastered)]:
+		mustEquip = $item[velour vaqueros];
+		useSkill = $skill[Dirge of Dreadfulness];
+		break;
 	case $effect[Disco Fever]:					useSkill = $skill[Disco Fever];					break;
 	case $effect[Disco Leer]:					useSkill = $skill[Disco Leer];					break;
 	case $effect[Disco Smirk]:					useSkill = $skill[Disco Smirk];					break;
@@ -520,6 +525,10 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Saucemastery]:					useSkill = $skill[Sauce Contemplation];			break;
 	case $effect[Sauce Monocle]:				useSkill = $skill[Sauce Monocle];				break;
 	case $effect[Savage Beast Inside]:			useItem = $item[jar of &quot;Creole Lady&quot; marrrmalade];break;
+	case $effect[Scariersauce]:
+		mustEquip = $item[velour viscometer];
+		useSkill = $skill[Scarysauce];
+		break;
 	case $effect[Scarysauce]:					useSkill = $skill[Scarysauce];					break;
 	case $effect[Scowl of the Auk]:				useSkill = $skill[Scowl of the Auk];			break;
 	case $effect[Screaming! \ SCREAMING! \ AAAAAAAH!]:useSkill = $skill[Powerful Vocal Chords];			break;
@@ -551,6 +560,10 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Smelly Pants]:					useItem = $item[Stench Powder];					break;
 	case $effect[Smooth Movements]:				useSkill = $skill[Smooth Movement];				break;
 	case $effect[Snarl of the Timberwolf]:		useSkill = $skill[Snarl of the Timberwolf];		break;
+	case $effect[Snarl of Three Timberwolves]:
+		mustEquip = $item[velour voulge];
+		useSkill = $skill[Snarl of the Timberwolf];
+		break;
 	case $effect[Snow Shoes]:					useItem = $item[Snow Cleats];					break;
 	case $effect[Somewhat Poisoned]:			useSkill = $skill[Disco Nap];					break;
 	case $effect[Song of Accompaniment]:		useSkill = $skill[Song of Accompaniment];		break;
@@ -823,6 +836,22 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 			{
 				uneffect(ef);
 			}
+		}
+	}
+	
+	//handling for buffs that must equip something first
+	if(mustEquip != $item[none])
+	{
+		if(!possessEquipment(mustEquip) ||	//we can not wear what we do not have. this checks both inventory and already worn
+		!auto_is_valid(mustEquip) ||	//checks path limitations
+		!can_equip(mustEquip))	//checks if stats are high enough
+		{
+			return false;	//we can not wear this equipment
+		}
+		if(!speculative)
+		{
+			//wear it now before using the buff. do not use the auto_ functions here because we only want to wear it long enough to cast the buff. not change what we wear to the next adventure
+			equip(mustEquip);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -204,12 +204,14 @@ boolean auto_pre_adventure()
 	{
 		uneffect($effect[Spiky Shell]);
 		uneffect($effect[Scarysauce]);
+		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
 	}
 
 	if($locations[Next to that Barrel with something Burning In It, Near an Abandoned Refrigerator, Over where the Old Tires Are, Out by that Rusted-Out Car] contains place)
 	{
 		uneffect($effect[Spiky Shell]);
 		uneffect($effect[Scarysauce]);
+		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
 	}
 
 	if(is_boris())

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -688,6 +688,7 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 		Astral Shell,
 		Hide of Sobek,
 		Spectral Awareness,
+		Scariersauce,
 		Scarysauce,
 		Blessing of the Bird,
 		Blessing of Your Favorite Bird,

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2623,31 +2623,32 @@ cabinet of Dr. Limpieza
 	return false;
 }
 
-boolean[skill] ATSongList()
+boolean[effect] ATSongList()
 {
 	// This List contains ALL AT songs in order from Most to Least Important as to determine what effect to shrug off.
-	boolean[skill] songs = $skills[
+	boolean[effect] songs = $effects[
 		Inigo\'s Incantation of Inspiration,
 		The Ballad of Richie Thingfinder,
 		Chorale of Companionship,
-		The Ode to Booze,
+		Ode to Booze,
 		Ur-Kel\'s Aria of Annoyance,
 		Carlweather\'s Cantata of Confrontation,
 		The Sonata of Sneakiness,
 		Fat Leon\'s Phat Loot Lyric,
-		The Polka of Plenty,
-		The Psalm of Pointiness,
+		Polka of Plenty,
+		Psalm of Pointiness,
 		Aloysius\' Antiphon of Aptitude,
 		Paul\'s Passionate Pop Song,
 		Donho\'s Bubbly Ballad,
 		Prelude of Precision,
 		Elron\'s Explosive Etude,
 		Benetton\'s Medley of Diversity,
+		Dirge of Dreadfulness (Remastered),
 		Dirge of Dreadfulness,
 		Stevedave\'s Shanty of Superiority,
 		Brawnee\'s Anthem of Absorption,
 		Jackasses\' Symphony of Destruction,
-		The Power Ballad of the Arrowsmith,
+		Power Ballad of the Arrowsmith,
 		Cletus\'s Canticle of Celerity,
 		Cringle\'s Curative Carol,
 		The Magical Mojomuscular Melody,
@@ -2696,17 +2697,17 @@ void shrugAT(effect anticipated)
 	}
 
 	int count = 1;
-
+	
 	effect last = $effect[none];
 	foreach ATsong in ATSongList()
 	{
-		if(have_effect(to_effect(ATsong)) > 0)
+		if(have_effect(ATsong) > 0)
 		{
 			count += 1;
 			if(count > maxSongs)
 			{
 				auto_log_info("Shrugging song: " + ATsong, "blue");
-				uneffect(to_effect(ATsong));
+				uneffect(ATsong);
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4099,6 +4099,7 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	{
 		buffMaintain($effect[Spiky Shell]);					//8 MP
 		buffMaintain($effect[Jalape&ntilde;o Saucesphere]);	//5 MP
+		buffMaintain($effect[Scariersauce]);				//10 MP
 		buffMaintain($effect[Scarysauce]);						//10 MP
 	}
 	

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1592,7 +1592,7 @@ void woods_questStart();
 int howLongBeforeHoloWristDrop();
 boolean hasShieldEquipped();
 boolean careAboutDrops(monster mon);
-boolean[skill] ATSongList();
+boolean[effect] ATSongList();
 void shrugAT();
 void shrugAT(effect anticipated);
 string auto_my_path();

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -904,6 +904,7 @@ boolean LA_cs_communityService()
 						buffMaintain($effect[Spiky Shell], 40, 1, 1);
 						buffMaintain($effect[Song of Starch], 132, 1, 1);
 						buffMaintain($effect[Rage of the Reindeer], 42, 1, 1);
+						buffMaintain($effect[Scariersauce], 42, 1, 1);
 						buffMaintain($effect[Scarysauce], 42, 1, 1);
 						buffMaintain($effect[Disco Fever], 42, 1, 1);
 

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -464,6 +464,7 @@ boolean L13_heavyrains_towerFinal()
 	
 	//buff up before the boss
 	buffMaintain($effect[Benetton's Medley of Diversity]);			//15 prismatic weapon dmg.
+	buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);		//36 spooky spell & weapon dmg
 	buffMaintain($effect[Dirge of Dreadfulness]);					//12 spooky weapon dmg
 	buffMaintain($effect[Boner Battalion]);						//32-33 sleaze and spooky passive dmg
 	buffMaintain($effect[Frigidalmatian]);							//40 (due to cap) cold passive dmg

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -68,6 +68,7 @@ boolean LX_koeInvaderHandler()
 
 	buffMaintain($effect[Astral Shell], 10, 1, 1);
 	buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
+	buffMaintain($effect[Scariersauce], 10, 1, 1);
 	buffMaintain($effect[Scarysauce], 10, 1, 1);
 
 	resetMaximize();

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -61,7 +61,9 @@ boolean auto_tavern()
 		}
 		else
 		{
+			buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);
 			buffMaintain($effect[Dirge of Dreadfulness], 20, 1, 1);
+			buffMaintain($effect[Snarl of Three Timberwolves]);
 			buffMaintain($effect[Snarl of the Timberwolf], 20, 1, 1);
 		}
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -544,6 +544,7 @@ boolean L9_aBooPeak()
 
 			buffMaintain($effect[Astral Shell], 10, 1, 1);
 			buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
+			buffMaintain($effect[Scariersauce], 10, 1, 1);
 			buffMaintain($effect[Scarysauce], 10, 1, 1);
 			buffMaintain($effect[Spookypants]);
 			buffMaintain($effect[Hyphemariffic]);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -514,8 +514,10 @@ boolean L13_towerNSContests()
 				if(crowd3Insufficient()) auto_beachCombHead("spooky");
 				if(crowd3Insufficient()) buffMaintain($effect[Spooky Hands]);
 				if(crowd3Insufficient()) buffMaintain($effect[Spooky Weapon]);
+				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);
 				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness], 10, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Intimidating Mien], 15, 1, 1);
+				if(crowd3Insufficient()) buffMaintain($effect[Snarl of Three Timberwolves]);
 				if(crowd3Insufficient()) buffMaintain($effect[Snarl of the Timberwolf], 10, 1, 1);
 				break;
 			}
@@ -1188,6 +1190,11 @@ boolean L13_towerNSTower()
 				}
 			}
 			
+			buffMaintain($effect[Scariersauce]);
+			if(have_effect($effect[Scariersauce]) > 0)
+			{
+				sourcesReactive += 1;
+			}
 			if(have_skill($skill[Scarysauce]))
 			{
 				buffMaintain($effect[Scarysauce]);
@@ -1404,6 +1411,11 @@ boolean L13_towerNSTower()
 		if(my_class() != $class[Sauceror] && !have_skill($skill[Garbage Nova]))
 		{
 			set_property("auto_getBoningKnife", true);		//can not towerkill. get boning knife instead
+		}
+		if(!uneffect($effect[Scariersauce]))
+		{
+			//passive dmg prevents tower kill. we can not uneffect it so get boning knife instead
+			set_property("auto_getBoningKnife", true);
 		}
 		
 		if(get_property("auto_getBoningKnife").to_boolean())	//grab boning knife if we deemed it necessary


### PR DESCRIPTION
* velour buffs: scariersauce, Dirge of Dreadfulness (Remastered), Snarl of Three Timberwolves
* use the velour skills when needed
* uneffect the velour skills when needed
* boolean[skill] ATSongList() -> boolean[effect] ATSongList()
  * this was needed to allow us to uneffect an accordion song when two different songs key off of the same skill. such as dirge of dreadfulness and its remastered version.

fixes #992

## How Has This Been Tested?

ash calls. see below

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
