### PR TITLE
removed [astral energy drink] from license to adventure

### DIFF
--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -292,15 +292,6 @@ boolean bond_buySkills()
 				points -= 3;
 			}
 		}
-		else if(!get_property("bondSpleen").to_boolean() && ((item_amount($item[Astral Energy Drink]) >= 1) || (item_amount($item[Carton Of Astral Energy Drinks]) > 0)))
-		{
-			if(points >= 4)
-			{
-				auto_log_info("Getting bondSpleen", "blue");
-				page = visit_url("choice.php?whichchoice=1259&pwd=&option=1&k=17&w=s");
-				points -= 4;
-			}
-		}
 		else if(!get_property("bondDesert").to_boolean() && (get_property("desertExploration").to_int() < 100))
 		{
 			if(points >= 5)


### PR DESCRIPTION
* in this old path we have code for consuming the old [astral energy drink] for adventures.
the code was not doing anything since astral energy drinks have been removed from the game.
in 2022 a different item with the same name was added to kol and mafia automatically assumes you are referencing the newer item. deleted that bit of code for using it as it inapplicable (their usage method is completely different and we do not want to consume the new astral energy drink at that spot).
* gets rid of 6 lines of mafia nag messages

see #995

## How Has This Been Tested?

validation

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
