### PR TITLE
remove Titanium Assault Umbrella pull

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -168,13 +168,9 @@ boolean L10_basement()
 	}
 
 	auto_forceNextNoncombat();
-	if(!possessEquipment($item[Amulet of Extreme Plot Significance]))
+	if(!autoEquip($item[Amulet of Extreme Plot Significance]))
 	{
 		autoEquip($item[Titanium Assault Umbrella]);
-	}
-	else
-	{
-		autoEquip($item[Amulet of Extreme Plot Significance]);
 	}
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 	

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -121,26 +121,34 @@ boolean L10_basement()
 		return false;
 	}
 
-	if(possessEquipment($item[Titanium Assault Umbrella]) && !auto_can_equip($item[Titanium Assault Umbrella]))
+	if(possessEquipment($item[Amulet of Extreme Plot Significance]))
 	{
-		return false;
+		if(!auto_can_equip($item[Amulet of Extreme Plot Significance]))
+		{
+			return false;
+		}
 	}
-
-	if(possessEquipment($item[Amulet of Extreme Plot Significance]) && !auto_can_equip($item[Amulet of Extreme Plot Significance]))
+	else if(possessEquipment($item[Titanium Assault Umbrella]) && !auto_can_equip($item[Titanium Assault Umbrella]))
 	{
 		return false;
 	}
 
 	auto_log_info("Castle (Basement) - Unlocking Ground Floor.", "blue");
-	
-	if(!possessEquipment($item[Titanium Assault Umbrella]) && auto_can_equip($item[Titanium Assault Umbrella]) && !in_hardcore())
-	{
-		pullXWhenHaveY($item[Titanium Assault Umbrella], 1, 0);
-	}
 
-	if(!possessEquipment($item[Amulet of Extreme Plot Significance]) && auto_can_equip($item[Amulet of Extreme Plot Significance]) && !in_hardcore())
+	if(!in_hardcore())
 	{
-		pullXWhenHaveY($item[Amulet of Extreme Plot Significance], 1, 0);
+		if(!possessEquipment($item[Amulet of Extreme Plot Significance]) && auto_can_equip($item[Amulet of Extreme Plot Significance]))
+		{
+			pullXWhenHaveY($item[Amulet of Extreme Plot Significance], 1, 0);
+		}
+		
+		if(!possessEquipment($item[Amulet of Extreme Plot Significance]))			//only consider umbrella if getting amulet fails somehow
+		{
+			if(!possessEquipment($item[Titanium Assault Umbrella]) && auto_can_equip($item[Titanium Assault Umbrella]))
+			{
+				pullXWhenHaveY($item[Titanium Assault Umbrella], 1, 0);
+			}
+		}
 	}
 
 	if(my_primestat() == $stat[Muscle])
@@ -160,8 +168,14 @@ boolean L10_basement()
 	}
 
 	auto_forceNextNoncombat();
-	autoEquip($item[Titanium Assault Umbrella]);
-	autoEquip($item[Amulet of Extreme Plot Significance]);
+	if(!possessEquipment($item[Amulet of Extreme Plot Significance]))
+	{
+		autoEquip($item[Titanium Assault Umbrella]);
+	}
+	else
+	{
+		autoEquip($item[Amulet of Extreme Plot Significance]);
+	}
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Basement)]);
 	
 	return true;


### PR DESCRIPTION
Amulet of Extreme Plot Significance is the only equipment needed. Titanium Assault Umbrella should not get pulled

## How Has This Been Tested?
run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
