### PR TITLE
L8 to L7 override

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -690,8 +690,9 @@ void initializeDay(int day)
 		boolean temp = cli_execute("make shoe gum");
 	}
 	
-	//a free to cast intrinsic that makes swords count as clubs. if you have it there is no reason to ever have it off regardless of class.
-	if(auto_have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
+	//a free to cast intrinsic that makes swords count as clubs. there is no reason to ever have it on if not a seal clubber?
+	//regardless of class there is a reason not to if auto_configureRetrocape("vampire", "kill") can be used. it needs the sword to count as a sword and not as a club
+	if(my_class() == $class[seal clubber] && auto_have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
 	{
 		use_skill(1, $skill[Iron Palm Technique]);
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1003,7 +1003,7 @@ void equipRollover(boolean silent)
 	}
 }
 
-boolean auto_forceEquipSword() {
+boolean auto_forceEquipSword(boolean speculative) {
 	item swordToEquip = $item[none];
 	// use the ebony epee if we have it
 	if (possessEquipment($item[ebony epee]))
@@ -1015,8 +1015,8 @@ boolean auto_forceEquipSword() {
 	{
 		// check for some swords that we might have acquired in run already. Yes machetes are actually swords.
 		foreach it in $items[antique machete, black sword, broken sword, cardboard katana, cardboard wakizashi,
-		drowsy sword, knob goblin deluxe scimitar, knob goblin scimitar, lupine sword, muculent machete,
-		ridiculously huge sword, serpentine sword, vorpal blade, white sword, sweet ninja sword]
+		knob goblin deluxe scimitar, knob goblin scimitar, lupine sword, muculent machete, serpentine sword,
+		vorpal blade, white sword, sweet ninja sword, drowsy sword, ridiculously huge sword]
 		{
 			if (possessEquipment(it) && auto_can_equip(it))
 			{
@@ -1041,7 +1041,28 @@ boolean auto_forceEquipSword() {
 		return false;
 	}
 
+	if (get_property("auto_equipment_override_weapon").to_item() != $item[none] && auto_can_equip(get_property("auto_equipment_override_weapon").to_item(),$slot[weapon]))
+	{
+		if (item_type(get_property("auto_equipment_override_weapon").to_item()) == "sword")
+		{
+			return true;
+		}
+		else
+		{
+			auto_log_debug("Can not successfully force equip a sword because user defined override weapon will replace it before combat", "gold");
+			return false;
+		}
+	}
+	
+	if (speculative)
+	{
+		return auto_can_equip(swordToEquip, $slot[weapon]);
+	}
 	return autoForceEquip($slot[weapon], swordToEquip);
+}
+
+boolean auto_forceEquipSword() {
+	return auto_forceEquipSword(false);
 }
 
 boolean is_watch(item it)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3204,6 +3204,9 @@ boolean auto_can_equip(item it, slot s)
 
 	if(s == $slot[off-hand] && it.to_slot() == $slot[weapon] && !auto_have_skill($skill[Double-Fisted Skull Smashing]))
 		return false;
+	
+	if((s == $slot[weapon] || s == $slot[off-hand]) && (in_wotsf() || (is_boris() && it != $item[Trusty])))
+		return false;
 
 	if(it.item_type() == "chefstaff" && (!(auto_have_skill($skill[Spirit of Rigatoni]) || (my_class() == $class[Sauceror] && equipped_amount($item[special sauce glove]) > 0) || my_class() == $class[Avatar of Jarlsberg]) || s != $slot[weapon]))
 		return false;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -918,6 +918,7 @@ boolean L6_dakotaFanning();
 //Defined in autoscend/quests/level_07.ash
 void cyrptChoiceHandler(int choice);
 boolean L7_crypt();
+boolean L7_override();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_08.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -917,6 +917,7 @@ boolean L6_dakotaFanning();
 ########################################################################################################
 //Defined in autoscend/quests/level_07.ash
 void cyrptChoiceHandler(int choice);
+int cyrptEvilBonus();
 boolean L7_crypt();
 boolean L7_override();
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1290,6 +1290,7 @@ boolean possessOutfit(string outfit);
 void equipBaseline();
 void ensureSealClubs();
 void equipRollover(boolean silent);
+boolean auto_forceEquipSword(boolean speculative);
 boolean auto_forceEquipSword();
 boolean is_watch(item it);
 

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -73,6 +73,7 @@ int cyrptEvilBonus()
 	//returns value of regularly available bonus to evil reduction
 	int cyrptBonus = (auto_hasRetrocape() && auto_forceEquipSword(true)) ? 1 : 0;
 	cyrptBonus += (possessEquipment($item[gravy boat]) && auto_is_valid($item[gravy boat])) ? 1 : 0;
+	cyrptBonus += (is_pete() && get_property("peteMotorbikeCowling") == "Ghost Vacuum") ? 1 : 0;
 	return cyrptBonus;
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -68,6 +68,14 @@ void cyrptChoiceHandler(int choice)
 	}
 }
 
+int cyrptEvilBonus()
+{
+	//returns value of regularly available bonus to evil reduction
+	int cyrptBonus = (auto_hasRetrocape() && auto_forceEquipSword(true)) ? 1 : 0;
+	cyrptBonus += (possessEquipment($item[gravy boat]) && auto_is_valid($item[gravy boat])) ? 1 : 0;
+	return cyrptBonus;
+}
+
 boolean L7_crypt()
 {
 	if(internalQuestStatus("questL07Cyrptic") != 0)
@@ -116,6 +124,11 @@ boolean L7_crypt()
 	{
 		if(auto_configureRetrocape("vampire", "kill"))
 		{
+			if(have_effect($effect[Iron Palms]) > 0 && auto_have_skill($skill[Iron Palm Technique]))
+			{
+				//slay the dead needs the sword to count as a sword and not as a club
+				use_skill(1, $skill[Iron Palm Technique]);
+			}
 			auto_forceEquipSword();
 		}
 	}
@@ -132,13 +145,16 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Reanimated Reanimator]);
 		}
 
-		provideInitiative(850, $location[The Defiled Alcove], true);
+		if(get_property("cyrptAlcoveEvilness").to_int() > (26 + cyrptEvilBonus()))
+		{
+			provideInitiative(850, $location[The Defiled Alcove], true);
+			addToMaximize("100initiative 850max");
+		}
 
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
-		addToMaximize("100initiative 850max");
 
-		if(get_property("cyrptAlcoveEvilness").to_int() >= 28)
+		if(get_property("cyrptAlcoveEvilness").to_int() >= (28 + cyrptEvilBonus()))
 		{
 			useNightmareFuelIfPossible();
 		}
@@ -161,14 +177,13 @@ boolean L7_crypt()
 	if((get_property("cyrptNookEvilness").to_int() > 0) && lar_repeat($location[The Defiled Nook]) && !skip_in_koe)
 	{
 		auto_log_info("The Nook!", "blue");
-		buffMaintain($effect[Joyful Resolve]);
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
 
-		bat_formBats();
-
-		if(get_property("cyrptNookEvilness").to_int() > 26)
+		if(get_property("cyrptNookEvilness").to_int() > (26 + cyrptEvilBonus()) && auto_is_valid($item[Evil Eye]))
 		{
+			buffMaintain($effect[Joyful Resolve]);
+			bat_formBats();
 			januaryToteAcquire($item[broken champagne bottle]);
 		}
 
@@ -198,13 +213,13 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
 
-		if(get_property("cyrptNicheEvilness").to_int() >= 28)
+		if(get_property("cyrptNicheEvilness").to_int() >= (28 + cyrptEvilBonus()))
 		{
 			useNightmareFuelIfPossible();
 		}
 
 		auto_log_info("The Niche!", "blue");
-		if(canSniff($monster[Dirty Old Lihc], $location[The Defiled Niche]) && auto_mapTheMonsters())
+		if(canSniff($monster[Dirty Old Lihc], $location[The Defiled Niche]) && get_property("cyrptNicheEvilness").to_int() >= (26 + cyrptEvilBonus()) && auto_mapTheMonsters())
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Dirty Old Lihc.");
 		}
@@ -233,7 +248,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
 
-		if(get_property("cyrptCrannyEvilness").to_int() >= 28)
+		if(get_property("cyrptCrannyEvilness").to_int() >= (28 + cyrptEvilBonus()))
 		{
 			useNightmareFuelIfPossible();
 		}
@@ -246,6 +261,12 @@ boolean L7_crypt()
 
 	if(get_property("cyrptTotalEvilness").to_int() <= 0)
 	{
+		if(my_class() == $class[seal clubber] && auto_have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
+		{
+			//if this was toggled off for retrocape slay the dead it can be toggled back on now
+			use_skill(1, $skill[Iron Palm Technique]);
+		}
+		
 		if(my_primestat() == $stat[Muscle])
 		{
 			buyUpTo(1, $item[Ben-Gal&trade; Balm]);
@@ -282,6 +303,37 @@ boolean L7_crypt()
 			abort("Failed to kill bonerdagon");
 		}
 		return true;
+	}
+	return false;
+}
+
+boolean L7_override()
+{
+	//check if olfaction or banishes are being used for ongoing L7 tasks and give those priority
+ 	if(internalQuestStatus("questL07Cyrptic") != 0)
+	{
+		return false;
+	}
+	
+	if(get_property("cyrptNookEvilness").to_int() <= 26 && get_property("cyrptNicheEvilness").to_int() <= 26)
+	{
+		return false;
+	}
+	
+	int evilBonus = cyrptEvilBonus();
+	if(get_property("cyrptNookEvilness").to_int() > (26 + evilBonus) && is_banished($monster[party skelteon]))
+	{
+		auto_log_info("Trying to check on the ongoing Nook before moving on to a different task");
+		if(L7_crypt()) { return true; }
+	}
+	if(get_property("cyrptNicheEvilness").to_int() > (26 + evilBonus))
+	{
+		boolean lihcbanihced = is_banished($monster[basic lihc]) || is_banished($monster[Senile Lihc]) || is_banished($monster[Slick Lihc]);
+		if(lihcbanihced || isSniffed($monster[Dirty Old Lihc]))
+		{
+			auto_log_info("Trying to check on the ongoing Niche before moving on to a different task");
+			if(L7_crypt()) { return true; }
+		}
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -137,6 +137,8 @@ boolean L7_crypt()
 	visit_url("crypt.php");
 	use(1, $item[Evilometer]);
 
+	int evilBonus = cyrptEvilBonus();
+
 	if((get_property("cyrptAlcoveEvilness").to_int() > 0) && ((get_property("cyrptAlcoveEvilness").to_int() <= get_property("auto_waitingArrowAlcove").to_int()) || (get_property("cyrptAlcoveEvilness").to_int() <= 25)) && edAlcove && lar_repeat($location[The Defiled Alcove]))
 	{
 
@@ -145,7 +147,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Reanimated Reanimator]);
 		}
 
-		if(get_property("cyrptAlcoveEvilness").to_int() > (26 + cyrptEvilBonus()))
+		if(get_property("cyrptAlcoveEvilness").to_int() > (26 + evilBonus))
 		{
 			provideInitiative(850, $location[The Defiled Alcove], true);
 			addToMaximize("100initiative 850max");
@@ -154,7 +156,7 @@ boolean L7_crypt()
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
 
-		if(get_property("cyrptAlcoveEvilness").to_int() >= (28 + cyrptEvilBonus()))
+		if(get_property("cyrptAlcoveEvilness").to_int() >= (28 + evilBonus))
 		{
 			useNightmareFuelIfPossible();
 		}
@@ -180,7 +182,7 @@ boolean L7_crypt()
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
 
-		if(get_property("cyrptNookEvilness").to_int() > (26 + cyrptEvilBonus()) && auto_is_valid($item[Evil Eye]))
+		if(get_property("cyrptNookEvilness").to_int() > (26 + evilBonus) && auto_is_valid($item[Evil Eye]))
 		{
 			buffMaintain($effect[Joyful Resolve]);
 			bat_formBats();
@@ -213,13 +215,13 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
 
-		if(get_property("cyrptNicheEvilness").to_int() >= (28 + cyrptEvilBonus()))
+		if(get_property("cyrptNicheEvilness").to_int() >= (28 + evilBonus))
 		{
 			useNightmareFuelIfPossible();
 		}
 
 		auto_log_info("The Niche!", "blue");
-		if(canSniff($monster[Dirty Old Lihc], $location[The Defiled Niche]) && get_property("cyrptNicheEvilness").to_int() >= (26 + cyrptEvilBonus()) && auto_mapTheMonsters())
+		if(canSniff($monster[Dirty Old Lihc], $location[The Defiled Niche]) && get_property("cyrptNicheEvilness").to_int() >= (26 + evilBonus) && auto_mapTheMonsters())
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Dirty Old Lihc.");
 		}
@@ -248,7 +250,7 @@ boolean L7_crypt()
 			handleFamiliar($familiar[Space Jellyfish]);
 		}
 
-		if(get_property("cyrptCrannyEvilness").to_int() >= (28 + cyrptEvilBonus()))
+		if(get_property("cyrptCrannyEvilness").to_int() >= (28 + evilBonus))
 		{
 			useNightmareFuelIfPossible();
 		}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -890,7 +890,23 @@ boolean L8_trapperQuest()
 		return false;
 	}
 
-	if(L8_trapperTalk() || L8_getGoatCheese() || L8_getMineOres() || L8_trapperSlope() || L8_trapperGroar())
+	if(L8_trapperTalk())
+	{
+		return true;
+	}
+
+	//at end of day last chance to get milk could be more valuable for characters with a stomach than not cancelling banishes used in L7
+	if(my_adventures() < 7 && !get_property("_milkOfMagnesiumUsed").to_boolean() && fullness_limit() != 0 && have_skill($skill[Advanced Saucecrafting]) && 
+	L8_getGoatCheese())
+	{
+		return true;
+	}
+	else if(L7_override())	//if any olfaction or banishes used in an earlier area finish there first
+	{
+		return true;
+	}
+
+	if(L8_getGoatCheese() || L8_getMineOres() || L8_trapperSlope() || L8_trapperGroar())
 	{
 		return true;
 	}


### PR DESCRIPTION
use evilness reduction bonus in L7 conditions
fix slay the dead incompatible with Iron Palm Technique or user forced weapon
don't switch right away from L7 to L8 quest to not waste current olfactions or banishes in paths that put L8 over L7


## How Has This Been Tested?

in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
