### PR TITLE
workaround Ed servant bug

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1142,6 +1142,11 @@ boolean doBedtime()
 		print("Plumber consumption is complicated. Please manually consume stuff then run me again.", "red");
 		return false;
 	}
+
+	//There is a bug where Ed servant's can't be switched due to an issue in KoL itself
+	//Per Discord, work around is to never log out with a level 7 or greater Scribe
+	//Priest is always unlocked prior to Scribe. Just always attempt to switch to Priest at bedtime
+	handleServant($servant[Priest]);
 	
 	boolean done = (my_inebriety() > inebriety_limit()) || (my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]);
 	if(in_gnoob() || !can_drink() || out_of_blood)

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -220,7 +220,27 @@ boolean handleServant(servant who)
 	}
 	if(!have_servant(who))
 	{
-		return false;
+		if(my_servant() == $servant[none])
+		{
+			//might have encounted bug in KoL. Try to work around it
+			//bug happens when level 7 or great scribe is active when logged out of KoL
+			//symptom is active servant is $servant[none] and can't change it
+			//priest is always unlocked prior to scribe. Try to switch to priest to clear bug
+			
+			//clear error
+			cli_execute("/servant priest");
+			//refresh mafia's servant info
+			visit_url("place.php?whichplace=edbase&action=edbase_door");
+			if(!have_servant(who))
+			{
+				//cleared bug. Must actually not have requested servant
+				return false;
+			}
+		}
+		else
+		{
+			return false;
+		}
 	}
 	if(my_servant() != who)
 	{


### PR DESCRIPTION
# Description

There is an issue in KoL itself where Ed servants can not be swapped if certain conditions happen. Per Discord this failure state happens when a level 7 or greater Scribe is in use during RO. This PR always changes our active servant to the Priest. Priest is unlocked prior to Scribe so this is a safe operation.

Note - even changing to a level 7 or greater Scribe during the day will make KoL's UI break when trying to switch familiars. In this state ash commands to swap servants still work. However issues gets worse when RO happens as ash commands don't work anymore.

## How Has This Been Tested?

Didn't get bug after RO

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
