### PR TITLE
AWOL support: Do not try to use Spinal fluid

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -696,7 +696,7 @@ void initializeDay(int day)
 	}
 
 	// Get emotionally chipped if you have the item.  boris\zombie slayer\ed cannot use this skill so excluding.
-	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !is_boris() && !in_zombieSlayer() && !isActuallyEd())
+	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || in_zombieSlayer() || isActuallyEd() || in_awol()))
 	{
 		use(1, $item[spinal-fluid-covered emotion chip]);
 	}


### PR DESCRIPTION


# Description

AWOL can't tap spinal fluid either. Adding that to the ever increasing list of paths it doesn't work on. Also changing that list to
!(a || b || c) instead of !a && !b && !c to make the path check  self contained and easier to read.


## How Has This Been Tested?
Run in Awol, confirm it doesn't get stuck doing nothing before turn 0. Did not test in Boris, ZS or Ed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
