### PR TITLE
Autumnaton path restrictions

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -443,7 +443,7 @@ boolean auto_handleParka()
 
 boolean auto_hasAutumnaton()
 {
-	return get_property("hasAutumnaton").to_boolean();
+	return get_property("hasAutumnaton").to_boolean() && auto_is_valid($item[autumn-aton]) && !in_pokefam();
 }
 
 // only valid when autumnaton is not current out on a quest


### PR DESCRIPTION
# Description

Autumnaton can not be used in g-lover or pokefam

## How Has This Been Tested?
validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
