### PR TITLE
suggest only correct war outfit

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -683,7 +683,7 @@ boolean doBedtime()
 			{
 				auto_log_info("Pulls remaining: " + pulls_remaining(), "olive");
 			}
-			if(!possessOutfit("frat warrior fatigues") && !get_property("auto_hippyInstead"))
+			if(!possessOutfit("frat warrior fatigues") && !get_property("auto_hippyInstead").to_boolean)
 			{
 				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 				if(canYellowRay())
@@ -691,7 +691,7 @@ boolean doBedtime()
 					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
 				}
 			}
-			else if(!possessOutfit("War Hippy Fatigues") && get_property("auto_hippyInstead"))
+			else if(!possessOutfit("War Hippy Fatigues") && get_property("auto_hippyInstead").to_boolean)
 			{
 				auto_log_info("Please consider a Bailey's Beetle (You want War Hippy Fatigues).", "blue");
 				if(canYellowRay())

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -683,7 +683,7 @@ boolean doBedtime()
 			{
 				auto_log_info("Pulls remaining: " + pulls_remaining(), "olive");
 			}
-			if(!possessOutfit("frat warrior fatigues") && !get_property("auto_hippyInstead").to_boolean)
+			if(!possessOutfit("frat warrior fatigues") && !get_property("auto_hippyInstead").to_boolean())
 			{
 				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 				if(canYellowRay())
@@ -691,7 +691,7 @@ boolean doBedtime()
 					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
 				}
 			}
-			else if(!possessOutfit("War Hippy Fatigues") && get_property("auto_hippyInstead").to_boolean)
+			else if(!possessOutfit("War Hippy Fatigues") && get_property("auto_hippyInstead").to_boolean())
 			{
 				auto_log_info("Please consider a Bailey's Beetle (You want War Hippy Fatigues).", "blue");
 				if(canYellowRay())

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -683,12 +683,20 @@ boolean doBedtime()
 			{
 				auto_log_info("Pulls remaining: " + pulls_remaining(), "olive");
 			}
-			if(!possessOutfit("frat warrior fatigues"))
+			if(!possessOutfit("frat warrior fatigues") && !get_property("auto_hippyInstead"))
 			{
 				auto_log_info("Please consider an orcish frat boy spy (You want Frat Warrior Fatigues).", "blue");
 				if(canYellowRay())
 				{
 					auto_log_info("Make sure to Ball Lightning the spy!!", "red");
+				}
+			}
+			else if(!possessOutfit("War Hippy Fatigues") && get_property("auto_hippyInstead"))
+			{
+				auto_log_info("Please consider a Bailey's Beetle (You want War Hippy Fatigues).", "blue");
+				if(canYellowRay())
+				{
+					auto_log_info("Make sure to Ball Lightning the hippy!!", "red");
 				}
 			}
 			else


### PR DESCRIPTION
# Description

Bedtime logic assumes you will be doing Frat side of war. Have added logic to prevent it suggesting you need to get the frat outfit when you are doing the hippy side (and logic to suggest getting it if you dont have it yet)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
