### PR TITLE
BHY Code Cleanup

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1063,7 +1063,8 @@ boolean dailyEvents()
 	while(zataraClanmate(""));
 
 	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]) && auto_is_valid($item[pocket wish]) && !in_glover())
-	{ // can't use genie bottle in BHY and can't use pocket wishes in G-Lover
+	{
+	//if bottle is valid and pocket wishes are not (such as in glover) then we should save the wishes for use and only convert leftovers into pocket wishes at bedtime
 		for(int i=get_property("_genieWishesUsed").to_int(); i<3; i++)
 		{
 			makeGeniePocket();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1062,8 +1062,8 @@ boolean dailyEvents()
 
 	while(zataraClanmate(""));
 
-	if (item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[pocket wish]) && !in_glover())
-	{
+	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]) && auto_is_valid($item[pocket wish]) && !in_glover())
+	{ // can't use genie bottle in BHY and can't use pocket wishes in G-Lover
 		for(int i=get_property("_genieWishesUsed").to_int(); i<3; i++)
 		{
 			makeGeniePocket();

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -662,9 +662,9 @@ boolean doBedtime()
 
 	if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
 	{
-		if(in_pokefam() || in_darkGyffte())
+		if(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_lta() || in_pokefam())
 		{
-			cli_execute("friars food");
+			cli_execute("friars food"); // paths that do not have a familiar
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -662,13 +662,13 @@ boolean doBedtime()
 
 	if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
 	{
-		if(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_lta() || in_pokefam())
+		if(pathHasFamiliar())
 		{
-			cli_execute("friars food"); // paths that do not have a familiar
+			cli_execute("friars familiar");
 		}
 		else
 		{
-			cli_execute("friars familiar");
+			cli_execute("friars food");
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -648,8 +648,8 @@ boolean doBedtime()
 	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel. also keep leftover charges for tomorrow.
 	loveTunnelAcquire(true, $stat[none], true, 3, true, 1);
 
-	if(item_amount($item[Genie Bottle]) > 0)
-	{
+	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]) && auto_is_valid($item[pocket wish]) && !in_glover())
+	{ // can't use genie bottle in BHY and can't use pocket wishes in G-Lover
 		for(int i=get_property("_genieWishesUsed").to_int(); i<3; i++)
 		{
 			makeGeniePocket();

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -648,8 +648,9 @@ boolean doBedtime()
 	januaryToteAcquire($item[Makeshift Garbage Shirt]);		//doubles stat gains in the LOV tunnel. also keep leftover charges for tomorrow.
 	loveTunnelAcquire(true, $stat[none], true, 3, true, 1);
 
-	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]) && auto_is_valid($item[pocket wish]) && !in_glover())
-	{ // can't use genie bottle in BHY and can't use pocket wishes in G-Lover
+	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]))
+	{
+	//we are in bedtime so any wishes we planned to use today were already used. thus even if we can not use pocket wishes in this path we should still make them to avoid waste
 		for(int i=get_property("_genieWishesUsed").to_int(); i<3; i++)
 		{
 			makeGeniePocket();

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -861,7 +861,7 @@ void acquireFamiliars()
 	{
 		return;
 	}
-	if(!in_bhy()) // BHY can't use either barrel mimic or blood-faced volleyball
+	if(in_bhy()) // BHY can't use either barrel mimic or blood-faced volleyball
 	{
 		return;
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -861,7 +861,11 @@ void acquireFamiliars()
 	{
 		return;
 	}
-	
+	if(!in_bhy()) // BHY can't use either barrel mimic or blood-faced volleyball
+	{
+		return;
+	}
+
 	//Very cheap and very useful IOTM derivative. MP/HP regen. drops lots of useful food and drink early on
 	if(!have_familiar($familiar[Lil\' Barrel Mimic]) && item_amount($item[tiny barrel]) == 0 && is_unrestricted($item[tiny barrel]) && canPull($item[tiny barrel]))
 	{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -861,20 +861,16 @@ void acquireFamiliars()
 	{
 		return;
 	}
-	if(in_bhy()) // BHY can't use either barrel mimic or blood-faced volleyball
-	{
-		return;
-	}
 
 	//Very cheap and very useful IOTM derivative. MP/HP regen. drops lots of useful food and drink early on
-	if(!have_familiar($familiar[Lil\' Barrel Mimic]) && item_amount($item[tiny barrel]) == 0 && is_unrestricted($item[tiny barrel]) && canPull($item[tiny barrel]))
+	if(!have_familiar($familiar[Lil\' Barrel Mimic]) && item_amount($item[tiny barrel]) == 0 && is_unrestricted($item[tiny barrel]) && canPull($item[tiny barrel]) && auto_is_valid($item[tiny barrel]))
 	{
 		acquireOrPull($item[tiny barrel]);		//mallbuy and pull it if we can
 	}
 	hatchFamiliar($familiar[Lil\' Barrel Mimic]);
 	
 	//stat gains. nonscaling. better at low levels. cheap and easy to acquire in run.
-	if(!have_familiar($familiar[Blood-Faced Volleyball]) && item_amount($item[blood-faced volleyball]) == 0 && my_meat() > meatReserve() + 1500)
+	if(!have_familiar($familiar[Blood-Faced Volleyball]) && item_amount($item[blood-faced volleyball]) == 0 && auto_is_valid($item[seal tooth]) && auto_is_valid($item[volleyball]) && my_meat() > meatReserve() + 1500)
 	{
 		foreach it in $items[volleyball, seal tooth]
 		{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -369,13 +369,19 @@ boolean autoChooseFamiliar(location place)
 
 	// Blackbird/Crow cut turns in the Black Forest but we only need to equip them
 	// if we don't have them in inventory.
-	if ($location[The Black Forest] == place) {
-		if (!in_bhy()) {
-			if (item_amount($item[Reassembled Blackbird]) == 0 && canChangeToFamiliar($familiar[Reassembled Blackbird])) {
+	if($location[The Black Forest] == place)
+	{
+		if(!in_bhy())
+		{
+			if(item_amount($item[Reassembled Blackbird]) == 0 && canChangeToFamiliar($familiar[Reassembled Blackbird]))
+			{
 				famChoice = $familiar[Reassembled Blackbird];
 			}
-		} else {
-			if (item_amount($item[Reconstituted Crow]) == 0 && canChangeToFamiliar($familiar[Reconstituted Crow])) {
+		}
+		else
+		{
+			if(item_amount($item[Reconstituted Crow]) == 0 && canChangeToFamiliar($familiar[Reconstituted Crow]))
+			{
 				famChoice = $familiar[Reconstituted Crow];
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2936,7 +2936,7 @@ boolean auto_is_valid(item it)
 
 boolean auto_is_valid(familiar fam)
 {
-	if(is100FamRun()
+	if(is100FamRun())
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2936,7 +2936,8 @@ boolean auto_is_valid(item it)
 
 boolean auto_is_valid(familiar fam)
 {
-	if(is100FamRun()){
+	if(is100FamRun()
+	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
 	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && is_unrestricted(fam);

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1765,8 +1765,8 @@ boolean makeGenieWish(effect eff)
 
 boolean canGenieCombat()
 {
-	if(item_amount($item[Genie Bottle]) == 0 && item_amount($item[pocket wish]) == 0)
-	{
+	if(item_amount($item[genie bottle]) == 0 && item_amount($item[pocket wish]) == 0 && !auto_is_valid($item[genie bottle]))
+	{ // can't use genie bottle in BHY
 		return false;
 	}
 	if((get_property("_genieWishesUsed").to_int() >= 3) && (0 == item_amount($item[pocket wish])))

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1765,21 +1765,22 @@ boolean makeGenieWish(effect eff)
 
 boolean canGenieCombat()
 {
-	if(item_amount($item[genie bottle]) == 0 && item_amount($item[pocket wish]) == 0 && !auto_is_valid($item[genie bottle]))
+	boolean haveBottle = item_amount($item[Genie Bottle]) > 0;
+	boolean bottleWishesLeft = get_property("_genieWishesUsed").to_int() < 3;
+	boolean canUseBottle = haveBottle && bottleWishesLeft && auto_is_valid($item[Genie Bottle]);
+	boolean havePocket = item_amount($item[pocket wish]) > 0;
+	boolean canUsePocket = havePocket && auto_is_valid($item[pocket wish]);
+	if(!canUseBottle && !canUsePocket)
 	{
 		return false;
 	}
-	if((get_property("_genieWishesUsed").to_int() >= 3) && (0 == item_amount($item[pocket wish])))
+	if(get_property("_genieFightsUsed").to_int() >= 3))
 	{
-		return false;
-	}
-	if(get_property("_genieFightsUsed").to_int() >= 3)
-	{
-		return false;
+		return false;  // max 3 fights per day
 	}
 	if(my_adventures() == 0)
 	{
-		return false;
+		return false;  // cannot fight if no adv remaining
 	}
 	return true;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1766,7 +1766,7 @@ boolean makeGenieWish(effect eff)
 boolean canGenieCombat()
 {
 	if(item_amount($item[genie bottle]) == 0 && item_amount($item[pocket wish]) == 0 && !auto_is_valid($item[genie bottle]))
-	{ // can't use genie bottle in BHY
+	{
 		return false;
 	}
 	if((get_property("_genieWishesUsed").to_int() >= 3) && (0 == item_amount($item[pocket wish])))

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1774,7 +1774,7 @@ boolean canGenieCombat()
 	{
 		return false;
 	}
-	if(get_property("_genieFightsUsed").to_int() >= 3))
+	if(get_property("_genieFightsUsed").to_int() >= 3)
 	{
 		return false;  // max 3 fights per day
 	}

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -3,7 +3,6 @@ boolean in_bhy()
 	return my_path() == "Bees Hate You";
 }
 
-
 void bhy_initializeSettings()
 {
 	if(in_bhy())
@@ -95,12 +94,12 @@ boolean LM_bhy()
 boolean L13_bhy_towerFinal()
 {
 	//Prepare for and defeat the final boss for a Bees hate You run. Which has special rules for engagement.
-	if (internalQuestStatus("questL13Final") != 11)
+	if(internalQuestStatus("questL13Final") != 11)
 	{
 		return false;
 	}
 	
-	if (item_amount($item[antique hand mirror]) < 1 )
+	if(item_amount($item[antique hand mirror]) < 1 )
 	{
 		abort("Need the [antique hand mirror] to defeat the guy made of bees. Please get one from the jewelry of the animated rustic nightstand and try again.");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -797,32 +797,32 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	if (contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
+	if(contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();
 		boolean needJar = ((oilProgress & 4) == 0) && item_amount($item[Jar Of Oil]) == 0;
-		if (!needJar || in_bhy())
+		if(!needJar || in_bhy())
 		{
 			return false;
 		}
-		else if (item_amount($item[Bubblin' Crude]) >= 12)
+		else if(item_amount($item[Bubblin' Crude]) >= 12)
 		{
 			if(in_glover())
 			{
-				if (item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 2)
+				if(item_amount($item[Crude Oil Congealer]) < 1 && item_amount($item[G]) > 2)
 				{
 					buy($coinmaster[G-Mart], 1, $item[Crude Oil Congealer]);
 				}
-				if (item_amount($item[Crude Oil Congealer]) > 0)
+				if(item_amount($item[Crude Oil Congealer]) > 0)
 				{
 					use(1, $item[Crude Oil Congealer]);
 				}
 			}
-			else if (auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0)
+			else if(auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0)
 			{
 				create(1, $item[Jar Of Oil]);
 			}
-			if (item_amount($item[Jar Of Oil]) > 0)
+			if(item_amount($item[Jar Of Oil]) > 0)
 			{
 				return true;
 			}


### PR DESCRIPTION
# Description

Removes some calls that won't work in BHY due to exclusion of B letters.  Can't use genie bottle, no need for Bloody Hand to make volleyball, can't use/pull tiny barrel familiar.

Also has various code cleanup for areas I reviewed for BHY.

## How Has This Been Tested?

Did a BHY run

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
