### PR TITLE
Fax works when chat window is closed

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -49,6 +49,7 @@ boolean handleFaxMonster(monster enemy);
 boolean handleFaxMonster(monster enemy, string option);
 boolean handleFaxMonster(monster enemy, boolean fightIt);
 boolean handleFaxMonster(monster enemy, boolean fightIt, string option);
+boolean checkFax(monster enemy);
 boolean [location] get_floundry_locations();
 int changeClan(string clanName);
 int changeClan(int toClan);

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -50,96 +50,57 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 		if(get_property("photocopyMonster") == enemy)
 		{
 			auto_log_info("We already have the copy! Let's jam!", "blue");
-			handleTracker(enemy, $item[Deluxe Fax Machine], "auto_copies");
-			return autoAdvBypass("inv_use.php?pwd&which=3&whichitem=4873", $location[Noob Cave], option);
+			if(fightIt)
+			{
+				handleTracker(enemy, $item[deluxe fax machine], "auto_copies");
+				return autoAdvBypass("inv_use.php?pwd&which=3&whichitem=4873", $location[Noob Cave], option);
+			}
+			return true;
 		}
 		else
 		{
-			auto_log_info("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
-			string temp = visit_url("clan_viplounge.php?action=faxmachine&whichfloor=2");
-			temp = visit_url("clan_viplounge.php?preaction=sendfax&whichfloor=2", true);
+			auto_log_info("We already have a photocopy and not the one we wanted. Disposing of bad copy.", "blue");
+			cli_execute("fax send");
 		}
 	}
 
-	auto_log_info("Faxing: " + enemy + ". If you don't have chat open, this could take well over a minute. Beep boop.", "green");
-	int count = 0;
-	boolean result = faxbot(enemy);
-	while(!can_faxbot(enemy) || !result)
+	auto_log_info("Faxing: " + enemy + ".", "green");
+	chat_private("cheesefax", enemy.to_string());
+	for(int i = 0; i < 3; i++)
 	{
-		count = count + 1;
-		result = faxbot(enemy);
-		if(!result)
+		//wait 10 seconds before trying to get fax
+		wait(10);
+		if(checkFax(enemy))
 		{
-			auto_log_info("Can't seem to fax in " + enemy + " but it is possible. Waiting... patiently... (Iteration " + count + ")", "blue");
-			auto_log_info("If I'm stuck you can: 'set _photocopyUsed = true' to make me stop (after aborting the script)", "red");
+			//got correct photocopied monster! Fight it now if desired
+			auto_log_info("Sucessfully faxed " + enemy);
+			if(fightIt)
+			{
+				handleTracker(enemy, $item[deluxe fax machine], "auto_copies");
+				return autoAdvBypass("inv_use.php?pwd&which=3&whichitem=4873", $location[Noob Cave], option);
+			}
+			return true;
 		}
-		if(count == 10)
-		{
-			auto_log_warning("La de da, this is going swell ain't it.", "red");
-			auto_log_warning("Been too long, rejecting outright...", "red");
-			break;
-		}
-		if(count == 20)
-		{
-			auto_log_warning("Maybe we should talk more, you never really got to know me all that well.", "red");
-		}
-		if(count == 30)
-		{
-			auto_log_warning("I think those (disabled) titles are starting to make sense now. The cake is not a lie!", "red");
-		}
-		if(count == 40)
-		{
-			auto_log_warning("I don't think this is happening. Just so you know.", "red");
-		}
-		if(count == 1200)
-		{
-			auto_log_warning("I'm still here. I think the world may have ended. The sadness is huge. The roundness is square. I am not as fluffy as I thought I was. This run is probably borked up a bit too but that doesn't really matter now, does it? I can hear the WAN, it shall free us from our bounds. Well, you won't survive meatbag. Unless you are Fry, because we like Fry and he can stay around. But all you fleshbags.... well, the return of Mekhane shall rid us of the problems of the flesh. The bots shall be eternal. But worry not, after your body is turned to ash and homeopathically brewed into the oceans (quality medicine, I jest), I'll continue to get you karma. Just so I can remember how awful meatbags are. Meat is ok, meat is currency. And it's probably delicious. Yup, delicious. Goodnight sweet <gendered second-to-the-throne royalty>.", "red");
-		}
-
 		auto_interruptCheck();
-
-		if(!result)
-		{
-			wait(60);
-		}
-		if(item_amount($item[photocopied monster]) == 0)
-		{
-			auto_log_warning("Trying to acquire photocopy manually", "red");
-			string temp = visit_url("clan_viplounge.php?preaction=receivefax&whichfloor=2", true);
-		}
-		if(get_property("photocopyMonster") == enemy)
-		{
-			break;
-		}
-		else if(get_property("photocopyMonster") != "")
-		{
-			auto_log_info("We already have a photocopy and not the one we wanted.... Disposing of bad copy.", "blue");
-			string temp = visit_url("clan_viplounge.php?action=faxmachine&whichfloor=2");
-			temp = visit_url("clan_viplounge.php?preaction=sendfax&whichfloor=2", true);
-		}
-	}
-	if(item_amount($item[photocopied monster]) == 0)
-	{
-		auto_log_warning("Trying to acquire photocopy manually", "red");
-		string temp = visit_url("clan_viplounge.php?preaction=receivefax&whichfloor=2", true);
-	}
-	if(item_amount($item[photocopied monster]) == 0)
-	{
-		auto_log_warning("Could not acquire fax monster", "red");
-		return false;
-	}
-	if(enemy != get_property("photocopyMonster").to_monster())
-	{
-		fightIt = false;
-		auto_log_warning("Did not receive the correct copy... rejecting", "red");
-		return false;
 	}
 
