### PR TITLE
Various G-Lover Changes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -569,7 +569,10 @@ void initializeDay(int day)
 		#}
 	}
 
-	auto_saberDailyUpgrade(day);
+	if(auto_is_valid($item[Fourth of May cosplay saber]))
+	{
+		auto_saberDailyUpgrade(day);
+	}
 
 	if((item_amount($item[cursed microwave]) >= 1) && !get_property("_cursedMicrowaveUsed").to_boolean())
 	{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -638,7 +638,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[mafia thumb ring], 1, 0);
 		}
 
-		if((storage_amount($item[can of rain-doh]) > 0) && glover_usable($item[Can Of Rain-Doh]) && (pullXWhenHaveY($item[can of Rain-doh], 1, 0)))
+		if((storage_amount($item[can of rain-doh]) > 0) && auto_is_valid($item[Can Of Rain-Doh]) && (pullXWhenHaveY($item[can of Rain-doh], 1, 0)))
 		{
 			if(item_amount($item[Can of Rain-doh]) > 0)
 			{
@@ -646,11 +646,11 @@ int handlePulls(int day)
 				put_closet(1, $item[empty rain-doh can]);
 			}
 		}
-		if(storage_amount($item[Buddy Bjorn]) > 0 && pathHasFamiliar())
+		if(storage_amount($item[Buddy Bjorn]) > 0 && auto_is_valid($item[Buddy Bjorn]) && pathHasFamiliar())
 		{
 			pullXWhenHaveY($item[Buddy Bjorn], 1, 0);
 		}
-		if((storage_amount($item[Camp Scout Backpack]) > 0) && !possessEquipment($item[Buddy Bjorn]) && glover_usable($item[Camp Scout Backpack]))
+		if((storage_amount($item[Camp Scout Backpack]) > 0) && !possessEquipment($item[Buddy Bjorn]) && auto_is_valid($item[Camp Scout Backpack]))
 		{
 			pullXWhenHaveY($item[Camp Scout Backpack], 1, 0);
 		}
@@ -710,13 +710,13 @@ int handlePulls(int day)
 			}
 		}
 
-		if((equipped_item($slot[folder1]) == $item[folder (tranquil landscape)]) && (equipped_item($slot[folder2]) == $item[folder (skull and crossbones)]) && (equipped_item($slot[folder3]) == $item[folder (Jackass Plumber)]) && glover_usable($item[Over-The-Shoulder Folder Holder]))
+		if((equipped_item($slot[folder1]) == $item[folder (tranquil landscape)]) && (equipped_item($slot[folder2]) == $item[folder (skull and crossbones)]) && (equipped_item($slot[folder3]) == $item[folder (Jackass Plumber)]) && auto_is_valid($item[Over-The-Shoulder Folder Holder]))
 		{
 			pullXWhenHaveY($item[over-the-shoulder folder holder], 1, 0);
 		}
 		if((my_primestat() == $stat[Muscle]) && !in_heavyrains() && !in_wotsf()) // no need for shields in way of the surprising fist
 		{
-			if((closet_amount($item[Fake Washboard]) == 0) && glover_usable($item[Fake Washboard]))
+			if((closet_amount($item[Fake Washboard]) == 0) && auto_is_valid($item[Fake Washboard]))
 			{
 				pullXWhenHaveY($item[Fake Washboard], 1, 0);
 			}
@@ -749,7 +749,7 @@ int handlePulls(int day)
 			{
 				pullXWhenHaveY($item[Thor\'s Pliers], 1, 0);
 			}
-			if(glover_usable($item[Basaltamander Buckler]))
+			if(auto_is_valid($item[Basaltamander Buckler]))
 			{
 				pullXWhenHaveY($item[Basaltamander Buckler], 1, 0);
 			}
@@ -766,14 +766,14 @@ int handlePulls(int day)
 
 		if(!in_heavyrains() && pathHasFamiliar())
 		{
-			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Astral Pet Sweater]) && glover_usable($item[Snow Suit]))
+			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Astral Pet Sweater]) && auto_is_valid($item[Snow Suit]))
 			{
 				pullXWhenHaveY($item[snow suit], 1, 0);
 			}
 			boolean famStatEq = possessEquipment($item[fuzzy polar bear ears]) || possessEquipment($item[miniature goose mask]) || possessEquipment($item[tiny glowing red nose]);
 			
 			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Filthy Child Leash]) && !possessEquipment($item[Astral Pet Sweater]) &&
