### PR TITLE
restart clover usage when interrupted by June cleaver

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1451,7 +1451,7 @@ boolean cloverUsageRestart()
 	{
 		return false;
 	}
-	if(equipped_amount($item[June cleaver]) > 0 && $strings[Poetic Justice, Aunts not Ants, Beware of Aligator, Beware of Alligator, Teacher's Pet, Lost and Found, Summer Days, Bath Time, Delicious Sprouts, Hypnotic Master] contains get_property("lastEncounter"))
+	if(equipped_amount($item[June cleaver]) > 0 && $strings[Poetic Justice, Aunts not Ants, Beware of Aligator, Beware of Alligator, Teacher\'s Pet, Lost and Found, Summer Days, Bath Time, Delicious Sprouts, Hypnotic Master] contains get_property("lastEncounter"))
 	{
 		//got interrupted and should adventure again in same location
 		return true;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1445,6 +1445,20 @@ boolean cloverUsageInit()
 	return false;
 }
 
+boolean cloverUsageRestart()
+{
+	if(have_effect($effect[Lucky!]) == 0)
+	{
+		return false;
+	}
+	if(equipped_amount($item[June cleaver]) > 0 && $strings[Poetic Justice, Aunts not Ants, Beware of Aligator, Beware of Alligator, Teacher's Pet, Lost and Found, Summer Days, Bath Time, Delicious Sprouts, Hypnotic Master] contains get_property("lastEncounter"))
+	{
+		//got interrupted and should adventure again in same location
+		return true;
+	}
+	return false;
+}
+
 boolean cloverUsageFinish()
 {
 	if(have_effect($effect[Lucky!]) > 0)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1586,6 +1586,7 @@ boolean isGhost(monster mon);
 boolean isProtonGhost(monster mon);
 int cloversAvailable();
 boolean cloverUsageInit();
+boolean cloverUsageRestart();
 boolean cloverUsageFinish();
 boolean isHermitAvailable();
 boolean isGalaktikAvailable();

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -243,6 +243,7 @@ boolean LX_acquireFamiliarLeprechaun()
 					{
 						cloverUsageInit();
 						boolean adventure = autoAdv($location[The Spooky Forest]);
+						if(cloverUsageRestart()) adventure = autoAdv($location[The Spooky Forest]);
 						cloverUsageFinish();
 						if(adventure) return true;
 					}

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -953,6 +953,7 @@ boolean LX_robot_powerlevel()
 
 			cloverUsageInit();
 			boolean adv_spent = autoAdv(whereTo);
+			if(cloverUsageRestart()) adv_spent = autoAdv(whereTo);
 			cloverUsageFinish();
 			if(adv_spent) return true;
 		}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -352,6 +352,7 @@ boolean L8_getMineOres()
 	{
 		cloverUsageInit();
 		autoAdvBypass(270, $location[Itznotyerzitz Mine]);
+		if(cloverUsageRestart()) autoAdvBypass(270, $location[Itznotyerzitz Mine]);
 		cloverUsageFinish();
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -390,6 +390,10 @@ boolean L9_aBooPeak()
 	{
 		cloverUsageInit();
 		autoAdvBypass(296, $location[A-Boo Peak]);
+		if(cloverUsageRestart())
+		{
+			autoAdvBypass(296, $location[A-Boo Peak]);
+		}
 		if(cloverUsageFinish())
 		{
 			set_property("auto_abooclover", false);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1349,6 +1349,7 @@ boolean L11_unlockHiddenCity()
 			//use clover to get 2x Stone Wool
 			cloverUsageInit();
 			boolean retval = autoAdv($location[The Hidden Temple]);
+			if(cloverUsageRestart()) retval = autoAdv($location[The Hidden Temple]);
 			cloverUsageFinish();
 			return retval;
 		}
@@ -2285,6 +2286,7 @@ boolean L11_redZeppelin()
 			}
 			cloverUsageInit();
 			boolean retval = autoAdv(1, $location[A Mob of Zeppelin Protesters]);
+			if(cloverUsageRestart()) retval = autoAdv(1, $location[A Mob of Zeppelin Protesters]);
 			cloverUsageFinish();
 			return retval;
 		}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1842,6 +1842,7 @@ boolean L12_themtharHills()
 		//use clover to get inhaler
 		cloverUsageInit();
 		boolean retval = autoAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
+		if(cloverUsageRestart()) retval = autoAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
 		cloverUsageFinish();
 		return retval;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1762,6 +1762,7 @@ boolean L13_towerNSNagamar()
 	{
 		cloverUsageInit();
 		autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
+		if(cloverUsageRestart()) autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
 		cloverUsageFinish();
 		if(creatable_amount($item[Wand Of Nagamar]) > 0)
 		{


### PR DESCRIPTION
restart clover usage when interrupted by June cleaver adventures, instead of aborting

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
