### PR TITLE
don't strip delevel familiars for gremlins

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -96,7 +96,6 @@ boolean isAttackFamiliar(familiar fam)
 	return false;
 }
 
-
 boolean pathHasFamiliar() 	// check for cases where the path bans traditional familiars.
 {
 	if(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_lta() || in_pokefam())

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -96,6 +96,7 @@ boolean isAttackFamiliar(familiar fam)
 	return false;
 }
 
+
 boolean pathHasFamiliar() 	// check for cases where the path bans traditional familiars.
 {
 	if(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_lta() || in_pokefam())
@@ -389,11 +390,14 @@ boolean autoChooseFamiliar(location place)
 	// places where item drop is required to help save adventures.
 	if ($locations[The Typical Tavern Cellar, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
 	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Hospital, The Hidden Bowling Alley, The Haunted Wine Cellar,
-	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, The Red Zeppelin, Whitey's Grove, The Oasis, The Middle Chamber,
+	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, Whitey's Grove, The Oasis, The Middle Chamber,
 	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,
 	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, 8-Bit Realm, The Degrassi Knoll Garage, The Old Landfill,
 	The Laugh Floor, Infernal Rackets Backstage] contains place) {
 		famChoice = lookupFamiliarDatafile("item");
+	}
+	if (place == $location[The Red Zeppelin] && internalQuestStatus("questL11Ron") < 4)	{
+		famChoice = lookupFamiliarDatafile("item");	//not useful for Ron Copperhead
 	}
 
 	// If we're down to 1 evilness left before the boss in the Nook, it doesn't matter if we get an Evil Eye or not.
@@ -530,8 +534,11 @@ boolean autoChooseFamiliar(location place)
 	}
 	
 	// places where meat drop is desirable due to high meat drop monsters.
-	if ($locations[The Boss Bat's Lair, Mist-Shrouded Peak, The Icy Peak, The Filthworm Queen's Chamber] contains place) {
+	if ($locations[The Boss Bat's Lair, The Icy Peak, The Filthworm Queen's Chamber] contains place) {
 		famChoice = lookupFamiliarDatafile("meat");
+	}
+	if (place == $location[Mist-Shrouded Peak] && place.turns_spent < 3) {
+		famChoice = lookupFamiliarDatafile("meat");	//not useful for Groar
 	}
 
 	//if critically low on MP and meat. use restore familiar to avoid going bankrupt

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -90,7 +90,10 @@ generic_t zone_needItem(location loc)
 		value = 10.0;
 		break;
 	case $location[The Oasis]:
-		value = 30.0;
+		if(have_effect($effect[Ultrahydrated]) > 0)
+		{
+			value = 30.0;
+		}
 		break;
 	case $location[The Middle Chamber]:
 		value = 20.0;

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -981,8 +981,6 @@ boolean L12_orchardFinalize()
 void gremlinsFamiliar()
 {
 	//when fighting gremlins we want to minimize the familiar ability to cause damage.
-	//maximizer will try to force an equip into familiar slot. So disable maximizer switching of familiar equipment
-	addToMaximize("-familiar");
 	
 	familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
 	boolean strip_familiar = true;
@@ -1000,11 +998,34 @@ void gremlinsFamiliar()
 		{
 			equip($slot[familiar], $item[little bitty bathysphere]);
 			strip_familiar = false;
+			//disable maximizer switching of familiar equipment
+			addToMaximize("-familiar");
+		}
+	}
+	else if(lookupFamiliarDatafile("gremlins") == $familiar[none])	//none of the desired familiars available
+	{
+		//don't know what familiar will be chosen or what its own equipment does
+		strip_familiar = true;
+		//maximizer will try to force an equip into familiar slot. So disable maximizer switching of familiar equipment
+		addToMaximize("-familiar");
+	}
+	else
+	{
+		//desired familiars will be available. their own equipment or generic weight boosting familiar equipment is beneficial
+		strip_familiar = false;
+
+		//there is a limited list of harmful familiar equipment to forbid
+		foreach fameq in $items[tiny bowler,ant hoe,ant pick,ant pitchfork,ant rake,ant sickle,plastic pumpkin bucket,little box of fireworks]
+		{
+			if(possessEquipment(fameq))
+			{
+				addToMaximize("-equip " + fameq.to_string());
+			}
 		}
 	}
 	if(strip_familiar)
 	{
-		equip($slot[familiar], $item[none]);	//strip familiar equipment if not in 100% run to avoid passive dmg
+		equip($slot[familiar], $item[none]);	//strip familiar equipment to avoid passive dmg
 	}
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1015,7 +1015,7 @@ void gremlinsFamiliar()
 		strip_familiar = false;
 
 		//there is a limited list of harmful familiar equipment to forbid
-		foreach fameq in $items[tiny bowler,ant hoe,ant pick,ant pitchfork,ant rake,ant sickle,plastic pumpkin bucket,little box of fireworks]
+		foreach fameq in $items[tiny bowler,ant hoe,ant pick,ant pitchfork,ant rake,ant sickle,oversized fish scaler,filthy child leash,plastic pumpkin bucket,little box of fireworks,moveable feast]
 		{
 			if(possessEquipment(fameq))
 			{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1104,7 +1104,7 @@ boolean L13_towerNSTower()
 
 			if(!familiarEquipped)
 			{
-				foreach it in $items[tiny bowler,filthy child leash]
+				foreach it in $items[filthy child leash,tiny bowler]
 				{
 					if(autoEquip(it))
 					{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1086,10 +1086,14 @@ boolean L13_towerNSTower()
 
 			if(!familiarEquipped)
 			{
-				if(autoEquip($item[tiny bowler]))
+				foreach it in $items[tiny bowler,filthy child leash]
 				{
-					sourcesPassive += 1;	//todo: confirm this damage only counts after getting hit, not with familiar damage
-					familiarEquipped = true;
+					if(autoEquip(it))
+					{
+						sourcesPassive += 1;	//todo: confirm this damage only counts after getting hit, not with familiar damage
+						familiarEquipped = true;
+						break;
+					}
 				}
 				if(!familiarEquipped)
 				{
@@ -1105,10 +1109,14 @@ boolean L13_towerNSTower()
 				}
 				if(!familiarEquipped)
 				{
-					if(autoEquip($item[plastic pumpkin bucket]))
+					foreach it in $items[plastic pumpkin bucket,moveable feast]
 					{
-						//attacks ~35% of the time?
-						familiarEquipped = true;
+						if(autoEquip(it))
+						{
+							//attacks ~35% of the time?
+							familiarEquipped = true;
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
don't strip delevel familiars for gremlins
meat familiar not useful for Groar
item familiar not useful for Ron Copperhead
item bonus not needed to get Ultrahydrated

Fixes # (issue)

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
