### PR TITLE
aboo clue failure

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -572,11 +572,10 @@ boolean L9_aBooPeak()
 			
 			if(get_property("auto_aboopending").to_int() == 0)
 			{
-				if(item_amount(clue) > 0)
+				if(item_amount(clue) > 0 && use(1, clue))
 				{
-					use(1, clue);
+					set_property("auto_aboopending", my_turncount());
 				}
-				set_property("auto_aboopending", my_turncount());
 			}
 			if(canChangeToFamiliar($familiar[Trick-or-Treating Tot]))
 			{
@@ -606,6 +605,11 @@ boolean L9_aBooPeak()
 				{
 					auto_log_warning("Wandering adventure interrupt of A-Boo Peak, refreshing inventory.", "red");
 					cli_execute("refresh inv");
+					if($strings[Battlie Knight Ghost,Claybender Sorcerer Ghost,Dusken Raider Ghost,Space Tourist Explorer Ghost,Whatsian Commando Ghost] 
+					contains get_property("lastEncounter"))	//clue usage probably failed somehow
+					{
+						catch use(1, clue);		//will not be consumed if a clue is already active
+					}
 				}
 				else
 				{


### PR DESCRIPTION
if clue use failed somehow autoscend would still think it had a clue pending and adventured 50 times, so only set the property that a clue was used if it was successful and try to re use a clue if the last encounter was one of the zone monsters instead of the clue

## How Has This Been Tested?
run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
