### PR TITLE
gremlin and flyering fixes

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -99,7 +99,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 			boolean gremlinTakesDamage = (isAttackFamiliar(my_familiar()) || (monster_hp() < (0.8*monster_hp(enemy))));
 			if(!gremlinTakesDamage && round < 10 && stunner != $skill[none])
 			{
-				combat_status_add(",stunned");
+				combat_status_add("stunned");
 				return useSkill(stunner);
 			}
 		}
@@ -108,7 +108,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	{
 		if(stunner != $skill[none] && !stunned)
 		{
-			combat_status_add(",stunned");
+			combat_status_add("stunned");
 			return useSkill(stunner);
 		}
 		if (isActuallyEd())

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -82,23 +82,46 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Good Medicine]);
 	}
 
-	if (my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
+	item flyer = $item[Rock Band Flyers];
+	if(auto_warSide() == "hippy")
 	{
-		if (canUse($item[Rock Band Flyers]) && get_property("flyeredML").to_int() < 10000)
+		flyer = $item[Jam Band Flyers];
+	}
+	skill stunner = getStunner(enemy);
+	boolean stunned = contains_text(combatState, "stunned");
+	
+	if (get_property("auto_gremlinMoly").to_boolean() && !canSurvive(20) && !stunned)		//don't flyer tool gremlins if it's dangerous to survive them for long
+	{
+		if(monster_attack() > ( my_buffedstat($stat[moxie]) + 10) && !canSurvive(10) && haveUsed($skill[Curse Of Weaksauce]))
 		{
-			if (isActuallyEd())
+			//if after all deleveling it's still too strong to safely stasis let weaksauce delevel it more in exchange for a few turns
+			//except if stuck with an attack familiar or unforeseen passive damage effects that can kill the gremlin
+			boolean gremlinTakesDamage = (isAttackFamiliar(my_familiar()) || (monster_hp() < (0.8*monster_hp(enemy))));
+			if(!gremlinTakesDamage && round < 10 && stunner != $skill[none])
 			{
-				set_property("auto_edStatus", "UNDYING!");
+				set_property("auto_combatHandler", get_property("auto_combatHandler")+",stunned");
+				return useSkill(stunner);
 			}
-			return useItem($item[Rock Band Flyers]);
 		}
-		if(canUse($item[Jam Band Flyers]) && get_property("flyeredML").to_int() < 10000)
+	}
+	else if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
+	{
+		if(stunner != $skill[none] && !stunned)
 		{
-			if (isActuallyEd())
-			{
-				set_property("auto_edStatus", "UNDYING!");
-			}
-			return useItem($item[Jam Band Flyers]);
+			set_property("auto_combatHandler", get_property("auto_combatHandler")+",stunned");
+			return useSkill(stunner);
+		}
+		if (isActuallyEd())
+		{
+			set_property("auto_edStatus", "UNDYING!");
+		}
+		if(canUse($item[Time-Spinner]) && auto_have_skill($skill[Ambidextrous Funkslinging]))
+		{
+			return useItems(flyer, $item[Time-Spinner]);
+		}
+		if(canSurvive(3.0) || stunned)
+		{
+			return useItem(flyer);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -88,7 +88,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		flyer = $item[Jam Band Flyers];
 	}
 	skill stunner = getStunner(enemy);
-	boolean stunned = contains_text(combatState, "stunned");
+	boolean stunned = combat_status_check("stunned");
 	
 	if (get_property("auto_gremlinMoly").to_boolean() && !canSurvive(20) && !stunned)		//don't flyer tool gremlins if it's dangerous to survive them for long
 	{
@@ -99,7 +99,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 			boolean gremlinTakesDamage = (isAttackFamiliar(my_familiar()) || (monster_hp() < (0.8*monster_hp(enemy))));
 			if(!gremlinTakesDamage && round < 10 && stunner != $skill[none])
 			{
-				set_property("auto_combatHandler", get_property("auto_combatHandler")+",stunned");
+				combat_status_add(",stunned");
 				return useSkill(stunner);
 			}
 		}
@@ -108,7 +108,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	{
 		if(stunner != $skill[none] && !stunned)
 		{
-			set_property("auto_combatHandler", get_property("auto_combatHandler")+",stunned");
+			combat_status_add(",stunned");
 			return useSkill(stunner);
 		}
 		if (isActuallyEd())


### PR DESCRIPTION
based on Combat #1019 

don't flyer gremlins if it will get you killed
stun if you need to let weaksauce delevel the gremlin longer before you can survive its attacks
update auto_JunkyardCombatHandler with the better flyering found in regular combat handler

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
