### PR TITLE
Pirates quest improvements

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -7,7 +7,7 @@ Pygmy Bowler
 Pygmy Witch Surgeon
 pygmy witch accountant	loc:The Hidden Office Building
 pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
-Pygmy Janitor	loc:The Hidden Park;!tavern:true
+Pygmy Janitor	loc:The Hidden Park;!tavern:true;!itemdropcapped:20=book of matches
 Quiet Healer	!prop:questL10Garbage=finished
 Tomb Rat
 Blooper	loc:8-Bit Realm
@@ -22,7 +22,7 @@ Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
 Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>29
-Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover
+Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
 bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
 elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
 spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
@@ -31,6 +31,10 @@ CH Imp	item:imp air<4
 Camel Toe	!sniffed:Skinflute
 Skinflute	!sniffed:Camel Toe
 Red Butler	prop:_glarkCableUses<5;item:glark cable<5
+# Pirate quest F'c'le's last missing item
+cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
+creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
+curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
 # Bugbear Invasion Wanderers
 scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
 hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared

--- a/BUILD/monsters/yellowray.dat
+++ b/BUILD/monsters/yellowray.dat
@@ -1,7 +1,7 @@
 # Gotta get that wig
-Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography
+Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography;!itemdropcapped:10=Mohawk wig
 # We also want an amulet, but not badly enough to yellow ray it unless we're backtracking to get it
-Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6
+Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6;!itemdropcapped:10=amulet of extreme plot significance
 # Dressing up as a harem girl because we have no shame
 Knob Goblin Harem Girl	!outfit:Knob Goblin Harem Girl Disguise
 # We don't want to yellow ray a mountain man if we already turned in ore

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -118,7 +118,7 @@ sniff	5	Pygmy Bowler
 sniff	6	Pygmy Witch Surgeon
 sniff	7	pygmy witch accountant	loc:The Hidden Office Building
 sniff	8	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
-sniff	9	Pygmy Janitor	loc:The Hidden Park;!tavern:true
+sniff	9	Pygmy Janitor	loc:The Hidden Park;!tavern:true;!itemdropcapped:20=book of matches
 sniff	10	Quiet Healer	!prop:questL10Garbage=finished
 sniff	11	Tomb Rat
 sniff	12	Blooper	loc:8-Bit Realm
@@ -133,7 +133,7 @@ sniff	20	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorori
 sniff	21	Possessed Wine Rack
 sniff	22	Blue Oyster cultist
 sniff	23	Dirty Old Lihc	prop:cyrptNicheEvilness>29
-sniff	24	Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover
+sniff	24	Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
 sniff	25	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
 sniff	26	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
 sniff	27	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
@@ -142,29 +142,33 @@ sniff	29	CH Imp	item:imp air<4
 sniff	30	Camel Toe	!sniffed:Skinflute
 sniff	31	Skinflute	!sniffed:Camel Toe
 sniff	32	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
+# Pirate quest F'c'le's last missing item
+sniff	33	cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
+sniff	34	creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
+sniff	35	curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
 # Bugbear Invasion Wanderers
-sniff	33	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
-sniff	34	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
-sniff	35	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
-sniff	36	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
-sniff	37	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
-sniff	38	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
-sniff	39	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
-sniff	40	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
-sniff	41	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
+sniff	36	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
+sniff	37	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
+sniff	38	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
+sniff	39	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
+sniff	40	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
+sniff	41	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
+sniff	42	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
+sniff	43	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
+sniff	44	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
 # Bugbear Invasion Mothership
-sniff	42	creepy eye-stalk tentacle monster	path:Bugbear Invasion
-sniff	43	anesthesiologist bugbear	path:Bugbear Invasion
-sniff	44	bugbear mortician	path:Bugbear Invasion
-sniff	45	N-space Virtual Assistant	path:Bugbear Invasion
-sniff	46	angry cavebugbear	path:Bugbear Invasion
+sniff	45	creepy eye-stalk tentacle monster	path:Bugbear Invasion
+sniff	46	anesthesiologist bugbear	path:Bugbear Invasion
+sniff	47	bugbear mortician	path:Bugbear Invasion
+sniff	48	N-space Virtual Assistant	path:Bugbear Invasion
+sniff	49	angry cavebugbear	path:Bugbear Invasion
 
 # Gotta get that wig
-yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography
+yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography;!itemdropcapped:10=Mohawk wig
 # We also want an amulet, but not badly enough to yellow ray it unless we're backtracking to get it
-yellowray	1	Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6
+yellowray	1	Quiet Healer	item:amulet of extreme plot significance<1;quest:questL10Garbage>6;!itemdropcapped:10=amulet of extreme plot significance
 # Dressing up as a harem girl because we have no shame
