### PR TITLE
reconsider pulling grimstone mask for exploration

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -319,6 +319,10 @@ boolean LX_ornateDowsingRod(boolean doing_desert_now)
 	{
 		return false;
 	}
+	if(possessEquipment($item[UV-resistant compass]))
+	{
+		return false;		//already chose the other off-hand
+	}
 	if(in_hardcore())		//will we be able to pull at any point in the run. not just right now (we might be out of pulls today)
 	{
 		if(!canChangeToFamiliar($familiar[Grimstone Golem]))	//no golem, or not allowed in path
@@ -335,13 +339,19 @@ boolean LX_ornateDowsingRod(boolean doing_desert_now)
 	{
 		return false;
 	}
-	if(get_counters("", 0, 6) != "")
-	{
-		return false;	//do not waste a semirare
-	}
 	
 	if(item_amount($item[Grimstone Mask]) == 0 && !canChangeToFamiliar($familiar[Grimstone Golem]) && canPull($item[Grimstone Mask]))
 	{
+		if(canPull($item[Shore Inc. Ship Trip Scrip]) && storage_amount($item[Shore Inc. Ship Trip Scrip]) > 2)
+		{
+			//since drum machine and killing jar get pulled it's not useful to explore faster than compass just to need more fights gathering pages anyway
+			//not worth spending the 5 adv to acquire rod in addition to the pull if Trip Scrip aren't in short supply
+			return false;
+		}
+		// if(canChangeToFamiliar($familiar[Melodramedary]))
+		// {
+		// 	//with Melodramedary, drum machine, killing jar and no Scrip pull, pulling the mask saves 2 turns compared to vacationing for Scrip? is that good enough?
+		// }
 		pullXWhenHaveY($item[Grimstone Mask], 1, 0);		//pull the mask if you do not have it and cannot use the golem
 	}
 	if(item_amount($item[Grimstone Mask]) == 0)


### PR DESCRIPTION
remove the semirare checker checking for any counter		 if(get_counters("", 0, 6) != "")

don't pull grimstone mask unless running short on scrips.
rod explores faster than compass, but pulling the mask for rod ends up worse on average than pulling a scrip for compass, because of the 5 advs spent taking silver coins instead of getting pages (and stats and flyering) from fights in the desert

## How Has This Been Tested?
softcore run

have not calculated if the mask is still useful in hardcore versus Melodramedary + killing jar + drum machine + stone rose. There is still a per-ascension preference that can be toggled off if someone wants to skip the mask in hardcore

in softcore autoscend pulls drum machine and killing jar. drum machine = 30% exploration, killing jar = 15%, can of black paint = 15%.
40% exploration left, without Melodramedary, when pulling scrip/mask = 20 fights with UV-resistant compass, or 19 (14 fights) with ornate dowsing rod.
at ~17 fights to get pages (I have between 13 and 22) pulling mask wastes on average 2 turns compared to pulling scrip

note #1041 may make it less certain that killing jar was pulled if one was not found, and then autoscend may decide to go get the stone rose before it considers pulling the killing jar.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
