### PR TITLE
use Jumpsuited Hound Dog at Sonofa Beach, Lair of the Ninja Snowmen

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -392,6 +392,11 @@ boolean autoChooseFamiliar(location place)
 		famChoice = lookupFamiliarDatafile("gremlins");
 	}
 
+	// places that benefit from + combat rate
+	if ($locations[Sonofa Beach, Lair of the Ninja Snowmen] contains place && zone_combatMod(place)._int > 0 && canChangeToFamiliar($familiar[Jumpsuited Hound Dog])) {
+		famChoice = $familiar[Jumpsuited Hound Dog];
+	}
+	
 	// places where item drop is required to help save adventures.
 	if ($locations[The Typical Tavern Cellar, Guano Junction, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
 	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Hospital, The Hidden Bowling Alley, The Haunted Wine Cellar,


### PR DESCRIPTION
when + combat rate is wanted, this is the only familiar that gives + combat rate

skipping + combat rate in these locations in some cases was put in another PR #1147

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
