### PR TITLE
Account for Ninja Snowmen Assassin Environmental Damage

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -386,7 +386,7 @@ boolean chateaumantegna_usePainting(string option)
 	}
 	if(get_property("chateauMonster") == $monster[Ninja Snowman Assassin])
 	{
-		if((item_amount($item[Ninja Carabiner]) > 0) && (item_amount($item[Ninja Crampons]) > 0) && (item_amount($item[Ninja Rope]) > 0))
+		if(((my_maxhp() <= expected_damage($monster[ninja snowman assassin]) * 1.2) && jump_chance($monster[ninja snowman assassin]) < 100 ) || ((item_amount($item[Ninja Carabiner]) > 0) && (item_amount($item[Ninja Crampons]) > 0) && (item_amount($item[Ninja Rope]) > 0)))
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -634,7 +634,7 @@ boolean L8_trapperNinjaLair()
 	// we must use two variables because there are too many special cases. maybe we can survive assassins but not encounter them due to +combat being too low. Copiers and pulls complicate matters. We could copy an assassin even if we cannot encounter it in the lair
 	
 	//check if we can survive a hit or get the jump on NSA
-	if((my_maxhp() <= expected_damage($monster[ninja snowman assassin])) && jump_chance($monster[ninja snowman assassin]) < 100 )
+	if((my_maxhp() <= expected_damage($monster[ninja snowman assassin]) * 1.2) && jump_chance($monster[ninja snowman assassin]) < 100 )
 	{
 		if(isAboutToPowerlevel())
 		{


### PR DESCRIPTION
Ninja snowmen have a separate tick of environmental damage at the start of their turn, which expected_damage() does not account for. This causes the script to waste 50 adventures and abort, if you are not able to survive but the script thinks you can. The environmental damage is likely around 15%, but I set it to 20% to have a 5% buffer.
![image](https://user-images.githubusercontent.com/70723278/168829173-b217d500-3d3f-4fb9-83e4-e90386e9857d.png)
![image](https://user-images.githubusercontent.com/70723278/168829138-316efdba-0930-4e4f-a079-86e803a54680.png)

Chateau painting snowmen did not check survival. Added survival check.
![image](https://user-images.githubusercontent.com/70723278/168832637-a5195ce1-d3c7-4ba5-bbb1-34bca551fdcb.png)