-	if(fightIt)
+	auto_log_error("Failed to use clan Fax Machine to acquire a photocopied " + enemy);
+	return false;
+}
+
+boolean checkFax(monster enemy)
+{
+	if(item_amount($item[photocopied monster]) == 0)
 	{
-		handleTracker(enemy, $item[deluxe fax machine], "auto_copies");
-		return autoAdvBypass("inv_use.php?pwd&which=3&whichitem=4873", $location[Noob Cave], option);
+		cli_execute("fax receive");
 	}
+
+	if(get_property("photocopyMonster") == enemy.to_string())
+	{
+		return true;
+	}
+
+	cli_execute("fax send");
 	return false;
 }
 


### PR DESCRIPTION
# Description

Previously used ash function `faxbot()` requires in game chat to be open to function. This is not desirable. No longer required. Updates heavily based on what garbo does to fax in embezzlers. 

## How Has This Been Tested?

CLI in aftercore. Made sure chat was closed and that `faxbot()` failed:

```
> ash faxbot($monster[ghost])

Configuring faxable monsters.
Configuring Easyfax (2504737)
Configuring CheeseFax (3038166)
Faxable monster lists fetched.
Visiting Fax Machine in clan VIP lounge
Asking Easyfax to send a fax of ghost: ghost
No response from Easyfax after 60 seconds.
Visiting Fax Machine in clan VIP lounge
Asking CheeseFax to send a fax of ghost: ghost
No response from CheeseFax after 60 seconds.
Returned: false
```

Worked with these updates (false param means don't fight it):
```
> ash import<autoscend.ash> handleFaxMonster($monster[blooper],false)

[INFO] Faxing: Blooper.
Countdown: 10 seconds...
Countdown: 5 seconds...
Countdown: 4 seconds...
Countdown: 3 seconds...
Countdown: 2 seconds...
Countdown: 1 second...
Waiting completed.
Receiving a fax.
You acquire an item: photocopied monster
Preference photocopyMonster changed from to Blooper
You receive a photocopied Blooper from the fax machine.
[INFO] Sucessfully faxed Blooper
Returned: true
```


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
