### PR TITLE
Remove adv limit warning in daily dungeon if auto_forceFatLootToken is true

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1270,6 +1270,11 @@ boolean adventureFailureHandler()
 		{
 			tooManyAdventures = false;
 		}
+
+		if ($locations[The Daily Dungeon] contains place && get_property("auto_forceFatLootToken").to_boolean())
+		{
+			tooManyAdventures = false;
+		}
 		
 		boolean can_powerlevel_stench = elementalPlanes_access($element[stench]) && auto_have_skill($skill[Summon Smithsness]) && get_property("auto_beatenUpCount").to_int() == 0;
 		boolean has_powerlevel_iotm = can_powerlevel_stench || elementalPlanes_access($element[spooky]) || elementalPlanes_access($element[cold]) || elementalPlanes_access($element[sleaze]) || elementalPlanes_access($element[hot]) || neverendingPartyAvailable();


### PR DESCRIPTION
# Description

Reported in Discord that adv limit abort was triggered for Daily Dungeon when auto_forceFatLootToken was true. In hardcore runs on accounts that don't have the cube, it is expected to reach the adv limit in this situation.

Removed adv limit abort in Daily Dungeon if auto_forceFatLootToken is true

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
