### PR TITLE
Flyer update

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1719,7 +1719,7 @@ float MLDamageToMonsterMultiplier()
 {
 	//Positive ML gives monsters damage resistance
 	//Negative ML increases the damage inflicted on monsters
-	float retval = 1 + 0.004*monster_level_adjustment();
+	float retval = 1 - 0.004*monster_level_adjustment();
 	if(retval < 0.5)
 	{
 		//damage resistance is capped at 50%

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1719,15 +1719,11 @@ float MLDamageToMonsterMultiplier()
 {
 	//Positive ML gives monsters damage resistance
 	//Negative ML increases the damage inflicted on monsters
-	float retval = 1;
-	if(monster_level_adjustment() > 0)
+	float retval = 1 + 0.004*monster_level_adjustment();
+	if(retval < 0.5)
 	{
 		//damage resistance is capped at 50%
-		retval -= min(0.5,(0.4*monster_level_adjustment()));
-	}
-	else
-	{
-		retval += 0.4*monster_level_adjustment();
+		retval = 0.5;
 	}
 	return retval;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1696,6 +1696,41 @@ boolean stunnable(monster mon)
 
 	return !(unstunnable_monsters contains mon);
 }
+					    
+float combatItemDamageMultiplier()
+{
+	float retval = 1;
+	if(auto_have_skill($skill[Deft Hands]))
+	{
+		retval += 0.25;
+	}
+	if(have_effect($effect[Mathematically Precise]) > 0)
+	{
+		retval += 0.50;
+	}
+	if(have_equipped($item[V for Vivala mask]))
+	{
+		retval += 0.50;
+	}
+	return retval;
+}
+
+float MLDamageToMonsterMultiplier()
+{
+	//Positive ML gives monsters damage resistance
+	//Negative ML increases the damage inflicted on monsters
+	float retval = 1;
+	if(monster_level_adjustment() > 0)
+	{
+		//damage resistance is capped at 50%
+		retval -= min(0.5,(0.4*monster_level_adjustment()));
+	}
+	else
+	{
+		retval += 0.4*monster_level_adjustment();
+	}
+	return retval;
+}
 
 int freeCrafts()
 {

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1564,6 +1564,8 @@ boolean allowSoftblockShen();
 boolean setSoftblockShen();
 boolean instakillable(monster mon);
 boolean stunnable(monster mon);
+float combatItemDamageMultiplier();
+float MLDamageToMonsterMultiplier();
 int freeCrafts();
 boolean isFreeMonster(monster mon);
 boolean declineTrades();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -189,8 +189,35 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 	if(canUse(flyer) && get_property("flyeredML").to_int() < 10000 && my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
 	{
+		boolean shouldFlyer = false;
+		boolean staggeringFlyer = false;
+		item flyerWith;
+		if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !(get_property("_auto_combatState").contains_text("(it")))
+		{
+			//first item throw in the fight staggers
+			staggeringFlyer = true;
+		}
+		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
+		{
+			int beehiveDamage = ceil(30*combatItemDamageMultiplier()*MLDamageToMonsterMultiplier());
+			if (canUse($item[Time-Spinner]))
+			{
+				flyerWith = $item[Time-Spinner];
+				staggeringFlyer = true;
+			}
+			else if (canUse($item[beehive]) && 
+			!(monster_hp() <= beehiveDamage && my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce])))	//don't miss MP by killing weak monsters with beehive
+			{
+				flyerWith = $item[beehive];
+				staggeringFlyer = true;
+			}
+		}
+		if(staggeringFlyer && (!stunnable(enemy) || monster_level_adjustment() > 150))
+		{
+			staggeringFlyer = false;
+		}
 		boolean stunned;
-		if(stunnable(enemy))
+		if(!staggeringFlyer && stunnable(enemy))
 		{
 			skill stunner = getStunner(enemy);
 			stunned = combat_status_check("stunned");
@@ -198,27 +225,6 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 			{
 				combat_status_add("stunned");
 				return useSkill(stunner);
-			}
-		}
-		boolean shouldFlyer = false;
-		boolean staggeringFlyer = false;
-		item flyerWith;
-		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
-		{
-			if (canUse($item[Time-Spinner]))
-			{
-				flyerWith = $item[Time-Spinner];
-				staggeringFlyer = true;
-			}
-			else if (canUse($item[beehive]) && 
-			!(monster_hp() <= 30 && my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce])))	//don't miss MP by killing weak monsters with beehive
-			{
-				flyerWith = $item[beehive];
-				staggeringFlyer = true;
-			}
-			if(staggeringFlyer && (!stunnable(enemy) || monster_level_adjustment() > 150))
-			{
-				staggeringFlyer = false;
 			}
 		}
 		if(canSurvive(3.0) || stunned || staggeringFlyer)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -192,24 +192,35 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 		boolean shouldFlyer = false;
 		boolean staggeringFlyer = false;
 		item flyerWith;
