### PR TITLE
don't delay filthworms if level 11 quest blocked

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -901,7 +901,14 @@ boolean L12_filthworms()
 			if(get_property("questL11MacGuffin") != "finished")
 			{
 				//level 11 quest not finished, filthworms can wait
-				delayFilthworms = true;
+				if(isAboutToPowerlevel())
+				{
+					auto_log_info("Proceeding with filthworms because something seems to be holding up the level 11 quest.");
+				}
+				else
+				{
+					delayFilthworms = true;
+				}
 			}
 			else if(auto_warSide() == "fratboy" && get_property("hippiesDefeated").to_int() < 64)
 			{


### PR DESCRIPTION
level 11 quest shouldn't get blocked now, but this is better in case of future changes to level 11


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
