### PR TITLE
pull potato alarm clock at bedtime and others

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -452,17 +452,18 @@ void bedtime_pulls()
 		return;
 	}
 	
+	if(my_daycount() == 1 && my_level() <= 8)
+	{
+		//this run looks like it will take a couple more days, give priority to good rollover equipment before other pulls
+		float desirability = max(5.0, get_property("auto_bedtime_pulls_min_desirability").to_float());
+		bedtime_pulls_rollover_equip(desirability);
+	}
+	
 	if(get_property("auto_bedtime_pulls_min_desirability").to_float() <= 5.0)
 	{
-		if(item_amount($item[potato alarm clock]) == 0 && storage_amount($item[potato alarm clock]) > 0)
+		if(storage_amount($item[potato alarm clock]) > 0)
 		{
 			pullXWhenHaveY($item[potato alarm clock], 1, 0);
-		}
-
-		if(my_daycount() == 1 && my_level() <= 8)
-		{
-			//this run looks like it will take a couple more days, give priority to good rollover equipment before level 11 quest pulls
-			bedtime_pulls_rollover_equip(5.0);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -249,7 +249,7 @@ float rollover_improvement(item it, slot sl)
 	return rollover_value(it) - rollover_value(equipped_item(sl));
 }
 
-void bedtime_pulls_rollover_equip()
+void bedtime_pulls_rollover_equip(float desirability)
 {
 	//scan through all pullable items for items that have a better rollover adv gain than currently best equipped item.
 	
@@ -425,7 +425,7 @@ void bedtime_pulls_rollover_equip()
 		}
 
 		very_best_improvement = rollover_improvement(very_best, very_best_slot);
-		if(very_best_improvement < get_property("auto_bedtime_pulls_min_desirability").to_float())
+		if(very_best_improvement < desirability)
 		{
 			break;
 		}
@@ -434,6 +434,11 @@ void bedtime_pulls_rollover_equip()
 		pullXWhenHaveY(very_best, 1, 0);
 		equipRollover(true);
 	}
+}
+
+void bedtime_pulls_rollover_equip()
+{
+	bedtime_pulls_rollover_equip(get_property("auto_bedtime_pulls_min_desirability").to_float());
 }
 
 void bedtime_pulls()
@@ -447,6 +452,20 @@ void bedtime_pulls()
 		return;
 	}
 	
