### PR TITLE
fix no familiar choice due to Red-Nosed Snapper handling

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -338,6 +338,11 @@ boolean handleFamiliar(familiar fam)
 		fam = $familiar[Ms. Puck Man];
 	}
 	
+	if(!canChangeToFamiliar(fam))
+	{
+		return false;
+	}
+	
 	//bjorning has priority
 	if(my_bjorned_familiar() == fam)
 	{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -307,17 +307,9 @@ boolean handleFamiliar(familiar fam)
 {
 	//This function takes a specific named familiar and sets it as our target familiar. To be changed during pre_adventure.
 
-	if(get_property("auto_disableFamiliarChanging").to_boolean())
-	{
-		return false;	//familiar changing temporarily disabled.
-	}
 	if(!pathHasFamiliar() || !pathAllowsChangingFamiliar())
 	{
 		return false;
-	}
-	if(is100FamRun() && get_property("auto_100familiar").to_familiar() != fam)
-	{
-		return false;	//do not break a 100% familiar run
 	}
 	if(fam == $familiar[none])
 	{


### PR DESCRIPTION
Red-Nosed Snapper handling always stops any choice even with no snapper
zones like Fantasy ship and Copperhead never chose a familiar

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
