### PR TITLE
skip sidequests if battlefield is empty

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1022,6 +1022,10 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
+	if(auto_warEnemiesRemaining() == 0)
+	{
+		return false;
+	}
 	if(in_glover())
 	{
 		int need = 30 - item_amount($item[Doc Galaktik\'s Pungent Unguent]);
@@ -1140,6 +1144,10 @@ boolean L12_sonofaBeach()
 		{
 			return false;
 		}
+	}
+	if(auto_warEnemiesRemaining() == 0)
+	{
+		return false;
 	}
 	if((get_property("fratboysDefeated").to_int() < 64) && get_property("auto_hippyInstead").to_boolean())
 	{
@@ -1529,6 +1537,11 @@ boolean L12_themtharHills()
 	{
 		return false;
 	}
+	
+	if(auto_warEnemiesRemaining() == 0)
+	{
+		return false;
+	}
 
 	if(in_tcrs() || in_koe() || in_wotsf())
 	{
@@ -1838,6 +1851,10 @@ boolean L12_farm()
 	if(get_property("sidequestFarmCompleted") != "none")
 	{
 		set_property("auto_skipL12Farm", "true");
+		return false;
+	}
+	if(auto_warEnemiesRemaining() == 0 && get_property("auto_L12FarmStage").to_int() < 4)
+	{
 		return false;
 	}
 	if(internalQuestStatus("questL12War") != 1)


### PR DESCRIPTION
skip sidequests if battlefield is empty. if script is restarted elsewhere or user finished the war

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
