### PR TITLE
Add basic cookbookbat support

### DIFF
--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -2,6 +2,8 @@
 #
 # First we grab up to small amount of various specific drops.
 #
+# every 2 cookbookbat ingredients generate a size 1 density 7 food. prioritize having enough to craft 1.
+Cookbookbat	item:Vegetable of Jarlsberg<2;item:Yeast of Boris<2;item:St. Sneaky Pete's Whey<2
 # 5 turkey booze drops a day. each is size 1 and density of either 5, 5.5, or 6
 Fist Turkey	prop:_turkeyBooze<5
 # every 10 yellow pixels make a size 2 density 5 food or drink. unlimited drops per day. prioritize having enough to craft 2.
@@ -31,6 +33,10 @@ Melodramedary	prop:camelSpit<100
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
 Intergnat	item:BACON<150
 #
+# Generate extra cookbookbat ingredients to make sure we have enough stock on hand for higher-tier foods
+Cookbookbat	item:Vegetable of Jarlsberg<4
+Cookbookbat	item:Yeast of Boris<4
+Cookbookbat	item:St. Sneaky Pete's Whey<4
 # Below this lines drops are not needed more of for the run and are just grabbing for profit.
 # Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
 #

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -22,58 +22,64 @@ boss	5	Mosquito
 #
 # First we grab up to small amount of various specific drops.
 #
+# every 2 cookbookbat ingredients generate a size 1 density 7 food. prioritize having enough to craft 1.
+drop	0	Cookbookbat	item:Vegetable of Jarlsberg<2;item:Yeast of Boris<2;item:St. Sneaky Pete's Whey<2
 # 5 turkey booze drops a day. each is size 1 and density of either 5, 5.5, or 6
-drop	0	Fist Turkey	prop:_turkeyBooze<5
+drop	1	Fist Turkey	prop:_turkeyBooze<5
 # every 10 yellow pixels make a size 2 density 5 food or drink. unlimited drops per day. prioritize having enough to craft 2.
 # drops 1 per combat with chance of 2nd if wearing familiar specific equip
-drop	1	Puck Man	item:Yellow Pixel<20
-drop	2	Ms. Puck Man	item:Yellow Pixel<20
+drop	2	Puck Man	item:Yellow Pixel<20
+drop	3	Ms. Puck Man	item:Yellow Pixel<20
 # 1st wax drop per run only takes 5 combats, afterwards 30. makes a single size 2 density 4.25 food or drink 
-drop	3	Optimistic Candle	prop:optimisticCandleProgress>=25
+drop	4	Optimistic Candle	prop:optimisticCandleProgress>=25
 # 1st robin egg per run only takes 5 combats, afterwards 30. potion that gives all res +3
-drop	4	Rockin' Robin	prop:rockinRobinProgress>=25
+drop	5	Rockin' Robin	prop:rockinRobinProgress>=25
 # 1st burning newspaper per run only takes 5 combats, afterwards 30. can be used for +5 adv on dayroll back equip
-drop	5	Garbage Fire	prop:garbageFireProgress>=25
+drop	6	Garbage Fire	prop:garbageFireProgress>=25
 # Hot ashes can make a potion that gives +15 ML for 15 adv. keep 1 of them in stock
-drop	6	Galloping Grill	prop:_hotAshesDrops<5;item:hot ashes<1
+drop	7	Galloping Grill	prop:_hotAshesDrops<5;item:hot ashes<1
 #
 # get substats from fist turkey in The Source path
-drop	7	Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
-drop	8	Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
-drop	9	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
+drop	8	Fist Turkey	prop:_turkeyMuscle<5;mainstat:Muscle;path:The Source
+drop	9	Fist Turkey	prop:_turkeyMyst<5;mainstat:Mysticality;path:The Source
+drop	10	Fist Turkey	prop:_turkeyMoxie<5;mainstat:Moxie;path:The Source
 #
 # Cat Burglar can charge up heists. 30 combats give it 2 charges.
-drop	10	Cat Burglar	prop:_catBurglarCharge<30
+drop	11	Cat Burglar	prop:_catBurglarCharge<30
 #
 # Melodramedary generating spit seems good
-drop	11	Melodramedary	prop:camelSpit<100
+drop	12	Melodramedary	prop:camelSpit<100
 #
 # Drops BACON every battle. 100 bacon makes size 15 density 4.83 food. 150 bacon can get you a fat loot token
