### PR TITLE
remove unnecessary zone preparation

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -399,7 +399,7 @@ boolean autoChooseFamiliar(location place)
 	
 	// places where item drop is required to help save adventures.
 	if ($locations[Guano Junction, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
-	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Hospital, The Hidden Bowling Alley, The Haunted Wine Cellar,
+	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Bowling Alley, The Haunted Wine Cellar,
 	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, Whitey's Grove, The Oasis, The Middle Chamber,
 	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,
 	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, 8-Bit Realm, The Degrassi Knoll Garage, The Old Landfill,

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -398,7 +398,7 @@ boolean autoChooseFamiliar(location place)
 	}
 	
 	// places where item drop is required to help save adventures.
-	if ($locations[The Typical Tavern Cellar, Guano Junction, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
+	if ($locations[Guano Junction, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
 	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Hospital, The Hidden Bowling Alley, The Haunted Wine Cellar,
 	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, Whitey's Grove, The Oasis, The Middle Chamber,
 	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -279,8 +279,9 @@ boolean auto_pre_adventure()
 	// this calls the appropriate provider for +combat or -combat depending on the zone we are about to adventure in..
 	boolean burningDelay = ((auto_voteMonster(true) || isOverdueDigitize() || auto_sausageGoblin() || auto_backupTarget()) && place == solveDelayZone());
 	boolean gettingLucky = (have_effect($effect[Lucky!]) > 0 && zone_hasLuckyAdventure(place));
+	boolean forcedNonCombat = auto_haveQueuedForcedNonCombat();
 	generic_t combatModifier = zone_combatMod(place);
-	if (combatModifier._boolean && !burningDelay && !gettingLucky && !auto_haveQueuedForcedNonCombat()) {
+	if (combatModifier._boolean && !burningDelay && !gettingLucky && !forcedNonCombat) {
 		acquireCombatMods(combatModifier._int, true);
 	}
 
@@ -480,8 +481,18 @@ boolean auto_pre_adventure()
 	auto_snapperPreAdventure(place);
 	sweatpantsPreAdventure();
 
+	boolean mayNeedItem = true;
+	if (burningDelay || forcedNonCombat) {
+		//when delay burning if the monster wants item drop it would not be the zone based value that follows
+		//none of the uses of auto_forceNextNoncombat() will need item drop
+		mayNeedItem = false;
+	}
+	else if (gettingLucky && !($locations[The Hidden Temple, The Red Zeppelin, A Maze of Sewer Tunnels] contains place)) {
+		//Baa'baa'bu'ran is probably the only Lucky adventure that will need item drop
+		mayNeedItem = false;
+	}
 	generic_t itemNeed = zone_needItem(place);
-	if(itemNeed._boolean)
+	if(mayNeedItem && itemNeed._boolean)
 	{
 		addToMaximize("50item " + (ceil(itemNeed._float) + 100.0) + "max"); // maximizer treats item drop as 100 higher than it actually is for some reason.
 		simMaximize();

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -156,7 +156,7 @@ generic_t zone_needItem(location loc)
 		value = 30.0;
 		break;
 	case $location[The Penultimate Fantasy Airship]:
-		if(!possessEquipment($item[Amulet Of Extreme Plot Significance]) && !possessEquipment($item[Titanium Assault Umbrella]) && !possessEquipment($item[unbreakable umbrella]))
+		if(!possessEquipment($item[Amulet Of Extreme Plot Significance]))
 		{
 			value = 10.0;
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -497,6 +497,20 @@ generic_t zone_combatMod(location loc)
 		value = -80;
 		break;
 	case $location[Sonofa Beach]:
+		//when wanderer replacing strategy is about to be used, combat modifier is useless. these are the replaced wanderers
+		if(auto_voteMonster())
+		{	foreach sl in $slots[acc3,acc2,acc1]
+			{	if(get_property("_auto_maximize_equip_" + sl.to_string()) == to_string($item[&quot;I voted!&quot; sticker]))
+				{	value = 0;
+					break;
+				}
+			}
+		}
+		if(auto_sausageGoblin() && get_property("_auto_maximize_equip_off-hand") == to_string($item[Kramco Sausage-o-Matic&trade;]))
+		{	value = 0;
+			break;
+		}
+		//otherwise if no wanderer replace
 		value = 90;
 		break;
 	case $location[The Upper Chamber]:

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -73,13 +73,17 @@ generic_t zone_needItem(location loc)
 			value = 5.0;
 		break;
 	case $location[Wartime Frat House]:
-		if (!possessOutfit("Frat Warrior Fatigues")) {
+		if (!possessOutfit("Frat Warrior Fatigues")
+		&& !is_wearing_outfit("War Hippy Fatigues")) {	//already in the other war outfit means only there to start the war
 			value = 5.0;
 		}
+		break;
 	case $location[Wartime Hippy Camp]:
-		if (!possessOutfit("War Hippy Fatigues")) {
+		if (!possessOutfit("War Hippy Fatigues")
+		&& !is_wearing_outfit("Frat Warrior Fatigues")) {	//already in the other war outfit means only there to start the war
 			value = 5.0;
 		}
+		break;
 	case $location[The Battlefield (Frat Uniform)]:
 	case $location[The Battlefield (Hippy Uniform)]:
 			value = 5.0;
@@ -499,9 +503,6 @@ generic_t zone_combatMod(location loc)
 	case $location[The Haunted Billiards Room]:
 		value = -85;
 		break;
-	case $location[The Haunted Library]:
-		value = 25;
-		break;
 	case $location[The Haunted Gallery]:
 		if((delay._int == 0) || (!contains_text(get_property("relayCounters"), "Garden Banished")))
 		{
@@ -582,7 +583,11 @@ generic_t zone_combatMod(location loc)
 		}
 		break;
 	case $location[Lair of the Ninja Snowmen]:
-		value = 80;
+		if(internalQuestStatus("questL08Trapper") < 3 &&
+		(item_amount($item[Ninja Carabiner]) == 0 || item_amount($item[Ninja Crampons]) == 0 || item_amount($item[Ninja Rope]) == 0))
+		{
+			value = 80;
+		}
 		break;
 	case $location[The Dark Neck of the Woods]:
 	case $location[The Dark Heart of the Woods]:
@@ -599,7 +604,7 @@ generic_t zone_combatMod(location loc)
 	case $location[The Typical Tavern Cellar]:
 		//We could cut it off early if the Rat Faucet is the last one
 		//And marginally if we know the 3rd/6th square are forced events.
-		value = -75;
+		//actual desired value for combat or non combat is decided by level_03.ash based on elemental damage bonus
 		break;
 	case $location[The Spooky Forest]:
 		if(delay._int == 0)

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -148,7 +148,9 @@ generic_t zone_needItem(location loc)
 		break;
 	case $location[The Copperhead Club]:
 	case $location[A Mob of Zeppelin Protesters]:
-		value = 15.0;
+		if(internalQuestStatus("questL11Ron") >= 1) {
+			value = 15.0;
+		}
 		break;
 	case $location[The Red Zeppelin]:
 		value = 30.0;
@@ -530,7 +532,9 @@ generic_t zone_combatMod(location loc)
 		}
 		break;
 	case $location[A Mob Of Zeppelin Protesters]:
-		value = -70;
+		if(internalQuestStatus("questL11Ron") >= 1) {
+			value = -70;
+		}
 		break;
 	case $location[The Black Forest]:
 		if (internalQuestStatus("questL13Final") < 6) {

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -91,9 +91,8 @@ boolean auto_tavern()
 
 	if(!maximized)
 	{
-		// tails are a better time saving investment
-		addToMaximize("80cold damage 20max,80hot damage 20max,80spooky damage 20max,80stench damage 20max,500ml " + auto_convertDesiredML(150) + "max");
-		simMaximize($location[Noob Cave]);
+		// Tails are a better time saving investment
+		simMaximizeWith("80cold damage 20max,80hot damage 20max,80spooky damage 20max,80stench damage 20max,500ml " + auto_convertDesiredML(150) + "max");
 		maximized = true;
 	}
 	int [string] eleChoiceCombos =
@@ -108,8 +107,15 @@ boolean auto_tavern()
 	{
 		boolean passed = simValue(ele + " Damage") >= 20.0;
 		set_property("choiceAdventure" + choicenum, passed ? "2" : "1");
-		if(passed) ++capped;
+		if(passed)
+		{
+			++capped;
+			//adding a 20min argument does not yield better combinations nor avoid giving value to failed elements
+			addToMaximize("80" + ele + " Damage 20max");	//only give value to elements that will pass
+		}
 	}
+	addToMaximize("500ml " + auto_convertDesiredML(150) + "max");
+	
 	if(capped >= 3)
 	{
 		providePlusNonCombat(25, $location[Noob Cave]);
@@ -138,7 +144,7 @@ boolean auto_tavern()
 			int actual = loc + 1;
 			boolean needReset = false;
 
-			if(autoAdvBypass("cellar.php?action=explore&whichspot=" + actual, $location[Noob Cave]))
+			if(autoAdvBypass("cellar.php?action=explore&whichspot=" + actual, $location[The Typical Tavern Cellar]))
 			{
 				return true;
 			}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2229,7 +2229,7 @@ boolean L11_redZeppelin()
 		return autoAdvBypass("inv_use.php?pwd=&whichitem=7204&checked=1", $location[A Mob of Zeppelin Protesters]);
 	}
 
-	if(cloversAvailable() > 0 && get_property("zeppelinProtestors").to_int() < 75)
+	if(get_property("zeppelinProtestors").to_int() < 75 && cloversAvailable() > 0)
 	{
 		if(cloversAvailable() >= 3 && auto_shouldUseWishes())
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1767,7 +1767,7 @@ boolean L11_hiddenCity()
 		}
 	}
 
-	if (internalQuestStatus("questL11Business") < 2 && my_adventures() >= 11)
+	if (internalQuestStatus("questL11Business") < 2 && (my_adventures() + $location[The Hidden Office Building].turns_spent) >= 11)
 	{
 		auto_log_info("The idden [sic] office!", "blue");
 


### PR DESCRIPTION
don't need item drop for forced encounters and most lucky adventures
don't need +combat for shen Lair of the Ninja Snowmen after peak
don't need +combat in The Haunted Library all the non combat are free to skip
don't need item drop to start the war

[The Typical Tavern Cellar] location was not used, autoAdvBypass used Noob Cave for this quest because The Typical Tavern Cellar is not a real location in the game but it is a virtual location in mafia that autoscend tries to check and that's how it knows where it is to handle things like monster level but removed what it tried to do in that location that was incorrect:
item familiar not needed for Typical Tavern Cellar
combat frequency modifier is already decided in the quest file instead of the zone file

in tavern quest only give value to elements that will pass, instead of directly adding to maximizer string simulate then add those that pass

in L11 quest the condition wants 11 adventures to do Hidden Office Building but it did not count turns already done so it would have stopped doing it suddenly when under 11 adventures during it

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
