### PR TITLE
Limit of 3 calculate the universe

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1279,7 +1279,7 @@ boolean doBedtime()
 		acquireMilkOfMagnesiumIfUnused(true);
 		consumeMilkOfMagnesiumIfUnused();
 
-		if(have_skill($skill[Calculate the Universe]) && auto_is_valid($skill[Calculate the Universe]) && (get_property("_universeCalculated").to_int() < get_property("skillLevel144").to_int()))
+		if(have_skill($skill[Calculate the Universe]) && auto_is_valid($skill[Calculate the Universe]) && (get_property("_universeCalculated").to_int() < min(3, get_property("skillLevel144").to_int())))
 		{
 			auto_log_info("You can still Calculate the Universe!", "blue");
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2495,7 +2495,7 @@ int doNumberology(string goal, boolean doIt, string option)
 	{
 		return -1;
 	}
-	if(get_property("_universeCalculated").to_int() >= get_property("skillLevel144").to_int())
+	if(get_property("_universeCalculated").to_int() >= min(3, get_property("skillLevel144").to_int()))
 	{
 		return -1;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -689,7 +689,7 @@ boolean L12_preOutfit()
 		}
 	}
 
-	if(have_skill($skill[Calculate the Universe]) && my_daycount() == 1 && get_property("_universeCalculated").to_int() < get_property("skillLevel144").to_int())
+	if(have_skill($skill[Calculate the Universe]) && my_daycount() == 1 && get_property("_universeCalculated").to_int() < min(3, get_property("skillLevel144").to_int()))
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Calculate the universe can only be cast 3 times now

## How Has This Been Tested?

Untested, trivial change to cap at 3 if skillLevel144 is greater.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
