### PR TITLE
Frat House In Disguise, Hippy Camp In Disguise, Post-War Junkyard removed

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r26540;	// Sweat tracking at the end of combat
+since r26631;	// Refactor KoLAdventure validation. (Frat House In Disguise/Hippy Camp In Disguise locations renamed)
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_canadv.ash
+++ b/RELEASE/scripts/autoscend/auto_canadv.ash
@@ -575,7 +575,7 @@ boolean can_adv(location where, boolean prep, int verb) {
    case $location[The Obligatory Pirate's Cove]: if (prep) cli_execute("unequip pirate fledges"); 
       return !have_equipped($item[pirate fledges]) && !is_wearing_outfit("swashbuckling getup");
    case $location[McMillicancuddy's Farm]:
-   case $location[Post-War Junkyard]: return qprop("questL12War");
+   case $location[The Junkyard]: return qprop("questL12War");
    case $location[The Hippy Camp (Bombed Back to the Stone Age)]: return qprop("questL12War") && get_property("sideDefeated") != "fratboys";
    case $location[The Orcish Frat House (Bombed Back to the Stone Age)]: return qprop("questL12War") && get_property("sideDefeated") != "hippies";
   // islewar

--- a/RELEASE/scripts/autoscend/auto_canadv.ash
+++ b/RELEASE/scripts/autoscend/auto_canadv.ash
@@ -568,9 +568,9 @@ boolean can_adv(location where, boolean prep, int verb) {
    case $location[The F'c'le]: return qprop("questM12Pirate > 4") && (equipcheck($item[pirate fledges],$slot[acc3]) || outfitcheck("swashbuckling getup"));
    case $location[The Poop Deck]: return qprop("questM12Pirate > 4") && equipcheck($item[pirate fledges]);
    case $location[Belowdecks]: return qprop("questM12Pirate") && equipcheck($item[pirate fledges],$slot[acc3]);
-   case $location[Hippy Camp In Disguise]: if (!outfitcheck("filthy hippy disguise")) return false;
+   case $location[Hippy Camp (Hippy Disguise)]: if (!outfitcheck("filthy hippy disguise")) return false;
    case $location[Hippy Camp]: return get_property("sideDefeated") != "hippies" && get_property("sideDefeated") != "both";
-   case $location[Frat House In Disguise]: if (!outfitcheck("frat boy ensemble")) return false;
+   case $location[Frat House (Frat Disguise)]: if (!outfitcheck("frat boy ensemble")) return false;
    case $location[Frat House]: return get_property("sideDefeated") != "fratboys" && get_property("sideDefeated") != "both";
    case $location[The Obligatory Pirate's Cove]: if (prep) cli_execute("unequip pirate fledges"); 
       return !have_equipped($item[pirate fledges]) && !is_wearing_outfit("swashbuckling getup");

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1223,8 +1223,8 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[Frat House In Disguise]:
-	case $location[Hippy Camp In Disguise]:
+	case $location[Frat House (Frat Disguise)]:
+	case $location[Hippy Camp (Hippy Disguise)]:
 		if(internalQuestStatus("questL12War") == 0 &&		//if the quest is exactly at started step.
 		(have_outfit("Filthy Hippy Disguise") || have_outfit("Frat Boy Ensemble")) &&	//either outfit works for either zone
 		get_property("lastIslandUnlock").to_int() == my_ascensions())
@@ -1849,7 +1849,7 @@ boolean zone_hasLuckyAdventure(location loc)
 	if ($locations[8-Bit Realm,A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
 	Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
 	Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,
-	Elf Alley,Exposure Esplanade,Frat House,Frat House In Disguise,Guano Junction,Hippy Camp,Hippy Camp In Disguise,Itznotyerzitz Mine,
+	Elf Alley,Exposure Esplanade,Frat House,Frat House (Frat Disguise),Guano Junction,Hippy Camp,Hippy Camp (Hippy Disguise),Itznotyerzitz Mine,
 	Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,
 	The "Fun" House,The Ancient Hobo Burial Ground,The Batrat and Ratbat Burrow,The Black Forest,The Brinier Deepers,The Briny Deeps,The Bugbear Pen,
 	The Castle in the Clouds in the Sky (Basement),The Castle in the Clouds in the Sky (Ground Floor),The Castle in the Clouds in the Sky (Top Floor),

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1224,13 +1224,21 @@ boolean zone_available(location loc)
 		}
 		break;
 	case $location[Frat House (Frat Disguise)]:
-	case $location[Hippy Camp (Hippy Disguise)]:
-		if(internalQuestStatus("questL12War") == 0 &&		//if the quest is exactly at started step.
-		(have_outfit("Filthy Hippy Disguise") || have_outfit("Frat Boy Ensemble")) &&	//either outfit works for either zone
-		get_property("lastIslandUnlock").to_int() == my_ascensions())
+		if(get_property("lastIslandUnlock").to_int() == my_ascensions() && 
+		have_outfit("Frat Boy Ensemble") &&
+		internalQuestStatus("questL12War") != 0 &&	//mafia always calls location Wartime with L12 quest
+		internalQuestStatus("questL12War") != 1)	//mafia always calls location Wartime with L12 quest
 		{
-			//currently not working quite right due to mafia issue
-			//retval = true;
+			retval = true;
+		}
+		break;
+	case $location[Hippy Camp (Hippy Disguise)]:
+		if(get_property("lastIslandUnlock").to_int() == my_ascensions() && 
+		have_outfit("Filthy Hippy Disguise") &&
+		internalQuestStatus("questL12War") != 0 &&	//mafia always calls location Wartime with L12 quest
+		internalQuestStatus("questL12War") != 1)	//mafia always calls location Wartime with L12 quest
+		{
+			retval = true;
 		}
 		break;
 	case $location[Wartime Hippy Camp (Frat Disguise)]:

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -461,11 +461,11 @@ boolean LX_wildfire_water()
 //  https://github.com/Loathing-Associates-Scripting-Society/autoscend/issues/892#issuecomment-934059485
 //		if(auto_warSide() == "fratboy")
 //		{
-//			LX_wildfire_hose($location[Frat House (Frat Disguise)]);
+//			LX_wildfire_hose($location[Wartime Frat House (Hippy Disguise)]);
 //		}
 //		else
 //		{
-//			LX_wildfire_hose($location[Hippy Camp (Hippy Disguise)]);
+//			LX_wildfire_hose($location[Wartime Hippy Camp (Frat Disguise)]);
 //		}
 	}
 	

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -461,11 +461,11 @@ boolean LX_wildfire_water()
 //  https://github.com/Loathing-Associates-Scripting-Society/autoscend/issues/892#issuecomment-934059485
 //		if(auto_warSide() == "fratboy")
 //		{
-//			LX_wildfire_hose($location[Frat House In Disguise]);
+//			LX_wildfire_hose($location[Frat House (Frat Disguise)]);
 //		}
 //		else
 //		{
-//			LX_wildfire_hose($location[Hippy Camp In Disguise]);
+//			LX_wildfire_hose($location[Hippy Camp (Hippy Disguise)]);
 //		}
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -3,9 +3,9 @@
 Below are relevant locations for the war.
 war not started or finished with this side undefeated:
 [Frat House]
-[Frat House (Frat Disguise)]	//r26631 [Frat House (Frat Disguise)] (previously [Frat House In Disguise]) is identified but can not be an adventure target
+[Frat House (Frat Disguise)]	//r26631 changed from [Frat House In Disguise]
 [Hippy Camp]
-[Hippy Camp (Hippy Disguise)]	//r26631 [Hippy Camp (Hippy Disguise)] (previously [Hippy Camp In Disguise]) is identified but can not be an adventure target
+[Hippy Camp (Hippy Disguise)]	//r26631 changed from [Hippy Camp In Disguise]
 
 War started:
 [Wartime Frat House]
@@ -627,8 +627,7 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "fratboy" && possessOutfit("Filthy Hippy Disguise"))
 	{
 		autoOutfit("Filthy Hippy Disguise");
-		//r25671 this should be [Frat House In Disguise] but due to mafia issue it currently needs to be as below
-		//r26631 "In Disguise" location names changed; [Frat House (Frat Disguise)] exists but no [Frat House (Hippy Disguise)] (yet?)
+		//this should go to [Wartime Frat House (Hippy Disguise)] (despite war not started)
 		return autoAdv($location[Frat House]);
 	}
 	
@@ -636,8 +635,7 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "hippy" && possessOutfit("Frat Boy Ensemble"))
 	{
 		autoOutfit("Frat Boy Ensemble");
-		//r25671 this should be [Hippy Camp In Disguise] but due to mafia issue it currently needs to be as below
-		//r26631 "In Disguise" location names changed; [Hippy Camp (Hippy Disguise)] exists but no [Hippy Camp (Frat Disguise)] (yet?)
+		//this should go to [Wartime Hippy Camp (Frat Disguise)] (despite war not started)
 		return autoAdv($location[Hippy Camp]);
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -3,9 +3,9 @@
 Below are relevant locations for the war.
 war not started or finished with this side undefeated:
 [Frat House]
-[Frat House (Frat Disguise)]	//r25731 incorrectly identified [Frat House In Disguise] as [Frat House] when encountered (r26631: [Frat House In Disguise] name changed to [Frat House (Frat Disguise)])
+[Frat House (Frat Disguise)]	//r26631 [Frat House (Frat Disguise)] (previously [Frat House In Disguise]) is identified but can not be an adventure target
 [Hippy Camp]
-[Hippy Camp (Hippy Disguise)]	//r25731 incorrectly identified [Hippy Camp In Disguise] as [Wartime Hippy Camp (Frat Disguise)] when encountered (r26631: [Hippy Camp In Disguise] name changed to [Hippy Camp (Hippy Disguise)])
+[Hippy Camp (Hippy Disguise)]	//r26631 [Hippy Camp (Hippy Disguise)] (previously [Hippy Camp In Disguise]) is identified but can not be an adventure target
 
 War started:
 [Wartime Frat House]
@@ -627,8 +627,8 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "fratboy" && possessOutfit("Filthy Hippy Disguise"))
 	{
 		autoOutfit("Filthy Hippy Disguise");
-		//r25671 this should be [Frat House (Frat Disguise)] but due to mafia issue it currently needs to be as below
-		//r26631 "In Disguise" location names changed; this issue not checked
+		//r25671 this should be [Frat House In Disguise] but due to mafia issue it currently needs to be as below
+		//r26631 "In Disguise" location names changed; [Frat House (Frat Disguise)] exists but no [Frat House (Hippy Disguise)] (yet?)
 		return autoAdv($location[Frat House]);
 	}
 	
@@ -636,8 +636,8 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "hippy" && possessOutfit("Frat Boy Ensemble"))
 	{
 		autoOutfit("Frat Boy Ensemble");
-		//r25671 this should be [Hippy Camp (Hippy Disguise)] but due to mafia issue it currently needs to be as below
-		//r26631 "In Disguise" location names changed; this issue not checked
+		//r25671 this should be [Hippy Camp In Disguise] but due to mafia issue it currently needs to be as below
+		//r26631 "In Disguise" location names changed; [Hippy Camp (Hippy Disguise)] exists but no [Hippy Camp (Frat Disguise)] (yet?)
 		return autoAdv($location[Hippy Camp]);
 	}
 	

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -3,9 +3,9 @@
 Below are relevant locations for the war.
 war not started or finished with this side undefeated:
 [Frat House]
-[Frat House In Disguise]	//r25731 incorrectly identifies this as [Frat House] when encountered
+[Frat House (Frat Disguise)]	//r25731 incorrectly identified [Frat House In Disguise] as [Frat House] when encountered (r26631: [Frat House In Disguise] name changed to [Frat House (Frat Disguise)])
 [Hippy Camp]
-[Hippy Camp In Disguise]	//r25731 incorrectly identifies this as [Wartime Hippy Camp (Frat Disguise)] when encountered
+[Hippy Camp (Hippy Disguise)]	//r25731 incorrectly identified [Hippy Camp In Disguise] as [Wartime Hippy Camp (Frat Disguise)] when encountered (r26631: [Hippy Camp In Disguise] name changed to [Hippy Camp (Hippy Disguise)])
 
 War started:
 [Wartime Frat House]
@@ -627,7 +627,8 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "fratboy" && possessOutfit("Filthy Hippy Disguise"))
 	{
 		autoOutfit("Filthy Hippy Disguise");
-		//r25671 this should be [Frat House In Disguise] but due to mafia issue it currently needs to be as below
+		//r25671 this should be [Frat House (Frat Disguise)] but due to mafia issue it currently needs to be as below
+		//r26631 "In Disguise" location names changed; this issue not checked
 		return autoAdv($location[Frat House]);
 	}
 	
@@ -635,7 +636,8 @@ boolean L12_getOutfit()
 	if(auto_warSide() == "hippy" && possessOutfit("Frat Boy Ensemble"))
 	{
 		autoOutfit("Frat Boy Ensemble");
-		//r25671 this should be [Hippy Camp In Disguise] but due to mafia issue it currently needs to be as below
+		//r25671 this should be [Hippy Camp (Hippy Disguise)] but due to mafia issue it currently needs to be as below
+		//r26631 "In Disguise" location names changed; this issue not checked
 		return autoAdv($location[Hippy Camp]);
 	}
 	


### PR DESCRIPTION
mafia has changed these location names and removed Post-War Junkyard

## How Has This Been Tested?
validate

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
