### PR TITLE
don't equip red badge only because of equipped red badge

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -579,14 +579,6 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
-	// Item specific Conditions
-	if((equipped_amount($item[Space Trip Safety Headphones]) > 0) || (equipped_amount($item[Red Badge]) > 0))
-	{
-		doML = false;
-		removeML = true;
-		purgeML = false;
-	}
-
 	// Backup Camera copies have double ML applied. Reduce ML to avoid getting beaten up
 	if(auto_backupTarget())
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2396,7 +2396,9 @@ boolean L11_shenCopperhead()
 			auto_changeSnapperPhylum($phylum[dude]);
 		}
 
+		// monster level increases zone damage
 		addToMaximize("-10ml");
+		uneffect($effect[Ur-Kel\'s Aria of Annoyance]);
 		if (autoAdv($location[The Copperhead Club]))
 		{
 			if (get_property("lastEncounter").contains_text("Shen Copperhead, "))


### PR DESCRIPTION
red badge / Space Trip Safety Headphones  -10ml in the maximizer gets set just for having them equipped, so once red badge gets equipped it keeps getting equipped into other zones that don't need -ML until 3 accessories can beat -10*25 score. no references to these items elsewhere.
you don't always have a red badge to wear, an example I found where this would sometimes get pre_adv to remove ML is L11_shenCopperhead maximizing with -10ml, with a red badge available Ur-kel\'s Aria of Annoyance would be removed by pre_adv next adventure for The Copperhead Club, but not without a red badge so this still wouldn't have worked well


## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
