### PR TITLE
check horsery is legal and bowling ball is available

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1489,10 +1489,7 @@ boolean asdonCanMissile()
 }
 
 boolean isHorseryAvailable() {
-	if(!get_property("horseryAvailable").to_boolean()) {
-		return false;
-	}
-	return true;
+	return (get_property("horseryAvailable").to_boolean() && auto_is_valid($item[Horsery contract]));
 }
 
 int horseCost()

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -2,7 +2,8 @@
 
 boolean auto_haveCosmicBowlingBall()
 {
-	return get_property("hasCosmicBowlingBall").to_boolean();
+	// ensure we not only own one but it's in allowed in path and also in inventory for us to do stuff with.
+	return (get_property("hasCosmicBowlingBall").to_boolean() && auto_is_valid($item[Cosmic Bowling Ball]) && available_amount($item[Cosmic Bowling Ball]) > 0);
 }
 
 string auto_bowlingBallCombatString(location place, boolean speculation)
@@ -12,12 +13,12 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 		return "";
 	}
 
-	if(auto_is_valid($item[Cosmic Bowling Ball]) && place == $location[The Hidden Bowling Alley] && get_property("auto_bowledAtAlley").to_int() != my_ascensions())
+	if(place == $location[The Hidden Bowling Alley] && get_property("auto_bowledAtAlley").to_int() != my_ascensions())
 	{
 		if(!speculation)
 		{
 			set_property("auto_bowledAtAlley", my_ascensions());
-			auto_log_info("Cosmic Bowling Ball used at Hidden Bowling Alley to adavnce quest.");
+			auto_log_info("Cosmic Bowling Ball used at Hidden Bowling Alley to advance quest.");
 		}	
 		return useItem($item[Cosmic Bowling Ball],!speculation);
 	}


### PR DESCRIPTION
Both issues reported in the discord channel.
- Cosmic Bowling Ball wasn't checking it is in inventory when attempting to throw it at a Pygmy Bowler & thus causing hangs in combat. Check we have one in inventory before trying to throw it at anyone (or like, use it at all).
- Mafia recently changed how it detects ownership of certain older IotMs which meant it now always sets the horseryAvailable property regardless of whether that is actually true in game due to path restricions. We will now check if it's not path restricted.

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