-drop	12	Intergnat	item:BACON<150
+drop	13	Intergnat	item:BACON<150
 #
+# Generate extra cookbookbat ingredients to make sure we have enough stock on hand for higher-tier foods
+drop	14	Cookbookbat	item:Vegetable of Jarlsberg<4
+drop	15	Cookbookbat	item:Yeast of Boris<4
+drop	16	Cookbookbat	item:St. Sneaky Pete's Whey<4
 # Below this lines drops are not needed more of for the run and are just grabbing for profit.
 # Most are useful in limited amounts which we already grab via boolean autoChooseFamiliar(location place)
 #
 # density 1.875 size 4 spleen consumables. boolean autoChooseFamiliar(location place) will already grab the amount needed for spleen
 # Here they are only used to grab extras.
-drop	13	Grim Brother	prop:_grimFairyTaleDrops<5
-drop	14	Pair of Stomping Boots	!path:G-Lover;prop:_bootStomps<7
-drop	15	Baby Sandworm	prop:_aguaDrops<5
-drop	16	Bloovian Groose	prop:_grooseDrops<5
-drop	17	Golden Monkey	prop:_powderedGoldDrops<5
-drop	18	Unconscious Collective	prop:_dreamJarDrops<5
+drop	17	Grim Brother	prop:_grimFairyTaleDrops<5
+drop	18	Pair of Stomping Boots	!path:G-Lover;prop:_bootStomps<7
+drop	19	Baby Sandworm	prop:_aguaDrops<5
+drop	20	Bloovian Groose	prop:_grooseDrops<5
+drop	21	Golden Monkey	prop:_powderedGoldDrops<5
+drop	22	Unconscious Collective	prop:_dreamJarDrops<5
 # psychoanalytic jar 1 per day.
-drop	19	Angry Jung Man	prop:_jungDrops<1
+drop	23	Angry Jung Man	prop:_jungDrops<1
 # grimstone mask 1 per day
-drop	20	Grimstone Golem	prop:_grimstoneMaskDrops<1
+drop	24	Grimstone Golem	prop:_grimstoneMaskDrops<1
 # tales of spelunking 1 per day
-drop	21	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
+drop	25	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 # can drop 5 devilish folio a day
-drop	22	Blavious Kloop	prop:_kloopDrops<5
+drop	26	Blavious Kloop	prop:_kloopDrops<5
 # can drop 5 absinthe a day
-drop	23	Green Pixie	prop:_absintheDrops<5
+drop	27	Green Pixie	prop:_absintheDrops<5
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
-drop	24	Galloping Grill	prop:_hotAshesDrops<5
+drop	28	Galloping Grill	prop:_hotAshesDrops<5
 
 # We want to delevel, but don't want to deal damage
 gremlins	0	Nosy Nose

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -911,7 +911,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	boolean[item] blacklist;
 	boolean[item] craftable_blacklist;
 
-	foreach it in $items[Cursed Punch, Unidentified Drink, FantasyRealm turkey leg, FantasyRealm mead]
+	foreach it in $items[Cursed Punch, Unidentified Drink, FantasyRealm turkey leg, FantasyRealm mead, Pizza of Legend, Calzone of Legend, Deep Dish of Legend]
 	{
 		blacklist[it] = true;
 	}


### PR DESCRIPTION
# Description

Add cookbookbat to drop familiars so that we generate ingredients, first prioritizing enough to be able to make a single tier 2 food and then generating excess ingredients so we can make multiple or make higher tier foods.

Prevent autoscend from ever trying to eat the 1x/ascension legendary Cookbookbat foods too, as 1) we don't have logic in place to stop trying to eat them after the 1st one 2) the player may wish to save them for aftercore or other purposes.

## How Has This Been Tested?

I've only done a single Standard day with this added (so not extensive testing, but also not a very complex change). During that day I generated significantly more turns – in my previous runs, it was using a lot of smiling rat and macaroni duck, and nearly all of those turns used Cookbookbat instead. The lost stat familiar turns are highly outweighed by the extra turngen from Cookbookbat, but let me know if there are other edge cases that should be considered.

I chose to put generating a single food above the existing entries in the list since the bat food has higher density. Then I was really conservative with the excess ingredients, placing it at the bottom of the list of things that matter in-run. Let me know if you have any feedback on how to improve the ordering.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
