### PR TITLE
prevent infinite loop by discount pants when buying from NPC store

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1578,6 +1578,17 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		return negative;
 	}
 
+	void recover_discount_pants()
+	{
+		foreach discountpants in $items[designer sweatpants,Travoltan trousers]
+		{
+			if(closet_amount(discountpants) > 0)
+			{
+				take_closet(1,discountpants);
+			}
+		}
+	}
+
 	auto_log_info("Target "+resource_type+" => "+goal+" - Considering restore options at " + my_hp() + "/" + my_maxhp() + " HP with " + my_mp() + "/" + my_maxmp() + " MP", "blue");
 	auto_log_info("Active Negative Effects => " + list_to_string(negative_effects()));
 
@@ -1604,6 +1615,30 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		boolean success = false;
 		foreach i, o in options
 		{
+			if(o.metadata.type == "item" && item_amount(to_item(o.metadata.name)) == 0)	//prevent infinite loop by discount pants when buying from NPC store
+			{
+				foreach discountpants in $items[designer sweatpants,Travoltan trousers]
+				{
+					if(available_amount(discountpants) > 0)
+					{
+						boolean mustnotpants = false;
+						cli_execute("whatif equip " + discountpants + "; quiet");
+						if(resource_type == "hp" && goal > numeric_modifier("_spec", "Buffed HP Maximum"))
+						{
+							mustnotpants = true;
+						}
+						if(resource_type == "mp" && goal > numeric_modifier("_spec", "Buffed MP Maximum"))
+						{
+							mustnotpants = true;
+						}
+						if(mustnotpants)
+						{
+							auto_log_info("Avoiding any discount pants restore loops");
+							put_closet(1,discountpants);	//yes this was the recommended and only? way to make mafia not auto equip the discount pants
+						}
+					}
+				}
+			}
 			use_opportunity_blood_skills(o.vars["hp_restored_per_use"], my_hp()+o.vars["hp_total_restored"]);
 			success = use_restore(o.metadata, meat_reserve, useFreeRests);
 			if(success)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1619,7 +1619,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 			{
 				foreach discountpants in $items[designer sweatpants,Travoltan trousers]
 				{
-					if(available_amount(discountpants) > 0)
+					if(item_amount(discountpants) > 0)
 					{
 						boolean mustnotpants = false;
 						cli_execute("whatif equip " + discountpants + "; quiet");

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1654,9 +1654,11 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		if(!success)
 		{
 			auto_log_warning("Target "+resource_type+" => " + goal + " - Uh oh. All restore options tried ("+count(options)+") failed. Sorry.", "red");
+			recover_discount_pants();
 			return false;
 		}
 	}
+	recover_discount_pants();
 	return true;
 }
 


### PR DESCRIPTION
if pants increase max resource and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource so will buy restore item and auto discount pants to buy restore items will lower current resource and out of meat so technically it's not infinite but you get the idea


## How Has This Been Tested?
run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
