### PR TITLE
fix auto_delayTimer

### DIFF
--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -107,7 +107,7 @@ void auto_settingsUpgrade()
 	
 	boolFix("auto_wandOfNagamar");
 	boolFix("auto_chasmBusted");
-	auto_rename_property("auto_delayTimer", "auto_edDelayTimer");
+	auto_rename_property("auto_edDelayTimer", "auto_delayTimer");
 	boolFix("auto_grimstoneFancyOilPainting");
 	boolFix("auto_grimstoneOrnateDowsingRod");
 


### PR DESCRIPTION
auto_edDelayTimer comment said "replaced with auto_delayTimer that works in all paths" but it was being renamed the other way around so instead it always cleared auto_delayTimer

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
