### PR TITLE
don't erase desertExploration on oasis failure

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1284,7 +1284,10 @@ boolean L11_aridDesert()
 					set_property("desertExploration", found);
 					return true;
 				}
-				abort("Tried to adventure in The Oasis but could not. property desertExploration determined to be correct");
+				if(!autoAdv(1, $location[The Oasis]))
+				{
+					abort("Tried to adventure in The Oasis but could not. property desertExploration determined to be correct");
+				}
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1271,8 +1271,25 @@ boolean L11_aridDesert()
 
 		if(!autoAdv(1, $location[The Oasis]))
 		{
-			auto_log_warning("Could not visit the Oasis for some reason, assuming desertExploration is incorrect.", "red");
-			set_property("desertExploration", 0);
+			auto_log_warning("Could not visit the Oasis for some reason, desertExploration may be incorrect.", "red");
+			int initial = get_property("desertExploration").to_int();
+			string page = visit_url("place.php?whichplace=desertbeach");
+			matcher desert_matcher = create_matcher("title=\"[(](\\d+)% explored[)]\"", page);
+			if(desert_matcher.find())
+			{
+				int found = to_int(desert_matcher.group(1));
+				if(found != initial)
+				{
+					auto_log_info("Incorrectly had exploration value of " + initial + " when it should be at " + found + ". This was corrected. Trying to resume.", "blue");
+					set_property("desertExploration", found);
+					return true;
+				}
+				abort("Tried to adventure in The Oasis but could not. property desertExploration determined to be correct");
+			}
+			else
+			{
+				abort("Tried to adventure in The Oasis but could not, and could not verify the actual exploration amount of the desert");
+			}
 		}
 	}
 	return true;


### PR DESCRIPTION
when failing to adventure in oasis for any reason autoscend would set mafia's desertExploration value to 0, this leads to keep adventuring in the desert after it is done, for as many ~50 adventures it is allowed to

instead use the same exploration check done when failing to enter the pyramid and abort if wrong exploration was not the issue

## How Has This Been Tested?

tested matcher in cli

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
