### PR TITLE
don't get free kill charges when about to do nuns

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -638,7 +638,38 @@ void auto_CMCconsult()
 {
 	//consume previously bought items if conditions are right
 	//perhaps pill was bought yesterday with full spleen
-	if(item_amount($item[Breathitin&trade;]) > 0)
+	boolean notAboutToDoNuns()
+	{
+		//should avoid getting more free kill charges when about to do nuns because the fights would be capped to 1000 meat
+		if(my_level() >= 12)
+		{
+			if(my_location() == $location[The Themthar Hills])
+			{
+				return false;
+			}
+			if(my_location() == $location[the battlefield (frat uniform)] && get_property("sidequestNunsCompleted") == "none")
+			{
+				int hippiesDefeated = get_property("hippiesDefeated").to_int();
+				if(hippiesDefeated <= 208 && auto_bestWarPlan().do_nuns)
+				{	
+					int turnsUntilNuns = min(16,ceil(max(0,191.0 - hippiesDefeated)/auto_warKillsPerBattle()));
+					if(get_property("breathitinCharges").to_int() + 5 >= turnsUntilNuns)
+					{
+						return false;	//may do nuns before breathitin charges get used up
+					}
+				}
+			}
+			if(get_property("auto_hippyInstead").to_boolean() && internalQuestStatus("questL12War") == 1 && get_property("sidequestNunsCompleted") == "none")
+			{
+				if(auto_bestWarPlan().do_nuns && (get_property("sidequestOrchardCompleted") != "none" || !auto_bestWarPlan().do_orchard))
+				{
+					return false;	//war started and about to start nuns as hippy anytime?
+				}
+			}
+		}
+		return true;
+	}
+	if(item_amount($item[Breathitin&trade;]) > 0 && notAboutToDoNuns() && !can_interact())
 	{
 		autoChew(1,$item[Breathitin&trade;]);
 	}
@@ -720,7 +751,7 @@ void auto_CMCconsult()
 		run_choice(bestOption);
 	}
 
-	if(consumableBought == $item[Breathitin&trade;] || consumableBought == $item[Homebodyl&trade;])
+	if(consumableBought == $item[Homebodyl&trade;] || (consumableBought == $item[Breathitin&trade;] && notAboutToDoNuns()))
 	{
 		autoChew(1,consumableBought);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -669,7 +669,17 @@ void auto_CMCconsult()
 		}
 		return true;
 	}
-	if(item_amount($item[Breathitin&trade;]) > 0 && notAboutToDoNuns() && !can_interact())
+	boolean shouldChewBreathitin()
+	{
+		if(my_location() == $location[The Hidden Park])
+		{
+			//already free [dense liana] should come right after and would waste charges
+			//can't know how many combats will remain in the park which is ideally noncombats
+			return false;
+		}
+		return notAboutToDoNuns();
+	}
+	if(item_amount($item[Breathitin&trade;]) > 0 && shouldChewBreathitin() && !can_interact())
 	{
 		autoChew(1,$item[Breathitin&trade;]);
 	}
@@ -751,7 +761,7 @@ void auto_CMCconsult()
 		run_choice(bestOption);
 	}
 
-	if(consumableBought == $item[Homebodyl&trade;] || (consumableBought == $item[Breathitin&trade;] && notAboutToDoNuns()))
+	if(consumableBought == $item[Homebodyl&trade;] || (consumableBought == $item[Breathitin&trade;] && shouldChewBreathitin()))
 	{
 		autoChew(1,consumableBought);
 	}


### PR DESCRIPTION
should avoid getting more free kill charges when about to do nuns because the fights would be capped to 1000 meat

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
