### PR TITLE
stillsuit doesn't need to be equipped to drink

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -106,12 +106,6 @@ boolean autoDrink(int howMany, item toDrink, boolean silent)
 	{
 		// record adv gain for more detailed reporting to user
 		int stillsuitAdvs = auto_expectedStillsuitAdvs();
-		if(familiar_equipped_equipment(my_familiar()) != $item[tiny stillsuit])
-		{
-			// allow pre adv to reequip appropriate fam equip
-			equip(my_familiar(), $item[tiny stillsuit]);
-		}
-		
 		visit_url("inventory.php?action=distill&pwd");
 		visit_url("choice.php?pwd&whichchoice=1476&option=1");
 		handleTracker(toDrink, stillsuitAdvs + "Advs", "auto_drunken");


### PR DESCRIPTION
stillsuit doesn't need to be equipped to drink, also avoids having to add the extra steps to recover from another terrarium familiar

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
