### PR TITLE
Update mr2015.ash

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -346,7 +346,7 @@ void chateaumantegna_useDesk()
 
 boolean chateaumantegna_havePainting()
 {
-	if(chateaumantegna_available())
+	if(chateaumantegna_available() && !contains_text(visit_url("place.php?whichplace=chateau"), "chateau_paintingnone"))
 	{
 		return !get_property("_chateauMonsterFought").to_boolean();
 	}


### PR DESCRIPTION
Script attempts to access empty painting in chateau. Fix correctly checks if there is an empty painting.
See below for before and after fix.

`ash import<autoscend.ash> chateaumantegna_havePainting() Returned: false`