### PR TITLE
facecheck string -> effect

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -849,7 +849,7 @@ boolean buffMaintain(effect buff)
 
 // Checks to see if we are already wearing a facial expression before using buffMaintain
 //	if an expression is REQUIRED force it using buffMaintain
-boolean auto_faceCheck(string face)
+boolean auto_faceCheck(effect face)
 {
 	boolean[effect] FacialExpressions = $effects[Snarl of the Timberwolf, Scowl of the Auk, Stiff Upper Lip, Patient Smile, Quiet Determination, Arched Eyebrow of the Archmage, Wizard Squint, Quiet Judgement, Icy Glare, Wry Smile, Disco Leer, Disco Smirk, Suspicious Gaze, Knowing Smile, Quiet Desperation, Inscrutable Gaze];
 	boolean CanEmote = true;
@@ -864,7 +864,7 @@ boolean auto_faceCheck(string face)
 
 	if(CanEmote)
 	{
-		buffMaintain(to_effect(face));
+		buffMaintain(face);
 	}
 	else
 	{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -889,24 +889,24 @@ boolean auto_post_adventure()
 		// +Stat expressions based on mainstat
 		if(my_primestat() == $stat[Muscle])
 		{
-			auto_faceCheck("Patient Smile");
+			auto_faceCheck($effect[Patient Smile]);
 		}
 		if(my_primestat() == $stat[Moxie])
 		{
-			auto_faceCheck("Knowing Smile");
+			auto_faceCheck($effect[Knowing Smile]);
 		}
 		if(my_primestat() == $stat[Mysticality])
 		{
 			// If Gaze succeeds Smile will fail the check and vice versa
-			auto_faceCheck("Inscrutable Gaze");
-			auto_faceCheck("Wry Smile");
+			auto_faceCheck($effect[Inscrutable Gaze]);
+			auto_faceCheck($effect[Wry Smile]);
 		}
 
 		// Catch-all Expressions in decending order of importance (in case we could not get a stat specific one)
-		auto_faceCheck("Inscrutable Gaze");
-		auto_faceCheck("Wry Smile");
-		auto_faceCheck("Patient Smile");
-		auto_faceCheck("Knowing Smile");
+		auto_faceCheck($effect[Inscrutable Gaze]);
+		auto_faceCheck($effect[Wry Smile]);
+		auto_faceCheck($effect[Patient Smile]);
+		auto_faceCheck($effect[Knowing Smile]);
 
 		if(my_meat() > meatReserve()+5000)		//these are only worth it if you have lots of excess meat
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1160,7 +1160,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean speculative);
 boolean buffMaintain(effect buff, int mp_min, int casts, int turns);
 boolean buffMaintain(effect buff);
-boolean auto_faceCheck(string face);
+boolean auto_faceCheck(effect face);
 
 ########################################################################################################
 //Defined in autoscend/auto_consume.ash


### PR DESCRIPTION
remove the use of to_effect() on the string and instead send $effect[] in the first place. This allows for automatic error detection and correction

## How Has This Been Tested?

ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
