### PR TITLE
Smut bridge

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -252,6 +252,20 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		{
 			boolean coldMortarShell = canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0;
 			skill coldSkillToUse;
+			int coldAttackDamageMultiplier = 1;
+			if(my_class() == $class[Seal Clubber])
+			{
+				if(canUse($skill[Lunging Thrust-Smack], false))
+				{
+					coldAttackDamageMultiplier = 3;	//triple elemental bonus
+				}
+				else if(canUse($skill[Thrust-Smack], false))
+				{
+					coldAttackDamageMultiplier = 2;	//double elemental bonus
+				}
+			}
+			int coldAttackDamage = numeric_modifier("cold damage")*coldAttackDamageMultiplier;	//todo add ML damage multiplier
+			
 			// Listed from Most to Least Damaging to hopefully cause Death on the turn when the Shell hits.
 			if(canUse($skill[Saucegeyser], false) && numeric_modifier("Cold Spell Damage") > numeric_modifier("Hot Spell Damage"))
 			{
@@ -269,6 +283,33 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			else if(canUse($skill[Northern Explosion], false))
 			{
 				coldSkillToUse = $skill[Northern Explosion];
+			}
+			else if(monster_level_adjustment() < -65 && canUse($skill[Saucestorm], false))
+			{
+				//in extreme case where orcs are reduced to few HP by -ML Saucestorm is better than 50% chance of cold Saucegeyser
+				//todo compare actual damage predictions instead
+				coldSkillToUse = $skill[Saucestorm];
+			}
+			else if(coldAttackDamage > 3*max(1,(69 + monster_level_adjustment())))
+			{
+				//cold bonus weapon attack can also be better than 50% chance of cold Saucegeyser
+				//todo compare actual damage predictions instead
+				if(my_class() == $class[Seal Clubber])
+				{
+					if(canUse($skill[Lunging Thrust-Smack], false))
+					{
+						coldSkillToUse = $skill[Lunging Thrust-Smack];	//triple elemental bonus
+					}
+					else if(canUse($skill[Thrust-Smack], false))
+					{
+						coldSkillToUse = $skill[Thrust-Smack];	//double elemental bonus
+					}
+					else if(canUse($skill[Lunge Smack], false))
+					{
+						coldSkillToUse = $skill[Lunge Smack];
+					}
+				}
+				//other classes default to regular attack later
 			}
 			else if(canUse($skill[Saucegeyser], false) && numeric_modifier("Cold Spell Damage") == numeric_modifier("Hot Spell Damage"))
 			{
@@ -341,7 +382,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			}
 			else if(!in_robot() && $classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class())
 			{
-				if(numeric_modifier("cold damage") > (69 + monster_level_adjustment()))
+				if(coldAttackDamage > (69 + monster_level_adjustment()) && coldAttackDamage > 0)
 				{
 					//if cold damage bonus > their health make sure an attack that uses elemental bonus gets to be used
 					if(my_class() == $class[Seal Clubber])

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -253,8 +253,9 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			boolean coldMortarShell = canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0;
 			skill coldSkillToUse;
 			// Listed from Most to Least Damaging to hopefully cause Death on the turn when the Shell hits.
-			if(canUse($skill[Saucegeyser], false))
+			if(canUse($skill[Saucegeyser], false) && numeric_modifier("Cold Spell Damage") > numeric_modifier("Hot Spell Damage"))
 			{
+				//100% chance of cold Saucegeyser
 				coldSkillToUse = $skill[Saucegeyser];
 			}
 			else if(canUse($skill[Saucecicle], false))
@@ -268,6 +269,11 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			else if(canUse($skill[Northern Explosion], false))
 			{
 				coldSkillToUse = $skill[Northern Explosion];
+			}
+			else if(canUse($skill[Saucegeyser], false) && numeric_modifier("Cold Spell Damage") == numeric_modifier("Hot Spell Damage"))
+			{
+				//equal is 50% chance of cold Saucegeyser. "cold > hot" is used higher in priority. "cold < hot" is 100% hot Saucegeyser and not worth using
+				coldSkillToUse = $skill[Saucegeyser];
 			}
 			
 			int MPreservedForColdSpells = coldMortarShell ? mp_cost($skill[Stuffed Mortar Shell]) : 0;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -122,9 +122,9 @@ void L9_chasmMaximizeForNoncombat()
 int fastenerCount()
 {
 	int base = get_property("chasmBridgeProgress").to_int();
-	base = base + item_amount($item[Morningwood Plank]);
-	base = base + item_amount($item[Raging Hardwood Plank]);
-	base = base + item_amount($item[Weirdwood Plank]);
+	base = base + item_amount($item[Thick Caulk]);
+	base = base + item_amount($item[Long Hard Screw]);
+	base = base + item_amount($item[Messy Butt Joint]);
 
 	return base;
 }
@@ -132,9 +132,9 @@ int fastenerCount()
 int lumberCount()
 {
 	int base = get_property("chasmBridgeProgress").to_int();
-	base = base + item_amount($item[Thick Caulk]);
-	base = base + item_amount($item[Long Hard Screw]);
-	base = base + item_amount($item[Messy Butt Joint]);
+	base = base + item_amount($item[Morningwood Plank]);
+	base = base + item_amount($item[Raging Hardwood Plank]);
+	base = base + item_amount($item[Weirdwood Plank]);
 
 	return base;
 }
@@ -259,9 +259,13 @@ boolean L9_chasmBuild()
 			}
 		}
 
-		foreach it in $items[Loadstone, Logging Hatchet]
+		if(fastenerCount() < 30)
 		{
-			autoEquip(it);
+			autoEquip($item[Loadstone]);
+		}
+		if(lumberCount() < 30)
+		{
+			autoEquip($item[Logging Hatchet]);
 		}
 
 		autoAdv(1, $location[The Smut Orc Logging Camp]);
@@ -294,9 +298,13 @@ boolean L9_chasmBuild()
 
 	if (get_property("chasmBridgeProgress").to_int() < 30)
 	{
-		foreach it in $items[Loadstone, Logging Hatchet]
+		if(fastenerCount() < 30)
 		{
-			autoEquip(it);
+			autoEquip($item[Loadstone]);
+		}
+		if(lumberCount() < 30)
+		{
+			autoEquip($item[Logging Hatchet]);
 		}
 
 		autoAdv(1, $location[The Smut Orc Logging Camp]);


### PR DESCRIPTION
fix lumberCount() and fastenerCount() wrong type
condition Logging hatchet and Loadstone
use Mating Call to balance bridge parts
use cold bonus or if negative ML try to default to saucestorm. override chance of non cold damage like spirit snap.

plus don't use Saucegeyser if it's going to be hot

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
