### PR TITLE
Hot Fix - BuffMaintain Speculation Fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -95,7 +95,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if((item_amount(source) < uses) && !in_wotsf())
+	if((item_amount(source) < uses) && !in_wotsf() && can_interact() && !source.quest)
 	{
 		if(historical_price(source) < 2000)
 		{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -97,12 +97,14 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	}
 	if((item_amount(source) < uses) && !in_wotsf())
 	{
+		int numToBuy = uses - item_amount(source);
+		int meatAvailableToBuy = my_meat() - meatReserve();
 		// attempt to buy from NPC for meat
-		if(npc_price(source) != 0 && my_meat() > meatReserve() + npc_price(source))
+		if(npc_price(source) != 0 && meatAvailableToBuy > npc_price(source))
 		{
 			if(!speculative)
 			{
-				buy(uses - item_amount(source), source);
+				buy(numToBuy, source);
 			}
 			else
 			{
@@ -115,7 +117,7 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 		{
 			if(!speculative)
 			{
-				buy(uses - item_amount(source), source);
+				buy(numToBuy, source);
 			}
 			else
 			{
@@ -124,11 +126,11 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 			}
 		}
 		// attempt to buy in mall
-		else if(can_interact() && historical_price(source) < 2000)
+		else if(can_interact() && historical_price(source) != 0 && meatAvailableToBuy > historical_price(source))
 		{
 			if(!speculative)
 			{
-				buy(uses - item_amount(source), source, 1000);
+				buy(numToBuy, source, meatAvailableToBuy / numToBuy);
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -112,19 +112,6 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 				return true;
 			}
 		}
-		// attempt to buy from NPC for coins
-		else if(is_accessible(source.seller) && source.seller.available_tokens > sell_price(source.seller, source))
-		{
-			if(!speculative)
-			{
-				buy(numToBuy, source);
-			}
-			else
-			{
-				//if speculating, assume buy works
-				return true;
-			}
-		}
 		// attempt to buy in mall
 		else if(can_interact() && historical_price(source) != 0 && meatAvailableToBuy > historical_price(source))
 		{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -95,9 +95,36 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		return false;
 	}
-	if((item_amount(source) < uses) && !in_wotsf() && can_interact() && !source.quest)
+	if((item_amount(source) < uses) && !in_wotsf())
 	{
-		if(historical_price(source) < 2000)
+		// attempt to buy from NPC for meat
+		if(npc_price(source) != 0 && my_meat() > meatReserve() + npc_price(source))
+		{
+			if(!speculative)
+			{
+				buy(uses - item_amount(source), source);
+			}
+			else
+			{
+				//if speculating, assume buy works
+				return true;
+			}
+		}
+		// attempt to buy from NPC for coins
+		else if(is_accessible(source.seller) && source.seller.available_tokens > sell_price(source.seller, source))
+		{
+			if(!speculative)
+			{
+				buy(uses - item_amount(source), source);
+			}
+			else
+			{
+				//if speculating, assume buy works
+				return true;
+			}
+		}
+		// attempt to buy in mall
+		else if(can_interact() && historical_price(source) < 2000)
 		{
 			if(!speculative)
 			{
@@ -107,16 +134,17 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 			{
 				//if speculating, assume buy works
 				return true;
-			}
-			
-		}
+			}		
+		}		
 	}
 	if(item_amount(source) < uses)
 	{
 		return false;
 	}
 	if(!speculative)
+	{
 		use(uses, source);
+	}	
 	return true;
 }
 


### PR DESCRIPTION
# Description

BuffMaintain when speculating would assume mall purchases would work. Which is fine, however we shouldn't even attempt to buy when in hardcore or if it is a quest item.

This fixes speculation thinking it can get buffs when it can not. Also fixes attempting to buy things and failing when not ran speculatively. 

Discovered when #1073 bought the ML hat when I couldn't max out -com or +com. 

## How Has This Been Tested?

Ash calls while in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
