### PR TITLE
hotfix stuck at trying to clover castle top floor when unavailable

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1696,7 +1696,7 @@ boolean L12_themtharHills()
 		}
 	}
 
-	if(item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && cloversAvailable() > 0)
+	if(item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
 	{
 		//use clover to get inhaler
 		cloverUsageInit();


### PR DESCRIPTION
boolean L12_themtharHills() make sure zone is available before we try to clover it

related to #995

## How Has This Been Tested?

was stuck failing at this spot until I switched to fix code

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
