### PR TITLE
Bedtime Halt Check Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bak
 *.sh
 .github/kolmafia.jar
+.vs*

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -575,6 +575,7 @@ boolean doBedtime()
 		{
 			if(!in_gnoob() && my_familiar() != $familiar[Stooper])
 			{
+				auto_log_warning("Still adventurous! Stopping bedtime.", "red");
 				return false;
 			}
 		}
@@ -582,10 +583,12 @@ boolean doBedtime()
 	boolean out_of_blood = (in_darkGyffte() && item_amount($item[blood bag]) == 0);
 	if((fullness_left() > 0) && can_eat() && !out_of_blood)
 	{
+		auto_log_warning("Still hungry! Stopping bedtime.", "red");
 		return false;
 	}
 	if((inebriety_left() > 0) && can_drink() && !out_of_blood)
 	{
+		auto_log_warning("Still sober! Stopping bedtime.", "red");
 		return false;
 	}
 	int spleenlimit = spleen_limit();
@@ -599,6 +602,7 @@ boolean doBedtime()
 	}
 	if((my_spleen_use() < spleenlimit) && !in_hardcore() && (inebriety_left() > 0))
 	{
+		auto_log_warning("Still spleeny! Stopping bedtime.", "red");
 		return false;
 	}
 
@@ -1318,5 +1322,7 @@ boolean doBedtime()
 		auto_log_info("You are probably done for today, beep.", "blue");
 		return true;
 	}
+	
+	auto_log_warning("Unexpected bedtime path! Stopping bedtime.", "red");
 	return false;
 }


### PR DESCRIPTION
# Description

Log when doBedtime() exits early due to having spare adventures, more to consume, or unexpectedly.

Add .vs* to .gitignore to allow coding in VS Code without adding all the VS autogen files.

## How Has This Been Tested?

**Prep:** In Autoscend.ash, comment out lines 1913-1929 (after "Actually doing stuff" to consumeStuff()) to focus only on running bedtime.
Do not consume anything to max before beginning testing.
Test will likely cover a full day's worth of adventuring, including overdrinking.

1. In kolmafia, run autoscend with more than 4 adventures. 
Should see "Still adventurous! Stopping bedtime."

2. Spend adventures, then rerun autoscend.
Should see "Still hungry! Stopping bedtime."

3. Eat to fullness, spend adventures, then rerun autoscend.
Should see "Still sober! Stopping bedtime."

4. Comment out inebriety check and spleenFamiliar to force spleen check (589-602).
Copy line 594 to below the comment block to ensure spleenlimit is still set.
Remove && !in_hardcore() check from 604 if in HC.
Should see "Still spleeny! Stopping bedtime."

5. Drink to max, spend adventures, fulfill any other currently logged bedtime reqs (overdrinking, etc.), then rerun autoscend to ensure bedtime working normally.
Should see the "You are probably done for today, beep." line.

6. In auto_bedtime.ash, comment out the 'return true' line (1323/4) at the end. Rerun autoscend.
Should see "Unexpected bedtime path! Stopping bedtime." after the 'done for today' line.

Test complete!

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. 
       _No comments, but each new line provides a descriptive log message._
- [X] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
