### PR TITLE
use food drop / booze drop bonus

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -502,6 +502,28 @@ boolean auto_pre_adventure()
 		}
 		if(itemDrop < itemNeed._float)
 		{
+			//if general item modifier isn't enough check specific item drop bonus
+			generic_t itemFoodNeed = zone_needItemFood(place);
+			generic_t itemBoozeNeed = zone_needItemBooze(place);
+			if(itemFoodNeed._boolean)
+			{
+				auto_log_debug("Trying food drop supplements");
+				//max at start of an expression with item and food drop is ineffective in combining them, have to let the maximizer try to add on top
+				addToMaximize("49food drop " + ceil(itemFoodNeed._float) + "max");
+				simMaximize();
+				itemDrop = simValue("Item Drop") + simValue("Food Drop");
+			}
+			if(itemBoozeNeed._boolean && itemDrop < itemNeed._float)
+			{
+				auto_log_debug("Trying booze drop supplements");
+				addToMaximize("49booze drop " + ceil(itemBoozeNeed._float) + "max");
+				simMaximize();
+				itemDrop = simValue("Item Drop") + simValue("Booze Drop");
+				itemDrop += !itemFoodNeed._boolean ? 0 : simValue("Food Drop");	//even though no zone yet needs both food and booze
+			}
+		}
+		if(itemDrop < itemNeed._float)
+		{
 			auto_log_debug("We can't cap this drop bear!", "purple");
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -507,26 +507,33 @@ boolean auto_pre_adventure()
 			//if general item modifier isn't enough check specific item drop bonus
 			generic_t itemFoodNeed = zone_needItemFood(place);
 			generic_t itemBoozeNeed = zone_needItemBooze(place);
-			if(itemFoodNeed._boolean)
+			float itemDropFood = itemDrop + simValue("Food Drop");
+			float itemDropBooze = itemDrop + simValue("Booze Drop");
+			if(itemFoodNeed._boolean && itemDropFood < itemFoodNeed._float)
 			{
 				auto_log_debug("Trying food drop supplements");
 				//max at start of an expression with item and food drop is ineffective in combining them, have to let the maximizer try to add on top
 				addToMaximize("49food drop " + ceil(itemFoodNeed._float) + "max");
 				simMaximize();
-				itemDrop = simValue("Item Drop") + simValue("Food Drop");
+				itemDropFood = simValue("Item Drop") + simValue("Food Drop");
 			}
-			if(itemBoozeNeed._boolean && itemDrop < itemNeed._float)
+			if(itemBoozeNeed._boolean && itemDropBooze < itemBoozeNeed._float)
 			{
 				auto_log_debug("Trying booze drop supplements");
 				addToMaximize("49booze drop " + ceil(itemBoozeNeed._float) + "max");
 				simMaximize();
-				itemDrop = simValue("Item Drop") + simValue("Booze Drop");
-				itemDrop += !itemFoodNeed._boolean ? 0 : simValue("Food Drop");	//even though no zone yet needs both food and booze
+				itemDropBooze = simValue("Item Drop") + simValue("Booze Drop");
+				//no zone item yet needs both food and booze, bottle of Chateau de Vinegar exception is a cooking ingredient but doesn't use food drop bonus
 			}
-		}
-		if(itemDrop < itemNeed._float)
-		{
-			auto_log_debug("We can't cap this drop bear!", "purple");
+			if((itemFoodNeed._boolean && itemDropFood >= itemFoodNeed._float) ||
+			(itemBoozeNeed._boolean && itemDropBooze >= itemBoozeNeed._float))
+			{
+				//the needed item was Food/Booze and need has been met with specific bonus
+			}
+			else
+			{
+				auto_log_debug("We can't cap this drop bear!", "purple");
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -192,9 +192,9 @@ generic_t zone_needItem(location loc)
 		}
 		break;
 	case $location[The Goatlet]:
-		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting]));
+		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting])) && fullness_limit() != 0;
 		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
-		int milkUsed = get_property("_milkOfMagnesiumUsed").to_boolean() ? 1 : 0;
+		int milkUsed = (get_property("_milkOfMagnesiumUsed").to_boolean() || fullness_left() == 0) ? 1 : 0;
 		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)
 		{	
 			getMilk = false;
@@ -407,9 +407,9 @@ generic_t zone_needItemFood(location loc)
 		}
 		break;
 	case $location[The Goatlet]:
-		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting]));
+		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting])) && fullness_limit() != 0;
 		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
-		int milkUsed = get_property("_milkOfMagnesiumUsed").to_boolean() ? 1 : 0;
+		int milkUsed = (get_property("_milkOfMagnesiumUsed").to_boolean() || fullness_left() == 0) ? 1 : 0;
 		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)
 		{	
 			getMilk = false;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -192,7 +192,7 @@ generic_t zone_needItem(location loc)
 		}
 		break;
 	case $location[The Goatlet]:
-		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting])) && fullness_limit() != 0;
+		boolean getMilk = (have_skill($skill[Advanced Saucecrafting]) || (my_class() == $class[Sauceror] && (guild_available() || !get_property('auto_skipUnlockGuild').to_boolean()))) && fullness_limit() != 0;
 		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
 		int milkUsed = (get_property("_milkOfMagnesiumUsed").to_boolean() || fullness_left() == 0) ? 1 : 0;
 		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)
@@ -407,7 +407,7 @@ generic_t zone_needItemFood(location loc)
 		}
 		break;
 	case $location[The Goatlet]:
