### PR TITLE
remove hardcoded price

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -226,18 +226,19 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 			int oldPrice = historical_price(it) * 1.2;
 			int curPrice = auto_mall_price(it);
 			int meat = my_storage_meat();
+			int priceLimit = get_property("autoBuyPriceLimit").to_int();
 			boolean getFromStorage = true;
 			if(can_interact() && (meat < curPrice))
 			{
 				meat = my_meat() - 5000;
 				getFromStorage = false;
 			}
-			if (curPrice >= get_property("autoBuyPriceLimit").to_int())
+			if (curPrice >= priceLimit)
 			{
 				auto_log_warning(it + " is too expensive at " + curPrice + " meat, we're gonna skip buying one in the mall.", "red");
 				break;
 			}
-			if((curPrice <= oldPrice) && (curPrice < get_property("autoBuyPriceLimit").to_int()) && (meat >= curPrice))
+			if((curPrice <= oldPrice) && (curPrice < priceLimit) && (meat >= curPrice))
 			{
 				if(getFromStorage)
 				{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -232,12 +232,12 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 				meat = my_meat() - 5000;
 				getFromStorage = false;
 			}
-			if (curPrice >= 30000)
+			if (curPrice >= get_property("autoBuyPriceLimit").to_int())
 			{
 				auto_log_warning(it + " is too expensive at " + curPrice + " meat, we're gonna skip buying one in the mall.", "red");
 				break;
 			}
-			if((curPrice <= oldPrice) && (curPrice < 30000) && (meat >= curPrice))
+			if((curPrice <= oldPrice) && (curPrice < get_property("autoBuyPriceLimit").to_int()) && (meat >= curPrice))
 			{
 				if(getFromStorage)
 				{
@@ -257,10 +257,6 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 				if(my_storage_meat() < curPrice)
 				{
 					auto_log_warning("Do not have enough meat in Hagnk's to buy " + it + ". Need " + curPrice + " have " + my_storage_meat() + ".", "blue");
-					if(curPrice > 10000000)
-					{
-						auto_log_warning("You must be a poor meatbag.", "green");
-					}
 				}
 			}
 			if(lastStorage == storage_amount(it))


### PR DESCRIPTION
# Description

Swapping the hardcoded 30k price limit on purchases for a player's `autoBuyPriceLimit`. 

## How Has This Been Tested?

Not yet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
