### PR TITLE
~~Update actually_ed_the_undying.ash~~ this PR obsolete

### DIFF
--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -594,7 +594,7 @@ skill ed_nextUpgrade()
 	}
 	else if (!have_skill($skill[Replacement Liver]))
 	{
-		return $skill[Replacement Liver]; // 30 Ka
+		return $skill[Replacement Liver]; // 30 Ka, with 4 astral pilsners @L11 1.47 adv/Ka
 	}
 	else if (!have_skill($skill[More Legs]))
 	{
@@ -602,15 +602,11 @@ skill ed_nextUpgrade()
 	}
 	else if (!have_skill($skill[Yet Another Extra Spleen]) && have_skill($skill[Another Extra Spleen]))
 	{
-		return $skill[Yet Another Extra Spleen]; // 15 Ka
+		return $skill[Yet Another Extra Spleen]; // 15 Ka; with haunch (15 Ka) 0.87 adv/Ka
 	}
 	else if (!have_skill($skill[Still Another Extra Spleen]))
 	{
 		return $skill[Still Another Extra Spleen]; // 20 Ka
-	}
-	else if (!have_skill($skill[Replacement Stomach]))
-	{
-		return $skill[Replacement Stomach]; // 30 Ka
 	}
 	else if (!have_skill($skill[Just One More Extra Spleen]))
 	{
@@ -631,6 +627,10 @@ skill ed_nextUpgrade()
 	else if (!have_skill($skill[More Elemental Wards]))
 	{
 		return $skill[More Elemental Wards]; // 20 Ka
+	}
+	else if (!have_skill($skill[Replacement Stomach]))
+	{
+		return $skill[Replacement Stomach]; // 30 Ka; with 3.5 adv/fullness foods, 0.58 adv/Ka
 	}
 	else if (!have_skill($skill[Even More Elemental Wards]))
 	{

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -592,10 +592,6 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Upgraded Legs]; // 10 Ka
 	}
-	else if (!have_skill($skill[Replacement Liver]))
-	{
-		return $skill[Replacement Liver]; // 30 Ka, with 4 astral pilsners @L11 1.47 adv/Ka
-	}
 	else if (!have_skill($skill[More Legs]))
 	{
 		return $skill[More Legs]; // 20 Ka
@@ -604,9 +600,13 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Yet Another Extra Spleen]; // 15 Ka; with haunch (15 Ka) 0.87 adv/Ka
 	}
+	else if (!have_skill($skill[Replacement Liver]))
+	{
+		return $skill[Replacement Liver]; // 30 Ka; with 4 astral pilsners @L11 1.47 adv/Ka
+	}	
 	else if (!have_skill($skill[Still Another Extra Spleen]))
 	{
-		return $skill[Still Another Extra Spleen]; // 20 Ka
+		return $skill[Still Another Extra Spleen]; // 20 Ka; with haunch (15 Ka) 0.74 adv/Ka
 	}
 	else if (!have_skill($skill[Just One More Extra Spleen]))
 	{

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -588,13 +588,13 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Another Extra Spleen]; // 10 Ka
 	}
-	else if (!have_skill($skill[Replacement Stomach]))
-	{
-		return $skill[Replacement Stomach]; // 30 Ka
-	}
 	else if (!have_skill($skill[Upgraded Legs]))
 	{
 		return $skill[Upgraded Legs]; // 10 Ka
+	}
+	else if (!have_skill($skill[Replacement Liver]))
+	{
+		return $skill[Replacement Liver]; // 30 Ka
 	}
 	else if (!have_skill($skill[More Legs]))
 	{
@@ -608,13 +608,13 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Still Another Extra Spleen]; // 20 Ka
 	}
+	else if (!have_skill($skill[Replacement Stomach]))
+	{
+		return $skill[Replacement Stomach]; // 30 Ka
+	}
 	else if (!have_skill($skill[Just One More Extra Spleen]))
 	{
 		return $skill[Just One More Extra Spleen]; // 25 Ka
-	}
-	else if (!have_skill($skill[Replacement Liver]))
-	{
-		return $skill[Replacement Liver]; // 30 Ka
 	}
 	else if (!have_skill($skill[Elemental Wards]))
 	{


### PR DESCRIPTION
# Description

- raised priority of liver slightly in hierarchy of organs
- lowered priority of stomach following removal of fortune cookie mechanic
- hierarchy reflects cost of buy the +adv organs, since spleen requires additional 15 Ka for the haunch for the organ to actually be useful

Fixes # (issue)

## How Has This Been Tested?

local, simple change of order

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
