### PR TITLE
Added Grey Goose to item familiars

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -46,6 +46,7 @@ Casagnova Gnome
 Psychedelic Bear
 Piano Cat
 # Slightly special fairies
+Grey Goose
 Ghost of Crimbo Carols
 Red-Nosed Snapper
 Pair of Stomping Boots	!path:G-Lover

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -137,34 +137,35 @@ item	27	Casagnova Gnome
 item	28	Psychedelic Bear
 item	29	Piano Cat
 # Slightly special fairies
-item	30	Ghost of Crimbo Carols
-item	31	Red-Nosed Snapper
-item	32	Pair of Stomping Boots	!path:G-Lover
-item	33	Gelatinous Cubeling
-item	34	Steam-Powered Cheerleader
-item	35	Obtuse Angel
-item	36	Green Pixie
+item	30	Grey Goose
+item	31	Ghost of Crimbo Carols
+item	32	Red-Nosed Snapper
+item	33	Pair of Stomping Boots	!path:G-Lover
+item	34	Gelatinous Cubeling
+item	35	Steam-Powered Cheerleader
+item	36	Obtuse Angel
+item	37	Green Pixie
 # Elemental fairies
-item	37	Sleazy Gravy Fairy
-item	38	Stinky Gravy Fairy
-item	39	Flaming Gravy Fairy
-item	40	Frozen Gravy Fairy
-item	41	Spooky Gravy Fairy
+item	38	Sleazy Gravy Fairy
+item	39	Stinky Gravy Fairy
+item	40	Flaming Gravy Fairy
+item	41	Frozen Gravy Fairy
+item	42	Spooky Gravy Fairy
 # Physical damage fairy
-item	42	Bowlet
+item	43	Bowlet
 # Barely special fairies
-item	43	Mechanical Songbird
-item	44	Grouper Groupie
-item	45	Peppermint Rhino
+item	44	Mechanical Songbird
+item	45	Grouper Groupie
+item	46	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	46	Slimeling
+item	47	Slimeling
 # Turtles are cute
-item	47	Syncopated Turtle
+item	48	Syncopated Turtle
 # The original
-item	48	Baby Gravy Fairy
+item	49	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	49	Mutant Fire Ant
+item	50	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1


### PR DESCRIPTION
# Description

Very basic Grey Goose support. Only added it to item familiars. Exact location in item fam hierarchy can be decided later when support for skills are added. Mafia does not yet support the goose combat skills.

## How Has This Been Tested?

Script switched to Grey Goose when needing an item type fam in standard PM

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