-		if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !(get_property("_auto_combatState").contains_text("(it")))
+		if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !combat_status_check("(it"))
 		{
 			//first item throw in the fight staggers
 			staggeringFlyer = true;
 		}
 		if(auto_have_skill($skill[Ambidextrous Funkslinging]))
 		{
-			int beehiveDamage = ceil(30*combatItemDamageMultiplier()*MLDamageToMonsterMultiplier());
 			if (canUse($item[Time-Spinner]))
 			{
 				flyerWith = $item[Time-Spinner];
 				staggeringFlyer = true;
 			}
-			else if (canUse($item[beehive]) && 
-			!(monster_hp() <= beehiveDamage && my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce])))	//don't miss MP by killing weak monsters with beehive
+			else if (canUse($item[beehive]))
 			{
-				flyerWith = $item[beehive];
-				staggeringFlyer = true;
+				if(my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce]))
+				{
+					//don't miss MP by killing weak monsters with beehive
+					int beehiveDamage = ceil(30*combatItemDamageMultiplier()*MLDamageToMonsterMultiplier());
+					if(monster_hp() > beehiveDamage)
+					{
+						flyerWith = $item[beehive];
+						staggeringFlyer = true;
+					}
+				}
+				else
+				{
+					flyerWith = $item[beehive];
+					staggeringFlyer = true;
+				}
 			}
 		}
 		if(staggeringFlyer && (!stunnable(enemy) || monster_level_adjustment() > 150))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -94,7 +94,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	boolean staggeringFlyer = false;
 	item flyerWith;
 	
-	if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !(get_property("_auto_combatState").contains_text("(it")))
+	if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !combat_status_check("(it"))
 	{
 		//first item throw in the fight staggers
 		staggeringFlyer = true;
@@ -145,7 +145,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 			}
 		}
 	}
-	else if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
+	else if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && !get_property("auto_ignoreFlyer").to_boolean())
 	{
 		if(!staggeringFlyer && stunner != $skill[none] && !stunned)
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -94,6 +94,11 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	boolean staggeringFlyer = false;
 	item flyerWith;
 	
+	if(my_class() == $class[Disco Bandit] && auto_have_skill($skill[Deft Hands]) && !(get_property("_auto_combatState").contains_text("(it")))
+	{
+		//first item throw in the fight staggers
+		staggeringFlyer = true;
+	}
 	if(auto_have_skill($skill[Ambidextrous Funkslinging]))
 	{	
 		if (canUse($item[Time-Spinner]))
@@ -104,15 +109,16 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		else if (canUse($item[beehive]))
 		{
 			boolean canBeehiveGremlin;
+			int beehiveDamage = ceil(30*combatItemDamageMultiplier()*MLDamageToMonsterMultiplier());
 			if (get_property("auto_gremlinMoly").to_boolean())
 			{
 				//don't kill tool gremlin with beehive
-				canBeehiveGremlin = !gremlinTakesDamage && monster_hp() > (60 - round) && canUse($item[Seal Tooth], false);
+				canBeehiveGremlin = !gremlinTakesDamage && monster_hp() > (beehiveDamage + 30 - round) && canUse($item[Seal Tooth], false);
 			}
 			else
 			{
 				//don't miss MP by killing weak monsters with beehive
-				canBeehiveGremlin = !(monster_hp() <= 30 && my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce]));
+				canBeehiveGremlin = !(monster_hp() <= beehiveDamage && my_class() == $class[Sauceror] && haveUsed($skill[Curse Of Weaksauce]));
 			}
 			if (canBeehiveGremlin)
 			{
@@ -120,7 +126,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 				staggeringFlyer = true;
 			}
 		}
