### PR TITLE
don't pull star chart when about to adventure in hole

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1039,6 +1039,7 @@ int towerKeyCount();
 int towerKeyCount(boolean effective);
 int whitePixelCount();
 boolean LX_getDigitalKey();
+boolean LX_buyStarKey();
 boolean LX_getStarKey();
 boolean beehiveConsider();
 int ns_crowd1();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1039,7 +1039,7 @@ int towerKeyCount();
 int towerKeyCount(boolean effective);
 int whitePixelCount();
 boolean LX_getDigitalKey();
-boolean LX_buyStarKey();
+void LX_buyStarKeyParts();
 boolean LX_getStarKey();
 boolean beehiveConsider();
 int ns_crowd1();

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -331,10 +331,13 @@ boolean L10_holeInTheSkyUnlock()
 		set_property("auto_holeinthesky", false);
 		return false;
 	}
+	if(can_interact())
+	{
+		LX_buyStarKey();
+	}
 	int day = get_property("shenInitiationDay").to_int();
 	boolean[location] shenLocs = shenSnakeLocations(day, 0);
-	if((!needStarKey() || (can_interact() && LX_getStarKey())) && 
-	!(shenLocs contains $location[The Hole in the Sky]))
+	if(!needStarKey() && !(shenLocs contains $location[The Hole in the Sky]))
 	{
 		// we force auto_holeinthesky to true in L11_shenCopperhead() as Ed if Shen sends us to the Hole in the Sky
 		// as otherwise the zone isn't required at all for Ed.

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -331,10 +331,7 @@ boolean L10_holeInTheSkyUnlock()
 		set_property("auto_holeinthesky", false);
 		return false;
 	}
-	if(can_interact())
-	{
-		LX_buyStarKey();
-	}
+	LX_buyStarKeyParts();
 	int day = get_property("shenInitiationDay").to_int();
 	boolean[location] shenLocs = shenSnakeLocations(day, 0);
 	if(!needStarKey() && !(shenLocs contains $location[The Hole in the Sky]))

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -333,11 +333,13 @@ boolean L10_holeInTheSkyUnlock()
 	}
 	int day = get_property("shenInitiationDay").to_int();
 	boolean[location] shenLocs = shenSnakeLocations(day, 0);
-	if(!needStarKey() && !(shenLocs contains $location[The Hole in the Sky]))
+	if((!needStarKey() || (can_interact() && LX_getStarKey())) && 
+	!(shenLocs contains $location[The Hole in the Sky]))
 	{
 		// we force auto_holeinthesky to true in L11_shenCopperhead() as Ed if Shen sends us to the Hole in the Sky
 		// as otherwise the zone isn't required at all for Ed.
 		// Should also handle situations where the player manually got the star key before unlocking Shen.
+		// or can buy the star key ingredients out of ronin.
 		set_property("auto_holeinthesky", false);
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -216,10 +216,7 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
-	if(can_interact())
-	{
-		LX_buyStarKey();
-	}
+	LX_buyStarKeyParts();
 
 	boolean at_tower_door = internalQuestStatus("questL13Final") == 5;
 	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key") && 

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -201,8 +201,22 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
+	if (can_interact())
+	{	
+		pullXWhenHaveY($item[Star Chart], 1, 0);
+		if (item_amount($item[Star]) < 8)
+		{
+			pullXWhenHaveY($item[Star], 8, item_amount($item[Star]));
+		}
+		if (item_amount($item[Star]) < 7)
+		{
+			pullXWhenHaveY($item[line], 7, item_amount($item[line]));
+		}
+	}
+	
 	boolean at_tower_door = internalQuestStatus("questL13Final") == 5;
-	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
+	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key") && 
+	item_amount($item[Star]) >= 8 && item_amount($item[Line]) >= 7)
 	{
 		pullXWhenHaveY($item[Star Chart], 1, 0);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -174,6 +174,24 @@ boolean LX_getDigitalKey()
 	return adv_spent;
 }
 
