### PR TITLE
hotfix [ghost of crimbo commerce] uncommenting error

### DIFF
--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -13,7 +13,7 @@ Elf Operative
 Optimistic Candle
 Rockin' Robin
 # Volleychauns
-Ghost of Crimbo Commerce - commented out until mafia bug with buy from mall is fixed
+Ghost of Crimbo Commerce
 Golden Monkey
 Bloovian Groose
 Unconscious Collective

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -300,7 +300,7 @@ stat	5	Elf Operative
 stat	6	Optimistic Candle
 stat	7	Rockin' Robin
 # Volleychauns
-stat	8	Ghost of Crimbo Commerce - commented out until mafia bug with buy from mall is fixed
+stat	8	Ghost of Crimbo Commerce
 stat	9	Golden Monkey
 stat	10	Bloovian Groose
 stat	11	Unconscious Collective


### PR DESCRIPTION
fix [ghost of crimbo commerce] which was uncommented incorrectly in https://github.com/Loathing-Associates-Scripting-Society/autoscend/commit/8d02212403f277760390ea009b9dce360c16f1d3
undeleted notes were left over after uncommenting which are being parsed as if they are part of the familiar name. resulting in an error in parsing the familiar name.

## How Has This Been Tested?

tested in post ronin

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
