### PR TITLE
put tiny stillsuit on terrarium familiar when not worn

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r26623;	// Add checking for availability of more Journeyman zones  (location_accessible added)
+since r26626;	// Add runtimelibrary function to equip an item to a specific familiar (even in terrarium), equip(familiar,item) added
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -763,6 +763,8 @@ boolean auto_pre_adventure()
 		pokefam_makeTeam();
 	}
 
+	utilizeStillsuit();
+
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");
 	

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -457,6 +457,7 @@ void juneCleaverChoiceHandler(int choice);
 boolean canUseSweatpants();
 int getSweat();
 void sweatpantsPreAdventure();
+void utilizeStillsuit();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -293,25 +293,27 @@ void utilizeStillsuit() {
 
 	familiar sweetestSweatFamiliar()
 	{
+		familiar currentFamiliar = my_familiar();
+		
 		//todo better choice of best familiar effects
 		foreach sweetSweatFamiliar in $familiars[Grinning Turtle,Grouper Groupie,Star Starfish,Cat Burglar,Slimeling,Sleazy Gravy Fairy]	//these give item and sleaze
 		{
-			if(have_familiar(sweetSweatFamiliar) && auto_is_valid(sweetSweatFamiliar))
+			if(have_familiar(sweetSweatFamiliar) && auto_is_valid(sweetSweatFamiliar) && sweetSweatFamiliar != currentFamiliar)
 			{
 				return sweetSweatFamiliar;
 			}
 		}
 		foreach commonFamiliar in $familiars[Baby Gravy Fairy,Smiling Rat,Mosquito,Reassembled Blackbird]		//default fall back, you probably have one of these
 		{
-			if(have_familiar(commonFamiliar) && auto_is_valid(commonFamiliar))
+			if(have_familiar(commonFamiliar) && auto_is_valid(commonFamiliar) && commonFamiliar != currentFamiliar)
 			{
 				return commonFamiliar;
 			}
 		}
 		foreach anyFamiliar in $familiars[]		//if all else failed just pick any available familiar that can wear equipment
 		{
-			if(have_familiar(anyFamiliar) && auto_is_valid(anyFamiliar) && 
-			!($familiars[Comma Chameleon,Mad Hatrack,Disembodied Hand,Ghost of Crimbo Carols,Ghost of Crimbo Cheer,Ghost of Crimbo Commerce] contains anyFamiliar))
+			if(have_familiar(anyFamiliar) && auto_is_valid(anyFamiliar) && anyFamiliar != currentFamiliar && 
+			!($familiars[Comma Chameleon,Mad Hatrack,Fancypants Scarecrow,Disembodied Hand,Ghost of Crimbo Carols,Ghost of Crimbo Cheer,Ghost of Crimbo Commerce] contains anyFamiliar))
 			{
 				return anyFamiliar;
 			}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -250,15 +250,76 @@ void sweatpantsPreAdventure() {
 		return;
 	}
 
+	if (my_location() == $location[A Mob of Zeppelin Protesters] && equipped_item($slot[pants]) != $item[lynyrdskin breeches]) {
+		return;	//want to keep all the sleaze damage bonus in this location
+	}
+
 	int sweat = getSweat();
 	int liverCleaned = get_property("_sweatOutSomeBoozeUsed").to_int();
 
 	if (sweat >= 25 && liverCleaned < 3 && my_inebriety() > 0) {
-		use_skill($skill[Sweat Out Some Booze]);
+		if (my_location() == $location[The Haunted Billiards Room] && my_inebriety() <= 10) {
+			//want to keep inebriety for pool skill
+		}
+		else {
+			use_skill($skill[Sweat Out Some Booze]);
+		}
 	}
 
 	// This is just opportunistic use of sweat. This skill should be used in auto_restore.ash.
 	if (sweat >= 95 && my_mp() < my_maxmp()) {
 		use_skill($skill[Sip Some Sweat]);
+	}
+}
+
+void utilizeStillsuit() {
+	//called at the end of pre adv to make sure stillsuit is at least kept equipped on a familiar in the terrarium
+	if(item_amount($item[tiny stillsuit]) > 0 && pathAllowsChangingFamiliar())
+	{
+		//if there is a tiny stillsuit in inventory then unless there was a tracking error it is not worn by any familiar
+		//make sure all this nice familiar sweat doesn't go uncollected when current familiar is wearing something else
+		familiar currentFamiliar = my_familiar();
+		if(familiar_equipped_equipment(currentFamiliar) != $item[tiny stillsuit])
+		{
+			familiar sweetestSweatFamiliar()
+			{
+				//todo better choice of best familiar effects
+				foreach sweetSweatFamiliar in $familiars[Grinning Turtle,Grouper Groupie,Star Starfish,Cat Burglar,Slimeling,Sleazy Gravy Fairy]	//these give item and sleaze
+				{
+					if(have_familiar(sweetSweatFamiliar) && auto_is_valid(sweetSweatFamiliar))
+					{
+						return sweetSweatFamiliar;
+					}
+				}
+				foreach commonFamiliar in $familiars[Baby Gravy Fairy,Smiling Rat,Mosquito,Reassembled Blackbird]		//default fall back, you probably have one of these
+				{
+					if(have_familiar(commonFamiliar) && auto_is_valid(commonFamiliar))
+					{
+						return commonFamiliar;
+					}
+				}
+				foreach anyFamiliar in $familiars[]		//if all else failed just pick any available familiar that can wear equipment
+				{
+					if(have_familiar(anyFamiliar) && auto_is_valid(anyFamiliar) && 
+					!($familiars[Comma Chameleon,Mad Hatrack,Disembodied Hand,Ghost of Crimbo Carols,Ghost of Crimbo Cheer,Ghost of Crimbo Commerce] contains anyFamiliar))
+					{
+						return anyFamiliar;
+					}
+				}
+				return $familiar[none];
+			}
+			if(is_familiar_equipment_locked())
+			{
+				lock_familiar_equipment(false);	//make sure current familiar's equipment is not lost during the temporary swap
+			}
+			familiar familiarWearer = sweetestSweatFamiliar();
+			if(familiarWearer != $familiar[none])
+			{	//since it's in the inventory, should not need to check (familiar_equipped_equipment(familiarWearer) != $item[tiny stillsuit])
+				auto_log_info("Putting the tiny stillsuit on a familiar in the terrarium", "blue");
+				use_familiar(familiarWearer);
+				equip($slot[familiar],$item[tiny stillsuit]);
+				use_familiar(currentFamiliar);
+			}
+		}
 	}
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -286,8 +286,7 @@ void utilizeStillsuit() {
 	}
 
 	//make sure all this nice familiar sweat doesn't go uncollected when current familiar is wearing something else
-	familiar currentFamiliar = my_familiar();
-	if(familiar_equipped_equipment(currentFamiliar) == $item[tiny stillsuit])
+	if(familiar_equipped_equipment(my_familiar()) == $item[tiny stillsuit])
 	{	//since it's in the inventory, should not need to check this
 		return;
 	}
@@ -319,16 +318,10 @@ void utilizeStillsuit() {
 		}
 		return $familiar[none];
 	}
-	if(is_familiar_equipment_locked())
+	equip(sweetestSweatFamiliar(),$item[tiny stillsuit]);
+
+	if(is100FamRun())
 	{
-		lock_familiar_equipment(false);	//make sure current familiar's equipment is not lost during the temporary swap
-	}
-	familiar familiarWearer = sweetestSweatFamiliar();
-	if(familiarWearer != $familiar[none])
-	{
-		auto_log_info("Putting the tiny stillsuit on a familiar in the terrarium", "blue");
-		use_familiar(familiarWearer);
-		equip($slot[familiar],$item[tiny stillsuit]);
-		use_familiar(currentFamiliar);
+		handleFamiliar(get_property("auto_100familiar").to_familiar());	//just make extra sure this didnt break 100 familiar runs but familiar should not have been swapped
 	}
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -274,52 +274,61 @@ void sweatpantsPreAdventure() {
 
 void utilizeStillsuit() {
 	//called at the end of pre adv to make sure stillsuit is at least kept equipped on a familiar in the terrarium
-	if(item_amount($item[tiny stillsuit]) > 0 && pathAllowsChangingFamiliar())
+	if(item_amount($item[tiny stillsuit]) == 0)
 	{
-		//if there is a tiny stillsuit in inventory then unless there was a tracking error it is not worn by any familiar
-		//make sure all this nice familiar sweat doesn't go uncollected when current familiar is wearing something else
-		familiar currentFamiliar = my_familiar();
-		if(familiar_equipped_equipment(currentFamiliar) != $item[tiny stillsuit])
+		return;
+	}
+
+	//if there is a tiny stillsuit in inventory then unless there was a tracking error it is not worn by any familiar
+	if(!pathAllowsChangingFamiliar())
+	{
+		return;
+	}
+
+	//make sure all this nice familiar sweat doesn't go uncollected when current familiar is wearing something else
+	familiar currentFamiliar = my_familiar();
+	if(familiar_equipped_equipment(currentFamiliar) == $item[tiny stillsuit])
+	{	//since it's in the inventory, should not need to check this
+		return;
+	}
+
+	familiar sweetestSweatFamiliar()
+	{
+		//todo better choice of best familiar effects
+		foreach sweetSweatFamiliar in $familiars[Grinning Turtle,Grouper Groupie,Star Starfish,Cat Burglar,Slimeling,Sleazy Gravy Fairy]	//these give item and sleaze
 		{
-			familiar sweetestSweatFamiliar()
+			if(have_familiar(sweetSweatFamiliar) && auto_is_valid(sweetSweatFamiliar))
 			{
-				//todo better choice of best familiar effects
-				foreach sweetSweatFamiliar in $familiars[Grinning Turtle,Grouper Groupie,Star Starfish,Cat Burglar,Slimeling,Sleazy Gravy Fairy]	//these give item and sleaze
-				{
-					if(have_familiar(sweetSweatFamiliar) && auto_is_valid(sweetSweatFamiliar))
-					{
-						return sweetSweatFamiliar;
-					}
-				}
-				foreach commonFamiliar in $familiars[Baby Gravy Fairy,Smiling Rat,Mosquito,Reassembled Blackbird]		//default fall back, you probably have one of these
-				{
-					if(have_familiar(commonFamiliar) && auto_is_valid(commonFamiliar))
-					{
-						return commonFamiliar;
-					}
-				}
-				foreach anyFamiliar in $familiars[]		//if all else failed just pick any available familiar that can wear equipment
-				{
-					if(have_familiar(anyFamiliar) && auto_is_valid(anyFamiliar) && 
-					!($familiars[Comma Chameleon,Mad Hatrack,Disembodied Hand,Ghost of Crimbo Carols,Ghost of Crimbo Cheer,Ghost of Crimbo Commerce] contains anyFamiliar))
-					{
-						return anyFamiliar;
-					}
-				}
-				return $familiar[none];
-			}
-			if(is_familiar_equipment_locked())
-			{
-				lock_familiar_equipment(false);	//make sure current familiar's equipment is not lost during the temporary swap
-			}
-			familiar familiarWearer = sweetestSweatFamiliar();
-			if(familiarWearer != $familiar[none])
-			{	//since it's in the inventory, should not need to check (familiar_equipped_equipment(familiarWearer) != $item[tiny stillsuit])
-				auto_log_info("Putting the tiny stillsuit on a familiar in the terrarium", "blue");
-				use_familiar(familiarWearer);
-				equip($slot[familiar],$item[tiny stillsuit]);
-				use_familiar(currentFamiliar);
+				return sweetSweatFamiliar;
 			}
 		}
+		foreach commonFamiliar in $familiars[Baby Gravy Fairy,Smiling Rat,Mosquito,Reassembled Blackbird]		//default fall back, you probably have one of these
+		{
+			if(have_familiar(commonFamiliar) && auto_is_valid(commonFamiliar))
+			{
+				return commonFamiliar;
+			}
+		}
+		foreach anyFamiliar in $familiars[]		//if all else failed just pick any available familiar that can wear equipment
+		{
+			if(have_familiar(anyFamiliar) && auto_is_valid(anyFamiliar) && 
+			!($familiars[Comma Chameleon,Mad Hatrack,Disembodied Hand,Ghost of Crimbo Carols,Ghost of Crimbo Cheer,Ghost of Crimbo Commerce] contains anyFamiliar))
+			{
+				return anyFamiliar;
+			}
+		}
+		return $familiar[none];
+	}
+	if(is_familiar_equipment_locked())
+	{
+		lock_familiar_equipment(false);	//make sure current familiar's equipment is not lost during the temporary swap
+	}
+	familiar familiarWearer = sweetestSweatFamiliar();
+	if(familiarWearer != $familiar[none])
+	{
+		auto_log_info("Putting the tiny stillsuit on a familiar in the terrarium", "blue");
+		use_familiar(familiarWearer);
+		equip($slot[familiar],$item[tiny stillsuit]);
+		use_familiar(currentFamiliar);
 	}
 }


### PR DESCRIPTION
mafia does not have tracking for familiar sweat yet, this just makes sure it gets collected
also add 2 location exceptions in sweatpantsPreAdventure

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
