### PR TITLE
fix Flavor of a Raver choice when trying to open hole

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -255,13 +255,13 @@ void castleTopFloorChoiceHandler(int choice)
 	}
 	else if(choice == 676) // Flavor of a Raver (The Castle in the Clouds in the Sky (Top Floor))
 	{	
-		if(internalQuestStatus("questL10Garbage") < 10 && equipped_amount($item[Mohawk wig]) > 0)
+		if(equipped_amount($item[Mohawk wig]) > 0 || internalQuestStatus("questL10Garbage") >= 10)
 		{
-			run_choice(4); // if quest not done and have mohawk wig on, move to Yeah, You're for Me (#678)
+			run_choice(4); // if quest not done and have mohawk wig on, or quest is done, move to Yeah, You're for Me (#678)
 		}	
 		else
 		{
-			run_choice(3); // if no mohawk wig, grab the drum n bass record. will skip if already have record
+			run_choice(3); // if no mohawk wig and quest not done, grab the drum n bass record. will skip if already have record
 		}
 	}
 	else if(choice == 677) // Copper Feel (The Castle in the Clouds in the Sky (Top Floor))
@@ -291,7 +291,7 @@ void castleTopFloorChoiceHandler(int choice)
 		}
 		else
 		{
-			run_choice(3); // if quest is done, go to Copper Feel (#677) to skip
+			run_choice(3); // if quest is done, go to Copper Feel (#677) to get rocket ship or skip
 		}
 	}
 	else if(choice == 679) // Keep On Turnin' the Wheel in the Sky (The Castle in the Clouds in the Sky (Top Floor))


### PR DESCRIPTION
# Description
after questL10Garbage is over Flavor of a Raver should choose Yeah, You're for Me, Punk Rock Giant then Copper Feel to unlock hole or skip

## How Has This Been Tested?

instead it took the drum 'n' bass 'n' drum 'n' bass record in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
