### PR TITLE
Add a bunch of missing get_property().to_int()

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -110,7 +110,7 @@ boolean pulledToday(item it)
 	string [int] allPulls = split_string(get_property("_roninStoragePulls"),",");
 	foreach i in allPulls
 	{
-		if(allPulls[i] == it.to_int())
+		if(allPulls[i].to_int() == it.to_int())
 		{
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/auto_canadv.ash
+++ b/RELEASE/scripts/autoscend/auto_canadv.ash
@@ -717,17 +717,17 @@ boolean can_adv(location where, boolean prep, int verb) {
    case $location[The Spooky Gravy Burrow]: return (famcheck($familiar[spooky gravy fairy]) || famcheck($familiar[sleazy gravy fairy]) ||
            famcheck($familiar[frozen gravy fairy]) || famcheck($familiar[flaming gravy fairy]) || famcheck($familiar[stinky gravy fairy]));
   // sorceress
-   case $location[Fastest Adventurer Contest]: return get_property("questL13Final") == "step1" && get_property("nsContestants1") > 0;
+   case $location[Fastest Adventurer Contest]: return get_property("questL13Final") == "step1" && get_property("nsContestants1").to_int() > 0;
    case $location[Strongest Adventurer Contest]:
    case $location[Smartest Adventurer Contest]:
    case $location[Smoothest Adventurer Contest]:
-   case $location[A Crowd of (Stat) Adventurers]: return get_property("questL13Final") == "step1" && get_property("nsContestants2") > 0;
+   case $location[A Crowd of (Stat) Adventurers]: return get_property("questL13Final") == "step1" && get_property("nsContestants2").to_int() > 0;
    case $location[Hottest Adventurer Contest]:
    case $location[Coldest Adventurer Contest]:
    case $location[Spookiest Adventurer Contest]:
    case $location[Stinkiest Adventurer Contest]:
    case $location[Sleaziest Adventurer Contest]:
-   case $location[A Crowd of (Element) Adventurers]: return get_property("questL13Final") == "step1" && get_property("nsContestants3") > 0;
+   case $location[A Crowd of (Element) Adventurers]: return get_property("questL13Final") == "step1" && get_property("nsContestants3").to_int() > 0;
    case $location[The Hedge Maze]: return get_property("questL13Final") == "step4";
    case $location[Tower Level 1]: return get_property("questL13Final") == "step6";
    case $location[Tower Level 2]: return get_property("questL13Final") == "step7";
@@ -736,7 +736,7 @@ boolean can_adv(location where, boolean prep, int verb) {
    case $location[Tower Level 5]: return get_property("questL13Final") == "step10";
    case $location[The Naughty Sorceress' Chamber]: return get_property("questL13Final") == "step11";
   // spacegate
-   case $location[Through the Spacegate]: return get_property("_spacegateCoordinates") != "" && get_property("_spacegateTurnsLeft") > 0;
+   case $location[Through the Spacegate]: return get_property("_spacegateCoordinates") != "" && get_property("_spacegateTurnsLeft").to_int() > 0;
   // spring break
    case $location[The Sunken Party Yacht]: return not_blind();
   // that 70s volcano

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -454,7 +454,7 @@ boolean autoChooseFamiliar(location place)
 	}
 
 	// Killing jar saves adventures unlocking the Pyramid.
-	if ($location[The Haunted Library] == place && item_amount($item[killing jar]) < 1 && (get_property("gnasirProgress").to_int() & 4) == 0 && get_property("desertExploration") < 100) {
+	if ($location[The Haunted Library] == place && item_amount($item[killing jar]) < 1 && (get_property("gnasirProgress").to_int() & 4) == 0 && get_property("desertExploration").to_int() < 100) {
 		famChoice = lookupFamiliarDatafile("item");
 	}
 

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -989,7 +989,7 @@ boolean auto_post_adventure()
 		{
 			bjornify_familiar($familiar[grim brother]);
 		}
-		if((my_bjorned_familiar() == $familiar[grimstone golem]) && (get_property("_grimstoneMaskDropsCrown") == 1) && have_familiar($familiar[El Vibrato Megadrone]))
+		if((my_bjorned_familiar() == $familiar[grimstone golem]) && (get_property("_grimstoneMaskDropsCrown").to_int() == 1) && have_familiar($familiar[El Vibrato Megadrone]))
 		{
 			bjornify_familiar($familiar[el vibrato megadrone]);
 		}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -626,13 +626,13 @@ boolean auto_pre_adventure()
 	if(doML)
 	{
 		// Catch when we leave lowMLZone, allow for being "side tracked" by delay burning
-		if((have_effect($effect[Driving Intimidatingly]) > 0) && (get_property("auto_debuffAsdonDelay") >= 2))
+		if((have_effect($effect[Driving Intimidatingly]) > 0) && (get_property("auto_debuffAsdonDelay").to_int() >= 2))
 		{
 			auto_log_debug("No Reason to delay Asdon Usage");
 			uneffect($effect[Driving Intimidatingly]);
 			set_property("auto_debuffAsdonDelay", 0);
 		}
-		else if((have_effect($effect[Driving Intimidatingly]).to_int() == 0)  && (get_property("auto_debuffAsdonDelay") >= 0))
+		else if((have_effect($effect[Driving Intimidatingly]).to_int() == 0)  && (get_property("auto_debuffAsdonDelay").to_int() >= 0))
 		{
 			set_property("auto_debuffAsdonDelay", 0);
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -103,7 +103,7 @@ generic_t zone_needItem(location loc)
 		value = 20.0;
 		break;
 	case $location[The Haunted Library]:
-		if (item_amount($item[killing jar]) < 1 && (get_property("gnasirProgress").to_int() & 4) == 0 && get_property("desertExploration") < 100) {
+		if (item_amount($item[killing jar]) < 1 && (get_property("gnasirProgress").to_int() & 4) == 0 && get_property("desertExploration").to_int() < 100) {
 			value = 10.0;
 		}
 		break;
@@ -119,7 +119,7 @@ generic_t zone_needItem(location loc)
 		}
 		break;
 	case $location[The Hidden Bowling Alley]:
-		if (item_amount($item[Bowling Ball]) == 0 && get_property("hiddenBowlingAlleyProgress") < 5) {
+		if (item_amount($item[Bowling Ball]) == 0 && get_property("hiddenBowlingAlleyProgress").to_int() < 5) {
 			value = 40.0;
 		}
 		break;
@@ -2007,7 +2007,7 @@ boolean is_ghost_in_zone(location loc)
 		
 	case $location[The Hidden Hospital]:
 		//if liana cleared then we can encounter ghost
-		return get_property("hiddenHospitalProgress") > 0 && get_property("hiddenHospitalProgress") < 7;
+		return get_property("hiddenHospitalProgress").to_int() > 0 && get_property("hiddenHospitalProgress").to_int() < 7;
 		
 	case $location[The Hidden Office Building]:
 		boolean hasMcCluskyFile = $item[McClusky file (complete)].available_amount() > 0;

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -584,7 +584,7 @@ boolean auto_spoonReadyToTuneMoon()
 		abort("Something weird is going on with auto_spoonsign. It's not an invalid/blank value, but also not a knoll, canadia, or gnomad sign? This is impossible.");
 	}
 
-	if(my_sign() == "Vole" && (get_property("cyrptAlcoveEvilness") > 26 || get_property("questL07Cyrptic") == "unstarted"))
+	if(my_sign() == "Vole" && (get_property("cyrptAlcoveEvilness").to_int() > 26 || get_property("questL07Cyrptic") == "unstarted"))
 	{
 		// we want to stay vole long enough to do the alcove, since the initiative helps
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -12,7 +12,7 @@ boolean auto_canFeelEnvy()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelEnvyUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelEnvyUsed").to_int() < 3;
 }
 
 boolean auto_canFeelHatred()
@@ -22,7 +22,7 @@ boolean auto_canFeelHatred()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelHatredUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelHatredUsed").to_int() < 3;
 }
 
 boolean auto_canFeelNostalgic()
@@ -32,7 +32,7 @@ boolean auto_canFeelNostalgic()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelNostalgicUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelNostalgicUsed").to_int() < 3;
 }
 
 boolean auto_canFeelPride()
@@ -42,7 +42,7 @@ boolean auto_canFeelPride()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelPrideUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelPrideUsed").to_int() < 3;
 }
 
 boolean auto_canFeelSuperior()
@@ -52,7 +52,7 @@ boolean auto_canFeelSuperior()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelSuperiorUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelSuperiorUsed").to_int() < 3;
 }
 
 boolean auto_canFeelLonely()
@@ -62,7 +62,7 @@ boolean auto_canFeelLonely()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelLonelyUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelLonelyUsed").to_int() < 3;
 }
 
 boolean auto_canFeelExcitement()
@@ -72,7 +72,7 @@ boolean auto_canFeelExcitement()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelExcitementUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelExcitementUsed").to_int() < 3;
 }
 
 boolean auto_canFeelNervous()
@@ -82,7 +82,7 @@ boolean auto_canFeelNervous()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelNervousUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelNervousUsed").to_int() < 3;
 }
 
 boolean auto_canFeelPeaceful()
