### PR TITLE
don't get combat rate modifiers for Lucky! adventures

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -277,8 +277,9 @@ boolean auto_pre_adventure()
 
 	// this calls the appropriate provider for +combat or -combat depending on the zone we are about to adventure in..
 	boolean burningDelay = ((auto_voteMonster(true) || isOverdueDigitize() || auto_sausageGoblin() || auto_backupTarget()) && place == solveDelayZone());
+	boolean gettingLucky = (have_effect($effect[Lucky!]) > 0 && zone_hasLuckyAdventure(place));
 	generic_t combatModifier = zone_combatMod(place);
-	if (combatModifier._boolean && !burningDelay && !auto_haveQueuedForcedNonCombat()) {
+	if (combatModifier._boolean && !burningDelay && !gettingLucky && !auto_haveQueuedForcedNonCombat()) {
 		acquireCombatMods(combatModifier._int, true);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -163,7 +163,10 @@ generic_t zone_needItem(location loc)
 		value = 20.0;
 		break;
 	case $location[The Smut Orc Logging Camp]:
-		value = 10.0;
+		if(get_property("chasmBridgeProgress").to_int() < 30)
+		{
+			value = 10.0;
+		}
 		break;
 	case $location[A-Boo Peak]:
 		if(get_property("auto_aboopending").to_int() == 0)

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1719,7 +1719,20 @@ generic_t zone_difficulty(location loc)
 
 boolean zone_hasLuckyAdventure(location loc)
 {
-	if ($locations[8-Bit Realm,A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,Elf Alley,Exposure Esplanade,Frat House,Frat House In Disguise,Guano Junction,Hippy Camp,Hippy Camp In Disguise,Itznotyerzitz Mine,Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,The "Fun" House,The Ancient Hobo Burial Ground,The Batrat and Ratbat Burrow,The Black Forest,The Brinier Deepers,The Briny Deeps,The Bugbear Pen,The Castle in the Clouds in the Sky (Basement),The Castle in the Clouds in the Sky (Ground Floor),The Castle in the Clouds in the Sky (Top Floor),The Copperhead Club,The Dark Elbow of the Woods,The Dark Heart of the Woods,The Dark Neck of the Woods,The Dive Bar,The Goatlet,The Hallowed Halls,The Haunted Ballroom,The Haunted Billiards Room,The Haunted Boiler Room,The Haunted Conservatory,The Haunted Gallery,The Haunted Kitchen,The Haunted Library,The Haunted Pantry,The Haunted Storage Room,The Heap,The Hidden Park,The Hidden Temple,The Icy Peak,The Knob Shaft,The Limerick Dungeon,The Mer-Kin Outpost,The Oasis,The Obligatory Pirate's Cove,The Outskirts of Cobb's Knob,The Poker Room,The Primordial Soup,The Purple Light District,The Red Zeppelin,The Roulette Tables,The Sleazy Back Alley,The Smut Orc Logging Camp,The Spectral Pickle Factory,The Spooky Forest,The Spooky Gravy Burrow,The Unquiet Garves,The VERY Unquiet Garves,The Valley of Rof L'm Fao,The Wreck of the Edgar Fitzsimmons,Thugnderdome,Tower Ruins,Twin Peak,Vanya's Castle Chapel,Whitey's Grove,Ye Olde Medievale Villagee] contains loc)
+	if ($locations[8-Bit Realm,A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
+	Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
+	Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,
+	Elf Alley,Exposure Esplanade,Frat House,Frat House In Disguise,Guano Junction,Hippy Camp,Hippy Camp In Disguise,Itznotyerzitz Mine,
+	Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,
+	The "Fun" House,The Ancient Hobo Burial Ground,The Batrat and Ratbat Burrow,The Black Forest,The Brinier Deepers,The Briny Deeps,The Bugbear Pen,
+	The Castle in the Clouds in the Sky (Basement),The Castle in the Clouds in the Sky (Ground Floor),The Castle in the Clouds in the Sky (Top Floor),
+	The Copperhead Club,The Dark Elbow of the Woods,The Dark Heart of the Woods,The Dark Neck of the Woods,The Dive Bar,The Goatlet,The Hallowed Halls,
+	The Haunted Ballroom,The Haunted Billiards Room,The Haunted Boiler Room,The Haunted Conservatory,The Haunted Gallery,The Haunted Kitchen,
+	The Haunted Library,The Haunted Pantry,The Haunted Storage Room,The Heap,The Hidden Park,The Hidden Temple,The Icy Peak,The Knob Shaft,
+	The Limerick Dungeon,The Mer-Kin Outpost,The Oasis,The Obligatory Pirate's Cove,The Outskirts of Cobb's Knob,The Poker Room,The Primordial Soup,
+	The Purple Light District,The Red Zeppelin,The Roulette Tables,The Sleazy Back Alley,The Smut Orc Logging Camp,The Spectral Pickle Factory,
+	The Spooky Forest,The Spooky Gravy Burrow,The Unquiet Garves,The VERY Unquiet Garves,The Valley of Rof L'm Fao,The Wreck of the Edgar Fitzsimmons,
+	Thugnderdome,Tower Ruins,Twin Peak,Vanya's Castle Chapel,Whitey's Grove,Ye Olde Medievale Villagee] contains loc)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1714,6 +1714,15 @@ generic_t zone_difficulty(location loc)
 	return retval;
 }
 
+boolean zone_hasLuckyAdventure(location loc)
+{
+	if ($locations[8-Bit Realm,A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,Elf Alley,Exposure Esplanade,Frat House,Frat House In Disguise,Guano Junction,Hippy Camp,Hippy Camp In Disguise,Itznotyerzitz Mine,Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,The "Fun" House,The Ancient Hobo Burial Ground,The Batrat and Ratbat Burrow,The Black Forest,The Brinier Deepers,The Briny Deeps,The Bugbear Pen,The Castle in the Clouds in the Sky (Basement),The Castle in the Clouds in the Sky (Ground Floor),The Castle in the Clouds in the Sky (Top Floor),The Copperhead Club,The Dark Elbow of the Woods,The Dark Heart of the Woods,The Dark Neck of the Woods,The Dive Bar,The Goatlet,The Hallowed Halls,The Haunted Ballroom,The Haunted Billiards Room,The Haunted Boiler Room,The Haunted Conservatory,The Haunted Gallery,The Haunted Kitchen,The Haunted Library,The Haunted Pantry,The Haunted Storage Room,The Heap,The Hidden Park,The Hidden Temple,The Icy Peak,The Knob Shaft,The Limerick Dungeon,The Mer-Kin Outpost,The Oasis,The Obligatory Pirate's Cove,The Outskirts of Cobb's Knob,The Poker Room,The Primordial Soup,The Purple Light District,The Red Zeppelin,The Roulette Tables,The Sleazy Back Alley,The Smut Orc Logging Camp,The Spectral Pickle Factory,The Spooky Forest,The Spooky Gravy Burrow,The Unquiet Garves,The VERY Unquiet Garves,The Valley of Rof L'm Fao,The Wreck of the Edgar Fitzsimmons,Thugnderdome,Tower Ruins,Twin Peak,Vanya's Castle Chapel,Whitey's Grove,Ye Olde Medievale Villagee] contains loc)
+	{
+		return true;
+	}
+	return false;
+}
+
 location[int] zones_available()
 {
 	location[int] retval;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1470,6 +1470,7 @@ generic_t zone_combatMod(location loc);
 generic_t zone_delay(location loc);
 boolean zone_available(location loc);
 generic_t zone_difficulty(location loc);
+boolean zone_hasLuckyAdventure(location loc);
 location[int] zones_available();
 monster[int] mobs_available();
 item[int] drops_available();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -248,7 +248,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			}
 		}
 
-		if(my_location() == $location[The Smut Orc Logging Camp] && canSurvive(1.0))
+		if(my_location() == $location[The Smut Orc Logging Camp] && canSurvive(1.0) && get_property("chasmBridgeProgress").to_int() < 30)
 		{
 			// Listed from Most to Least Damaging to hopefully cause Death on the turn when the Shell hits.
 			if(canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0)


### PR DESCRIPTION
don't get combat rate modifiers for Lucky! adventures
also no item bonus or cold damage at The Smut Orc Logging Camp after bridge built (Shen)

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
