### PR TITLE
don't use Saber YR in combat when we shouldn't

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -61,7 +61,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 	//yellowray instantly kills the enemy and makes them drop all items they can drop.
 	if(!combat_status_check("yellowray") && auto_wantToYellowRay(enemy, my_location()))
 	{
-		string combatAction = yellowRayCombatString(enemy, true);
+		string combatAction = yellowRayCombatString(enemy, true, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains enemy);
 		if(combatAction != "")
 		{
 			combat_status_add("yellowray");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -357,7 +357,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	if(!combat_status_check("yellowray") && auto_wantToYellowRay(enemy, my_location()))
 	{
-		string combatAction = yellowRayCombatString(enemy, true);
+		string combatAction = yellowRayCombatString(enemy, true, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains enemy);
 		if(combatAction != "")
 		{
 			combat_status_add("yellowray");


### PR DESCRIPTION
# Description

Certain monsters we don't want to use the Saber YR since Use the Force doesn't end combat "properly".
The Knight (Snake) is only YR'd in Ed & I think this is a mafia bug with Ed which breaks NC handling. Regardless if you have the Saber you don't need the Knight's sword & shield for ML.
The topiary monsters are Spit on by the Melodramedary in paths which can use familiars. YR'ing them with the Saber will not give 4x drops since the Saber YR forgets everything that happened in combat thus wasting the use of Spit.

I think these changes were overlooked during refactoring the combat code.

## How Has This Been Tested?

Validates. Theophrastus has been running the Ed change manually however.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
