### PR TITLE
allow wearing non 100% kramco in delay zone and other

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -717,7 +717,11 @@ int handlePulls(int day)
 		}
 		if((my_primestat() == $stat[Muscle]) && !in_heavyrains() && !in_wotsf()) // no need for shields in way of the surprising fist
 		{
-			if((closet_amount($item[Fake Washboard]) == 0) && auto_is_valid($item[Fake Washboard]))
+			if(possessEquipment($item[familiar scrapbook]) && auto_is_valid($item[familiar scrapbook]) && my_class() != $class[Turtle Tamer])
+			{
+				//familiar scrapbook will probably be equipped in preference to Fake Washboard
+			}
+			else if((closet_amount($item[Fake Washboard]) == 0) && auto_is_valid($item[Fake Washboard]))
 			{
 				pullXWhenHaveY($item[Fake Washboard], 1, 0);
 			}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1435,7 +1435,8 @@ void auto_overdrinkGreenBeers()
 				ConsumeAction greenBeerAction = MakeConsumeAction(daily_special());
 				greenBeerAction.cafeId = daily_special().to_int();
 				greenBeerAction.it = $item[none];
-				int daily_special_limit = min(my_meat()/get_property("_dailySpecialPrice").to_int(), (inebriety_left()+11)/(daily_special().inebriety));
+				int beerMeat = my_meat() - (in_wotsf() ? meatReserve() : 0); //extra advs are almost always worth more, but meat is hard to get in wotsf
+				int daily_special_limit = min(beerMeat/get_property("_dailySpecialPrice").to_int(), (inebriety_left()+11)/(daily_special().inebriety));
 				for (int i=0; i < daily_special_limit; i++)
 				{
 					autoConsume(greenBeerAction);

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1844,11 +1844,15 @@ boolean auto_breakfastCounterVisit() {
 		auto_log_info("Going to the breakfast counter to grab/order a breakfast muffin.");
 		visit_url("place.php?whichplace=monorail&action=monorail_downtown");
 		run_choice(7); // Visit the Breakfast Counter
-		if (get_property("muffinOnOrder") != "" && item_amount(get_property("muffinOnOrder").to_item()) > 0)
+		if (get_property("muffinOnOrder") != "")
 		{
-			// workaround mafia not clearing the property occasionally
-			// see https://kolmafia.us/threads/ordering-a-muffin-at-the-breakfast-counter-doesnt-always-set-the-muffinonorder-property.26072/
-			set_property("muffinOnOrder", "");
+			cli_execute("refresh inv");
+			if (item_amount(get_property("muffinOnOrder").to_item()) > 0)
+			{
+				// workaround mafia not clearing the property occasionally
+				// see https://kolmafia.us/threads/ordering-a-muffin-at-the-breakfast-counter-doesnt-always-set-the-muffinonorder-property.26072/
+				set_property("muffinOnOrder", "");
+			}
 		}
 		if (!get_property("_muffinOrderedToday").to_boolean() && item_amount($item[earthenware muffin tin]) > 0) {
 			auto_log_info("Ordering a bran muffin for tomorrow to keep you regular.");

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -666,8 +666,8 @@ void finalizeMaximize(boolean speculative)
 
 	if (auto_haveKramcoSausageOMatic())
 	{
-		// Save the first 8 sausage goblins for delay burning
-		boolean saveGoblinForDelay = (auto_sausageFightsToday() < 8 && solveDelayZone() != $location[none]);
+		// Save the first 8 sausage goblins for delay burning, if current location isn't itself a delay zone after SoftblockDelay released
+		boolean saveGoblinForDelay = (auto_sausageFightsToday() < 8 && !zone_delay(my_location())._boolean && solveDelayZone() != $location[none]);
 		// don't interfere with backups unless they're equivalent or worse
 		boolean dontSausageBackups = auto_backupTarget() && !($monsters[sausage goblin,eldritch tentacle] contains get_property("lastCopyableMonster").to_monster());
 		// also don't equip Kramco when using Map the Monsters as sausage goblins override the NC

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3089,7 +3089,7 @@ boolean canBurnDelay(location loc)
 	{
 		return true;
 	}
-	else if (my_daycount() < 2 && (auto_haveVotingBooth() || auto_haveKramcoSausageOMatic()))
+	else if (my_daycount() < 2 && (auto_haveVotingBooth() || auto_haveKramcoSausageOMatic() || auto_haveBackupCamera()))
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3077,7 +3077,11 @@ boolean canBurnDelay(location loc)
 	{
 		return false;
 	}
-	if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 9)
+	if (auto_haveBackupCamera() && auto_backupUsesLeft() > 0)
+	{
+		return true;
+	}
+	else if (auto_haveKramcoSausageOMatic() && auto_sausageFightsToday() < 9)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2122,6 +2122,10 @@ boolean L11_mauriceSpookyraven()
 		{
 			bat_formBats();
 		}
+		if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
+		{
+			cli_execute("friars booze");
+		}
 		if (canSniff($monster[Possessed Wine Rack], $location[The Haunted Wine Cellar]) && auto_mapTheMonsters())
 		{
 			auto_log_info("Attemping to use Map the Monsters to olfact a Possessed Wine Rack.");

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -891,7 +891,7 @@ boolean L12_filthworms()
 	{
 		auto_log_info("We're going to yellow ray the stench glands.");
 	}
-	else		//could not guarentee stealing. check if it should be delayed otherwise buff item drops instead
+	else if(item_drop_modifier() < 900.0)	//could not guarentee stealing. check if it should be delayed otherwise buff item drops instead
 	{
 		if(have_effect($effect[Everything Looks Yellow]) > 0 && have_effect($effect[Everything Looks Yellow]) <= 100)
 		{


### PR DESCRIPTION
allow wearing non 100% kramco when adventuring in delay zone anyway
add backup camera to canBurnDelay to keep delay zones for backups

use friars booze buff for bottle of Chateau de Vinegar
do not delay filthworms if capped item
add conditions to pull Fake Washboard
limit meat spent on green beer in Surprising Fist
refresh inventory before checking muffin fail

## How Has This Been Tested?

run, keep delay zones for backups was not checked with backups left but it's same code as other delay burns

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
