### PR TITLE
add divine champagne popppers as a banish

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -677,6 +677,10 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "item " + $item[Deathchucks];
 	}
+	if((item_amount($item[divine champagne popper]) > keep) && (!(used contains "divine champagne popper"))&& auto_is_valid($item[divine champagne popper]))
+	{
+		return "item " + $item[divine champagne popper];
+	}
 
 	return "";
 }


### PR DESCRIPTION
# Description

Adds divine champagne popper as a banisher

Fixes # (issue)

## How Has This Been Tested?

Several LKS runs. They're mostly used in the pyramid chambers once other stuff has run out. They're properly tracked on the relay status page as well.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
