### PR TITLE
Modifier after x turns

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -420,14 +420,25 @@ boolean auto_post_adventure()
 		{
 			use_skill(1, $skill[Soul Rotation]);
 		}
-		int missing = (my_maxmp() - my_mp()) / 15;		//soul food restores 15 MP per cast.
+		
+		int maxMPNextTurn;
+		int MPtoRestore = my_maxmp() - my_mp();
+		if(my_maxmp() > 150 && my_soulsauce() < 90)	//todo how much MP wanted for buffing before next turn?
+		{
+			maxMPNextTurn = modifierAfterXTurns("Buffed MP Maximum",1);
+			if(maxMPNextTurn > 100)	//todo how much MP wanted for combat?
+			{
+				//don't restore MP that will expire with effects
+				MPtoRestore = max(0,maxMPNextTurn - my_mp());
+			}
+		}
+		int casts = MPtoRestore / 15;		//soul food restores 15 MP per cast.
 		int availableSauce = my_soulsauce();
-		int minMPexpected = my_mp() + (availableSauce - 5) * 15; //mp expected after soul food if last 5 soulsauce is saved
-		if(availableSauce >= 5 && minMPexpected > 100 && minMPexpected > 0.8*my_maxmp())
+		if(availableSauce >= 5 && my_mp() > 100 && my_mp() > 0.8*my_maxmp())
 		{
 			availableSauce -= 5;	//keep 5 soulsauce for soul bubble if not missing much MP
 		}
-		int casts = min(missing, availableSauce / 5);	//soul food costs 5 soulsauce per cast.
+		casts = min(casts, availableSauce / 5);	//soul food costs 5 soulsauce per cast.
 		if(casts > 0)
 		{
 			use_skill(casts, $skill[Soul Food]);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -721,7 +721,18 @@ boolean auto_pre_adventure()
 	//my_mp is broken in Dark Gyffte
 	if (!in_darkGyffte())
 	{
+		//TODO don't do this when next turn is free since that gives no effect from mp_regen()
 		int wasted_mp = my_mp() + mp_regen() - my_maxmp();
+		if(my_maxmp() > 400)	//todo how much MP wanted for combat? but for now there is no MP burning after this without 400 MP anyway so check 400
+		{
+			int maxMPNextTurn = modifierAfterXTurns("Buffed MP Maximum",1);
+			if(maxMPNextTurn != my_maxmp())
+			{
+				//count MP that will expire with effects next turn
+				maxMPNextTurn = max(100,maxMPNextTurn);	//todo how much MP wanted for combat?
+				wasted_mp = my_mp() + mp_regen() - maxMPNextTurn;
+			}
+		}
 		if(wasted_mp > 0 && my_mp() > 400)
 		{
 			auto_log_info("Burning " + wasted_mp + " MP...");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1487,6 +1487,8 @@ boolean autoMaximize(string req, boolean simulate);
 boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate);
 aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate, boolean includeEquip);
 void debugMaximize(string req, int meat);
+float modifierAfterXTurns(string mod, int turns, boolean forceMaintainable);
+float modifierAfterXTurns(string mod, int turns);
 string trim(string input);
 string safeString(string input);
 string safeString(skill input);


### PR DESCRIPTION
add function that gives modifierAfterXTurns
waste less soul food to restore MP that will be lost next turn from expired buffs
burn MP in pre adv if it will be lost by reduced max MP next turn


## How Has This Been Tested?

in run. only starts being useful over 400 MP for now because pre adv doesn't burn at lower MP than that

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
