### PR TITLE
Parka check for torso

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -873,7 +873,7 @@ boolean canYellowRay(monster target)
 		}
 
 		// parka has 100 turn cooldown, but is a free-kill and has 0 meat cost, so prioritised over yellow rocket
-		if(auto_hasParka() && hasTorso())
+		if(auto_hasParka() && auto_is_valid($skill[Spit jurassic acid]) && hasTorso())
 		{
 			return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "";
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -708,7 +708,7 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 		{
 			return "item " + $item[yellow rocket]; // 75 turns & 250 meat - better than wasting a freekill on an already free monster
 		}
-		if(inCombat ? have_skill($skill[Spit jurassic acid]) : auto_hasParka() && auto_is_valid($skill[Spit jurassic acid]))
+		if(inCombat ? have_skill($skill[Spit jurassic acid]) : auto_hasParka() && auto_is_valid($skill[Spit jurassic acid]) && hasTorso())
 		{
 			return "skill " + $skill[Spit jurassic acid]; //100 Turns and free kill
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -336,7 +336,7 @@ boolean auto_hasParka()
 
 boolean auto_configureParka(string tag)
 {
-	if (!auto_hasParka())
+	if (!auto_hasParka() || !hasTorso())
 	{
 		return false;
 	}
@@ -351,7 +351,7 @@ boolean auto_configureParka(string tag)
 
 boolean auto_handleParka()
 {
-	if (!auto_hasParka())
+	if (!auto_hasParka() || !hasTorso())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

User in discord reported that Avatar of Boris was trying to use parka. This is bad because Boris can't wear shirts.

Culprit was `auto_handleParka()`. Added check for torso there plus a couple other spots.

Fixes # (issue)

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
