### PR TITLE
Care about drops

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2566,9 +2566,9 @@ boolean careAboutDrops(monster mon)
 		//We could refine this to get rid of all the all stars / lines mobs but meh.
 		if(($monster[Astronomer] != mon) && ((item_amount($item[Star]) < 8) || (item_amount($item[Line]) < 7)))
 		{
-			return false;
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	if($monsters[Blooper, Ghost] contains mon)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -52,7 +52,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 	//instakill using [Pair of Stomping Boots] iotm familiar which will produce spleen consumables
 	if((my_familiar() == $familiar[Pair of Stomping Boots]) && (get_property("_bootStomps").to_int()) < 7 && instakillable(enemy) && get_property("bootsCharged").to_boolean())
 	{
-		if(!($monsters[Dairy Goat, Lobsterfrogman, Writing Desk] contains enemy) && !($locations[The Laugh Floor, Infernal Rackets Backstage] contains my_location()) && canUse($skill[Release the boots]))
+		//neither the below checks nor careAboutDrops are complete enough
+		if(!($monsters[Dairy Goat, Lobsterfrogman] contains enemy) && !careAboutDrops(enemy) && !($locations[The Laugh Floor, Infernal Rackets Backstage] contains my_location()) && canUse($skill[Release the boots]))
 		{
 			return useSkill($skill[Release the boots]);
 		}


### PR DESCRIPTION
fix careAboutDrops() false return

Writing Desk is a valid target for Stomping Boots
check careAboutDrops, it's unfinished but better than not checking

## How Has This Been Tested?
validates only

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
