### PR TITLE
liver of steel bedtime and drinking

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1306,6 +1306,17 @@ void auto_drinkNightcap()
 		use_familiar($familiar[Stooper]);
 	}
 	
+	if(item_amount($item[Steel Margarita]) > 0)
+	{
+		//LX_steelOrgan may wait to drink the Steel Margarita for Billiards, if drunkenness never went over 12 it could have been skipped
+		//this should only be possible in Avatar of West of Loathing?
+		boolean wontBeOverdrunk = inebriety_left() >= $item[Steel Margarita].inebriety - 5;
+		if(wontBeOverdrunk)
+		{
+			autoDrink(1, $item[Steel Margarita]);
+		}
+	}
+	
 	//fill up remaining liver first. such as stooper space.
 	while(inebriety_left() > 0 && auto_autoConsumeOne("drink"));
 	

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -285,7 +285,7 @@ boolean canDrinkSpeakeasyDrink(item drink)
 		return false;
 	}
 
-	if(drink.inebriety > inebriety_left())
+	if(inebriety_left() < 0)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -246,32 +246,20 @@ boolean LA_cs_communityService()
 		auto_log_info("Beginning early quest actions (" + curQuest + ")", "green");
 		if(curQuest != 7)
 		{
-			if((my_inebriety() == 0) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]) && (item_amount($item[Clan VIP Lounge Key]) > 0) && (my_meat() >= 500))
+			if((item_amount($item[Clan VIP Lounge Key]) > 0) && (auto_get_clan_lounge() contains $item[Clan Speakeasy]))
 			{
-				autoDrink(1, $item[Lucky Lindy]);
-				if(my_inebriety() != $item[Lucky Lindy].inebriety)
+				//this used to start by drinking a Lucky Lindy when it was size 1 and semi rares existed
+				//now Lucky Lindy is size 6 so should no longer do this, only leaving the url visit on error in case later drinks relied on it
+				if(!(auto_get_clan_lounge() contains $item[Lucky Lindy]))
 				{
-					if(auto_get_clan_lounge() contains $item[Lucky Lindy])
-					{
-						auto_log_warning("Confused!! Mafia reports Lucky Lindy but we couldn't drink it?", "red");
-					}
-					auto_log_warning("Mafia knows we have a speakeasy but could not drink a Lucky Lindy", "red");
-					string temp = visit_url("clan_viplounge.php?whichfloor=2&action=speakeasy");
+					auto_log_warning("Confused!! Mafia reports a Speakeasy but we see no Lucky Lindy?", "red");
+					visit_url("clan_viplounge.php?whichfloor=2&action=speakeasy");
 					if(auto_get_clan_lounge() contains $item[Lucky Lindy])
 					{
 						auto_log_info("Mafia now knows we have a Lucky Lindy", "green");
 						return true;
 					}
-					else
-					{
-						abort("Speakeasy issue, could not resolve contents and use them. Try visiting Clan Speakeasy and run again, do not manually drink a Lucky Lindy");
-					}
 				}
-			}
-
-			if((my_inebriety() == 0) && !(auto_get_clan_lounge() contains $item[Clan Speakeasy]))
-			{
-				abort("Your clan does not have a Clan Speakeasy or mafia doesn't understand that you do. Change clans and try again");
 			}
 
 			if((item_amount($item[Time-Spinner]) > 0) && (get_property("_timeSpinnerMinutesUsed").to_int() == 0))


### PR DESCRIPTION
make sure to have used steel margarita before overdrinking

canDrinkSpeakeasyDrink is only used from autoDrink which is the same general function used for overdrinking, so canDrinkSpeakeasyDrink should allow overdrinking, inebriety checks would be done when selecting the drink in the first place. no speakeasy drinks are used yet except in community service with inebriety checks so this change makes no difference right now

community_service.ash: removed starting with the size 6 drink now that it has changed

## How Has This Been Tested?

validated only, the situations are in theory or were not encountered

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
