### PR TITLE
when Farming for a Bitchin' Meatcar check if you should pull the meat engine

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -61,6 +61,25 @@ boolean LX_bitchinMeatcar()
 		}
 	}
 	
+	int enginePartsMissing = 0;
+	foreach it in $items[Spring, Sprocket, Cog, Empty Meat Tank]
+	{
+		if(item_amount(it) == 0)
+		{
+			enginePartsMissing += 1;
+		}
+	}
+	if (item_amount($item[Tires]) > 0 && enginePartsMissing >= 4 && 
+	appearance_rates($location[The Degrassi Knoll Garage])[$monster[Gnollish Gearhead]] < 77.0)
+	{
+		//all parts of the engine are missing and would take a while to acquire from lootboxes at normal appearance rates
+		if (pullXWhenHaveY($item[meat engine],1,0))
+		{
+			auto_log_info("Already have tires, better skip the toolbox gacha", "blue");
+			return true;
+		}
+	}
+	
 	//if you reached this point then it means you need to spend adventures to acquire more parts
 	auto_log_info("Farming for a Bitchin' Meatcar", "blue");
 	


### PR DESCRIPTION
if you found the tires first and have 0/4 meat engine parts and farming the parts in softcore it must be smarter to pull the meat engine

even above 0/4 in paths where Gnollish Gearhead can fail to drop toolbox but don't want to calculate the odds.

autoscend doesn't try to isolate gearheads but added an appearance_rates exception tested in cli

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
