### PR TITLE
hotfix: temporary workaround for #1011

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -11,7 +11,9 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 
 	//use industrial fire extinguisher zone specific skills
 	string extinguisherSkill = auto_FireExtinguisherCombatString(my_location());
-	if(extinguisherSkill != "" && have_equipped($item[industrial fire extinguisher]))
+	if(extinguisherSkill != "" && have_equipped($item[industrial fire extinguisher])
+	//below is temp workaround for https://github.com/Loathing-Associates-Scripting-Society/autoscend/issues/1011
+	&& enemy != $monster[screambat])
 	{
 		handleTracker(enemy, to_skill(substring(extinguisherSkill, 6)), "auto_otherstuff");
 		return extinguisherSkill;


### PR DESCRIPTION
disable using fire extinguisher against screambat as a temporary workaround for the issue where combat fails against screambats if you have fire extinguisher

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
