### PR TITLE
hotfix lots of errors when looking at red rocket

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -270,11 +270,12 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 			return useItem($item[red rocket]);
 		}
 		//use if next food is large in size. Currently autoConsume doesn't analyze stat gain, which would be better
-		item simulationOutput = auto_autoConsumeOneSimulation("eat");
-		if (simulationOutput != $item[none] && simulationOutput.fullness > 3)
-		{
+		//disabled until fix: https://github.com/Loathing-Associates-Scripting-Society/autoscend/issues/1053
+		//item simulationOutput = auto_autoConsumeOneSimulation("eat");
+		//if (simulationOutput != $item[none] && simulationOutput.fullness > 3)
+		//{
 			return useItem($item[red rocket]);
-		}
+		//}
 	}
 
 	// use cosmic bowling ball iotm


### PR DESCRIPTION
#1053 red rocket hotfix workaround. simply disable the check for fullness > 3 on next item to be consumed.
will reenable it once a better fix is finalized.

## How Has This Been Tested?

validates. but I need to wait until dayroll to properly test it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
