### PR TITLE
fix Home on the Free Range repeat choice

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -458,13 +458,14 @@ boolean auto_run_choice(int choice, string page)
 			edUnderworldChoiceHandler(choice);
 			break;
 		case 1026: // Home on the Free Range (Castle in the Clouds in the Sky (Ground Floor))
-			if(isActuallyEd() || in_bugbear() || in_pokefam()) // paths that don't require a boning knife for the tower
+			if(item_amount($item[electric boning knife]) > 0 ||
+			isActuallyEd() || in_bugbear() || in_pokefam()) // paths that don't require a boning knife for the tower
 			{
 				run_choice(3); // skip
 			}
 			else
 			{
-				run_choice(2); // get Electric Boning Knife then skip
+				run_choice(2); // get Electric Boning Knife
 			}
 			break;
 		case 1056: // Now It's Dark (Lost in the Great Overlook Lodge)


### PR DESCRIPTION
choice was not supported if already got boning knife, skip choice is different

## How Has This Been Tested?
confirmed choice 2 no longer exists

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
