### PR TITLE
Skip some unnecessary operations

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -786,13 +786,7 @@ void initializeDay(int day)
 						buyUpTo(1, $item[Toy Accordion]);
 					}
 				}
-				if(!possessEquipment($item[Turtle Totem]))
-				{
-					if(have_skill($skill[Empathy of the Newt]) || have_skill($skill[Astral Shell]) || have_skill($skill[Ghostly Shell]) || have_skill($skill[Tenacity of the Snapper]) || have_skill($skill[Spiky Shell]) || have_skill($skill[Reptilian Fortitude]) || have_skill($skill[Jingle Bells]) || have_skill($skill[Curiosity of Br\'er Tarrypin]))
-					{
-						acquireGumItem($item[Turtle Totem]);
-					}
-				}
+				acquireTotem();
 				if(!possessEquipment($item[Saucepan]))
 				{
 					acquireGumItem($item[Saucepan]);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -788,7 +788,10 @@ void initializeDay(int day)
 				}
 				if(!possessEquipment($item[Turtle Totem]))
 				{
-					acquireGumItem($item[Turtle Totem]);
+					if(have_skill($skill[Empathy of the Newt]) || have_skill($skill[Astral Shell]) || have_skill($skill[Ghostly Shell]) || have_skill($skill[Tenacity of the Snapper]) || have_skill($skill[Spiky Shell]) || have_skill($skill[Reptilian Fortitude]) || have_skill($skill[Jingle Bells]) || have_skill($skill[Curiosity of Br\'er Tarrypin]))
+					{
+						acquireGumItem($item[Turtle Totem]);
+					}
 				}
 				if(!possessEquipment($item[Saucepan]))
 				{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -449,8 +449,15 @@ boolean acquireTotem()
 		}
 	}
 
-	if(auto_have_skill($skill[Empathy of the Newt]) || auto_have_skill($skill[Astral Shell]) || auto_have_skill($skill[Ghostly Shell]) || auto_have_skill($skill[Tenacity of the Snapper]) || 
-	auto_have_skill($skill[Spiky Shell]) || auto_have_skill($skill[Reptilian Fortitude]) || auto_have_skill($skill[Jingle Bells]) || auto_have_skill($skill[Curiosity of Br\'er Tarrypin]))
+	boolean want_totem = false;
+	foreach sk in $skills[Empathy of the Newt, Astral Shell, Ghostly Shell, Tenacity of the Snapper, Spiky Shell, Reptilian Fortitude, Jingle Bells, Curiosity of Br\'er Tarrypin]
+	{
+		if(auto_have_skill(sk))
+		{
+			want_totem = true;
+		}
+	}
+	if(want_totem)
 	{	
 		//try fishing in the sewer for a turtle totem
 		if(acquireGumItem($item[turtle totem]))

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -449,14 +449,17 @@ boolean acquireTotem()
 		}
 	}
 
-	//try fishing in the sewer for a turtle totem
-	
-	if(acquireGumItem($item[turtle totem]))
-	{
-		return true;
+	if(auto_have_skill($skill[Empathy of the Newt]) || auto_have_skill($skill[Astral Shell]) || auto_have_skill($skill[Ghostly Shell]) || auto_have_skill($skill[Tenacity of the Snapper]) || 
+	auto_have_skill($skill[Spiky Shell]) || auto_have_skill($skill[Reptilian Fortitude]) || auto_have_skill($skill[Jingle Bells]) || auto_have_skill($skill[Curiosity of Br\'er Tarrypin]))
+	{	
+		//try fishing in the sewer for a turtle totem
+		if(acquireGumItem($item[turtle totem]))
+		{
+			return true;
+		}
 	}
 	
-	//still could not get a totem. Give up
+	//did not get a totem. Give up
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -111,7 +111,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Ashen]:					useItem = $item[pile of ashes];						break;
 	case $effect[Ashen Burps]:					useItem = $item[ash soda];						break;
 	case $effect[Astral Shell]:
-		if(have_skill($skill[Astral Shell]) && acquireTotem())
+		if(auto_have_skill($skill[Astral Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Astral Shell];
 		}																						break;
@@ -204,7 +204,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Contemptible Emanations]:		useItem = $item[Cologne of Contempt];			break;
 	case $effect[The Cupcake of Wrath]:			useItem = $item[Green-Frosted Astral Cupcake];	break;
 	case $effect[Curiosity of Br\'er Tarrypin]:
-		if(pathHasFamiliar() && have_skill($skill[Curiosity of Br\'er Tarrypin]) && acquireTotem())
+		if(pathHasFamiliar() && auto_have_skill($skill[Curiosity of Br\'er Tarrypin]) && acquireTotem())
 		{
 			useSkill = $skill[Curiosity of Br\'er Tarrypin];
 		}																						break;
@@ -236,7 +236,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Eldritch Alignment]:			useItem = $item[Eldritch Alignment Spray];		break;
 	case $effect[Elemental Saucesphere]:		useSkill = $skill[Elemental Saucesphere];		break;
 	case $effect[Empathy]:
-		if(pathHasFamiliar() && have_skill($skill[Empathy of the Newt]) && acquireTotem())
+		if(pathHasFamiliar() && auto_have_skill($skill[Empathy of the Newt]) && acquireTotem())
 		{
 			useSkill = $skill[Empathy of the Newt];
 		}																						break;
@@ -302,7 +302,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Funky Coal Patina]:			useItem = $item[Coal Dust];						break;
 	case $effect[Gelded]:						useItem = $item[Chocolate Filthy Lucre];		break;
 	case $effect[Ghostly Shell]:
-		if(have_skill($skill[Ghostly Shell]) && acquireTotem())
+		if(auto_have_skill($skill[Ghostly Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Ghostly Shell];
 		}																						break;
@@ -364,7 +364,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Jackasses\' Symphony of Destruction]:useSkill = $skill[Jackasses\' Symphony of Destruction];	break;
 	case $effect[Jalape&ntilde;o Saucesphere]:	useSkill = $skill[Jalape&ntilde;o Saucesphere];	break;
 	case $effect[Jingle Jangle Jingle]:
-		if(have_skill($skill[Jingle Bells]) && acquireTotem())
+		if(auto_have_skill($skill[Jingle Bells]) && acquireTotem())
 		{
 			useSkill = $skill[Jingle Bells];
 		}																						break;
@@ -511,7 +511,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Red Lettered]:					useItem = $item[Red Letter];					break;
 	case $effect[Red Door Syndrome]:			useItem = $item[Can of Black Paint];			break;
 	case $effect[Reptilian Fortitude]:
-		if(have_skill($skill[Reptilian Fortitude]) && acquireTotem())
+		if(auto_have_skill($skill[Reptilian Fortitude]) && acquireTotem())
 		{
 			useSkill = $skill[Reptilian Fortitude];
 		}																						break;
@@ -587,7 +587,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Spice Haze]:					useSkill = $skill[Bind Spice Ghost];			break;
 	case $effect[Spiky Hair]:					useItem = $item[Super-Spiky Hair Gel];			break;
 	case $effect[Spiky Shell]:
-		if(have_skill($skill[Spiky Shell]) && acquireTotem())
+		if(auto_have_skill($skill[Spiky Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Spiky Shell];
 		}																						break;
@@ -630,7 +630,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Taunt of Horus]:				useItem = $item[Talisman of Horus];				break;
 	case $effect[Temporary Lycanthropy]:		useItem = $item[Blood of the Wereseal];			break;
 	case $effect[Tenacity of the Snapper]:
-		if(have_skill($skill[Tenacity of the Snapper]) && acquireTotem())
+		if(auto_have_skill($skill[Tenacity of the Snapper]) && acquireTotem())
 		{
 			useSkill = $skill[Tenacity of the Snapper];
 		}																						break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -111,7 +111,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Ashen]:					useItem = $item[pile of ashes];						break;
 	case $effect[Ashen Burps]:					useItem = $item[ash soda];						break;
 	case $effect[Astral Shell]:
-		if(acquireTotem())
+		if(have_skill($skill[Astral Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Astral Shell];
 		}																						break;
@@ -204,7 +204,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Contemptible Emanations]:		useItem = $item[Cologne of Contempt];			break;
 	case $effect[The Cupcake of Wrath]:			useItem = $item[Green-Frosted Astral Cupcake];	break;
 	case $effect[Curiosity of Br\'er Tarrypin]:
-		if(acquireTotem())
+		if(pathHasFamiliar() && have_skill($skill[Curiosity of Br\'er Tarrypin]) && acquireTotem())
 		{
 			useSkill = $skill[Curiosity of Br\'er Tarrypin];
 		}																						break;
@@ -236,7 +236,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Eldritch Alignment]:			useItem = $item[Eldritch Alignment Spray];		break;
 	case $effect[Elemental Saucesphere]:		useSkill = $skill[Elemental Saucesphere];		break;
 	case $effect[Empathy]:
-		if(pathHasFamiliar() && acquireTotem())
+		if(pathHasFamiliar() && have_skill($skill[Empathy of the Newt]) && acquireTotem())
 		{
 			useSkill = $skill[Empathy of the Newt];
 		}																						break;
@@ -302,7 +302,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Funky Coal Patina]:			useItem = $item[Coal Dust];						break;
 	case $effect[Gelded]:						useItem = $item[Chocolate Filthy Lucre];		break;
 	case $effect[Ghostly Shell]:
-		if(acquireTotem())
+		if(have_skill($skill[Ghostly Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Ghostly Shell];
 		}																						break;
@@ -364,7 +364,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Jackasses\' Symphony of Destruction]:useSkill = $skill[Jackasses\' Symphony of Destruction];	break;
 	case $effect[Jalape&ntilde;o Saucesphere]:	useSkill = $skill[Jalape&ntilde;o Saucesphere];	break;
 	case $effect[Jingle Jangle Jingle]:
-		if(acquireTotem())
+		if(have_skill($skill[Jingle Bells]) && acquireTotem())
 		{
 			useSkill = $skill[Jingle Bells];
 		}																						break;
@@ -511,7 +511,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Red Lettered]:					useItem = $item[Red Letter];					break;
 	case $effect[Red Door Syndrome]:			useItem = $item[Can of Black Paint];			break;
 	case $effect[Reptilian Fortitude]:
-		if(acquireTotem())
+		if(have_skill($skill[Reptilian Fortitude]) && acquireTotem())
 		{
 			useSkill = $skill[Reptilian Fortitude];
 		}																						break;
@@ -587,7 +587,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Spice Haze]:					useSkill = $skill[Bind Spice Ghost];			break;
 	case $effect[Spiky Hair]:					useItem = $item[Super-Spiky Hair Gel];			break;
 	case $effect[Spiky Shell]:
-		if(acquireTotem())
+		if(have_skill($skill[Spiky Shell]) && acquireTotem())
 		{
 			useSkill = $skill[Spiky Shell];
 		}																						break;
@@ -630,7 +630,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Taunt of Horus]:				useItem = $item[Talisman of Horus];				break;
 	case $effect[Temporary Lycanthropy]:		useItem = $item[Blood of the Wereseal];			break;
 	case $effect[Tenacity of the Snapper]:
-		if(acquireTotem())
+		if(have_skill($skill[Tenacity of the Snapper]) && acquireTotem())
 		{
 			useSkill = $skill[Tenacity of the Snapper];
 		}																						break;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1472,7 +1472,7 @@ int auto_spleenFamiliarAdvItemsPossessed()
 	
 	foreach it in $items[Unconscious Collective Dream Jar, Grim Fairy Tale, Powdered Gold, Groose Grease, beastly paste, bug paste, cosmic paste, oily paste, demonic paste, gooey paste, elemental paste, Crimbo paste, fishy paste, goblin paste, hippy paste, hobo paste, indescribably horrible paste, greasy paste, Mer-kin paste, orc paste, penguin paste, pirate paste, chlorophyll paste, slimy paste, ectoplasmic paste, strange paste, Agua De Vida]
 	{
-		if(auto_is_valid(it) && mall_price(it) < get_property("autoBuyPriceLimit").to_int())	//even when not mallbuying them we do not want to use exceptionally expensive items
+		if(item_amount(it) > 0 && auto_is_valid(it) && mall_price(it) < get_property("autoBuyPriceLimit").to_int())	//even when not mallbuying them we do not want to use exceptionally expensive items
 		{
 			spleenFamiliarAdvItemsCount += item_amount(it);
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2648,6 +2648,11 @@ void shrugAT(effect anticipated)
 		//We have the effect, we do not need to shrug it, just let it propagate.
 		return;
 	}
+	
+	if(!have_skill(to_skill(anticipated)))
+	{	//We don't know that song anyway
+		return;
+	}
 
 	int maxSongs = 3;
 	if(have_equipped($item[Brimstone Beret]) || have_equipped($item[Operation Patriot Shield]) || have_equipped($item[Plexiglass Pendant]) || have_equipped($item[Scandalously Skimpy Bikini]) || have_equipped($item[Sombrero De Vida]) || have_equipped($item[Super-Sweet Boom Box]))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2649,7 +2649,7 @@ void shrugAT(effect anticipated)
 		return;
 	}
 	
-	if(!have_skill(to_skill(anticipated)))
+	if(!auto_have_skill(to_skill(anticipated)))
 	{	//We don't know that song anyway
 		return;
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -532,7 +532,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Curse Of Vacation];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Show Them Your Ring]) : possessEquipment($item[Mafia middle finger ring])) && !get_property("_mafiaMiddleFingerRingUsed").to_boolean() && (my_mp() >= mp_cost($skill[Show Them Your Ring])))
+	if((inCombat ? auto_have_skill($skill[Show Them Your Ring]) : possessEquipment($item[Mafia middle finger ring])) && can_equip($item[Mafia middle finger ring]) && !get_property("_mafiaMiddleFingerRingUsed").to_boolean() && (my_mp() >= mp_cost($skill[Show Them Your Ring])))
 	{
 		return "skill " + $skill[Show Them Your Ring];
 	}


### PR DESCRIPTION
auto_consume.ash
avoid unnecessary mall_price searches by auto_spleenFamiliarAdvItemsPossessed

auto_buff.ash
autoscend.ash
don't acquireTotem to cast a skill you don't have

combat/auto_combat_util.ash
don't pick middle finger ring banish when muscle too low for can_equip($item[Mafia middle finger ring])

auto_util.ash
skip shrugAT when anticipated song is not known, skips many INFO messages like "I think we're good to go to apply Carlweather's Cantata of Confrontation" when you don't have the skill
assumes it's not asking for a song from another player out of ronin, I don't find autoscend doing that and the same is already assumed for the 6 avatar classes skipped by shrugAT


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
