### PR TITLE
Saucestorm instead of low damage attacks

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -758,5 +758,10 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		return useSkill($skill[Saucestorm], false);
 	}
 
+	if((attackMinor == "attack with weapon") && (buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false))
+	{
+		return useSkill($skill[Saucestorm], false);
+	}
+
 	return attackMinor;
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -758,7 +758,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		return useSkill($skill[Saucestorm], false);
 	}
 
-	if((attackMinor == "attack with weapon") && (buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false))
+	if((attackMinor == "attack with weapon") && monster_defense() > 20 && (buffed_hit_stat() - 20) < monster_defense() && canUse($skill[Saucestorm], false))
 	{
 		return useSkill($skill[Saucestorm], false);
 	}


### PR DESCRIPTION
# Description

Currently in HC TT run. Noticed I was attacking a lot for little damage, then using major attack once. If that didn't kill the monster I then had to manually kill it. This change helps by avoiding doing low damage attacks and instead using saucestorm.

## How Has This Been Tested?

2 days of HC TT

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