-yellowray	2	Knob Goblin Harem Girl	!outfit:Knob Goblin Harem Girl Disguise
+yellowray	2	Knob Goblin Harem Girl	!outfit:Knob Goblin Harem Girl Disguise;!itemdropcapped:20=Knob Goblin harem pants
 # We don't want to yellow ray a mountain man if we already turned in ore
 # although I'm not sure why we'd be fighting one in that case...
 yellowray	3	Mountain Man	quest:questL08Trapper<2

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -877,8 +877,31 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	int[item] large_owned;
 	int[item] craftables;
 
-	boolean[item] blacklist = $items[Cursed Punch, Unidentified Drink, FantasyRealm turkey leg, FantasyRealm mead];
+	boolean[item] blacklist;
 	boolean[item] craftable_blacklist;
+
+	foreach it in $items[Cursed Punch, Unidentified Drink, FantasyRealm turkey leg, FantasyRealm mead]
+	{
+		blacklist[it] = true;
+	}
+	if(item_amount($item[Wet Stunt Nut Stew]) == 0 && !possessEquipment($item[Mega Gem]) && !isActuallyEd())
+	{
+		blacklist[$item[wet stew]] = true;
+	}
+	if(internalQuestStatus("questL07Cyrptic") < 1)
+	{
+		//don't consume gravy boat
+		craftable_blacklist[$item[warm gravy]] = true;
+	}
+	if(in_lowkeysummer() && internalQuestStatus("questM12Pirate") <= 2 && item_amount($item[hot wing]) < 4)
+	{
+		// TODO replace in_lowkeysummer check with a check that we are doing pirates? we are only doing pirates quest in that path now
+		blacklist[$item[hot wing]] = true;
+		if(item_amount($item[Devil's Elbow Hot Sauce]) == 0)
+		{	//don't use hot wings if pirates quest still needs them
+			craftable_blacklist[$item[devil hair pasta]] = true;
+		}
+	}
 
 	// If we have 2 sticks of firewood, the current knapsack-solver
 	// tries to get one of everything. So we blacklist everything other

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -893,9 +893,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		//don't consume gravy boat
 		craftable_blacklist[$item[warm gravy]] = true;
 	}
-	if(in_lowkeysummer() && internalQuestStatus("questM12Pirate") <= 2 && item_amount($item[hot wing]) < 4)
+	if(LX_doingPirates() && internalQuestStatus("questM12Pirate") <= 2 && item_amount($item[hot wing]) < 4)
 	{
-		// TODO replace in_lowkeysummer check with a check that we are doing pirates? we are only doing pirates quest in that path now
 		blacklist[$item[hot wing]] = true;
 		if(item_amount($item[Devil's Elbow Hot Sauce]) == 0)
 		{	//don't use hot wings if pirates quest still needs them

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3310,6 +3310,18 @@ boolean auto_check_conditions(string conds)
 				if(req_item == $item[none])
 					abort('"' + m5.group(1) + '" does not properly convert to an item!');
 				return compare_numbers(item_amount(req_item) + equipped_amount(req_item), m5.group(3).to_int(), m5.group(2));
+			// data: <value><equal sign separator><item name>
+			// The chance of getting the item at the end of the fight from that base drop rate value must be 100
+			// As a precaution, autoscend aborts if to_item returns $item[none]
+			case "itemdropcapped":
+				matcher m7 = create_matcher("([^=<>]+)=(.+)", condition_data);
+				if(!m7.find())
+					abort('"' + condition_data + '" is not a proper item condition format!');
+				item todrop_item = to_item(m7.group(2));
+				float base_drop_chance = to_float(m7.group(1));
+				if(todrop_item == $item[none])
+					abort('"' + m7.group(1) + '" does not properly convert to an item!');
+				return (effectiveDropChance(todrop_item,base_drop_chance) >= 100);
 			// data: The outfit name as used by have_outfit
 			// You must have the given outfit
 			// No safety checking here possible, at least not conveniently

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -232,6 +232,15 @@ generic_t zone_needItem(location loc)
 			value = 20.0;
 		}
 		break;
+	case $location[The Dark Neck of the Woods]:
+	case $location[The Dark Heart of the Woods]:
+	case $location[The Dark Elbow of the Woods]:
+	case $location[Pandamonium Slums]:
+		if(LX_doingPirates() && item_amount($item[hot wing]) < 3 && internalQuestStatus("questM12Pirate") <= 2)
+		{
+			value = 30;
+		}
+		break;
 	case $location[Cobb\'s Knob Barracks]:
 		if(!have_outfit("Knob Goblin Elite Guard Uniform"))
 		{
@@ -295,6 +304,10 @@ generic_t zone_needItem(location loc)
 			}
 		}
 		break;
+	case $location[The Obligatory Pirate\'s Cove]:
+		if(!possessOutfit("Swashbuckling Getup") && !possessEquipment($item[pirate fledges])) {
+			value = 10.0;
+		}
 	case $location[The Old Landfill]:
 		value = 5.0 * (1.0 + get_property("auto_junkspritesencountered").to_float());
 		break;
@@ -438,6 +451,15 @@ generic_t zone_needItemFood(location loc)
 		else
 		{
 			value = 40.0;
+		}
+		break;
+	case $location[The Dark Neck of the Woods]:
+	case $location[The Dark Heart of the Woods]:
+	case $location[The Dark Elbow of the Woods]:
+	case $location[Pandamonium Slums]:
+		if(LX_doingPirates() && item_amount($item[hot wing]) < 3 && internalQuestStatus("questM12Pirate") <= 2)
+		{
+			value = 30;
 		}
 		break;
 	case $location[The Haunted Pantry]:
@@ -658,7 +680,11 @@ generic_t zone_combatMod(location loc)
 		break;
 	case $location[The Obligatory Pirate\'s Cove]:
 		if(!possessOutfit("Swashbuckling Getup")) {
-			value = -60;
+			if(item_amount($item[The Big Book Of Pirate Insults]) > 0 && numPirateInsults() < 3) {
+				value = 0; // fights can give both outfit pieces and insults. better not start avoiding fights until first insults learned
+			} else {
+				value = -60;
+			}
 		} else if (numPirateInsults() < 8) {
 			value = 40;
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1117,6 +1117,7 @@ boolean LX_galaktikSubQuest();
 boolean startMeatsmithSubQuest();
 boolean finishMeatsmithSubQuest();
 boolean LX_meatsmithSubQuest();
+boolean LX_doingPirates();
 boolean LX_pirateOutfit();
 void piratesCoveChoiceHandler(int choice);
 string beerPong(string page);

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -681,12 +681,17 @@ boolean LX_galaktikSubQuest()
 	return autoAdv($location[The Overgrown Lot]);
 }
 
+
+boolean LX_doingPirates() {
+	return in_lowkeysummer(); //we are only doing pirates in that path now
+}
+
 boolean LX_pirateOutfit() {
 	if (get_property("lastIslandUnlock").to_int() < my_ascensions()) {
 		return LX_islandAccess();
 	}
 	if (in_lowkeysummer() && !in_hardcore()) {
-		// TODO replace in_lowkeysummer check with a check that we are doing pirates quest? we are only doing pirates in that path now
+		// in_lowkeysummer() means that turns are being spent in the Cove first which makes this worth doing
 		// pull book to learn insults ahead of starting beerpong quest. saves at least however many fights on the way to gathering the outfit
 		// plus lets you keep trying to gather the outfit while learning insults, can save the pulls for missing pieces that come next
 		pullXWhenHaveY($item[The Big Book Of Pirate Insults], 1, 0);

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -685,10 +685,19 @@ boolean LX_pirateOutfit() {
 	if (get_property("lastIslandUnlock").to_int() < my_ascensions()) {
 		return LX_islandAccess();
 	}
-	if (possessEquipment($item[peg key]) && !in_hardcore()) {
-		// if we have the key, just pull any outfit parts we are still missing
-		foreach _, it in outfit_pieces("Swashbuckling Getup") {
-			pullXWhenHaveY(it, 1, 0);
+	if (in_lowkeysummer() && !in_hardcore()) {
+		// TODO replace in_lowkeysummer check with a check that we are doing pirates quest? we are only doing pirates in that path now
+		// pull book to learn insults ahead of starting beerpong quest. saves at least however many fights on the way to gathering the outfit
+		// plus lets you keep trying to gather the outfit while learning insults, can save the pulls for missing pieces that come next
+		pullXWhenHaveY($item[The Big Book Of Pirate Insults], 1, 0);
+		//want 6 insults to try but learning another finding Cap'm Caronch can still improve chances more
+		boolean preGatheringInsults = item_amount($item[The Big Book Of Pirate Insults]) > 0 && (numPirateInsults() < 6);
+		
+		if (possessEquipment($item[peg key]) && !preGatheringInsults) {
+			// if we have the key and insults, just pull any outfit parts we are still missing
+			foreach _, it in outfit_pieces("Swashbuckling Getup") {
+				pullXWhenHaveY(it, 1, 0);
+			}
 		}
 	}
 	if (possessOutfit("Swashbuckling Getup")) {

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -865,34 +865,66 @@ boolean LX_joinPirateCrew() {
 			auto_log_info("We have the Frat Boy Ensemble, begin infiltration!", "blue");
 			outfit("Frat Boy Ensemble");
 			infiltrationReady = true;
-		} else if (possessEquipment($item[mullet wig]) && item_amount($item[briefcase]) > 0) {
+		} else if (possessEquipment($item[mullet wig]) && auto_can_equip($item[mullet wig]) && item_amount($item[briefcase]) > 0) {
 			auto_log_info("We have a mullet wig and a briefcase, begin infiltration!", "blue");
 			autoForceEquip($item[mullet wig]);
 			infiltrationReady = true;
-		} else if (possessEquipment($item[frilly skirt]) && item_amount($item[hot wing]) > 2) {
+		} else if (possessEquipment($item[frilly skirt]) && auto_can_equip($item[frilly skirt]) && item_amount($item[hot wing]) > 2) {
 			auto_log_info("We have hot wings and a frilly skirt, begin infiltration!", "blue");
 			autoForceEquip($item[frilly skirt]);
 			infiltrationReady = true;
 		}
-
-		if (!infiltrationReady) {
-			if (item_amount($item[hot wing]) > 2) {
-				if (knoll_available() && my_meat() > npc_price($item[frilly skirt])) {
-					auto_log_info("We have hot wings but no frilly skirt. Lets go shopping!", "blue");
-					buyUpTo(1, $item[frilly skirt]);
-					autoForceEquip($item[frilly skirt]);
-					infiltrationReady = true;
-				} else {
-					auto_log_info("We have hot wings but no frilly skirt. Lets go to the gym!", "blue");
-					if (internalQuestStatus("questM01Untinker") == -1) {
-						visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
-					}
-					if (autoAdv($location[The Degrassi Knoll Gym])) {
-						return true;
+		
+		if (!infiltrationReady)	{
+			boolean mightGetHotwings() {
+				return (internalQuestStatus("questL06Friar") < 2 || (in_lowkeysummer() && !possessEquipment($item[Demonic key])));
+			}
+			boolean mightCatburgle = (item_amount($item[hot wing]) > 2 || mightGetHotwings()) && (knoll_available() || possessEquipment($item[frilly skirt]));
+			
+			if (!infiltrationReady && !mightCatburgle) {
+				if (item_amount($item[briefcase]) > 0) {
+					// missing only mullet wig and not expecting Catburgle
+					if (pullXWhenHaveY($item[mullet wig], 1, 0) && autoForceEquip($item[mullet wig])) {
+						infiltrationReady = true;
 					}
 				}
 			}
-			// TODO: add handling for the other methods here? Do we care about anything other than Catburgling?
+
+			if (!infiltrationReady) {
+				if (item_amount($item[hot wing]) > 2 && auto_can_equip($item[frilly skirt])) {
+					if (knoll_available() && my_meat() > npc_price($item[frilly skirt])) {
+						auto_log_info("We have hot wings but no frilly skirt. Lets go shopping!", "blue");
+						buyUpTo(1, $item[frilly skirt]);
+						autoForceEquip($item[frilly skirt]);
+						infiltrationReady = true;
+					} else {
+						//frilly skirt is 25% drop from 1 of 3 gym monsters, try pulling it before spending adventures
+						if (pullXWhenHaveY($item[frilly skirt], 1, 0) && autoForceEquip($item[frilly skirt])) {
+							infiltrationReady = true;
+						}
+						else {
+							auto_log_info("We have hot wings but no frilly skirt. Lets go to the gym!", "blue");
+							if (internalQuestStatus("questM01Untinker") == -1) {
+								visit_url("place.php?whichplace=forestvillage&preaction=screwquest&action=fv_untinker_quest");
+							}
+							if (autoAdv($location[The Degrassi Knoll Gym])) {
+								return true;
+							}
+						}
+					}
+				}
+				else if (possessEquipment($item[mullet wig]) && auto_can_equip($item[mullet wig])) {
+					// easiest to get or wait to get a briefcase
+					// todo modify banish list to not banish pygmy headhunters if wanting a briefcase in hardcore?
+					if (!mightCatburgle && internalQuestStatus("questL04Bat") >= 1 && internalQuestStatus("hiddenOfficeProgress") >= 6) {	
+						// briefcase zones already finished and not expecting Catburgle then try to pull it
+						if (pullXWhenHaveY($item[briefcase], 1, 0) && autoForceEquip($item[mullet wig])) {
+							infiltrationReady = true;
+						}
+					}
+				}
+				// else: todo get frat boy ensemble if possible. may not be possible if frat house is (Bombed Back to the Stone Age)
+			}
 		}
 
 		if (infiltrationReady) {


### PR DESCRIPTION
pulling alternatives for LX_joinPirateCrew. partially addresses #472
consider pull The Big Book Of Pirate Insults ahead of starting beerpong quest and keep trying to get outfit and insults together, saves fights and pulls for missing pieces
added to consume blacklist hot wing, wet stew, gravy boat
update zone goals for pirate outfit, hot wings
sniff last missing F'c'le pirate if its drop not capped
use the added itemdropcapped check to avoid some unnecessary sniffs and yellow ray

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
