### PR TITLE
add zombieSlayer_usable function

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -874,14 +874,14 @@ void acquireFamiliars()
 	}
 
 	//Very cheap and very useful IOTM derivative. MP/HP regen. drops lots of useful food and drink early on
-	if(!have_familiar($familiar[Lil\' Barrel Mimic]) && item_amount($item[tiny barrel]) == 0 && is_unrestricted($item[tiny barrel]) && canPull($item[tiny barrel]) && auto_is_valid($item[tiny barrel]))
+	if(!have_familiar($familiar[Lil\' Barrel Mimic]) && auto_is_valid($familiar[Lil\' Barrel Mimic]) && item_amount($item[tiny barrel]) == 0 && is_unrestricted($item[tiny barrel]) && canPull($item[tiny barrel]) && auto_is_valid($item[tiny barrel]))
 	{
 		acquireOrPull($item[tiny barrel]);		//mallbuy and pull it if we can
 	}
 	hatchFamiliar($familiar[Lil\' Barrel Mimic]);
 	
 	//stat gains. nonscaling. better at low levels. cheap and easy to acquire in run.
-	if(!have_familiar($familiar[Blood-Faced Volleyball]) && item_amount($item[blood-faced volleyball]) == 0 && auto_is_valid($item[seal tooth]) && auto_is_valid($item[volleyball]) && my_meat() > meatReserve() + 1500)
+	if(!have_familiar($familiar[Blood-Faced Volleyball]) && auto_is_valid($familiar[Blood-faced Volleyball]) && item_amount($item[blood-faced volleyball]) == 0 && auto_is_valid($item[seal tooth]) && auto_is_valid($item[volleyball]) && my_meat() > meatReserve() + 1500)
 	{
 		foreach it in $items[volleyball, seal tooth]
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3120,7 +3120,7 @@ boolean auto_is_valid(familiar fam)
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
-	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zslayer_usable(fam) && is_unrestricted(fam);
+	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && is_unrestricted(fam);
 }
 
 boolean auto_is_valid(skill sk)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3120,7 +3120,7 @@ boolean auto_is_valid(familiar fam)
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
-	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && is_unrestricted(fam);
+	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zslayer_usable(fam) && is_unrestricted(fam);
 }
 
 boolean auto_is_valid(skill sk)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -880,7 +880,7 @@ void zombieSlayer_initializeSettings();
 boolean zombieSlayer_buySkills();
 boolean zombieSlayer_acquireMP(int goal, int meat_reserve);
 boolean zombieSlayer_acquireHP(int goal);
-boolean zslayer_usable(familiar fam);
+boolean zombieSlayer_usable(familiar fam);
 
 ########################################################################################################
 //Defined in autoscend/quests/level_01.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -880,6 +880,7 @@ void zombieSlayer_initializeSettings();
 boolean zombieSlayer_buySkills();
 boolean zombieSlayer_acquireMP(int goal, int meat_reserve);
 boolean zombieSlayer_acquireHP(int goal);
+boolean zslayer_usable(familiar fam);
 
 ########################################################################################################
 //Defined in autoscend/quests/level_01.ash

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -211,3 +211,15 @@ boolean zombieSlayer_acquireHP(int goal)
 	return my_hp() >= goal;
 }
 
+
+boolean zslayer_usable(familiar fam){
+	if (!in_zombieSlayer)
+	{
+		return true;
+	}
+	if (contains_text(fam.attributes, "undead"))
+	{
+		return true;
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -218,5 +218,5 @@ boolean zombieSlayer_usable(familiar fam)
 	{
 		return true;
 	}
-	return contains_text(fam.attributes, "undead"));
+	return contains_text(fam.attributes, "undead");
 }

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -212,14 +212,11 @@ boolean zombieSlayer_acquireHP(int goal)
 }
 
 
-boolean zslayer_usable(familiar fam){
-	if (!in_zombieSlayer)
+boolean zombieSlayer_usable(familiar fam)
+{
+	if (!in_zombieSlayer())
 	{
 		return true;
 	}
-	if (contains_text(fam.attributes, "undead"))
-	{
-		return true;
-	}
-	return false;
+	return contains_text(fam.attributes, "undead"));
 }


### PR DESCRIPTION
Adds a function to check if a given familiar is actually useable in Zombie Slayer

## How Has This Been Tested?

It hasn't

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