-		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting])) && fullness_limit() != 0;
+		boolean getMilk = (have_skill($skill[Advanced Saucecrafting]) || (my_class() == $class[Sauceror] && (guild_available() || !get_property('auto_skipUnlockGuild').to_boolean()))) && fullness_limit() != 0;
 		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
 		int milkUsed = (get_property("_milkOfMagnesiumUsed").to_boolean() || fullness_left() == 0) ? 1 : 0;
 		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -400,6 +400,11 @@ generic_t zone_needItemFood(location loc)
 	case $location[The Haunted Laundry Room]:
 		value = 5.0 * (1.0 + get_property("auto_cabinetsencountered").to_float());
 		break;
+	case $location[Inside the Palindome]:
+		if (item_amount($item[Stunt Nuts]) == 0 && item_amount($item[Wet Stunt Nut Stew]) == 0) {
+			value = 30.0;
+		}
+		break;
 	case $location[Whitey\'s Grove]:
 		if(((item_amount($item[Lion Oil]) == 0) || (item_amount($item[Bird Rib]) == 0)) && (item_amount($item[Wet Stew]) == 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0) && (internalQuestStatus("questL11Palindome") < 5))
 		{

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -192,7 +192,21 @@ generic_t zone_needItem(location loc)
 		}
 		break;
 	case $location[The Goatlet]:
-		value = 40.0;
+		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting]));
+		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
+		int milkUsed = get_property("_milkOfMagnesiumUsed").to_boolean() ? 1 : 0;
+		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)
+		{	
+			getMilk = false;
+		}
+		if(getMilk)
+		{
+			value = 20.0;
+		}
+		else
+		{
+			value = 40.0;
+		}
 		break;
 	case $location[The Extreme Slope]:
 		if(!possessOutfit("eXtreme Cold-Weather Gear"))
@@ -316,6 +330,111 @@ generic_t zone_needItem(location loc)
 		retval._float = 50.0;
 		break;
 	// End Bugbear Invasion Locations
+	default:
+		retval._error = true;
+		break;
+	}
+
+	if(expectGhostReport() && (loc == get_property("ghostLocation").to_location()) && (get_property("questPAGhost") == "started"))
+	{
+		value = 0.0;
+	}
+
+
+	if(value != 0.0)
+	{
+		retval._boolean = true;
+		retval._float = 10000.0/value;
+
+		if(in_lar())
+		{
+			retval._float = 5000.0/value;
+		}
+		retval._float -= 100.0;
+	}
+	return retval;
+}
+
+generic_t zone_needItemBooze(location loc)
+{
+	// these matching a location case in zone_needItem will be called if the general item bonus could not be reached
+	generic_t retval;
+	float value = 0.0;
+	switch(loc)
+	{
+	case $location[The Haunted Wine Cellar]:
+		value = 5.0 * (1.0 + get_property("auto_wineracksencountered").to_float());
+		break;
+	default:
+		retval._error = true;
+		break;
+	}
+
+	if(expectGhostReport() && (loc == get_property("ghostLocation").to_location()) && (get_property("questPAGhost") == "started"))
+	{
+		value = 0.0;
+	}
+
+
+	if(value != 0.0)
+	{
+		retval._boolean = true;
+		retval._float = 10000.0/value;
+
+		if(in_lar())
+		{
+			retval._float = 5000.0/value;
+		}
+		retval._float -= 100.0;
+	}
+	return retval;
+}
+
+generic_t zone_needItemFood(location loc)
+{
+	// these matching a location case in zone_needItem will be called if the general item bonus could not be reached
+	generic_t retval;
+	float value = 0.0;
+	switch(loc)
+	{
+	case $location[The Haunted Laundry Room]:
+		value = 5.0 * (1.0 + get_property("auto_cabinetsencountered").to_float());
+		break;
+	case $location[Whitey\'s Grove]:
+		if(((item_amount($item[Lion Oil]) == 0) || (item_amount($item[Bird Rib]) == 0)) && (item_amount($item[Wet Stew]) == 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0) && (internalQuestStatus("questL11Palindome") < 5))
+		{
+			value = 25.0;
+		}
+		break;
+	case $location[The Goatlet]:
+		boolean getMilk = (my_class() == $class[Sauceror] || have_skill($skill[Advanced Saucecrafting]));
+		int milksPerMilk = (my_class() == $class[Sauceror]) ? 3 : 1;
+		int milkUsed = get_property("_milkOfMagnesiumUsed").to_boolean() ? 1 : 0;
+		if((item_amount($item[Milk Of Magnesium]) + milksPerMilk * item_amount($item[Glass Of Goat\'s Milk]) + milkUsed) >= 3)
+		{	
+			getMilk = false;
+		}
+		if(getMilk)
+		{
+			value = 20.0;
+		}
+		else
+		{
+			value = 40.0;
+		}
+		break;
+	case $location[The Haunted Pantry]:
+		if(in_community() && (item_amount($item[Tomato]) < 2) && have_skill($skill[Advanced Saucecrafting]))
+		{
+			retval._float = 59.4;
+		}
+		break;
+	case $location[The Skeleton Store]:
+		if(in_community() && have_skill($skill[Advanced Saucecrafting]) && ((item_amount($item[Cherry]) < 1) || (item_amount($item[Grapefruit]) < 1) || (item_amount($item[Lemon]) < 1)))
+		{	//No idea, should spade this for great justice.
+			retval._float = 33.0;
+		}
+		break;
 	default:
 		retval._error = true;
 		break;


### PR DESCRIPTION
examples like goatlet (L8) blasting soda (L13)
also increase item bonus target in goatlet if want goat's milk on the way


## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
