### PR TITLE
use cache prices and remove some unnecessary operations

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -938,10 +938,13 @@ void initializeDay(int day)
 
 	set_property("auto_forceNonCombatSource", "");
 
-	// Until KoL fix the utterly stupid bug that requires a manual visit to the fireworks shop
-	// before you can even buy anything from it, we will have to do this.
-	// Why is this so hard? Also why is this even a Clan VIP room item? It's just a shop which charges meat.
-	visit_url("clan_viplounge.php?action=fwshop");
+	if(have_fireworks_shop())
+	{
+		// Until KoL fix the utterly stupid bug that requires a manual visit to the fireworks shop
+		// before you can even buy anything from it, we will have to do this.
+		// Why is this so hard? Also why is this even a Clan VIP room item? It's just a shop which charges meat.
+		visit_url("clan_viplounge.php?action=fwshop");
+	}
 
 	set_property("auto_day_init", day);
 }

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -938,14 +938,6 @@ void initializeDay(int day)
 
 	set_property("auto_forceNonCombatSource", "");
 
-	if(have_fireworks_shop())
-	{
-		// Until KoL fix the utterly stupid bug that requires a manual visit to the fireworks shop
-		// before you can even buy anything from it, we will have to do this.
-		// Why is this so hard? Also why is this even a Clan VIP room item? It's just a shop which charges meat.
-		visit_url("clan_viplounge.php?action=fwshop");
-	}
-
 	set_property("auto_day_init", day);
 }
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -719,8 +719,15 @@ void initializeDay(int day)
 	if(!in_hardcore() && get_property("auto_day_init").to_int() < day)
 	{
 		auto_log_info("Bulk caching mall prices for consumables");
-		mall_prices("food");
-		mall_prices("booze");
+		if(get_property("auto_last_mallcached") != today_to_string())
+		{
+			mall_prices("food");
+			mall_prices("booze");
+			set_property("auto_last_mallcached",today_to_string());	//should not cache food,booze again after starting a new ascension on the same day
+		}
+		//food,booze will explicitly request historical_price to avoid making individual mall searches, in case a new mafia session gets started
+		//hprestore and mprestore types corresponding with mall_prices search categories are not available. but it's not as many searches as food,booze
+		//so cache those again even in a new ascension in case it's getting started in a new session
 		mall_prices("hprestore");
 		mall_prices("mprestore");
 	}

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -123,7 +123,19 @@ int auto_mall_price(item it)
 	}
 	if(is_tradeable(it))
 	{
-		int retval = mall_price(it);
+		int retval;
+		string it_type = item_type(it);
+		if(it_type == "food" || it_type == "booze")
+		{
+			//autoscend does Bulk cache mall prices for food,booze,hprestore,mprestore so mafia will give historical_price when asked for mall_price
+			//directly ask for historical_price here because if mafia session has to be restarted mafia will forget it has already cached these prices
+			//hprestore and mprestore types corresponding with mall_prices search categories are not available
+			retval = historical_price(it);
+		}
+		else
+		{
+			retval = mall_price(it);
+		}
 		if(retval == -1)
 		{
 			//0 could be due to item not being tradeable.

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -762,7 +762,10 @@ int handlePulls(int day)
 			{
 				pullXWhenHaveY($item[snow suit], 1, 0);
 			}
-			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Filthy Child Leash]) && !possessEquipment($item[Astral Pet Sweater]) && glover_usable($item[Filthy Child Leash]))
+			boolean famStatEq = possessEquipment($item[fuzzy polar bear ears]) || possessEquipment($item[miniature goose mask]) || possessEquipment($item[tiny glowing red nose]);
+			
+			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Filthy Child Leash]) && !possessEquipment($item[Astral Pet Sweater]) &&
+			!famStatEq && glover_usable($item[Filthy Child Leash]))
 			{
 				pullXWhenHaveY($item[Filthy Child Leash], 1, 0);
 			}

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -147,12 +147,15 @@ void acquireFamiliarsCasual()
 	}
 	hatchFamiliar($familiar[hovering sombrero]);
 	
-	//delevel enemy cheaply
-	if(!have_familiar($familiar[barrrnacle]) && item_amount($item[Barrrnacle]) == 0 && auto_mall_price($item[Barrrnacle]) < 1000 && my_meat() > 10000)
+	if(!have_familiar($familiar[Gelatinous Cubeling]) && !have_familiar($familiar[Nosy Nose]))	//if none of the common better delevel familiars
 	{
-		retrieve_item(1, $item[Barrrnacle]);			//will mallbuy it
+		//delevel enemy cheaply
+		if(!have_familiar($familiar[barrrnacle]) && item_amount($item[Barrrnacle]) == 0 && auto_mall_price($item[Barrrnacle]) < 1000 && my_meat() > 10000)
+		{
+			retrieve_item(1, $item[Barrrnacle]);			//will mallbuy it
+		}
+		hatchFamiliar($familiar[Barrrnacle]);
 	}
-	hatchFamiliar($familiar[Barrrnacle]);
 	
 	//meat, MP/HP, confuse, or attack enemy. cheap
 	if(!have_familiar($familiar[Cocoabo]) && item_amount($item[cocoa egg]) == 0)


### PR DESCRIPTION
some changes that can save hundreds of mall searches
- should not need Bulk caching mall prices for consumables again after ascending on the same day
- explicitly request historical_price of consumables that were already cached
if item type is food or booze for them price already gets cached on autoscend day start so that mafia will give historical_price when asked for mall_price, but if mafia session has to be restarted then mafia will have lost its cache and will do mall searches looking for every consume item considered. so ask explicitly for historical instead.
can't do the same for hprestore,mprestore, autoscend caches them but hprestore and mprestore types corresponding with mall_prices search categories are not available, can't use item subrecords .maxhp and .maxmp because they could be in other types of items? to avoid new searches in a new session would need to maintain a hard coded list of mall hprestore,mprestore items or make a cache file for them

- remove useless url visits to no fireworks shop
- skip Filthy Child Leash if have other 5wt equip
- barrrnacle not acquired if better gremlins familiar

## How Has This Been Tested?

in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
