### PR TITLE
nc504 fix

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_02.ash
+++ b/RELEASE/scripts/autoscend/quests/level_02.ash
@@ -37,7 +37,7 @@ void spookyForestChoiceHandler(int choice)
 	}
 	else if(choice == 504) // Tree's Last Stand (The Spooky Forest)
 	{
-		//when selling [bar skin] we must immediately queue up the next action(s).
+		//when selling [bar skin] or buying [spooky sapling] we must immediately queue up the next action(s).
 		//otherwise mafia will think our NC handling failed and fallback to the mafia handling.
 		if(item_amount($item[bar skin]) > 1)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_02.ash
+++ b/RELEASE/scripts/autoscend/quests/level_02.ash
@@ -37,6 +37,8 @@ void spookyForestChoiceHandler(int choice)
 	}
 	else if(choice == 504) // Tree's Last Stand (The Spooky Forest)
 	{
+		//when selling [bar skin] we must immediately queue up the next action.
+		//otherwise mafia will think our NC handling failed and fallback to the mafia handling.
 		if(item_amount($item[bar skin]) > 1)
 		{
 			run_choice(2); // sell all bar skins (doesn't leave choice)
@@ -45,7 +47,7 @@ void spookyForestChoiceHandler(int choice)
 		{
 			run_choice(1); // sell bar skin (doesn't leave choice)
 		}
-		else if(!hidden_temple_unlocked() && item_amount($item[Spooky Sapling]) == 0 && my_meat() > 100)
+		if(!hidden_temple_unlocked() && item_amount($item[Spooky Sapling]) == 0 && my_meat() > 100)
 		{
 			run_choice(3); // get the spooky sapling (doesn't leave choice)
 		}

--- a/RELEASE/scripts/autoscend/quests/level_02.ash
+++ b/RELEASE/scripts/autoscend/quests/level_02.ash
@@ -37,7 +37,7 @@ void spookyForestChoiceHandler(int choice)
 	}
 	else if(choice == 504) // Tree's Last Stand (The Spooky Forest)
 	{
-		//when selling [bar skin] we must immediately queue up the next action.
+		//when selling [bar skin] we must immediately queue up the next action(s).
 		//otherwise mafia will think our NC handling failed and fallback to the mafia handling.
 		if(item_amount($item[bar skin]) > 1)
 		{
@@ -51,10 +51,7 @@ void spookyForestChoiceHandler(int choice)
 		{
 			run_choice(3); // get the spooky sapling (doesn't leave choice)
 		}
-		else
-		{
-			run_choice(4); // leave the choice
-		}
+		run_choice(4); // leave the choice
 	}
 	else if(choice == 505) // Consciousness of a Stream (The Spooky Forest)
 	{


### PR DESCRIPTION
fix #999
when selling [bar skin] or buying [spooky sapling] we must immediately queue up the next action.
otherwise mafia will think our NC handling failed and fallback to the mafia handling.

## How Has This Been Tested?

untested

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
