### PR TITLE
qterrarium.php fix

### DIFF
--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -72,12 +72,11 @@ void qt_initializeSettings()
 	}
 }
 
-string qt_TerrariumPage = visit_url("qterrarium.php");
-
 boolean qt_FamiliarAvailable (familiar fam)
 {
 	//Check to see if target familiar can be forced.
 	string qt_FamiliarKey = "<option value=\"" + fam.to_int().to_string() + "\">";
+	string qt_TerrariumPage = visit_url("qterrarium.php");
 	matcher qt_FamiliarSearch = create_matcher(qt_FamiliarKey, qt_TerrariumPage);
 
 	if (qt_turnsToNextQuantumAlignment() > 1)


### PR DESCRIPTION
the quantum_terrarium.ash file is visiting qterrarium.php every time it is loaded, which seems to be every pre_adv, every post_adv, every choice, sometimes just on the main loop
- it records the terrarium in a string but none of the related functions are used anywhere
- if it's also supposed to be a terrarium visit to update familiars it would not be the right way to do that due to the high amount of requests and running even outside of path

this pr moves it into the only function that would refer to its data if these functions are ever used

## How Has This Been Tested?

in non quantum terrarium run and with debug trace on
have not tested if quantum terrarium path ever loses track of its familiar without these visits

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