-			!famStatEq && glover_usable($item[Filthy Child Leash]))
+			!famStatEq && auto_is_valid($item[Filthy Child Leash]))
 			{
 				pullXWhenHaveY($item[Filthy Child Leash], 1, 0);
 			}
@@ -784,7 +784,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[Shore Inc. Ship Trip Scrip], 3, 0);
 		}
 
-		if(!in_glover())
+		if(auto_is_valid($item[Infinite BACON Machine]))
 		{
 			pullXWhenHaveY($item[Infinite BACON Machine], 1, 0);
 		}
@@ -794,7 +794,7 @@ int handlePulls(int day)
 			string temp = visit_url("storage.php?action=pull&whichitem1=" + to_int($item[Bastille Battalion Control Rig]) + "&howmany1=1&pwd");
 		}
 
-		if(!in_pokefam())
+		if(!in_pokefam() && auto_is_valid($item[Replica Bat-oomerang]))
 		{
 			pullXWhenHaveY($item[Replica Bat-oomerang], 1, 0);
 		}
@@ -867,7 +867,7 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	if(knoll_available() && (item_amount($item[Detuned Radio]) == 0) && (my_meat() >= npc_price($item[Detuned Radio])) && !in_glover())
+	if(knoll_available() && (item_amount($item[Detuned Radio]) == 0) && (my_meat() >= npc_price($item[Detuned Radio])) && auto_is_valid($item[Detuned Radio]))
 	{
 		buyUpTo(1, $item[Detuned Radio]);
 		auto_setMCDToCap();
@@ -901,11 +901,11 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	if(item_amount($item[Seal Tooth]) == 0)
+	if(item_amount($item[Seal Tooth]) == 0 && auto_is_valid($item[Seal Tooth]))
 	{
 		//saucerors want to use sealtooth to delay so that mortar shell delivers final blow for weaksauce MP explosion
 		//TODO: add delaying for mortar for other classes in combat and then remove the sauceror requirement here.
-		if( my_meat() > 7500 || (my_class() == $class[Sauceror] && canUse($skill[Stuffed Mortar Shell])) )
+		if(my_meat() > 7500 || (my_class() == $class[Sauceror] && canUse($skill[Stuffed Mortar Shell])))
 		{
 			acquireHermitItem($item[Seal Tooth]);
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -786,7 +786,7 @@ boolean doBedtime()
 	}
 	if (get_property("telescopeUpgrades").to_int() > 0 && internalQuestStatus("questL13Final") < 0)
 	{
-		if(get_property("telescopeLookedHigh") == "false")
+		if(get_property("telescopeLookedHigh") == "false" && auto_is_valid($effect[Starry-Eyed]))
 		{
 			cli_execute("telescope high");
 		}
@@ -804,7 +804,7 @@ boolean doBedtime()
 		}
 	}
 
-	if((my_daycount() == 1) && (possessEquipment($item[Thor\'s Pliers]) || (freeCrafts() > 0)) && !possessEquipment($item[Chrome Sword]) && !inAftercore() && !in_tcrs())
+	if((my_daycount() == 1) && (possessEquipment($item[Thor\'s Pliers]) || (freeCrafts() > 0)) && !possessEquipment($item[Chrome Sword]) && auto_is_valid($item[chrome sword]) && !inAftercore() && !in_tcrs())
 	{
 		item oreGoal = to_item(get_property("trapperOre"));
 		int need = 1;
@@ -813,7 +813,8 @@ boolean doBedtime()
 		{
 			need = 4;
 		}
-		if (!haveAdvSmithing) {
+		if (!haveAdvSmithing)
+		{
 			auto_log_info('No Super-Advanced Meatsmithing for chrome sword crafting!');
 		}
 		if((item_amount($item[Chrome Ore]) >= need) && !possessEquipment($item[Chrome Sword]) && isArmoryAvailable() && haveAdvSmithing)
@@ -973,9 +974,19 @@ boolean doBedtime()
 	}
 
 	// Is +50% to all stats the best choice here? I don't know!
-	spacegateVaccine($effect[Broad-Spectrum Vaccine]);
+	if(auto_is_valid($effect[Broad-Spectrum Vaccine]))
+	{
+		spacegateVaccine($effect[Broad-Spectrum Vaccine]);
+	}
 
-	zataraSeaside("item");
+	if(!auto_is_valid($effect[There\'s No N In Love]))
+	{
+		zataraSeaside("familiar");
+	}
+	else
+	{
+		zataraSeaside("item");
+	}
 
 	if(is_unrestricted($item[Source Terminal]) && (get_campground() contains $item[Source Terminal]))
 	{
@@ -1106,7 +1117,7 @@ boolean doBedtime()
 		use(1, $item[School of Hard Knocks Diploma]);
 	}
 
-	if(!get_property("_lyleFavored").to_boolean())
+	if(!get_property("_lyleFavored").to_boolean() && auto_is_valid($effect[Favored by Lyle]))
 	{
 		string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 	}
@@ -1252,7 +1263,7 @@ boolean doBedtime()
 			auto_log_info("You can still fight a Chateau Mangtegna Painting today.", "blue");
 		}
 
-		if(!get_property("_streamsCrossed").to_boolean() && possessEquipment($item[Protonic Accelerator Pack]))
+		if(!get_property("_streamsCrossed").to_boolean() && possessEquipment($item[Protonic Accelerator Pack]) && auto_is_valid($effect[Total Protonic Reversal]))
 		{
 			cli_execute("crossstreams");
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1237,12 +1237,12 @@ boolean doBedtime()
 			auto_log_info("You can still Calculate the Universe!", "blue");
 		}
 
-		if(is_unrestricted($item[Deck of Every Card]) && (item_amount($item[Deck of Every Card]) > 0) && (get_property("_deckCardsDrawn").to_int() < 15))
+		if(is_unrestricted($item[Deck of Every Card]) && (item_amount($item[Deck of Every Card]) > 0) && (get_property("_deckCardsDrawn").to_int() < 15) && auto_is_valid($item[Deck of Every Card]))
 		{
 			auto_log_info("You have a Deck of Every Card and " + (15 - get_property("_deckCardsDrawn").to_int()) + " draws remaining!", "blue");
 		}
 
-		if(is_unrestricted($item[Time-Spinner]) && (item_amount($item[Time-Spinner]) > 0) && (get_property("_timeSpinnerMinutesUsed").to_int() < 10) && glover_usable($item[Time-Spinner]))
+		if(is_unrestricted($item[Time-Spinner]) && (item_amount($item[Time-Spinner]) > 0) && (get_property("_timeSpinnerMinutesUsed").to_int() < 10) && auto_is_valid($item[Time-Spinner]))
 		{
 			auto_log_info("You have " + (10 - get_property("_timeSpinnerMinutesUsed").to_int()) + " minutes left to Time-Spinner!", "blue");
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -975,9 +975,17 @@ boolean doBedtime()
 		int enhances = auto_sourceTerminalEnhanceLeft();
 		while(enhances > 0)
 		{
-			auto_sourceTerminalEnhance("items");
-			auto_sourceTerminalEnhance("meat");
-			enhances -= 2;
+			if(in_glover())
+			{
+				auto_sourceTerminalEnhance("damage");
+				enhances -= 1;				
+			}
+			else
+			{
+				auto_sourceTerminalEnhance("items");
+				auto_sourceTerminalEnhance("meat");
+				enhances -= 2;
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -541,7 +541,7 @@ void bedtime_pulls()
 	if(internalQuestStatus("questL11Desert") < 1)
 	{
 		int gnasirProgress = get_property("gnasirProgress").to_int();
-		if ((gnasirProgress & 16) == 0)
+		if ((gnasirProgress & 16) == 0 && auto_is_valid($item[drum machine]))
 		{
 			pullXWhenHaveY($item[drum machine], 1, 0);
 		}
@@ -778,7 +778,11 @@ boolean doBedtime()
 	{
 		visit_url("clan_viplounge.php?preaction=poolgame&stance=1");
 		visit_url("clan_viplounge.php?preaction=poolgame&stance=1");
-		visit_url("clan_viplounge.php?preaction=poolgame&stance=3");
+		if(auto_is_valid($effect[Hustlin\']))
+		{
+			visit_url("clan_viplounge.php?preaction=poolgame&stance=3");
+		}
+		visit_url("clan_viplounge.php?preaction=poolgame&stance=1");		
 	}
 	if(is_unrestricted($item[Colorful Plastic Ball]) && !get_property("_ballpit").to_boolean() && (get_clan_id() != -1))
 	{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -900,6 +900,10 @@ boolean doBedtime()
 				{
 					cli_execute("shower ice");
 				}
+				else if(in_glover())
+				{
+					cli_execute("shower mp") // can't use the effects or the ice
+				}
 				else
 				{
 					cli_execute("shower " + my_primestat());

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -900,7 +900,7 @@ boolean doBedtime()
 				{
 					cli_execute("shower ice");
 				}
-				else if(in_glover())
+				if(in_glover())
 				{
 					cli_execute("shower mp") // can't use the effects or the ice
 				}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -900,9 +900,9 @@ boolean doBedtime()
 				{
 					cli_execute("shower ice");
 				}
-				if(in_glover())
+				else if(in_glover())
 				{
-					cli_execute("shower mp") // can't use the effects or the ice
+					cli_execute("shower mp"); // can't use the effects or the ice
 				}
 				else
 				{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -320,13 +320,10 @@ boolean auto_post_adventure()
 		{
 			use_skill(1, $skill[Disco Nap]);
 		}
-		else if(isGeneralStoreAvailable())
+		else if(isGeneralStoreAvailable() && auto_is_valid($item[Anti-Anti-Antidote]))
 		{
 			buyUpTo(1, $item[Anti-Anti-Antidote], 30);
-			if(!in_glover())
-			{
-				use(1, $item[Anti-Anti-Antidote]);
-			}
+			use(1, $item[Anti-Anti-Antidote]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -658,7 +658,7 @@ boolean auto_pre_adventure()
 	enforceMLInPreAdv();
 	
 	// Last minute switching for garbage tote. But only if nothing called on januaryToteAcquire this turn.
-	if(!get_property("auto_januaryToteAcquireCalledThisTurn").to_boolean())
+	if(!get_property("auto_januaryToteAcquireCalledThisTurn").to_boolean() && auto_is_valid($item[Wad of Used Tape]))
 	{
 		januaryToteAcquire($item[Wad Of Used Tape]);
 	}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -494,7 +494,7 @@ float provideInitiative(int amt, location loc, boolean doEquips, boolean specula
 	]))
 		return result();
 
-	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[init.enh]) == 0)
+	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[init.enh]) == 0 && auto_is_valid($effect[init.enh]))
 	{
 		if(!speculative)
 			auto_sourceTerminalEnhance("init");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3102,7 +3102,7 @@ boolean auto_is_valid(skill sk)
 
 boolean auto_is_valid(effect eff)
 {
-	return glover_usable(eff.to_string());
+	return glover_usable(eff.to_string()) && is_unrestricted(eff);
 }
 
 void auto_log(string s, string color, int log_level)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3100,6 +3100,11 @@ boolean auto_is_valid(skill sk)
 	return (glover_usable(sk.to_string()) || sk.passive) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
 }
 
+boolean auto_is_valid(effect eff)
+{
+	return glover_usable(eff.to_string());
+}
+
 void auto_log(string s, string color, int log_level)
 {
 	if(log_level > get_property("auto_log_level").to_int())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3102,7 +3102,7 @@ boolean auto_is_valid(skill sk)
 
 boolean auto_is_valid(effect eff)
 {
-	return glover_usable(eff.to_string()) && is_unrestricted(eff);
+	return glover_usable(eff.to_string());
 }
 
 void auto_log(string s, string color, int log_level)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1639,6 +1639,7 @@ boolean canBurnDelay(location loc);
 boolean auto_is_valid(item it);
 boolean auto_is_valid(familiar fam);
 boolean auto_is_valid(skill sk);
+boolean auto_is_valid(effect eff);
 void auto_log(string s, string color, int log_level);
 void auto_log_error(string s);
 void auto_log_warning(string s, string color);

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -613,7 +613,7 @@ boolean chateauPainting()
 
 boolean deck_available()
 {
-	return ((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]));
+	return ((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card]));
 }
 
 int deck_draws_left()

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -350,14 +350,19 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 
 	if(!have_skill($skill[Torso Awareness]) && !have_skill($skill[Best Dressed]) && (statValue == 1))
 	{
-		if(possessEquipment($item[Protonic Accelerator Pack]) || possessEquipment($item[Vampyric Cloake]))
-		{
-			statValue = 3;
-		}
-		else
+		if(!(possessEquipment($item[Protonic Accelerator Pack]) || possessEquipment($item[Vampyric Cloake])) && auto_is_valid($item[LOV Epaulettes]))
 		{
 			statValue = 2;
 		}
+		else
+		{
+			statValue = 3;
+		}
+	}
+
+	if(!auto_is_valid($item[LOV Epaulettes]) && (statValue == 2))  // if myst and in G-Lover
+	{
+		statValue = 3; // Resistance and Meat seems better than ML
 	}
 
 	backupSetting("choiceAdventure1224", to_string(statValue)); // L.O.V. Equipment Room

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -787,7 +787,7 @@ boolean neverendingPartyCombat()
 	fightClubSpa();
 	//May need to actually have 1 adventure left.
 
-	if (hasTorso() && januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) > 0)
+	if(hasTorso() && januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) > 0 && auto_is_valid($item[Makeshift Garbage Shirt]))
 	{
 		januaryToteAcquire($item[Makeshift Garbage Shirt]);
 		autoEquip($slot[shirt], $item[Makeshift Garbage Shirt]);
@@ -821,7 +821,11 @@ void neverendingPartyChoiceHandler(int choice)
 				buff = $effect[The Best Hair You've Ever Had];
 				break;
 		}
-		if (buff != $effect[none] && have_effect(buff) < 9)
+		if(in_glover()) // Can't use any of the buffs, may as well fight
+		{
+			run_choice(5); // Pick a fight (fight a random monster from the zone)
+		}
+		else if (buff != $effect[none] && have_effect(buff) < 9)
 		{
 			// Get the +mainstat% buff if we don't have enough turns of it to get us to the next scheduled NC.
 			switch (my_primestat())
@@ -852,7 +856,9 @@ void neverendingPartyChoiceHandler(int choice)
 			{
 				run_choice(5); // Pick a fight (fight a random monster from the zone)
 			}
-		} else {
+		}
+		else
+		{
 			run_choice(5); // Pick a fight (fight a random monster from the zone)
 		}
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -784,7 +784,10 @@ boolean neverendingPartyCombat()
 		return false;
 	}
 
-	fightClubSpa();
+	if(!in_glover()) // no benefit to stats in G-Lover
+	{
+		fightClubSpa();
+	}
 	//May need to actually have 1 adventure left.
 
 	if(hasTorso() && januaryToteTurnsLeft($item[Makeshift Garbage Shirt]) > 0 && auto_is_valid($item[Makeshift Garbage Shirt]))

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -784,7 +784,11 @@ boolean neverendingPartyCombat()
 		return false;
 	}
 
-	if(!in_glover()) // no benefit to stats in G-Lover
+	if(in_glover()) // only non stat effect is valid in G-Lover
+	{
+		fightClubSpa($effect[Flagrantly Fragrant]);
+	}
+	else
 	{
 		fightClubSpa();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -81,7 +81,14 @@ boolean auto_tavern()
 	{
 		if(numeric_modifier(element_type + " Damage") < 20.0)
 		{
-			auto_beachCombHead(element_type);
+			if(in_glover())
+			{
+				auto_beachCombHead(stench); // the only one that works in g-lover
+			}
+			else
+			{
+				auto_beachCombHead(element_type);	
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -83,7 +83,7 @@ boolean auto_tavern()
 		{
 			if(in_glover())
 			{
-				auto_beachCombHead(stench); // the only one that works in g-lover
+				auto_beachCombHead("stench"); // the only one that works in g-lover
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -81,14 +81,11 @@ boolean auto_tavern()
 	{
 		if(numeric_modifier(element_type + " Damage") < 20.0)
 		{
-			if(in_glover())
+			if(in_glover() && element_type != "Stench") // the only one that works in g-lover
 			{
-				auto_beachCombHead("stench"); // the only one that works in g-lover
+				continue;
 			}
-			else
-			{
-				auto_beachCombHead(element_type);	
-			}
+			auto_beachCombHead(element_type);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -223,7 +223,10 @@ boolean L7_crypt()
 		autoEquip($item[Gravy Boat]);
 		knockOffCapePrep();
 
-		spacegateVaccine($effect[Emotional Vaccine]);
+		if(auto_is_valid($effect[Emotional Vaccine]))
+		{
+			spacegateVaccine($effect[Emotional Vaccine]);
+		}
 
 		if(auto_have_familiar($familiar[Space Jellyfish]) && (get_property("_spaceJellyfishDrops").to_int() < 3))
 		{

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -164,7 +164,7 @@ boolean L9_chasmBuild()
 	// make sure our progress count is correct before we do anything.
 	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 
-	if (!in_glover() && get_property("chasmBridgeProgress").to_int() < 30 && auto_cargoShortsOpenPocket(666))
+	if (auto_is_valid($item[Smut Orc Keepsake Box]) && get_property("chasmBridgeProgress").to_int() < 30 && auto_cargoShortsOpenPocket(666))
 	{
  		// fight Smut Orc Pervert from Cargo Shorts for a Smut Orc Keepsake Box
  		use(1, $item[Smut Orc Keepsake Box]);
@@ -271,12 +271,9 @@ boolean L9_chasmBuild()
 
 		autoAdv(1, $location[The Smut Orc Logging Camp]);
 
-		if(item_amount($item[Smut Orc Keepsake Box]) > 0)
+		if(item_amount($item[Smut Orc Keepsake Box]) > 0 && auto_is_valid($item[Smut Orc Keepsake Box]))
 		{
-			if(!in_glover())
-			{
-				use(1, $item[Smut Orc Keepsake Box]);
-			}
+			use(1, $item[Smut Orc Keepsake Box]);
 		}
 		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 		if(get_property("chasmBridgeProgress").to_int() >= 30)
@@ -309,12 +306,9 @@ boolean L9_chasmBuild()
 		}
 
 		autoAdv(1, $location[The Smut Orc Logging Camp]);
-		if(item_amount($item[Smut Orc Keepsake Box]) > 0)
+		if(item_amount($item[Smut Orc Keepsake Box]) > 0  && auto_is_valid($item[Smut Orc Keepsake Box]))
 		{
-			if(!in_glover())
-			{
-				use(1, $item[Smut Orc Keepsake Box]);
-			}
+			use(1, $item[Smut Orc Keepsake Box]);
 		}
 		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 		return true;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -556,8 +556,14 @@ boolean L9_aBooPeak()
 			buffMaintain($effect[Red Door Syndrome]);
 			buffMaintain($effect[Well-Oiled]);
 
-			auto_beachCombHead("cold");
-			auto_beachCombHead("spooky");
+			if(auto_is_valid($effect[Cold as Nice]))
+			{
+				auto_beachCombHead("cold");
+			}
+			if(auto_is_valid($effect[Does It Have a Skull In There??]))			
+			{
+				auto_beachCombHead("spooky");
+			}
 
 			set_property("choiceAdventure611", "1");
 			

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2166,7 +2166,11 @@ boolean L11_redZeppelin()
 	}
 
 	addToMaximize("100sleaze damage,100sleaze spell damage");
-	auto_beachCombHead("sleaze");
+	if(auto_is_valid($effect[Oiled, Slick]))
+	{
+		auto_beachCombHead("sleaze");
+	}
+
 	foreach it in $items[lynyrdskin breeches, lynyrdskin cap, lynyrdskin tunic]
 	{
 		if(possessEquipment(it) && auto_can_equip(it) &&

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2870,7 +2870,7 @@ boolean L11_unlockEd()
 			cli_execute("make sugar fairy");
 			buffMaintain($effect[Dance of the Sugar Fairy]);
 		}
-		if(have_effect($effect[items.enh]) == 0)
+		if(have_effect($effect[items.enh]) == 0 && auto_is_valid($effect[items.enh]))
 		{
 			auto_sourceTerminalEnhance("items");
 		}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1849,7 +1849,10 @@ boolean L12_themtharHills()
 	buffMaintain($effect[Sweet Heart], 0, 1, 20);
 	buffMaintain($effect[Good Things Are Coming, You Can Smell It]);
 	bat_formWolf();
-	zataraSeaside("meat");
+	if(auto_is_valid($effect[Meet the Meat]))
+	{
+		zataraSeaside("meat");
+	}
 
 	{
 		equipWarOutfit();

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1759,7 +1759,7 @@ boolean L12_themtharHills()
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
 	//count inhaler if we have one or if we have a clover to obtain one and can use one
-	if(item_amount(($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || cloversAvailable() > 0) && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]))
+	if((item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || cloversAvailable() > 0) && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]))
 	{
 		meat_need = meat_need - 200;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1758,8 +1758,8 @@ boolean L12_themtharHills()
 	}
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
-	//count inhaler if we have one or if we have a clover to obtain one
-	if(item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || cloversAvailable() > 0)
+	//count inhaler if we have one or if we have a clover to obtain one and can use one
+	if(item_amount(($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || cloversAvailable() > 0) && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]))
 	{
 		meat_need = meat_need - 200;
 	}
@@ -1767,7 +1767,7 @@ boolean L12_themtharHills()
 	{
 		meat_need = meat_need - 150;
 	}
-	if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])))
+	if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
 	{
 		meat_need = meat_need - 100;
 	}
@@ -1822,7 +1822,7 @@ boolean L12_themtharHills()
 		}
 	}
 
-	if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
+	if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]) && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
 	{
 		//use clover to get inhaler
 		cloverUsageInit();

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1732,7 +1732,7 @@ boolean L12_themtharHills()
 	{
 		autoChew(1, $item[body spradium]);
 	}
-	if(have_effect($effect[meat.enh]) == 0)
+	if(have_effect($effect[meat.enh]) == 0 && auto_is_valid($effect[meat.enh]))
 	{
 		if(auto_sourceTerminalEnhanceLeft() > 0)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -448,7 +448,7 @@ boolean L13_towerNSContests()
 			case $stat[moxie]:
 				autoMaximize("moxie -equip snow suit", 1500, 0, false);
 
-				if(have_effect($effect[Ten out of Ten]) == 0)
+				if(have_effect($effect[Ten out of Ten]) == 0 && auto_is_valid($effect[Ten out of Ten]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Ten out of Ten]);
 				}
@@ -456,7 +456,7 @@ boolean L13_towerNSContests()
 			case $stat[muscle]:
 				autoMaximize("muscle -equip snow suit", 1500, 0, false);
 
-				if(have_effect($effect[Muddled]) == 0)
+				if(have_effect($effect[Muddled]) == 0 && auto_is_valid($effect[Muddled]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Muddled]);
 				}
@@ -464,7 +464,7 @@ boolean L13_towerNSContests()
 			case $stat[mysticality]:
 				autoMaximize("myst -equip snow suit", 1500, 0, false);
 
-				if(have_effect($effect[Uncucumbered]) == 0)
+				if(have_effect($effect[Uncucumbered]) == 0 && auto_is_valid($effect[Uncucumbered]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Uncucumbered]);
 				}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -381,7 +381,7 @@ boolean L13_towerNSContests()
 			{
 				cli_execute("grim init");
 			}
-			if((get_property("telescopeUpgrades").to_int() > 0) && (!get_property("telescopeLookedHigh").to_boolean()))
+			if((get_property("telescopeUpgrades").to_int() > 0) && (!get_property("telescopeLookedHigh").to_boolean()) && auto_is_valid($effect[Starry-Eyed]))
 			{
 				cli_execute("telescope high");
 			}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -420,7 +420,7 @@ boolean L13_towerNSContests()
 		if(get_property("nsContestants2").to_int() == -1)
 		{
 			resetMaximize();
-			if(!get_property("_lyleFavored").to_boolean())
+			if(!get_property("_lyleFavored").to_boolean() && auto_is_valid($effect[Favored by Lyle]))
 			{
 				string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 			}

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -238,7 +238,7 @@ boolean LX_steelOrgan()
 		auto_log_info("I am hungry for some steel.", "blue");
 	}
 
-	if(have_effect($effect[items.enh]) == 0)
+	if(have_effect($effect[items.enh]) == 0 && auto_is_valid($effect[items.enh]))
 	{
 		auto_sourceTerminalEnhance("items");
 	}


### PR DESCRIPTION
Various clean-up items for G-Lover.  Adds in auto_is_valid($effect) for ability to check effects that can't be used in G-Lover and removes those effects from functioning.


## How Has This Been Tested?

Several G-Lover runs

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
