### PR TITLE
fixed debug mode

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1618,7 +1618,7 @@ boolean doTasks()
 	
 	print_header();
 
-	auto_interruptCheck();
+	auto_interruptCheck(false);
 
 	int delay = get_property("auto_delayTimer").to_int();
 	if(delay > 0)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3339,7 +3339,7 @@ boolean auto_badassBelt()
 	}
 }
 
-void auto_interruptCheck()
+void auto_interruptCheck(boolean debug)
 {
 	if(get_property("auto_interrupt").to_boolean())
 	{
@@ -3347,11 +3347,17 @@ void auto_interruptCheck()
 		restoreAllSettings();
 		abort("auto_interrupt detected and aborting, auto_interrupt disabled.");
 	}
-	else if (get_property("auto_debugging").to_boolean())
+	else if (get_property("auto_debugging").to_boolean() && debug)
 	{
 		set_property("auto_interrupt", true);
 		auto_log_info("auto_debugging detected, auto_interrupt enabled.");
 	}
+}
+
+void auto_interruptCheck()
+{
+	//we check for interrupt at multiple locations. but we only want to set it once per loop in debug mode.
+	auto_interruptCheck(true);
 }
 
 element currentFlavour()

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1633,6 +1633,7 @@ boolean auto_wantToYellowRay(monster enemy, location loc);
 boolean auto_wantToReplace(monster enemy, location loc);
 int total_items(boolean [item] items);
 boolean auto_badassBelt();
+void auto_interruptCheck(boolean debug);
 void auto_interruptCheck();
 element currentFlavour();
 boolean setFlavour(element ele);


### PR DESCRIPTION
debug mode was not working since we were checking
for interrupt in multiple spots. which meant we were setting interrupt and then discharging it before any adventuring could be done.
fixed it by limited when it actually sets the interrupt

## How Has This Been Tested?

tested in ed. path does not matter though

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
