### PR TITLE
HotFix - Don't Mark CBB Skills/Item as used if only speculating using them

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -20,7 +20,7 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 			set_property("auto_bowledAtAlley", my_ascensions());
 			auto_log_info("Cosmic Bowling Ball used at Hidden Bowling Alley to adavnce quest.");
 		}	
-		return useItem($item[Cosmic Bowling Ball]);
+		return useItem($item[Cosmic Bowling Ball],!speculation);
 	}
 
 	// determine if we want more stats
@@ -29,12 +29,12 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 		//increase stats if we are power leveling
 		if(isAboutToPowerlevel())
 		{
-			return useSkill($skill[Bowl Sideways]);
+			return useSkill($skill[Bowl Sideways],!speculation);
 		}
 		//increase stats if we are farming Ka as Ed
 		if(get_property("_auto_farmingKaAsEd").to_boolean())
 		{
-			return useSkill($skill[Bowl Sideways]);
+			return useSkill($skill[Bowl Sideways],!speculation);
 		}
 	}
 
@@ -47,14 +47,14 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 		{
 			if(item_drop_modifier() < itemNeed._float)
 			{
-				return useSkill($skill[Bowl Straight Up]);
+				return useSkill($skill[Bowl Straight Up],!speculation);
 			}
 		}
 
 		//increase meat bonus if doing nuns
 		if(place == $location[The Themthar Hills])
 		{
-			return useSkill($skill[Bowl Straight Up]);
+			return useSkill($skill[Bowl Straight Up],!speculation);
 		}	
 	}
 


### PR DESCRIPTION
# Description

auto_bowlingBallCombatString is used both to determine if a skill/item will be use speculatively and then if it will be used, actually uses them. Speculation was incorrectly marking the skill/item as used, so couldn't be cast when we wanted it to be

Relates to #997 

## How Has This Been Tested?

Validates and ran a day. Confirmed skills used as expected

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