-		if(staggeringFlyer && monster_level_adjustment() > 150)
+		if(staggeringFlyer && monster_level_adjustment() > 150)	//gremlins only, no need to check stunnable
 		{
 			staggeringFlyer = false;
 		}
@@ -141,7 +147,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	}
 	else if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && my_location() != $location[The Battlefield (Frat Uniform)] && my_location() != $location[The Battlefield (Hippy Uniform)] && !get_property("auto_ignoreFlyer").to_boolean())
 	{
-		if(stunner != $skill[none] && !stunned)
+		if(!staggeringFlyer && stunner != $skill[none] && !stunned)
 		{
 			combat_status_add("stunned");
 			return useSkill(stunner);

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -185,10 +185,14 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=6", true);
 		}
-		if((my_level() >= 12) && (my_meat() >= 500) && !have_skill($skill[Deft Hands]) && 
-		(!have_skill($skill[Ambidextrous Funkslinging]) || (item_amount($item[beehive]) == 0 && item_amount($item[Time-Spinner]) == 0)))	//safe flyering
+		if((my_level() >= 12) && (my_meat() >= 500) && !have_skill($skill[Deft Hands]) && get_property("sidequestArenaCompleted") == "none")	//safe flyering
 		{
-			visit_url("guild.php?action=buyskill&skillid=6", true);
+			boolean noStaggerItem = item_amount($item[beehive]) == 0 && item_amount($item[Time-Spinner]) == 0;
+			boolean needStagger = (noStaggerItem || !have_skill($skill[Ambidextrous Funkslinging]));
+			if(needStagger && auto_bestWarPlan().do_arena)
+			{
+				visit_url("guild.php?action=buyskill&skillid=25", true);
+			}
 		}
 		break;
 	case $class[Accordion Thief]:

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -189,8 +189,8 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			//safe flyering
 			boolean noStaggerItem = item_amount($item[beehive]) == 0 && item_amount($item[Time-Spinner]) == 0;
-			boolean needStagger = (noStaggerItem || !have_skill($skill[Ambidextrous Funkslinging]));
-			if(needStagger && auto_bestWarPlan().do_arena)
+			boolean cantStagger = noStaggerItem || !have_skill($skill[Ambidextrous Funkslinging]);
+			if(cantStagger && !get_property("auto_ignoreFlyer").to_boolean() && auto_bestWarPlan().do_arena)
 			{
 				//buy Deft hands = first item throw in the fight staggers
 				visit_url("guild.php?action=buyskill&skillid=25", true);

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -185,12 +185,14 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=6", true);
 		}
-		if((my_level() >= 12) && (my_meat() >= 500) && !have_skill($skill[Deft Hands]) && get_property("sidequestArenaCompleted") == "none")	//safe flyering
+		if((my_level() >= 12) && (my_meat() >= 500) && !have_skill($skill[Deft Hands]) && get_property("sidequestArenaCompleted") == "none")
 		{
+			//safe flyering
 			boolean noStaggerItem = item_amount($item[beehive]) == 0 && item_amount($item[Time-Spinner]) == 0;
 			boolean needStagger = (noStaggerItem || !have_skill($skill[Ambidextrous Funkslinging]));
 			if(needStagger && auto_bestWarPlan().do_arena)
 			{
+				//buy Deft hands = first item throw in the fight staggers
 				visit_url("guild.php?action=buyskill&skillid=25", true);
 			}
 		}

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -185,6 +185,11 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=6", true);
 		}
+		if((my_level() >= 12) && (my_meat() >= 500) && !have_skill($skill[Deft Hands]) && 
+		(!have_skill($skill[Ambidextrous Funkslinging]) || (item_amount($item[beehive]) == 0 && item_amount($item[Time-Spinner]) == 0)))	//safe flyering
+		{
+			visit_url("guild.php?action=buyskill&skillid=6", true);
+		}
 		break;
 	case $class[Accordion Thief]:
 		if((my_level() >= 1) && (my_meat() >= 400) && !have_skill($skill[The Moxious Madrigal]))


### PR DESCRIPTION
count beehive item damage multipliers
don't stun for flyering if already staggers
buy Deft Hands skill if needed

## How Has This Been Tested?
in run. other item damage multiplier sources not tested

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
