### PR TITLE
gremlins junkyard ML pre_adv fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -206,8 +206,10 @@ boolean auto_pre_adventure()
 		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
 	}
 
+	boolean junkyardML;
 	if($locations[Next to that Barrel with something Burning In It, Near an Abandoned Refrigerator, Over where the Old Tires Are, Out by that Rusted-Out Car] contains place)
 	{
+		junkyardML = true;
 		uneffect($effect[Spiky Shell]);
 		uneffect($effect[Scarysauce]);
 		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
@@ -554,6 +556,13 @@ boolean auto_pre_adventure()
 		removeML = true;
 		purgeML = false;
 	}
+	// Gremlins specific. need to let them hit so avoid ML unless defense is very high
+	if(junkyardML && my_buffedstat($stat[moxie]) < (2*monster_attack($monster[erudite gremlin])))
+	{
+		doML = false;
+		removeML = true;
+		purgeML = false;
+	}
 
 	// Location Specific Conditions
 	if(lowMLZones contains place)
@@ -646,7 +655,7 @@ boolean auto_pre_adventure()
 	else
 	{
 		// Last minute MCD alterations if Limit set, otherwise trust maximizer
-		if(get_property("auto_MLSafetyLimit") != "")
+		if(get_property("auto_MLSafetyLimit") != "" && !removeML)
 		{
 			auto_setMCDToCap();
 		}


### PR DESCRIPTION
use removeML settings when going to the junkyard without very high moxie
fix the "Last minute MCD alterations if Limit set" that was ignoring removeML and capping up to ML limit anyway

## How Has This Been Tested?

sauceror run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
