### PR TITLE
add dough for cookbookbat and frilly skirt for LKS to knoll sign

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -604,10 +604,19 @@ boolean auto_spoonReadyToTuneMoon()
 			// we want to get the meatcar via the knoll store
 			return false;
 		}
-		if((auto_get_campground() contains $item[Asdon Martin Keyfob]) && is_unrestricted($item[Asdon Martin Keyfob]))
+		if((auto_get_campground() contains $item[Asdon Martin Keyfob]) && is_unrestricted($item[Asdon Martin Keyfob]) ||
+		   (auto_is_valid($familiar[cookbookbat]) && have_familiar($familiar[cookbookbat])))
 		{
 			// we want to get the bugbear outfit before switching away for easy bread access
 			if(!buyUpTo(1, $item[bugbear beanie]) || !buyUpTo(1, $item[bugbear bungguard]))
+			{
+				return false;
+			}
+		}
+		// We want the frilly skirt in LKS
+		if(in_lowkeysummer())
+		{
+			if(!buyUpTo(1, $item[frilly skirt]))
 			{
 				return false;
 			}


### PR DESCRIPTION
# Description

Autoscend optionall uses the hewn moon rune spoon to tune the moon. Before doing that, it checks it has everything it wants from the sign you're leaving. This adds two new conditions:
1) If you have a cookbookbat, it'll buy a bugbear outfit before moving signs, so it can still buy dough.
2) If you are in LKS, it'll make sure you have a frilly skirt for the pirate unlock.

Fixes # (issue)

## How Has This Been Tested?

Two runs moving from knoll sign to canadia sign.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
