### PR TITLE
Add Throat Refrigerant to Smut Orc skill logic

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -341,6 +341,9 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 				//equal is 50% chance of cold Saucegeyser. "cold > hot" is used higher in priority. "cold < hot" is 100% hot Saucegeyser and not worth using
 				coldSkillToUse = $skill[Saucegeyser];
 			}
+			else if(in_nuclear() && canUse($skill[Throat Refrigerant], false)){
+				coldSkillToUse = $skill[Throat Refrigerant];
+			}
 			
 			int MPreservedForColdSpells = coldMortarShell ? mp_cost($skill[Stuffed Mortar Shell]) : 0;
 			if(coldSkillToUse != $skill[none])	MPreservedForColdSpells += mp_cost(coldSkillToUse);


### PR DESCRIPTION
# Description

Include logic to use the NA Skill Throat Refrigerant against Smut Orcs for Blech House when in NA

## How Has This Been Tested?

-

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
