### PR TITLE
add check for Palindome Stage 4 Status

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2649,8 +2649,12 @@ boolean L11_palindome()
 		}
 		if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
 			equip($slot[acc3], $item[Talisman o\' Namsilat]);
-		visit_url("place.php?whichplace=palindome&action=pal_drlabel");
-		visit_url("choice.php?pwd&whichchoice=872&option=1&photo1=2259&photo2=7264&photo3=7263&photo4=7265");
+
+		if (internalQuestStatus("questL11Palindome") < 4)
+		{
+			visit_url("place.php?whichplace=palindome&action=pal_drlabel");
+			visit_url("choice.php?pwd&whichchoice=872&option=1&photo1=2259&photo2=7264&photo3=7263&photo4=7265");
+		}
 
 		if (isActuallyEd())
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2650,7 +2650,7 @@ boolean L11_palindome()
 		if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
 			equip($slot[acc3], $item[Talisman o\' Namsilat]);
 
-		if (internalQuestStatus("questL11Palindome") < 4)
+		if (internalQuestStatus("questL11Palindome") <= 1)
 		{
 			visit_url("place.php?whichplace=palindome&action=pal_drlabel");
 			visit_url("choice.php?pwd&whichchoice=872&option=1&photo1=2259&photo2=7264&photo3=7263&photo4=7265");

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2650,7 +2650,7 @@ boolean L11_palindome()
 		if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
 			equip($slot[acc3], $item[Talisman o\' Namsilat]);
 
-		if (internalQuestStatus("questL11Palindome") <= 1)
+		if (internalQuestStatus("questL11Palindome") < 1)
 		{
 			visit_url("place.php?whichplace=palindome&action=pal_drlabel");
 			visit_url("choice.php?pwd&whichchoice=872&option=1&photo1=2259&photo2=7264&photo3=7263&photo4=7265");


### PR DESCRIPTION
Hi, this is my first PR. Am starting small, but please provide any feedback :)

# Description

I was getting stuck whenever I got to Palindome Stage 5 because it would throw `Whoops! You're not actually in a choice adventure` I think this is because it is trying to reacquire 2 Love Me Vol 2 when it should be continuing passed it, so I added a check for the internalQuestProgress 

## How Has This Been Tested?

I ran it this ascension and didnt get stuck

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
