### PR TITLE
[Feature] 1021 - Use autoBuyPriceLimit Property

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -375,6 +375,9 @@ boolean buyUpTo(int num, item it)
 {
 	//use autoBuyPriceLimit from mafia to determine price cap
 	int abpl = get_property("autoBuyPriceLimit").to_int();
+	
+	//We do not automatically buy at this point -
+	//below call checks if we have item before buying.
 	return buyUpTo(num, it, abpl);
 }
 

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -373,7 +373,9 @@ boolean buy_item(item it, int quantity, int maxprice)
 
 boolean buyUpTo(int num, item it)
 {
-	return buyUpTo(num, it, 20000);
+	//use autoBuyPriceLimit from mafia to determine price cap
+	int abpl = get_property("autoBuyPriceLimit").to_int();
+	return buyUpTo(num, it, abpl);
 }
 
 boolean buyUpTo(int num, item it, int maxprice)

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1323,6 +1323,8 @@ boolean doBedtime()
 		return true;
 	}
 	
+	/*Commenting out to prevent unreachable code warning.
 	auto_log_warning("Unexpected bedtime path! Stopping bedtime.", "red");
 	return false;
+	Comment back in if there is reason to suspect we are skipping bedtime.*/
 }

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -102,31 +102,59 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 		int meatLimit = min(meatAvailableToBuy, get_property("autoBuyPriceLimit").to_int());		
 
 		// attempt to buy from NPC for meat
-		if(npc_price(source) != 0 && meatLimit > npc_price(source))
+		if(npc_price(source) != 0)
 		{
-			if(!speculative)
+			if(npc_price(source) < meatLimit)
 			{
-				buy(numToBuy, source);
+				if(!speculative)
+				{
+					buy(numToBuy, source);
+				}
+				else
+				{
+					//if speculating, assume buy works
+					return true;
+				}
 			}
-			else
+			else //too expensive
 			{
-				//if speculating, assume buy works
-				return true;
+				//Capped by meat or ABPL?
+				string limitReason = "meatAvailableToBuy: ";
+				if (get_property("autoBuyPriceLimit").to_int() < meatAvailableToBuy)
+					limitReason = "autoBuyPriceLimit set at: ";
+
+				auto_log_info("Could not buffMaintain " + numToBuy + " of " + source + " for " 
+					+ historical_price(source) + " meat.", "blue");
+				auto_log_info(limitReason + meatLimit, "blue");
 			}
 		}
 		// attempt to buy in mall
