### PR TITLE
stillsuit recovery hotfix

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -338,11 +338,31 @@ void utilizeStillsuit() {
 		}
 		return $familiar[none];
 	}
-	equip(sweetestSweatFamiliar(),$item[tiny stillsuit]);
-
-	if(is100FamRun())
+	familiar chosenStillsuitFamiliar = sweetestSweatFamiliar();
+	if(familiar_equipped_equipment(chosenStillsuitFamiliar) != $item[tiny stillsuit])
 	{
-		handleFamiliar(get_property("auto_100familiar").to_familiar());	//just make extra sure this didnt break 100 familiar runs but familiar should not have been swapped
+		if(item_amount($item[tiny stillsuit]) == 0)
+		{
+			foreach f in $familiars[]
+			{
+				if (have_familiar(f) && familiar_equipped_equipment(f) == $item[tiny stillsuit])
+				{	//recover the stillsuit
+					visit_url("familiar.php?action=unequip&pwd&famid=" + f.to_int(), true);
+				}
+			}
+		}
+		if(item_amount($item[tiny stillsuit]) > 0)
+		{
+			equip(chosenStillsuitFamiliar,$item[tiny stillsuit]);
+		}
+		else
+		{
+			auto_log_warning("Failed to recover tiny stillsuit from the familiar mafia thinks is wearing it");
+		}
+		if(is100FamRun())
+		{
+			handleFamiliar(get_property("auto_100familiar").to_familiar());	//just make extra sure this didnt break 100 familiar runs but familiar should not have been swapped
+		}
 	}
 }
 


### PR DESCRIPTION
recover stillsuit before trying to equip it, I don't know if it's the most efficient way to do it but seems needed to properly run with the last stillsuit changes after a familiar uses different equipment

## How Has This Been Tested?
not tested

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