@@ -92,7 +92,7 @@ boolean auto_canFeelPeaceful()
 	{
 		return false;
 	}
-	return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed") < 3;
+	return auto_haveEmotionChipSkills() && get_property("_feelPeacefulUsed").to_int() < 3;
 }
 
 boolean auto_haveBackupCamera()

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -163,7 +163,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1468: // Aunts not Ants
 			if ((my_primestat() == $stat[moxie] && (my_level() < 13 || disregardInstantKarma())) || (my_primestat() == $stat[muscle] && my_level() > 12 && disregardInstantKarma() == false)) {
 				run_choice(1); // 150 moxie substat
-			} else if(get_property("_juneCleaverSkips") < 5) {
+			} else if(get_property("_juneCleaverSkips").to_int() < 5) {
 				run_choice(4); // skip
 			} else {
 				run_choice(2); // 250 muscle substat
@@ -183,7 +183,7 @@ void juneCleaverChoiceHandler(int choice)
 				run_choice(2); // accessory, +2 fam exp, +3 stats per fight
 			} else if (my_primestat() == $stat[muscle] && (my_level() < 13 || disregardInstantKarma())) {
 				run_choice(3);
-			} else if(get_property("_juneCleaverSkips") < 5) {
+			} else if(get_property("_juneCleaverSkips").to_int() < 5) {
 				run_choice(4); // skip
 			} else {
 				run_choice(2); // accessory, +2 fam exp, +3 stats per fight
@@ -204,7 +204,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1473: // Bath Time
 			if(my_primestat() == $stat[muscle] && (my_level() < 13 || disregardInstantKarma())) {
 				run_choice(1); // 250 muscle substat
-			} else if(get_property("_juneCleaverSkips") < 5) {
+			} else if(get_property("_juneCleaverSkips").to_int() < 5) {
 				run_choice(4); // skip
 			} else {
 				run_choice(3); // effect, 30 turns of +3 hot res, +50% init

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -1357,10 +1357,10 @@ void robot_directive()
 	boolean city_ready = internalQuestStatus("questL11Worship") == 3;		//we unlocked the hidden city
 	boolean city_ziggurat_ready = internalQuestStatus("questL11Worship") == 4;		//we are about to do ziggurat next
 	boolean city_finished = get_property("questL11Worship") == "finished";
-	boolean liana_cleared = get_property("hiddenApartmentProgress") > 0 &&
-	get_property("hiddenOfficeProgress") > 0 &&
-	get_property("hiddenHospitalProgress") > 0 &&
-	get_property("hiddenBowlingAlleyProgress") > 0 &&
+	boolean liana_cleared = get_property("hiddenApartmentProgress").to_int() > 0 &&
+	get_property("hiddenOfficeProgress").to_int() > 0 &&
+	get_property("hiddenHospitalProgress").to_int() > 0 &&
+	get_property("hiddenBowlingAlleyProgress").to_int() > 0 &&
 	get_property("auto_openedziggurat").to_boolean();
 	if(directive == "machete" && liana_cleared)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1916,28 +1916,28 @@ boolean L11_hiddenCityZones()
 		return autoAdv($location[The Hidden Park]);
 	}
 
-	if (get_property("hiddenApartmentProgress") == 0) {
+	if (get_property("hiddenApartmentProgress").to_int() == 0) {
 		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Northwest)]);
 	}
 
-	if (get_property("hiddenOfficeProgress") == 0) {
+	if (get_property("hiddenOfficeProgress").to_int() == 0) {
 		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Northeast)]);
 	}
 
-	if (get_property("hiddenHospitalProgress") == 0) {
+	if (get_property("hiddenHospitalProgress").to_int() == 0) {
 		if (canUseMachete && !equipMachete()) {
 			return false;
 		}
 		return autoAdv($location[An Overgrown Shrine (Southwest)]);
 	}
 
-	if (get_property("hiddenBowlingAlleyProgress") == 0) {
+	if (get_property("hiddenBowlingAlleyProgress").to_int() == 0) {
 		if (canUseMachete && !equipMachete()) {
 			return false;
 		}


### PR DESCRIPTION
# Description

Convert a bunch of get_property strings to ints when comparisons are made. Workaround for recent mafia bug. There may be more strings that need to be coerced this but should be most of them I hope.

## How Has This Been Tested?

Minimal local testing.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
