### PR TITLE
Adds missing commas to defaultMaximizeStatement

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -572,11 +572,11 @@ string defaultMaximizeStatement()
 		//>= level 12 or almost there, more offstat experience may be needed for the war outfit (requires 70 mox and 70 mys)
 		if(my_basestat($stat[moxie]) < 70 && get_property("warProgress") != "finished")
 		{
-			res += "10moxie experience,3moxie experience percent";
+			res += ",10moxie experience,3moxie experience percent";
 		}
 		if(my_basestat($stat[mysticality]) < 70 && get_property("warProgress") != "finished")
 		{
-			res += "10mysticality experience,3mysticality experience percent";
+			res += ",10mysticality experience,3mysticality experience percent";
 		}
 	}
 


### PR DESCRIPTION
# Description

Adds missing commas to defaultMaximizeStatement

## How Has This Been Tested?

Running autoscend with mainstat > 122

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
