### PR TITLE
don't prepare to banish impossible monsters

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -955,6 +955,10 @@ boolean[string] auto_banishesUsedAt(location loc)
 
 boolean auto_wantToBanish(monster enemy, location loc)
 {
+	if(appearance_rates(loc,true)[enemy] <= 0)
+	{
+		return false;
+	}
 	location locCache = my_location();
 	set_location(loc);
 	boolean [monster] monstersToBanish = auto_getMonsters("banish");


### PR DESCRIPTION
added appearance_rates check

queue argument must be true, example:
pygmy witch lawyer only appears in The Hidden Park if relocatePygmyLawyer == my_ascensions()
pygmy witch lawyer is always in monsters list of $location[The Hidden Park]
appearance_rates($location[The Hidden Park]) without queue argument shows 20.0 pygmy witch lawyer

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
