### PR TITLE
keep soulsauce for soul bubble

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -428,6 +428,7 @@ boolean auto_post_adventure()
 			availableSauce -= 5;	//keep 5 soulsauce for soul bubble if not missing much MP
 		}
 		int casts = min(missing, availableSauce / 5);	//soul food costs 5 soulsauce per cast.
+		//trying to fix github workflow. delete this later
 		if(casts > 0)
 		{
 			use_skill(casts, $skill[Soul Food]);

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -422,7 +422,8 @@ boolean auto_post_adventure()
 		}
 		int missing = (my_maxmp() - my_mp()) / 15;		//soul food restores 15 MP per cast.
 		int availableSauce = my_soulsauce();
-		if(availableSauce >= 5 && my_mp() > 100 && my_mp() > 0.8*my_maxmp())
+		int minMPexpected = my_mp() + (availableSauce - 5) * 15; //mp expected after soul food if last 5 soulsauce is saved
+		if(availableSauce >= 5 && minMPexpected > 100 && minMPexpected > 0.8*my_maxmp())
 		{
 			availableSauce -= 5;	//keep 5 soulsauce for soul bubble if not missing much MP
 		}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -421,7 +421,12 @@ boolean auto_post_adventure()
 			use_skill(1, $skill[Soul Rotation]);
 		}
 		int missing = (my_maxmp() - my_mp()) / 15;		//soul food restores 15 MP per cast.
-		int casts = min(missing, my_soulsauce() / 5);	//soul food costs 5 soulsauce per cast.
+		int availableSauce = my_soulsauce();
+		if(availableSauce >= 5 && my_mp() > 100 && my_mp() > 0.8*my_maxmp())
+		{
+			availableSauce -= 5;	//keep 5 soulsauce for soul bubble if not missing much MP
+		}
+		int casts = min(missing, availableSauce / 5);	//soul food costs 5 soulsauce per cast.
 		if(casts > 0)
 		{
 			use_skill(casts, $skill[Soul Food]);

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -428,7 +428,6 @@ boolean auto_post_adventure()
 			availableSauce -= 5;	//keep 5 soulsauce for soul bubble if not missing much MP
 		}
 		int casts = min(missing, availableSauce / 5);	//soul food costs 5 soulsauce per cast.
-		//trying to fix github workflow. delete this later
 		if(casts > 0)
 		{
 			use_skill(casts, $skill[Soul Food]);


### PR DESCRIPTION
keep 5 soulsauce for soul bubble if not missing much MP
at high MP soulsauce can get wasted on soul food leaving a sauceror with no ability to stun in combat


## How Has This Been Tested?
sauceror run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