-		else if(can_interact() && historical_price(source) != 0 && meatLimit > historical_price(source))
+		else if(can_interact() && historical_price(source) != 0)
 		{
-			if(!speculative)
+			if (meatLimit > historical_price(source))
 			{
-				buy(numToBuy, source, meatLimit / numToBuy);
+				if(!speculative)
+				{
+					buy(numToBuy, source, meatLimit / numToBuy);
+				}
+				else
+				{
+					//if speculating, assume buy works
+					return true;
+				}		
 			}
-			else
+			else //too expensive
 			{
-				//if speculating, assume buy works
-				return true;
-			}		
-		}		
+				//Capped by meat or ABPL?
+				string limitReason = "meatAvailableToBuy: ";
+				if (get_property("autoBuyPriceLimit").to_int() < meatAvailableToBuy)
+					limitReason = "autoBuyPriceLimit set at: ";
+
+				auto_log_info("Could not buffMaintain " + numToBuy + " of " + source + " for " 
+					+ historical_price(source) + " meat.", "blue");
+				auto_log_info(limitReason + meatLimit, "blue");
+			}
+		}
 	}
 	if(item_amount(source) < uses)
 	{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -99,8 +99,10 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 	{
 		int numToBuy = uses - item_amount(source);
 		int meatAvailableToBuy = my_meat() - meatReserve();
+		int meatLimit = min(meatAvailableToBuy, get_property("autoBuyPriceLimit").to_int());		
+
 		// attempt to buy from NPC for meat
-		if(npc_price(source) != 0 && meatAvailableToBuy > npc_price(source))
+		if(npc_price(source) != 0 && meatLimit > npc_price(source))
 		{
 			if(!speculative)
 			{
@@ -113,11 +115,11 @@ boolean buffMaintain(item source, effect buff, int uses, int turns, boolean spec
 			}
 		}
 		// attempt to buy in mall
-		else if(can_interact() && historical_price(source) != 0 && meatAvailableToBuy > historical_price(source))
+		else if(can_interact() && historical_price(source) != 0 && meatLimit > historical_price(source))
 		{
 			if(!speculative)
 			{
-				buy(numToBuy, source, meatAvailableToBuy / numToBuy);
+				buy(numToBuy, source, meatLimit / numToBuy);
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -322,7 +322,10 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 		&& (get_property("mayoInMouth") == "") 
 		&& auto_is_valid($item[Portable Mayo Clinic]))
 		{
-			int priceCap = min(get_property("autoBuyPriceLimit").to_int(), my_meat());
+			//Determine spending limit
+			int meatFree = my_meat() - meatReserve();
+			int priceCap = min(get_property("autoBuyPriceLimit").to_int(), meatFree);
+
 			buyUpTo(1, $item[Mayoflex], priceCap);
 			use(1, $item[Mayoflex]);
 		}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -316,11 +316,17 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 	while(howMany > 0)
 	{
 		buffMaintain($effect[Song of the Glorious Lunch], 10, 1, toEat.fullness);
-		if((auto_get_campground() contains $item[Portable Mayo Clinic]) && (my_meat() > 11000) && (get_property("mayoInMouth") == "") && auto_is_valid($item[Portable Mayo Clinic]))
+
+		//If able, use Mayoflex for +1 adv / food
+		if((auto_get_campground() contains $item[Portable Mayo Clinic]) 
+		&& (get_property("autoBuyPriceLimit").to_int() < my_meat()) //Make sure we can afford the mayo
+		&& (get_property("mayoInMouth") == "") 
+		&& auto_is_valid($item[Portable Mayo Clinic]))
 		{
-			buyUpTo(1, $item[Mayoflex], 1000);
+			buyUpTo(1, $item[Mayoflex], get_property("autoBuyPriceLimit").to_int());
 			use(1, $item[Mayoflex]);
 		}
+
 		if(have_effect($effect[Ready to Eat]) > 0)
 		{
 			wasReadyToEat = true;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -319,11 +319,11 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 
 		//If able, use Mayoflex for +1 adv / food
 		if((auto_get_campground() contains $item[Portable Mayo Clinic]) 
-		&& (get_property("autoBuyPriceLimit").to_int() < my_meat()) //Make sure we can afford the mayo
 		&& (get_property("mayoInMouth") == "") 
 		&& auto_is_valid($item[Portable Mayo Clinic]))
 		{
-			buyUpTo(1, $item[Mayoflex], get_property("autoBuyPriceLimit").to_int());
+			int priceCap = min(get_property("autoBuyPriceLimit").to_int(), my_meat());
+			buyUpTo(1, $item[Mayoflex], priceCap);
 			use(1, $item[Mayoflex]);
 		}
 

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -150,9 +150,20 @@ void acquireFamiliarsCasual()
 	if(!have_familiar($familiar[Gelatinous Cubeling]) && !have_familiar($familiar[Nosy Nose]))	//if none of the common better delevel familiars
 	{
 		//delevel enemy cheaply
-		if(!have_familiar($familiar[barrrnacle]) && item_amount($item[Barrrnacle]) == 0 && auto_mall_price($item[Barrrnacle]) < 1000 && my_meat() > 10000)
+		//don't already have?
+		if(!have_familiar($familiar[barrrnacle]) && item_amount($item[Barrrnacle]) == 0)
 		{
-			retrieve_item(1, $item[Barrrnacle]);			//will mallbuy it
+			int barnaclePrice = auto_mall_price($item[Barrrnacle]);
+			//cheap enough?
+			if(barnaclePrice < get_property("autoBuyPriceLimit").to_int())
+			{
+				//do we got the meat?
+				if(barnaclePrice < my_meat())
+				{
+					auto_log_info("Retrieving a barrnacle for " + barnaclePrice + "meat as a deleveling option.", "blue");
+					retrieve_item(1, $item[Barrrnacle]); //will mallbuy it
+				}
+			}
 		}
 		hatchFamiliar($familiar[Barrrnacle]);
 	}
@@ -175,9 +186,13 @@ void acquireFamiliarsCasual()
 	if(!have_familiar($familiar[Stooper]) && item_amount($item[Stooper]) == 0)
 	{
 		int price = auto_mall_price($item[Stooper]);
-		if(price < 20000 && price < my_meat())
+		if(price < get_property("autoBuyPriceLimit").to_int()) //cheap enough?
 		{
-			retrieve_item($item[Stooper]);
+			if(price < my_meat()) //do we got the meat?
+			{
+				auto_log_info("Retrieving a Stooper for " + price + " meat for better drinking.", "blue");
+				retrieve_item($item[Stooper]);
+			}
 		}
 		else if(price < my_meat())
 		{
@@ -190,9 +205,13 @@ void acquireFamiliarsCasual()
 	if(!have_familiar($familiar[Cute Meteor]) && item_amount($item[cute meteoroid]) == 0)
 	{
 		int price = auto_mall_price($item[cute meteoroid]);
-		if(price < 20000 && price < my_meat())
+		if(price < get_property("autoBuyPriceLimit").to_int()) //cheap enough?
 		{
-			retrieve_item($item[cute meteoroid]);
+			if(price < my_meat()) //do we got the meat?
+			{
+				auto_log_info("Retrieving a cute meteoroid for " + price + " meat for init and hot damage.", "blue");
+				retrieve_item($item[cute meteoroid]);
+			}
 		}
 	}
 	hatchFamiliar($familiar[Cute Meteor]);
@@ -219,20 +238,23 @@ boolean LX_acquireFamiliarLeprechaun()
 	{
 		return false;	//already have it
 	}
-	if(item_amount($item[leprechaun hatchling]) == 0 && my_meat() > 10000)
+	if(item_amount($item[leprechaun hatchling]) == 0)
 	{
+		int priceCap = min(my_meat(), get_property("autoBuyPriceLimit").to_int()); //Need both the meat to spend and the desire to spend it
 		int price_hatch = auto_mall_price($item[leprechaun hatchling]);
 		int price_bowl = auto_mall_price($item[bowl of lucky charms]);
-		if(price_hatch < 8000)		//at this price we might as well mallbuy the hatchling
+		if(price_hatch < priceCap)		//at this price we might as well mallbuy the hatchling
 		{
+			auto_log_info("Retrieving a leprechaun hatchling for " + price + " meat to increase meat gain.", "blue");
 			retrieve_item(1, $item[leprechaun hatchling]);
 		}
 		else if(auto_is_valid($item[bowl of lucky charms]))		//try to get hatchling via eating bowl of lucky charms.
 		{
 			if(item_amount($item[bowl of lucky charms]) == 0)
 			{
-				if(price_bowl < 3000)
+				if(price_bowl < priceCap)
 				{
+					auto_log_info("Retrieving a bowl of lucky charms for " + price + " meat to get a leprechaun hatchling.", "blue");
 					retrieve_item(1, $item[bowl of lucky charms]);		//just mallbuy it at this price
 				}
 				else if(zone_available($location[The Spooky Forest]))	//spend 1 adv and one clover to get it instead.

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -164,6 +164,8 @@ void acquireFamiliarsCasual()
 					retrieve_item(1, $item[Barrrnacle]); //will mallbuy it
 				}
 			}
+			else auto_log_info("Price of barrrnacle exceeds autoBuyPriceLimit of " + 
+				get_property("autoBuyPriceLimit"), "blue");
 		}
 		hatchFamiliar($familiar[Barrrnacle]);
 	}
@@ -198,6 +200,7 @@ void acquireFamiliarsCasual()
 		{
 			auto_log_info("You should consider buying [Stooper] from the mall. it only costs " +price+ " meat and gives you +1 liver space", "blue");
 		}
+		else auto_log_info("Stooper offers better drinking, but is too expensive.", "blue");
 	}
 	hatchFamiliar($familiar[Stooper]);
 	
@@ -212,7 +215,10 @@ void acquireFamiliarsCasual()
 				auto_log_info("Retrieving a cute meteoroid for " + price + " meat for init and hot damage.", "blue");
 				retrieve_item($item[cute meteoroid]);
 			}
+			else auto_log_info("Don't have the maeat to buy cute meteoroid", "orange");
 		}
+		else auto_log_info("Price of cute meteoroid exceeds autoBuyPriceLimit of " + 
+				get_property("autoBuyPriceLimit"), "blue");
 	}
 	hatchFamiliar($familiar[Cute Meteor]);
 }

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -245,7 +245,7 @@ boolean LX_acquireFamiliarLeprechaun()
 		int price_bowl = auto_mall_price($item[bowl of lucky charms]);
 		if(price_hatch < priceCap)		//at this price we might as well mallbuy the hatchling
 		{
-			auto_log_info("Retrieving a leprechaun hatchling for " + price + " meat to increase meat gain.", "blue");
+			auto_log_info("Retrieving a leprechaun hatchling for " + priceCap + " meat to increase meat gain.", "blue");
 			retrieve_item(1, $item[leprechaun hatchling]);
 		}
 		else if(auto_is_valid($item[bowl of lucky charms]))		//try to get hatchling via eating bowl of lucky charms.
@@ -254,7 +254,7 @@ boolean LX_acquireFamiliarLeprechaun()
 			{
 				if(price_bowl < priceCap)
 				{
-					auto_log_info("Retrieving a bowl of lucky charms for " + price + " meat to get a leprechaun hatchling.", "blue");
+					auto_log_info("Retrieving a bowl of lucky charms for " + priceCap + " meat to get a leprechaun hatchling.", "blue");
 					retrieve_item(1, $item[bowl of lucky charms]);		//just mallbuy it at this price
 				}
 				else if(zone_available($location[The Spooky Forest]))	//spend 1 adv and one clover to get it instead.

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -2379,6 +2379,7 @@ boolean LA_cs_communityService()
 			}
 
 			int questCost = get_cs_questCost(curQuest);
+			int priceLmt = get_property("autoBuyPriceLimit").to_int(); //desired spending cap for certain buffs
 			if(my_adventures() < questCost)
 			{
 				buffMaintain($effect[A Rose by Any Other Material]);
@@ -2388,11 +2389,11 @@ boolean LA_cs_communityService()
 			{
 				buffMaintain($effect[Throwing Some Shade]);
 			}
-			if((auto_mall_price($item[Shady Shades]) < 20000) && (questCost > 12))
+			if((auto_mall_price($item[Shady Shades]) < priceLmt) && (questCost > 12))
 			{
 				buffMaintain($effect[Throwing Some Shade]);
 			}
-			if((auto_mall_price($item[Squeaky Toy Rose]) < 20000) && (questCost > 12))
+			if((auto_mall_price($item[Squeaky Toy Rose]) < priceLmt) && (questCost > 12))
 			{
 				buffMaintain($effect[A Rose by Any Other Material]);
 			}
@@ -2407,13 +2408,16 @@ boolean LA_cs_communityService()
 				autoChew(item_amount($item[Handful of Smithereens]), $item[Handful of Smithereens]);
 			}
 
-			if((my_adventures() < questCost) || (auto_mall_price($item[Pocket Wish]) < 35000))
+			if((my_adventures() < questCost))
 			{
-				foreach eff in $effects[Chocolatesphere, Disquiet Riot, Patent Invisibility]
+				if ((auto_mall_price($item[Pocket Wish]) < priceLmt))
 				{
-					if(have_effect(eff) == 0)
+					foreach eff in $effects[Chocolatesphere, Disquiet Riot, Patent Invisibility]
 					{
-						makeGenieWish(eff);
+						if(have_effect(eff) == 0)
+						{
+							makeGenieWish(eff);
+						}
 					}
 				}
 			}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -184,9 +184,10 @@ void LX_buyStarKeyParts()
 	{
 		return;	//no unrestricted mall access
 	}
-	buyUpTo(1, $item[Star Chart], 1000);
-	buyUpTo(8, $item[Star], 1000);
-	buyUpTo(7, $item[line], 1000);
+	int pLimit = get_property("autoBuyPriceLimit").to_int(); //Desired spending cap from mafia
+	buyUpTo(1, $item[Star Chart], pLimit);
+	buyUpTo(8, $item[Star], pLimit);
+	buyUpTo(7, $item[line], pLimit);
 }
 
 boolean LX_getStarKey()


### PR DESCRIPTION
# Description

Change several hardcoded buy limits to function based off of Mafia's autoBuyPriceLimit property.

- Use ABPL in auto_acquire for heavily referenced 'buyUpTo' function.
- Make various familiar-buying related improvements to paths\casual.
- Add ABPL to a handful of community_service noncombat buffs.
- Replace hardcoded amounts with ABPL for acquiring parts of Richard's Star Key (Star Chart, Star, Line).
- Add ABPL to MayoFlex acquisition.
- Modify the existing mayoflex my_meat() check to avoid scenarios where we can afford mayo but don't buy it because our meat isn't at the ABPL.
- Add ABPL to buff item purchases.
- Add additional logging to cases where ABPL prevents a buy attempt.

### Fixes #1021

## How Has This Been Tested?
- Run for several weeks on low-budget hardcore, softcore, and casual.
- Run with autoBuyPriceLimit set to 0-99 meat - KoL mafia has built-in functionality to reset autoBuyPriceLimit to a default 20000 at values this low when trying to buy certain NPC items.
- Run with autoBuyPriceLimit set to 500 meat. Several ascensions complete at this value. Only issues found at this value seem to occur when trying to buy Black Market items forged identification documents (5000 meat, autoscend will hard stop to ensure progress) or can of black paint (1000 meat, autoscend will log the inability to buy and proceed with a different solution).
- Not run with mid-sized budget (2,000,000+ meat) to identify possible additional meat leaks not already identified/fixed by this commit, or to test feel of setting ABPL to higher than default values (>20,000) for people who want to spend *more* with autoscend.
- Confirm changes are working as expected by observing related log messages. Examples include "Could not buyUpTo..." and "Could not buffMaintain..."
- Pass CI.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
