### PR TITLE
guild skills of seal clubber, sauceror, accordion thief

### DIFF
--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -31,9 +31,15 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=28", true);
 		}
-		if((my_level() >= 4) && (my_meat() >= 4500) && (!have_skill($skill[Wrath of the Wolverine])))
+		if((my_level() >= 4) && (!have_skill($skill[Wrath of the Wolverine])) && 
+		((my_meat() >= 5500) || ((my_meat() >= 3500) && have_skill($skill[Club Foot])) || 
+		((my_meat() >= 2500) && have_skill($skill[Batter Up!]) && have_skill($skill[Ire of the Orca]))))
 		{
 			visit_url("guild.php?action=buyskill&skillid=29", true);
+		}
+		if((my_level() >= 8) && (my_meat() >= 8000) && (!have_skill($skill[Club Foot])))
+		{
+			visit_url("guild.php?action=buyskill&skillid=33", true);
 		}
 		if((my_level() >= 10) && (my_meat() >= 12000) && (!have_skill($skill[Ire of the Orca])))
 		{
@@ -149,17 +155,17 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=27", true);
 		}
-		if((my_level() >= 8) && (my_meat() >= 12000) && !have_skill($skill[Itchy Curse Finger]))
-		{
-			visit_url("guild.php?action=buyskill&skillid=30", true);
-		}
-		if((my_level() >= 11) && (my_meat() >= 20000) && !have_skill($skill[Saucemaven]))
+		if((my_level() >= 11) && (my_meat() >= 20000) && !have_skill($skill[Saucemaven]) && ((stomach_left() >= 4) || in_tcrs()))
 		{
 			visit_url("guild.php?action=buyskill&skillid=39", true);
 		}
 		if((my_level() >= 12) && (my_meat() >= 20000) && !have_skill($skill[Curse of Weaksauce]))
 		{
 			visit_url("guild.php?action=buyskill&skillid=34", true);
+		}
+		if((my_level() >= 8) && (my_meat() >= 12000) && !have_skill($skill[Itchy Curse Finger]) && have_skill($skill[Curse of Weaksauce]))
+		{
+			visit_url("guild.php?action=buyskill&skillid=30", true);
 		}
 		break;
 	case $class[Disco Bandit]:
@@ -201,7 +207,8 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=10", true);
 		}
-		if((my_level() >= 7) && (my_meat() >= 25000) && !have_skill($skill[Five Finger Discount]))
+		if((my_level() >= 7) && (my_meat() >= 25000) && !have_skill($skill[Five Finger Discount]) &&
+		((my_level() < 11) || meatReserve() > 10000))	//useless discount if large store expenses already taken care of
 		{
 			visit_url("guild.php?action=buyskill&skillid=35", true);
 		}

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -207,11 +207,6 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=10", true);
 		}
-		if((my_level() >= 7) && (my_meat() >= 25000) && !have_skill($skill[Five Finger Discount]) &&
-		((my_level() < 11) || meatReserve() > 10000))	//useless discount if large store expenses already taken care of
-		{
-			visit_url("guild.php?action=buyskill&skillid=35", true);
-		}
 		if((my_level() >= 10) && (my_meat() >= 12500) && !have_skill($skill[Thief Among the Honorable]))
 		{
 			visit_url("guild.php?action=buyskill&skillid=38", true);


### PR DESCRIPTION
- seal clubber
buy Club Foot for getStunner()
usefulness of Wolverine at level 4 depends on fury skills, buy it at lower meat if it will enable banish or stun, higher meat otherwise

- sauceror
buying Itchy Curse Finger is useless to autoscend without Curse of Weaksauce, it never uses the other curses
buying Saucemaven is useless when there is no stomach space for any of the saucy foods

- accordion thief
removed  Five Finger Discount
~~add conditions for buying Five Finger Discount  to be either < level 11 or have planned 10000 of expenses in meatReserve. I think better not to buy the skill at all, it won't break even under 50000 meat spent. autoscend barely spends 1/3 that in discountable stores in a normal path? unless all meat always gets spent on MP restores but the high meat requirement to buy the skill excludes that situation anyway and doesn't help if that much meat is only reached after level 11 with no expenses left~~

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
