### PR TITLE
don't try to join the pirate crew when the war is in progress

### DIFF
--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -855,6 +855,9 @@ boolean LX_joinPirateCrew() {
 	if (internalQuestStatus("questM12Pirate") > 4) {
 		return false;
 	}
+	if (internalQuestStatus("questL12War") == 1) {
+		return false;
+	}
 	if (!possessOutfit("Swashbuckling Getup", true)) {
 		auto_log_info("Can not equip, or do not have the Swashbuckling Getup. Delaying.", "red");
 		return false;


### PR DESCRIPTION
# Description

During Low Key Summer, we need to do the pirates unlock and join the crew. This isn't possible when the Island war is in Progress. This could previously cause a halt in the script.

Fixes # (issue)

## How Has This Been Tested?

Several HC LKS runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
