### PR TITLE
Move prep for smut orcs to pre adv

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -207,6 +207,11 @@ boolean auto_pre_adventure()
 		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
 	}
 
+	if(place == $location[The Smut Orc Logging Camp])
+	{
+		prepareForSmutOrcs();
+	}
+
 	boolean junkyardML;
 	if($locations[Next to that Barrel with something Burning In It, Near an Abandoned Refrigerator, Over where the Old Tires Are, Out by that Rusted-Out Car] contains place)
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3721,14 +3721,14 @@ boolean autoFlavour(location place)
 			setFlavour($element[none]);
 			return true;
 		case $location[The Ice Hotel]:
-			if(get_property("walfordBucketItem") == "rain" && equipped_item($slot[off-hand]) == $item[Walford's bucket])
+			if(get_property("walfordBucketItem") == "rain" && equipped_item($slot[off-hand]) == $item[Walford\'s bucket])
 			{
 				setFlavour($element[hot]); // doing 100 hot damage in a fight will fill bucket faster
 				return true;
 			}
 			// INTENTIONAL LACK OF BREAK
 		case $location[VYKEA]:
-			if(get_property("walfordBucketItem") == "ice" && equipped_item($slot[off-hand]) == $item[Walford's bucket])
+			if(get_property("walfordBucketItem") == "ice" && equipped_item($slot[off-hand]) == $item[Walford\'s bucket])
 			{
 				setFlavour($element[cold]);
 				return true;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -960,6 +960,7 @@ boolean L9_leafletQuest();
 void L9_chasmMaximizeForNoncombat();
 int fastenerCount();
 int lumberCount();
+void prepareForSmutOrcs();
 boolean L9_chasmBuild();
 boolean L9_aBooPeak();
 int hedgeTrimmersNeeded();

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -564,8 +564,7 @@ void auto_autumnatonQuest()
 		if(auto_sendAutumnaton($location[Sonofa Beach])) return;
 	}
 
-	// camel spit is a good option for getting hedge trimmers
-	if(hedgeTrimmersNeeded() > 0 && !have_familiar($familiar[Melodramedary]))
+	if(hedgeTrimmersNeeded() > 0)
 	{
 		if(auto_sendAutumnaton($location[Twin Peak])) return;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -140,41 +140,16 @@ int lumberCount()
 	return base;
 }
 
-boolean L9_chasmBuild()
+void prepareForSmutOrcs()
 {
-	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= 30)
-	{
-		return false;
-	}
 
-	if (shenShouldDelayZone($location[The Smut Orc Logging Camp]))
+	if(lumberCount() >= 30 && fastenerCount() >= 30)
 	{
-		auto_log_debug("Delaying Logging Camp in case of Shen.");
-		return false;
-	}
-	if(robot_delay("chasm"))
-	{
-		return false;	//delay for You, Robot path
-	}
-	if(auto_hasAutumnaton() && !isAboutToPowerlevel() && $location[The Smut Orc Logging Camp].turns_spent > 0)
-	{
-		// delay zone to allow autumnaton to grab bridge parts
-		// unless we have ran out of other stuff to do
-		return false;
-	}
-
-	if (LX_loggingHatchet()) { return true; } // turn free, might save some adventures. May as well get it if we can.
-
-	auto_log_info("Chasm time", "blue");
-	
-	// make sure our progress count is correct before we do anything.
-	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-
-	if (auto_is_valid($item[Smut Orc Keepsake Box]) && get_property("chasmBridgeProgress").to_int() < 30 && auto_cargoShortsOpenPocket(666))
-	{
- 		// fight Smut Orc Pervert from Cargo Shorts for a Smut Orc Keepsake Box
- 		use(1, $item[Smut Orc Keepsake Box]);
-		return true;
+		// must be here for shen snake and quest objective is already done
+		// set blech NC and don't bother prepping for the zone
+		auto_log_info("Adventuring at Smut Orc Logging Camp when quest is done. Skipping preparing to maximize zone progress.", "blue");
+		set_property("choiceAdventure1345", 1);
+		return;
 	}
 
 	// -Combat is useless here since NC is triggered by killing Orcs...So we kill orcs better!
@@ -246,13 +221,7 @@ boolean L9_chasmBuild()
 		// TODO: once explicit formulas are spaded, use simulated maximizer
 		// to determine best approach.
 		L9_chasmMaximizeForNoncombat();
-		autoAdv(1, $location[The Smut Orc Logging Camp]);
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-		if(get_property("chasmBridgeProgress").to_int() >= 30)
-		{
-			visit_url("place.php?whichplace=highlands&action=highlands_dude");
-		}
-		return true;
+		return;
 	}
 
 	if(in_plumber() && possessEquipment($item[frosty button]))
@@ -280,18 +249,7 @@ boolean L9_chasmBuild()
 			autoEquip($item[Logging Hatchet]);
 		}
 
-		autoAdv(1, $location[The Smut Orc Logging Camp]);
-
-		if(item_amount($item[Smut Orc Keepsake Box]) > 0 && auto_is_valid($item[Smut Orc Keepsake Box]))
-		{
-			use(1, $item[Smut Orc Keepsake Box]);
-		}
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
-		if(get_property("chasmBridgeProgress").to_int() >= 30)
-		{
-			visit_url("place.php?whichplace=highlands&action=highlands_dude");
-		}
-		return true;
+		return;
 	}
 
 	int need = (30 - get_property("chasmBridgeProgress").to_int()) / 5;
@@ -316,15 +274,63 @@ boolean L9_chasmBuild()
 			autoEquip($item[Logging Hatchet]);
 		}
 
-		autoAdv(1, $location[The Smut Orc Logging Camp]);
-		if(item_amount($item[Smut Orc Keepsake Box]) > 0  && auto_is_valid($item[Smut Orc Keepsake Box]))
-		{
-			use(1, $item[Smut Orc Keepsake Box]);
-		}
-		visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
+		return;
+	}
+}
+
+boolean L9_chasmBuild()
+{
+	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= 30)
+	{
+		return false;
+	}
+
+	if (shenShouldDelayZone($location[The Smut Orc Logging Camp]))
+	{
+		auto_log_debug("Delaying Logging Camp in case of Shen.");
+		return false;
+	}
+	if(robot_delay("chasm"))
+	{
+		return false;	//delay for You, Robot path
+	}
+	if(auto_hasAutumnaton() && !isAboutToPowerlevel() && $location[The Smut Orc Logging Camp].turns_spent > 0)
+	{
+		// delay zone to allow autumnaton to grab bridge parts
+		// unless we have ran out of other stuff to do
+		return false;
+	}
+
+	if (LX_loggingHatchet()) { return true; } // turn free, might save some adventures. May as well get it if we can.
+
+	auto_log_info("Chasm time", "blue");
+	
+	// make sure our progress count is correct before we do anything.
+	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
+
+	// use any keepsake boxes we have
+	if(item_amount($item[Smut Orc Keepsake Box]) > 0 && auto_is_valid($item[Smut Orc Keepsake Box]))
+	{
+		use(1, $item[Smut Orc Keepsake Box]);
+	}
+
+	// finish chasm if we can
+	if(get_property("chasmBridgeProgress").to_int() >= 30)
+	{
+		visit_url("place.php?whichplace=highlands&action=highlands_dude");
 		return true;
 	}
-	visit_url("place.php?whichplace=highlands&action=highlands_dude");
+
+	if (auto_is_valid($item[Smut Orc Keepsake Box]) && get_property("chasmBridgeProgress").to_int() < 30 && auto_cargoShortsOpenPocket(666))
+	{
+ 		// fight Smut Orc Pervert from Cargo Shorts for a Smut Orc Keepsake Box
+ 		use(1, $item[Smut Orc Keepsake Box]);
+		return true;
+	}
+
+	// prepareForSmutOrcs() called in pre-adv
+	autoAdv(1, $location[The Smut Orc Logging Camp]);
+
 	return true;
 }
 
@@ -681,6 +687,13 @@ boolean L9_twinPeak()
 
 	if (get_property("twinPeakProgress").to_int() >= 15)
 	{
+		return false;
+	}
+
+	if(auto_hasAutumnaton() && !isAboutToPowerlevel() && $location[Twin Peak].turns_spent > 0)
+	{
+		// delay zone to allow autumnaton to grab rusty hedge trimmers
+		// unless we have ran out of other stuff to do
 		return false;
 	}
 		


### PR DESCRIPTION
# Description

Fixes #1219 by breaking out logic to prep for smut orc logging camp into it's own function. Then calling this new function in pre-adv. This way regardless of why we are adving in the logging camp (normally or via shen snakes), we always prep. Added check to not prep if bridge progress is complete.

Also adjusted autumnaton going to twin peaks even if user has camel. 

## How Has This Been Tested?

In normal standard seal clubber run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
