### PR TITLE
Gelatinous Cubeling is better than Barrrnacle for gremlins

### DIFF
--- a/BUILD/familiars/gremlins.dat
+++ b/BUILD/familiars/gremlins.dat
@@ -2,4 +2,5 @@
 Nosy Nose
 Plastic Pirate Skull
 Space Jellyfish
+Gelatinous Cubeling
 Barrrnacle

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -79,7 +79,8 @@ drop	24	Galloping Grill	prop:_hotAshesDrops<5
 gremlins	0	Nosy Nose
 gremlins	1	Plastic Pirate Skull
 gremlins	2	Space Jellyfish
-gremlins	3	Barrrnacle
+gremlins	3	Gelatinous Cubeling
+gremlins	4	Barrrnacle
 
 init	0	Xiblaxian Holo-Companion
 init	1	Cute Meteor


### PR DESCRIPTION
Gelatinous Cubeling is better than Barrrnacle for gremlins
## How Has This Been Tested?

it delevels more often? either its base chance is higher or it's going to be heavier because it gets used for at least 12 fights and the Barrrnacle	doesn't. plus it's a fairy.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
