### PR TITLE
increase shore vacation statgains 

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -670,13 +670,21 @@ boolean auto_pre_adventure()
 	auto_handleRetrocape(); // has to be done after equipMaximizedGear otherwise the maximizer reconfigures it
 	cli_execute("checkpoint clear");
 
+	//before guaranteed non combats that give stats, overrule maximized equipment to increase stat gains
 	if(place == $location[The Hidden Bowling Alley] && item_amount($item[Bowling Ball]) > 0 && get_property("hiddenBowlingAlleyProgress").to_int() < 5)
 	{
-		equipStatgainIncreasers();	//guaranteed non combat that gives stats
+		equipStatgainIncreasers();
+		plumber_forceEquipTool();
 	}
 	else if(place == $location[The Haunted Ballroom] && internalQuestStatus("questM21Dance") == 3)
 	{
-		equipStatgainIncreasers();	//guaranteed non combat that gives stats
+		equipStatgainIncreasers();
+		plumber_forceEquipTool();
+	}
+	else if(place == $location[The Shore\, Inc. Travel Agency] && item_amount($item[Forged Identification Documents]) == 0)
+	{
+		equipStatgainIncreasers(my_primestat(),true);	//The Shore, Inc. Travel Agency choice 793 is configured to pick main stat
+		plumber_forceEquipTool();
 	}
 
 	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -767,7 +767,9 @@ boolean plumber_buyStuff();
 int plumber_ppCost(skill sk);
 boolean plumber_canDealScalingDamage();
 boolean plumber_skillValid(skill sk);
+boolean plumber_equipTool(stat st, boolean forceEquipRightNow);
 boolean plumber_equipTool(stat st);
+boolean plumber_forceEquipTool();
 void plumber_eat_xp();
 boolean LM_plumber();
 

--- a/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
+++ b/RELEASE/scripts/autoscend/paths/path_of_the_plumber.ash
@@ -394,25 +394,46 @@ boolean plumber_skillValid(skill sk)
 	return true;
 }
 
-boolean plumber_equipTool(stat st)
+boolean plumber_equipTool(stat st, boolean forceEquipRightNow)
 {
 	if (!in_plumber()) return false;
 
 	boolean equipWithFallback(item to_equip, item fallback_to_equip)
 	{
-		if (possessEquipment(to_equip) && autoEquip(to_equip))
+		if (possessEquipment(to_equip))
 		{
-			return true;
+			if(forceEquipRightNow)
+			{
+				return autoForceEquip(to_equip);
+			}
+			else
+			{
+				return autoEquip(to_equip);
+			}
 		}
 		else if (possessEquipment(fallback_to_equip))
 		{
-			return autoEquip(fallback_to_equip);
+			if(forceEquipRightNow)
+			{
+				return autoForceEquip(fallback_to_equip);
+			}
+			else
+			{
+				return autoEquip(fallback_to_equip);
+			}
 		}
 		else if (item_amount($item[coin]) >= 20)
 		{
 			// 20 coins to avoid doing clever re-routing? Yes please!
 			retrieve_item(1, fallback_to_equip);
-			return autoEquip(fallback_to_equip);
+			if(forceEquipRightNow)
+			{
+				return autoForceEquip(fallback_to_equip);
+			}
+			else
+			{
+				return autoEquip(fallback_to_equip);
+			}
 		}
 		return false;
 	}
@@ -424,6 +445,26 @@ boolean plumber_equipTool(stat st)
 		case $stat[moxie]: return equipWithFallback($item[fancy boots], $item[work boots]);
 	}
 	return false;
+}
+
+boolean plumber_equipTool(stat st)
+{
+	return plumber_equipTool(st,false);
+}
+
+boolean plumber_forceEquipTool()
+{
+	//just make sure a tool, any tool, is equipped
+	foreach it in $items[fancy boots,work boots,bonfire flower,[10462]fire flower,heavy hammer,hammer]
+	{
+		if(equipped_amount(it) > 0)
+		{
+			return true;
+		}
+	}
+	
+	//if not equip the moxie accessory as pre_adv does by default, but without waiting for maximizer to equip it
+	return plumber_equipTool($stat[moxie],true);
 }
 
 void plumber_eat_xp()


### PR DESCRIPTION
use same statgains boosting as in previous cases
plumber force equip option added because plumber is not allowed to adventure without tool, and arbitrary equipment changes made after maximize in pre adv could unequip it

## How Has This Been Tested?

script run but not triggered plumber change it's fixing an edge case that doesn't happen in ronin (need 3 statgains accessories to lose tool)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
