### PR TITLE
G lover pie and sniff nurses

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -1,8 +1,8 @@
 pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
-Writing Desk	!prop:writingDesksDefeated=5
+Writing Desk	prop:writingDesksDefeated<4
 cabinet of Dr. Limpieza
 Dairy Goat	loc:The Goatlet
-Morbid Skull
+Morbid Skull	loc:Fear Man's Level
 Pygmy Bowler
 Pygmy Witch Surgeon
 pygmy witch accountant	loc:The Hidden Office Building

--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -17,15 +17,20 @@ Government Scientist	class:Ed the Undying
 Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
+Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
+Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
 Possessed Wine Rack
 Blue Oyster cultist
-Dirty Old Lihc	prop:cyrptNicheEvilness>28
-Possibility Giant	!path:G-Lover;!path:Pocket Familiars;!path:Bees Hate You;prop:chaosButterflyThrown=false;item:chaos butterfly<1
-Serialbus	item:bus pass<5
-CH Imp	item:imp air<5
+Dirty Old Lihc	prop:cyrptNicheEvilness>29
+Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover
+bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
+elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
+spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
+Serialbus	item:bus pass<4
+CH Imp	item:imp air<4
 Camel Toe	!sniffed:Skinflute
 Skinflute	!sniffed:Camel Toe
-Red Butler
+Red Butler	prop:_glarkCableUses<5;item:glark cable<5
 # Bugbear Invasion Wanderers
 scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
 hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -110,10 +110,10 @@ replace	46	ancient unspeakable bugbear	path:Bugbear Invasion;loc:Navigation
 replace	47	trendy bugbear chef	path:Bugbear Invasion;loc:Galley
 
 sniff	0	pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed
-sniff	1	Writing Desk	!prop:writingDesksDefeated=5
+sniff	1	Writing Desk	prop:writingDesksDefeated<4
 sniff	2	cabinet of Dr. Limpieza
 sniff	3	Dairy Goat	loc:The Goatlet
-sniff	4	Morbid Skull
+sniff	4	Morbid Skull	loc:Fear Man's Level
 sniff	5	Pygmy Bowler
 sniff	6	Pygmy Witch Surgeon
 sniff	7	pygmy witch accountant	loc:The Hidden Office Building

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -128,31 +128,36 @@ sniff	15	Government Scientist	class:Ed the Undying
 sniff	16	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 sniff	17	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
 sniff	18	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
-sniff	19	Possessed Wine Rack
-sniff	20	Blue Oyster cultist
-sniff	21	Dirty Old Lihc	prop:cyrptNicheEvilness>28
-sniff	22	Possibility Giant	!path:G-Lover;!path:Pocket Familiars;!path:Bees Hate You;prop:chaosButterflyThrown=false;item:chaos butterfly<1
-sniff	23	Serialbus	item:bus pass<5
-sniff	24	CH Imp	item:imp air<5
-sniff	25	Camel Toe	!sniffed:Skinflute
-sniff	26	Skinflute	!sniffed:Camel Toe
-sniff	27	Red Butler
+sniff	19	Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
+sniff	20	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
+sniff	21	Possessed Wine Rack
+sniff	22	Blue Oyster cultist
+sniff	23	Dirty Old Lihc	prop:cyrptNicheEvilness>29
+sniff	24	Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover
+sniff	25	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	26	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	27	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
+sniff	28	Serialbus	item:bus pass<4
+sniff	29	CH Imp	item:imp air<4
+sniff	30	Camel Toe	!sniffed:Skinflute
+sniff	31	Skinflute	!sniffed:Camel Toe
+sniff	32	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
 # Bugbear Invasion Wanderers
-sniff	28	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
-sniff	29	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
-sniff	30	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
-sniff	31	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
-sniff	32	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
-sniff	33	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
-sniff	34	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
-sniff	35	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
-sniff	36	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
+sniff	33	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
+sniff	34	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
+sniff	35	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
+sniff	36	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
+sniff	37	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
+sniff	38	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
+sniff	39	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
+sniff	40	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
+sniff	41	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
 # Bugbear Invasion Mothership
-sniff	37	creepy eye-stalk tentacle monster	path:Bugbear Invasion
-sniff	38	anesthesiologist bugbear	path:Bugbear Invasion
-sniff	39	bugbear mortician	path:Bugbear Invasion
-sniff	40	N-space Virtual Assistant	path:Bugbear Invasion
-sniff	41	angry cavebugbear	path:Bugbear Invasion
+sniff	42	creepy eye-stalk tentacle monster	path:Bugbear Invasion
+sniff	43	anesthesiologist bugbear	path:Bugbear Invasion
+sniff	44	bugbear mortician	path:Bugbear Invasion
+sniff	45	N-space Virtual Assistant	path:Bugbear Invasion
+sniff	46	angry cavebugbear	path:Bugbear Invasion
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -998,15 +998,15 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		void considerNextPie()
 		{
 			//missing at least 1 key/token, in case it will be only one first consider mainstat pie if possible
-			if(my_primestat() == $stat[muscle] && item_amount($item[Boris\'s key]) == 0)
+			if(!wantBorisPie && my_primestat() == $stat[muscle] && item_amount($item[Boris\'s key]) == 0 && auto_is_valid($item[Boris\'s key lime pie]))
 				wantBorisPie = true;
-			else if(my_primestat() == $stat[mysticality] && item_amount($item[Jarlsberg\'s key]) == 0)
+			else if(!wantJarlsbergPie && my_primestat() == $stat[mysticality] && item_amount($item[Jarlsberg\'s key]) == 0 && auto_is_valid($item[Jarlsberg\'s key lime pie]))
 				wantJarlsbergPie = true;
-			else if(!wantPetePie && item_amount($item[Sneaky Pete\'s key]) == 0)
+			else if(!wantPetePie && item_amount($item[Sneaky Pete\'s key]) == 0 && auto_is_valid($item[Sneaky Pete\'s key lime pie]))
 				wantPetePie = true;
-			else if(!wantJarlsbergPie && item_amount($item[Jarlsberg\'s key]) == 0)
+			else if(!wantJarlsbergPie && item_amount($item[Jarlsberg\'s key]) == 0 && auto_is_valid($item[Jarlsberg\'s key lime pie]))
 				wantJarlsbergPie = true;
-			else if(!wantBorisPie && item_amount($item[Boris\'s key]) == 0)
+			else if(!wantBorisPie && item_amount($item[Boris\'s key]) == 0 && auto_is_valid($item[Boris\'s key lime pie]))
 				wantBorisPie = true;
 		}
 		for (int i=0; i<missingHeroKeys; i++)


### PR DESCRIPTION
don't skip valid key lime pies for non valid pies, for g lover

filthy poultices not g valid so g-lovers doing hippy war should olfact nurses for gauze garters for shadow,
change to sniff naughty version after normal would be better with some sniffs but hits the usual limitations of sniff data system so just mirrored Exploathing conditions

added topiary animals sniff and improved conditions for other sniffs

## How Has This Been Tested?
run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
