### PR TITLE
acquire 11-leaf clovers from hermit

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -923,7 +923,7 @@ void initializeDay(int day)
 				pulverizeThing($item[Hairpiece On Fire]);
 				pulverizeThing($item[Vicar\'s Tutu]);
 			}
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && isUnclePAvailable() && ((my_meat() > npc_price($item[Antique Accordion])) && (npc_price($item[Antique Accordion]) != 0)) && (auto_predictAccordionTurns() < 10) && !(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_plumber() || !in_glover()))
 			{
 				buyUpTo(1, $item[Antique Accordion]);
@@ -965,7 +965,7 @@ void initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 3)
 		{
-			while(acquireHermitItem($item[Ten-leaf Clover]));
+			while(acquireHermitItem($item[11-leaf Clover]));
 
 			picky_pulls();
 		}
@@ -974,7 +974,7 @@ void initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 4)
 		{
-			while(acquireHermitItem($item[Ten-leaf Clover]));
+			while(acquireHermitItem($item[11-leaf Clover]));
 		}
 	}
 	if(day >= 2)

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -477,11 +477,7 @@ boolean acquireHermitItem(item it)
 	{
 		return false;
 	}
-	if(it == $item[Disassembled Clover])
-	{
-		it = $item[Ten-leaf Clover];
-	}
-	if(!($items[Banjo Strings, Catsup, Chisel, Figurine of an Ancient Seal, Hot Buttered Roll, Jaba&ntilde;ero Pepper, Ketchup, Petrified Noodles, Seal Tooth, Ten-Leaf Clover, Volleyball, Wooden Figurine] contains it))
+	if(!($items[Banjo Strings, Catsup, Chisel, Figurine of an Ancient Seal, Hot Buttered Roll, Jaba&ntilde;ero Pepper, Ketchup, Petrified Noodles, Seal Tooth, 11-Leaf Clover, Volleyball, Wooden Figurine] contains it))
 	{
 		return false;
 	}
@@ -499,29 +495,9 @@ boolean acquireHermitItem(item it)
 	{
 		if((item_amount($item[Worthless Trinket]) + item_amount($item[Worthless Gewgaw]) + item_amount($item[Worthless Knick-knack])) > 0)
 		{
-			if(it == $item[Ten-Leaf Clover])
-			{
-				have = item_amount($item[Disassembled Clover]);
-			}
 			if(!hermit(1, it))
 			{
 				return false;
-			}
-			if(it == $item[Ten-Leaf Clover])
-			{
-				if(have == item_amount($item[Disassembled Clover]))
-				{
-					return false;
-				}
-				else if((have + 1) == item_amount($item[Disassembled Clover]))
-				{
-					return true;
-				}
-				else
-				{
-					auto_log_warning("Invalid clover count from hermit behavior, reporting failure.", "red");
-					return false;
-				}
 			}
 		}
 		else

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -650,7 +650,7 @@ boolean doBedtime()
 
 	//We are committing to end of day now...
 	getSpaceJelly();
-	while(acquireHermitItem($item[Ten-leaf Clover]));
+	while(acquireHermitItem($item[11-leaf Clover]));
 
 	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel. also keep leftover charges for tomorrow.
 	loveTunnelAcquire(true, $stat[none], true, 3, true, 1);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -94,7 +94,7 @@ void boris_initializeDay(int day)
 			{
 				acquireHermitItem($item[Seal Tooth]);
 			}
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
 			pullXWhenHaveY(whatHiMein(), 1, 0);
@@ -104,7 +104,7 @@ void boris_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 3)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 3);
 		}
 	}
@@ -112,7 +112,7 @@ void boris_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 4)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 4);
 		}
 	}

--- a/RELEASE/scripts/autoscend/paths/avatar_of_jarlsberg.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_jarlsberg.ash
@@ -44,7 +44,7 @@ void jarlsberg_initializeDay(int day)
 			{
 				acquireHermitItem($item[Seal Tooth]);
 			}
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0); 
 		}
@@ -53,7 +53,7 @@ void jarlsberg_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 3)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 3);
 		}
 	}
@@ -61,7 +61,7 @@ void jarlsberg_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 4)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 4);
 		}
 	}

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -45,7 +45,7 @@ void pete_initializeDay(int day)
 			{
 				acquireHermitItem($item[Seal Tooth]);
 			}
-			while(acquireHermitItem($item[Ten-leaf Clover]));
+			while(acquireHermitItem($item[11-leaf Clover]));
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
 			pullXWhenHaveY(whatHiMein(), 1, 0);
@@ -55,7 +55,7 @@ void pete_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 3)
 		{
-			while(acquireHermitItem($item[Ten-leaf Clover]));
+			while(acquireHermitItem($item[11-leaf Clover]));
 			set_property("auto_day_init", 3);
 		}
 	}
@@ -63,7 +63,7 @@ void pete_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 4)
 		{
-			while(acquireHermitItem($item[Ten-leaf Clover]));
+			while(acquireHermitItem($item[11-leaf Clover]));
 			set_property("auto_day_init", 4);
 		}
 	}

--- a/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
+++ b/RELEASE/scripts/autoscend/paths/nuclear_autumn.ash
@@ -64,7 +64,7 @@ void nuclear_initializeDay(int day)
 			{
 				acquireHermitItem($item[Seal Tooth]);
 			}
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 			pullXWhenHaveY($item[blackberry galoshes], 1, 0);
 			pullXWhenHaveY(whatHiMein(), 1, 0);
@@ -74,7 +74,7 @@ void nuclear_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 3)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 3);
 		}
 	}
@@ -82,7 +82,7 @@ void nuclear_initializeDay(int day)
 	{
 		if(get_property("auto_day_init").to_int() < 4)
 		{
-			while(acquireHermitItem($item[Ten-Leaf Clover]));
+			while(acquireHermitItem($item[11-Leaf Clover]));
 			set_property("auto_day_init", 4);
 		}
 	}


### PR DESCRIPTION
# Description

Attempt to buy 11-leaf clovers from hermit instead of ten-leaf. Didn't touch logic as to when we buy. Likely should since clovers are much more valuable now and want to grab all 3 at beginning of every day.

In support of #995 

## How Has This Been Tested?

cli commands

```
> ash import<autoscend.ash> acquireHermitItem($item[11-Leaf Clover])

Changing "ed" to "Ed the Undying" would get rid of this message. (zlib.ash, line 503, char 29 to char 31)
[INFO] Hermit acquistion of: 11-leaf clover
Purchasing chewing gum on a string (1 @ 50)...
You spent 50 Meat
You acquire an item: chewing gum on a string
Purchases complete.
Using 1 chewing gum on a string...
You acquire an item: worthless knick-knack
Finished using 1 chewing gum on a string.
Visiting the Hermit...
You acquire an item: 11-leaf clover
Hermit successfully looted!
Returned: true
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
