### PR TITLE
Fix Emotion Chip Skill Tracking

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -831,14 +831,22 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	if ($effects[Feeling Lonely, Feeling Excited, Feeling Nervous, Feeling Peaceful] contains buff && auto_haveEmotionChipSkills())
 	{
 		skill feeling = buff.to_skill();
-		if (speculative)
+		//speculate to see if buff will be cast. Return false if it will not be
+		if(buffMaintain(feeling, buff, mustEquip, mp_min, casts, turns, true))
 		{
-			return feeling.timescast < feeling.dailylimit;
-		}
-		else if (feeling.timescast < feeling.dailylimit)
-		{
-			useSkill = buff.to_skill();
-			handleTracker(useSkill, "auto_otherstuff");
+			if (speculative)
+			{
+				return feeling.timescast < feeling.dailylimit;
+			}
+			else if (feeling.timescast < feeling.dailylimit)
+			{
+				useSkill = buff.to_skill();
+				handleTracker(useSkill, "auto_otherstuff");
+			}
+			else
+			{
+				return false;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
# Description

Emo chip skills were only being checked for < 3 casts that day before being tracked. There are many other checks, such as already have the buff, that could later cause the buff not to be cast. 

Added a check to confirm the buff will actually be cast prior to tracking them as being cast

Fixes #972 

## How Has This Been Tested?

Ran HC standard AT. Only tracked emotion skills when actually cast

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