+	if(get_property("auto_bedtime_pulls_min_desirability").to_float() <= 5.0)
+	{
+		if(item_amount($item[potato alarm clock]) == 0 && storage_amount($item[potato alarm clock]) > 0)
+		{
+			pullXWhenHaveY($item[potato alarm clock], 1, 0);
+		}
+
+		if(my_daycount() == 1 && my_level() <= 8)
+		{
+			//this run looks like it will take a couple more days, give priority to good rollover equipment before level 11 quest pulls
+			bedtime_pulls_rollover_equip(5.0);
+		}
+	}
+
 	if(item_amount($item[Muculent Machete]) == 0 && (!is_boris() || !in_wotsf() || !in_pokefam())) // no need in paths where can't use machete
 	{
 		pullXWhenHaveY($item[Antique Machete], 1, 0);
@@ -784,44 +803,47 @@ boolean doBedtime()
 	dailyEvents();
 	if((get_property("auto_clanstuff").to_int() < my_daycount()) && (get_clan_id() != -1))
 	{
-		if(is_unrestricted($item[Olympic-sized Clan Crate]) && !get_property("_olympicSwimmingPool").to_boolean())
-		{
-			cli_execute("swim noncombat");
-		}
-		if(is_unrestricted($item[Olympic-sized Clan Crate]) && !get_property("_olympicSwimmingPoolItemFound").to_boolean())
-		{
-			cli_execute("swim item");
-		}
 		if(get_property("_klawSummons").to_int() == 0 && get_clan_rumpus() contains 'Mr. Klaw "Skill" Crane Game')
 		{
 			cli_execute("clan_rumpus.php?action=click&spot=3&furni=3");
 			cli_execute("clan_rumpus.php?action=click&spot=3&furni=3");
 			cli_execute("clan_rumpus.php?action=click&spot=3&furni=3");
 		}
-		if(is_unrestricted($item[Clan Looking Glass]) && !get_property("_lookingGlass").to_boolean())
+		if(item_amount($item[Clan VIP Lounge Key]) > 0)
 		{
-			string temp = visit_url("clan_viplounge.php?action=lookingglass");
-		}
-		if(get_property("_deluxeKlawSummons").to_int() == 0)
-		{
-			cli_execute("clan_viplounge.php?action=klaw");
-			cli_execute("clan_viplounge.php?action=klaw");
-			cli_execute("clan_viplounge.php?action=klaw");
-		}
-		if(!get_property("_aprilShower").to_boolean())
-		{
-			if(inAftercore())
+			if(is_unrestricted($item[Olympic-sized Clan Crate]) && !get_property("_olympicSwimmingPool").to_boolean())
 			{
-				cli_execute("shower ice");
+				cli_execute("swim noncombat");
 			}
-			else
+			if(is_unrestricted($item[Olympic-sized Clan Crate]) && !get_property("_olympicSwimmingPoolItemFound").to_boolean())
 			{
-				cli_execute("shower " + my_primestat());
+				cli_execute("swim item");
 			}
-		}
-		if(is_unrestricted($item[Crimbough]) && !get_property("_crimboTree").to_boolean())
-		{
-			cli_execute("crimbotree get");
+			if(is_unrestricted($item[Clan Looking Glass]) && !get_property("_lookingGlass").to_boolean())
+			{
+				string temp = visit_url("clan_viplounge.php?action=lookingglass");
+			}
+			if(get_property("_deluxeKlawSummons").to_int() == 0)
+			{
+				cli_execute("clan_viplounge.php?action=klaw");
+				cli_execute("clan_viplounge.php?action=klaw");
+				cli_execute("clan_viplounge.php?action=klaw");
+			}
+			if(!get_property("_aprilShower").to_boolean())
+			{
+				if(inAftercore())
+				{
+					cli_execute("shower ice");
+				}
+				else
+				{
+					cli_execute("shower " + my_primestat());
+				}
+			}
+			if(is_unrestricted($item[Crimbough]) && !get_property("_crimboTree").to_boolean())
+			{
+				cli_execute("crimbotree get");
+			}
 		}
 		set_property("auto_clanstuff", ""+my_daycount());
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -370,8 +370,13 @@ void finalizeMaximize(boolean speculative)
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
 	}
-	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
+	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
+	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
+	{
+		addBonusToMaximize($item[carnivorous potted plant], 200); // 4% chance free kill but also 25 ML
+	}
 	addBonusToMaximize($item[Mr. Screege\'s spectacles], 100); // meat stuff
+	addBonusToMaximize($item[can of mixed everything], 100); // random stuff
 	if(have_effect($effect[blood bubble]) == 0)
 	{
 		// blocks first hit, but doesn't stack with blood bubble

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -329,6 +329,28 @@ void finalizeMaximize(boolean speculative)
 		// also don't equip Kramco when using Map the Monsters as sausage goblins override the NC
 		addToMaximize("-equip " + $item[Kramco Sausage-o-Matic&trade;].to_string());
 	}
+	if (possessEquipment($item[Cursed Magnifying Glass]))
+	{
+		if (get_property("cursedMagnifyingGlassCount").to_int() == 13)
+		{
+			if(get_property("mappingMonsters").to_boolean() || (get_property("_voidFreeFights").to_int() >= 5 && !in_hardcore()))
+			{
+				// don't equip for non free fights in softcore? (pending allowed conditions like delay zone && none of the monsters in the zone is a sniff/YR target?)
+				// don't equip when using Map the Monsters?
+				addToMaximize("-equip " + $item[Cursed Magnifying Glass].to_string());
+			}
+			else if(get_property("_voidFreeFights").to_int() < 5)
+			{
+				// add bonus if next fight is a free void monster
+				addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
+			}
+		}
+		else if(get_property("_voidFreeFights").to_int() < 5 && solveDelayZone() != $location[none])
+		{
+			// add bonus to charge free fights
+			addBonusToMaximize($item[Cursed Magnifying Glass], 200);
+		}
+	}
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
 	{
 		string pref = getMaximizeSlotPref(s);
@@ -347,11 +369,6 @@ void finalizeMaximize(boolean speculative)
 	if(pathHasFamiliar() || in_darkGyffte())
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
-	}
-	// add bonus if next fight is a free void monster
-	if((get_property("_voidFreeFights").to_int() < 5) && (get_property("cursedMagnifyingGlassCount").to_int() == 13))
-	{
-		addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
 	}
 	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
 	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -354,7 +354,12 @@ void finalizeMaximize(boolean speculative)
 		addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
 	}
 	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
+	if(get_property("auto_MLSafetyLimit").to_int() >= 25)
+	{
+		addBonusToMaximize($item[carnivorous potted plant], 200); // free kills
+	}
 	addBonusToMaximize($item[Mr. Screege\'s spectacles], 100); // meat stuff
+	addBonusToMaximize($item[can of mixed everything], 100); // random stuff
 	if(have_effect($effect[blood bubble]) == 0)
 	{
 		// blocks first hit, but doesn't stack with blood bubble

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -329,28 +329,6 @@ void finalizeMaximize(boolean speculative)
 		// also don't equip Kramco when using Map the Monsters as sausage goblins override the NC
 		addToMaximize("-equip " + $item[Kramco Sausage-o-Matic&trade;].to_string());
 	}
-	if (possessEquipment($item[Cursed Magnifying Glass]))
-	{
-		if (get_property("cursedMagnifyingGlassCount").to_int() == 13)
-		{
-			if(get_property("mappingMonsters").to_boolean() || (get_property("_voidFreeFights").to_int() >= 5 && !in_hardcore()))
-			{
-				// don't equip for non free fights in softcore? (pending allowed conditions like delay zone && none of the monsters in the zone is a sniff/YR target?)
-				// don't equip when using Map the Monsters?
-				addToMaximize("-equip " + $item[Cursed Magnifying Glass].to_string());
-			}
-			else if(get_property("_voidFreeFights").to_int() < 5)
-			{
-				// add bonus if next fight is a free void monster
-				addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
-			}
-		}
-		else if(get_property("_voidFreeFights").to_int() < 5 && solveDelayZone() != $location[none])
-		{
-			// add bonus to charge free fights
-			addBonusToMaximize($item[Cursed Magnifying Glass], 200);
-		}
-	}
 	foreach s in $slots[hat, back, shirt, weapon, off-hand, pants, acc1, acc2, acc3, familiar]
 	{
 		string pref = getMaximizeSlotPref(s);
@@ -370,6 +348,8 @@ void finalizeMaximize(boolean speculative)
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
 	}
+	// add bonus if next fight is a free void monster
+	if((get_property("_voidFreeFights").to_int() < 5) && (get_property("cursedMagnifyingGlassCount").to_int() == 13))
 	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
 	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -353,10 +353,10 @@ void finalizeMaximize(boolean speculative)
 	{
 		addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
 	}
-	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
-	if(get_property("auto_MLSafetyLimit").to_int() >= 25)
+	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
+	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
 	{
-		addBonusToMaximize($item[carnivorous potted plant], 200); // free kills
+		addBonusToMaximize($item[carnivorous potted plant], 200); // 4% chance free kill but also 25 ML
 	}
 	addBonusToMaximize($item[Mr. Screege\'s spectacles], 100); // meat stuff
 	addBonusToMaximize($item[can of mixed everything], 100); // random stuff

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -350,13 +350,11 @@ void finalizeMaximize(boolean speculative)
 	}
 	// add bonus if next fight is a free void monster
 	if((get_property("_voidFreeFights").to_int() < 5) && (get_property("cursedMagnifyingGlassCount").to_int() == 13))
-	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
-	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
 	{
-		addBonusToMaximize($item[carnivorous potted plant], 200); // 4% chance free kill but also 25 ML
+		addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
 	}
+	addBonusToMaximize($item[mafia thumb ring], 200); // adventures
 	addBonusToMaximize($item[Mr. Screege\'s spectacles], 100); // meat stuff
-	addBonusToMaximize($item[can of mixed everything], 100); // random stuff
 	if(have_effect($effect[blood bubble]) == 0)
 	{
 		// blocks first hit, but doesn't stack with blood bubble

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -371,7 +371,7 @@ void finalizeMaximize(boolean speculative)
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
 	}
 	addBonusToMaximize($item[mafia thumb ring], 200); // 4% chance +1 adventure
-	if(get_property("auto_MLSafetyLimit").to_int() == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
+	if(get_property("auto_MLSafetyLimit") == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
 	{
 		addBonusToMaximize($item[carnivorous potted plant], 200); // 4% chance free kill but also 25 ML
 	}


### PR DESCRIPTION
- pull potato alarm clock at bedtime
- addBonusToMaximize for can of mixed everything and carnivorous potted plant
if user decided to pull them under their own responsibility only, not pulled by the script. because plant = 25 ML no requirements and autoscend can't be reasonable yet with ML, and mixed everything can drop things like firemilk for auto_consume

- pull the rollover improvements that are of same quality as potato alarm clock earlier in the bedtime pulls
at low level day 1 bedtime, try to pull the >=5 rollover improvements over level 11 items for more benefit early
in slow runs they get pulled at the end of day 2 anyway while the level 11 items can be pulled with the same benefit even on day 2,3 or later.

- don't call bedtime VIP clan without VIP key

## How Has This Been Tested?
in run
## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
