### PR TITLE
remove dependency on can_adv

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -3,5 +3,4 @@ https://github.com/Ezandora/Helix-Fossil/branches/Release/
 https://github.com/Ezandora/Far-Future/branches/Release/
 https://github.com/Ezandora/Voting-Booth/trunk/Release/
 https://github.com/Ezandora/Comb-Beach/trunk/Release/
-https://svn.code.sf.net/p/therazekolmafia/canadv/code/
 https://github.com/gausie/excavator/trunk/RELEASE/

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r26540;	// Sweat tracking at the end of combat
+since r26623;	// Add checking for availability of more Journeyman zones  (location_accessible added)
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -10,7 +10,6 @@ since r26540;	// Sweat tracking at the end of combat
 import <autoscend/autoscend_header.ash>
 import <autoscend/combat/auto_combat.ash>		//this file contains its own header. so it needs to be imported early
 import <autoscend/autoscend_migration.ash>
-import <canadv.ash>
 
 import <autoscend/auto_acquire.ash>
 import <autoscend/auto_adventure.ash>

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1548,10 +1548,10 @@ boolean zone_available(location loc)
 	}
 
 	// compare our result with canadv(https://svn.code.sf.net/p/therazekolmafia/canadv/code/), log a warning if theres a difference. Ideally we can see if there are any differences between our code and Bales, and if not remove all of ours in favor of the dependency
-	boolean canAdvRetval = can_adv(loc);
-	if(canAdvRetval != retval){
-		auto_log_debug("Uh oh, autoscend and canadv dont agree on whether we can adventure at " + loc + " (autoscend: "+retval+", canadv: "+canAdvRetval+"). Will assume locaiton available if either is true.");
-		retval = retval || canAdvRetval;
+	boolean loc_ass = location_accessible(loc);
+	if(loc_ass != retval){
+		auto_log_debug("Uh oh, autoscend and location_accessible() dont agree on whether we can adventure at " + loc + " (autoscend: "+retval+", location_accessible: "+loc_ass+"). Will assume location available if either is true.");
+		retval = retval || loc_ass;
 	}
 
 	return retval;


### PR DESCRIPTION
# Description

remove dependency on can_adv as it has disappeared from SourceForge
use newly added location_accessible() function in mafia instead

## How Has This Been Tested?

Hasn't tbh. Validates though.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
