### PR TITLE
More shirts that make Torso worth it

### DIFF
--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -2,13 +2,17 @@
 
 boolean auto_buySkills()  // This handles skill acquisition for general paths
 {
-	// TODO: Torso Awareness is worth obtaining in other cases too.
+	// See if we have any shirts worth wearing
+	boolean have_useful_shirt = false;
+	foreach it in $items[January\'s Garbage Tote, astral shirt, Shoe ad T-shirt, Fresh coat of paint, tunac]
+	{
+		have_useful_shirt = have_useful_shirt || (item_amount(it) != 0 && is_unrestricted(it));
+	}
 	//we need 5000 meat for the skill. and want to save an additional 1000 meat above meat reserve since torso awareness is somewhat low priority
 	if((my_meat() >= meatReserve() + 6000)
 	   && gnomads_available()
 	   && (!have_skill($skill[Torso Awareness]))
-	   && (item_amount($item[January\'s Garbage Tote]) != 0)
-	   && (is_unrestricted($item[January\'s Garbage Tote])))
+	   && have_useful_shirt)
 	{
 		visit_url("gnomes.php?action=trainskill&whichskill=12");
 	}


### PR DESCRIPTION
# Description

If Torso Awareness isn't available, the script will buy it in a Gnome sign if it has the spare meat, and a good shirt. At the moment, it only considers the Garbage Tote to be worth it. This slightly expands the list of shirts that are considered worthwhile (including Astral, Shoe Ad, Tunac and Fresh Coat of Paint).

Fixes # (issue)

## How Has This Been Tested?

Couple of Ed ascensions.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
