### PR TITLE
re do compensate current equipment when calling provideResistances with doEquips = false

### DIFF
--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -560,10 +560,12 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 		uneffect($effect[Flared Nostrils]);
 	}
 	
+	int [element] gearLoss;
 	if(!doEquips)
-	{	//if trying to provide without equipment then value provided by current equipment is not being locked
-		//equipment may be changed in pre adv after the provider returns success
-		//so may need to raise goal value to take into account what is provided by current equipment
+	{	//trying to provide without equipment also means trying to reach goal without value provided by current equipment
+		//currently equipment is not being locked and may be changed in pre adv after the provider returns success
+		//so may need to take into account removal of what is provided by current equipment to compensate
+		//must reduce the result (not raise goal value) since other functions look at the result
 		string unequipsString;
 		foreach sl in $slots[hat,weapon,off-hand,back,shirt,pants,acc1,acc2,acc3,familiar]
 		{
@@ -575,8 +577,8 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 			cli_execute("speculate quiet; " + unequipsString);
 			foreach ele in amt
 			{
-				//add amount below goal that would be lost without current gear
-				amt[ele] += max(0,(min(amt[ele],numeric_modifier(ele + " resistance")) - simValue(ele + " resistance")));
+				//record the amount that would be lost to modify the result with
+				gearLoss[ele] = min(0,simValue(ele + " resistance") - numeric_modifier(ele + " resistance"));
 			}
 		}
 	}
@@ -585,7 +587,7 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 
 	int result(element ele)
 	{
-		return numeric_modifier(ele + " Resistance") + delta[ele];
+		return numeric_modifier(ele + " Resistance") + delta[ele] + gearLoss[ele];
 	}
 
 	int [element] result()


### PR DESCRIPTION
previous PR seemed to work but not in some cases because modifying the goal in the final int [element] provideResistances  function doesn't directly modify the result returned when the provider fails and in the other boolean provideResistances functions that call it,
must modify its results instead of the goal

issue details #1156

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
