### PR TITLE
skip unavailable autumn-aton requests

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -454,6 +454,12 @@ boolean auto_autumnatonCanAdv(location canAdventureInloc)
 		return false;
 	}
 
+	if(canAdventureInloc.turns_spent == 0 && !($locations[Noob Cave, The Haunted Pantry, The Sleazy Back Alley] contains canAdventureInloc))
+	{
+		//zones have turn spent requirement except initial three
+		return false;
+	}
+
 	if(canAdventureInloc == $location[8-bit realm] && possessEquipment($item[continuum transfunctioner]) && auto_is_valid($item[continuum transfunctioner]))
 	{
 		equip($item[continuum transfunctioner]);


### PR DESCRIPTION
# Description

skips multiple url requests every turn for autumn-aton zones when wanted zones have no turn spent

## How Has This Been Tested?

run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