+boolean LX_buyStarKey()
+{
+	pullXWhenHaveY($item[Star Chart], 1, 0);
+	if (item_amount($item[Star]) < 8)
+	{
+		pullXWhenHaveY($item[Star], (8 - item_amount($item[Star])), item_amount($item[Star]));
+	}
+	if (item_amount($item[Star]) < 7)
+	{
+		pullXWhenHaveY($item[line], (7 - item_amount($item[line])), item_amount($item[line]));
+	}
+	if (item_amount($item[Star Chart]) >= 1 && item_amount($item[Star]) >= 8 && item_amount($item[Line]) >= 7)
+	{
+		return true;
+	}
+	return false;
+}
+
 boolean LX_getStarKey()
 {
 	if(!get_property("auto_getStarKey").to_boolean())
@@ -201,19 +219,11 @@ boolean LX_getStarKey()
 		return false;
 	}
 	
-	if (can_interact())
-	{	
-		pullXWhenHaveY($item[Star Chart], 1, 0);
-		if (item_amount($item[Star]) < 8)
-		{
-			pullXWhenHaveY($item[Star], (8 - item_amount($item[Star])), item_amount($item[Star]));
-		}
-		if (item_amount($item[Star]) < 7)
-		{
-			pullXWhenHaveY($item[line], (7 - item_amount($item[line])), item_amount($item[line]));
-		}
+	if(can_interact())
+	{
+		LX_buyStarKey();
 	}
-	
+
 	boolean at_tower_door = internalQuestStatus("questL13Final") == 5;
 	if (!in_hardcore() && at_tower_door && item_amount($item[Richard\'s Star Key]) == 0 && item_amount($item[Star Chart]) == 0 && !get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key") && 
 	item_amount($item[Star]) >= 8 && item_amount($item[Line]) >= 7)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -174,22 +174,19 @@ boolean LX_getDigitalKey()
 	return adv_spent;
 }
 
-boolean LX_buyStarKey()
+void LX_buyStarKeyParts()
 {
-	pullXWhenHaveY($item[Star Chart], 1, 0);
-	if (item_amount($item[Star]) < 8)
+	if(item_amount($item[Richard\'s Star Key]) > 0 || get_property("nsTowerDoorKeysUsed").contains_text("Richard's star key"))
 	{
-		pullXWhenHaveY($item[Star], (8 - item_amount($item[Star])), item_amount($item[Star]));
+		return;	//already have it
 	}
-	if (item_amount($item[Star]) < 7)
+	if(!can_interact())
 	{
-		pullXWhenHaveY($item[line], (7 - item_amount($item[line])), item_amount($item[line]));
+		return;	//no unrestricted mall access
 	}
-	if (item_amount($item[Star Chart]) >= 1 && item_amount($item[Star]) >= 8 && item_amount($item[Line]) >= 7)
-	{
-		return true;
-	}
-	return false;
+	buyUpTo(1, $item[Star Chart], 1000);
+	buyUpTo(8, $item[Star], 1000);
+	buyUpTo(7, $item[line], 1000);
 }
 
 boolean LX_getStarKey()

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -206,11 +206,11 @@ boolean LX_getStarKey()
 		pullXWhenHaveY($item[Star Chart], 1, 0);
 		if (item_amount($item[Star]) < 8)
 		{
-			pullXWhenHaveY($item[Star], 8, item_amount($item[Star]));
+			pullXWhenHaveY($item[Star], (8 - item_amount($item[Star])), item_amount($item[Star]));
 		}
 		if (item_amount($item[Star]) < 7)
 		{
-			pullXWhenHaveY($item[line], 7, item_amount($item[line]));
+			pullXWhenHaveY($item[line], (7 - item_amount($item[line])), item_amount($item[line]));
 		}
 	}
 	


### PR DESCRIPTION
don't pull star chart when about to adventure in hole in the sky for stars or lines anyway
also pull and buy missing stars and lines out of ronin. are the existing price checks enough?

then, no need to unlock hole after breaking ronin if the key components could be bought

## How Has This Been Tested?
broke ronin

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
