### PR TITLE
8-Bit Realm Changes

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -10,7 +10,6 @@ pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-Cursed
 Pygmy Janitor	loc:The Hidden Park;!tavern:true;!itemdropcapped:20=book of matches
 Quiet Healer	!prop:questL10Garbage=finished
 Tomb Rat
-Blooper	loc:8-Bit Realm
 Bob Racecar	!sniffed:Racecar Bob
 Racecar Bob	!sniffed:Bob Racecar
 Government Scientist	class:Ed the Undying

--- a/BUILD/settings_extra/post.dat
+++ b/BUILD/settings_extra/post.dat
@@ -1,6 +1,5 @@
 auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
 auto_cookie	integer	HCCS Only: Tracks fortune cookie.
-auto_crackpotjar	string	Status of Crackpot Mystic Jar of Psychoses
 auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
 auto_day_init	string	Current daycount if we finished initializing today.
 auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -121,49 +121,48 @@ sniff	8	pygmy witch accountant	loc:The Hidden Apartment Building;effect:Thrice-C
 sniff	9	Pygmy Janitor	loc:The Hidden Park;!tavern:true;!itemdropcapped:20=book of matches
 sniff	10	Quiet Healer	!prop:questL10Garbage=finished
 sniff	11	Tomb Rat
-sniff	12	Blooper	loc:8-Bit Realm
-sniff	13	Bob Racecar	!sniffed:Racecar Bob
-sniff	14	Racecar Bob	!sniffed:Bob Racecar
-sniff	15	Government Scientist	class:Ed the Undying
-sniff	16	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
-sniff	17	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
-sniff	18	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
-sniff	19	Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
-sniff	20	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
-sniff	21	Possessed Wine Rack
-sniff	22	Blue Oyster cultist
-sniff	23	Dirty Old Lihc	prop:cyrptNicheEvilness>17
-sniff	24	Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
-sniff	25	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
-sniff	26	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
-sniff	27	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
-sniff	28	Serialbus	item:bus pass<4
-sniff	29	CH Imp	item:imp air<4
-sniff	30	Camel Toe	!sniffed:Skinflute
-sniff	31	Skinflute	!sniffed:Camel Toe
-sniff	32	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
+sniff	12	Bob Racecar	!sniffed:Racecar Bob
+sniff	13	Racecar Bob	!sniffed:Bob Racecar
+sniff	14	Government Scientist	class:Ed the Undying
+sniff	15	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
+sniff	16	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
+sniff	17	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
+sniff	18	Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
+sniff	19	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
+sniff	20	Possessed Wine Rack
+sniff	21	Blue Oyster cultist
+sniff	22	Dirty Old Lihc	prop:cyrptNicheEvilness>17
+sniff	23	Possibility Giant	loc:The Castle in the Clouds in the Sky (Ground Floor);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
+sniff	24	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	25	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	26	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
+sniff	27	Serialbus	item:bus pass<4
+sniff	28	CH Imp	item:imp air<4
+sniff	29	Camel Toe	!sniffed:Skinflute
+sniff	30	Skinflute	!sniffed:Camel Toe
+sniff	31	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
 # Unlocking Knob Menagerie
-sniff	33	Knob Goblin Very Mad Scientist	loc:Cobb's Knob Laboratory;item:Cobb's Knob Menagerie key<1;turnsspent:Cobb's Knob Laboratory>7
+sniff	32	Knob Goblin Very Mad Scientist	loc:Cobb's Knob Laboratory;item:Cobb's Knob Menagerie key<1;turnsspent:Cobb's Knob Laboratory>7
 # Pirate quest F'c'le's last missing item
-sniff	34	cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
-sniff	35	creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
-sniff	36	curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
+sniff	33	cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
+sniff	34	creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
+sniff	35	curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
 # Bugbear Invasion Wanderers
-sniff	37	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
-sniff	38	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
-sniff	39	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
-sniff	40	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
-sniff	41	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
-sniff	42	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
-sniff	43	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
-sniff	44	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
-sniff	45	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
+sniff	36	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
+sniff	37	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
+sniff	38	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
+sniff	39	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
+sniff	40	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
+sniff	41	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
+sniff	42	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
+sniff	43	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
+sniff	44	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
 # Bugbear Invasion Mothership
-sniff	46	creepy eye-stalk tentacle monster	path:Bugbear Invasion
-sniff	47	anesthesiologist bugbear	path:Bugbear Invasion
-sniff	48	bugbear mortician	path:Bugbear Invasion
-sniff	49	N-space Virtual Assistant	path:Bugbear Invasion
-sniff	50	angry cavebugbear	path:Bugbear Invasion
+sniff	45	creepy eye-stalk tentacle monster	path:Bugbear Invasion
+sniff	46	anesthesiologist bugbear	path:Bugbear Invasion
+sniff	47	bugbear mortician	path:Bugbear Invasion
+sniff	48	N-space Virtual Assistant	path:Bugbear Invasion
+sniff	49	angry cavebugbear	path:Bugbear Invasion
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography;!itemdropcapped:10=Mohawk wig

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -22,36 +22,35 @@ any	11	_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ig
 
 post	0	auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
 post	1	auto_cookie	integer	HCCS Only: Tracks fortune cookie.
-post	2	auto_crackpotjar	string	Status of Crackpot Mystic Jar of Psychoses
-post	3	auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
-post	4	auto_day_init	string	Current daycount if we finished initializing today.
-post	5	auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?
-post	6	auto_gnasirUnlocked	boolean	Have we found gnasir in the Desert?
-post	7	auto_grimstoneFancyOilPainting	boolean	do grimstone for fancy oil painting this ascension?
-post	8	auto_grimstoneOrnateDowsingRod	boolean	do grimstone for ornate dowsing rod this ascension?
-post	9	auto_hedge	string	'fast' or 'slow', determining how quickly we want to finish the Hedge Maze.
-post	10	auto_powerLevelLastLevel	string	Last Level that we had nothing to do.
-post	11	auto_powerLevelAdvCount	string	Adventures count of times we had nothing to do.
-post	12	auto_powerLevelLastAttempted	string	Last adventure that we did nothing on.
-post	13	auto_skipNuns	boolean	Skip nuns quest this ascension?
-post	14	auto_waitingArrowAlcove	integer	If we arrowed a modern zmobie, this tells us when to return to the Alcove (cyrptAlcoveEvilness value).
-post	15	auto_100familiar	string	If a familiar type, do not allow familiar switching (for 100% runs). Otherwise, can be none or blank.
-post	16	auto_beatenUpCount	integer	How many times were we beaten up this ascension. Affects ML and whether we try to heal or abort when we get beaten up.
-post	17	auto_doneInitialize	integer	Indicates last ascension that we initialized with the script.
-post	18	auto_noSnakeOil	integer	Last day that we could no longer Extract Oil.
-post	19	auto_renenutetBought	integer	Number of Talisman of Renenutet's bought on last tracking.
-post	20	auto_batoomerangDay	integer	Part of Replica Bat-oomerang Tracker
-post	21	auto_batoomerangUse	integer	Part of Replica Bat-oomerang Tracker
-post	22	_auto_lastABooConsider	integer	Last turn that we considered doing A-Boo Peak
-post	23	_auto_lastABooCycleFix	integer	Tracker to prevent us infinitely looping on A-Boo Peak
-post	24	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actually needed).
-post	25	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
-post	26	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
-post	27	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
-post	28	auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
-post	29	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
-post	30	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
-post	31	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
+post	2	auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
+post	3	auto_day_init	string	Current daycount if we finished initializing today.
+post	4	auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?
+post	5	auto_gnasirUnlocked	boolean	Have we found gnasir in the Desert?
+post	6	auto_grimstoneFancyOilPainting	boolean	do grimstone for fancy oil painting this ascension?
+post	7	auto_grimstoneOrnateDowsingRod	boolean	do grimstone for ornate dowsing rod this ascension?
+post	8	auto_hedge	string	'fast' or 'slow', determining how quickly we want to finish the Hedge Maze.
+post	9	auto_powerLevelLastLevel	string	Last Level that we had nothing to do.
+post	10	auto_powerLevelAdvCount	string	Adventures count of times we had nothing to do.
+post	11	auto_powerLevelLastAttempted	string	Last adventure that we did nothing on.
+post	12	auto_skipNuns	boolean	Skip nuns quest this ascension?
+post	13	auto_waitingArrowAlcove	integer	If we arrowed a modern zmobie, this tells us when to return to the Alcove (cyrptAlcoveEvilness value).
+post	14	auto_100familiar	string	If a familiar type, do not allow familiar switching (for 100% runs). Otherwise, can be none or blank.
+post	15	auto_beatenUpCount	integer	How many times were we beaten up this ascension. Affects ML and whether we try to heal or abort when we get beaten up.
+post	16	auto_doneInitialize	integer	Indicates last ascension that we initialized with the script.
+post	17	auto_noSnakeOil	integer	Last day that we could no longer Extract Oil.
+post	18	auto_renenutetBought	integer	Number of Talisman of Renenutet's bought on last tracking.
+post	19	auto_batoomerangDay	integer	Part of Replica Bat-oomerang Tracker
+post	20	auto_batoomerangUse	integer	Part of Replica Bat-oomerang Tracker
+post	21	_auto_lastABooConsider	integer	Last turn that we considered doing A-Boo Peak
+post	22	_auto_lastABooCycleFix	integer	Tracker to prevent us infinitely looping on A-Boo Peak
+post	23	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actually needed).
+post	24	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
+post	25	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
+post	26	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
+post	27	auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
+post	28	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
+post	29	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+post	30	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
 pre	0	auto_doGalaktik_initialize	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r26812;	// allow specifying "github" dependencies
+since r27108;	// new 8-bit realm
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -154,7 +154,6 @@ void initializeSettings() {
 	set_property("auto_clanstuff", "0");
 	set_property("auto_cookie", -1);
 	set_property("auto_copies", "");
-	set_property("auto_crackpotjar", "");
 	set_property("auto_dakotaFanning", false);
 	set_property("auto_day_init", 0);
 	set_property("auto_day1_dna", "");

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -179,12 +179,6 @@ int pullsNeeded(string data)
 			}
 		}
 
-		if(item_amount($item[Digital Key]) == 0 && whitePixelCount() < 30)
-		{
-			auto_log_warning("Need " + (30-whitePixelCount()) + " white pixels.", "red");
-			count = count + (30 - whitePixelCount());
-		}
-
 		if(item_amount($item[skeleton key]) == 0)
 		{
 			if((item_amount($item[skeleton bone]) > 0) && (item_amount($item[loose teeth]) > 0))

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -402,7 +402,7 @@ boolean autoChooseFamiliar(location place)
 	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Bowling Alley, The Haunted Wine Cellar,
 	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, Whitey's Grove, The Oasis, The Middle Chamber,
 	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,
-	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, 8-Bit Realm, The Degrassi Knoll Garage, The Old Landfill,
+	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, Hero's Field, The Degrassi Knoll Garage, The Old Landfill,
 	The Laugh Floor, Infernal Rackets Backstage] contains place) {
 		famChoice = lookupFamiliarDatafile("item");
 	}
@@ -491,9 +491,16 @@ boolean autoChooseFamiliar(location place)
 	if ($location[The Themthar Hills] == place) {
 		famChoice = lookupFamiliarDatafile("meat");
 	}
+	if ($location[The Fungus Plains] == place) {
+		famChoice = lookupFamiliarDatafile("meat");
+	}
 	
 	// places where initiative is required to help save adventures.
 	if ($location[The Defiled Alcove] == place && get_property("cyrptAlcoveEvilness").to_int() > 14)
+	{
+		famChoice = lookupFamiliarDatafile("init");
+	}
+	if($location[Vanya\'s Castle])
 	{
 		famChoice = lookupFamiliarDatafile("init");
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -551,15 +551,6 @@ boolean autoChooseFamiliar(location place)
 		famChoice = $familiar[Grimstone Golem];
 	}
 	
-	//[Angry Jung Man] drops [psychoanalytic jar]. we want 1 to save adventures on getting [digital key]
-	if(famChoice == $familiar[none] &&
-	canChangeToFamiliar($familiar[Angry Jung Man]) &&
-	!possessEquipment($item[Powerful Glove]) &&		//powerful glove is a better way to get digital key
-	$familiar[Angry Jung Man].drops_today < 1)
-	{
-		famChoice = $familiar[Angry Jung Man];
-	}
-	
 	// places where meat drop is desirable due to high meat drop monsters.
 	if ($locations[The Boss Bat's Lair, The Icy Peak, The Filthworm Queen's Chamber] contains place) {
 		famChoice = lookupFamiliarDatafile("meat");

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -500,7 +500,7 @@ boolean autoChooseFamiliar(location place)
 	{
 		famChoice = lookupFamiliarDatafile("init");
 	}
-	if($location[Vanya\'s Castle])
+	if($location[Vanya\'s Castle] == place)
 	{
 		famChoice = lookupFamiliarDatafile("init");
 	}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -431,7 +431,7 @@ boolean auto_pre_adventure()
 		auto_log_debug("Re-equipped your " + get_property("auto_100familiar") + " as something had unequipped it. This is bad and should be investigated.");
 	}
 
-	if((place == $location[8-Bit Realm]) && (my_turncount() != 0))
+	if($locations[Vanya's Castle, The Fungus Plains, Megalo-City, Hero's Field] contains place && (my_turncount() != 0))
 	{
 		if(!possessEquipment($item[Continuum Transfunctioner]))
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -796,11 +796,6 @@ boolean summonMonster(string option)
 			targets[count(targets)].amt = max(stars, lines);
 		}
 	}
-	if(needDigitalKey())
-	{
-		targets[count(targets)].target = $monster[Ghost];
-		targets[count(targets)].amt = (34 - whitePixelCount()) / 5;
-	}
 	if(item_amount($item[Barrel Of Gunpowder]) < 5)
 	{
 		int need = 5 - item_amount($item[Barrel Of Gunpowder]);
@@ -2638,15 +2633,6 @@ boolean careAboutDrops(monster mon)
 			return true;
 		}
 		return false;
-	}
-
-	if($monsters[Blooper, Ghost] contains mon)
-	{
-		if(!needDigitalKey())
-		{
-			return false;
-		}
-		return true;
 	}
 
 /*

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -60,8 +60,9 @@ generic_t zone_needItem(location loc)
 	float value = 0.0;
 	switch(loc)
 	{
-	case $location[8-Bit Realm]:
-		value = 50.0;
+	case $location[Hero\'s Field]:
+		// bonus points cap at +400% item. Equivalent to a 20% item drop
+		value = 20.0;
 		break;
 	case $location[The Hole in the Sky]:
 		if (item_amount($item[Star]) < 8 || item_amount($item[Line]) < 7) {
@@ -197,7 +198,7 @@ generic_t zone_needItem(location loc)
 			}
 		}
 		break;
-	case $location[The Valley of Rof L'm Fao]:
+	case $location[The Valley of Rof L\'m Fao]:
 		if(item_amount($item[lowercase N]) == 0 && item_amount($item[ND]) == 0 && item_amount($item[Wand of Nagamar]) == 0 && get_property("auto_wandOfNagamar").to_boolean())
 		{
 			value = 30.0;
@@ -643,7 +644,7 @@ generic_t zone_combatMod(location loc)
 	case $location[The Defiled Alcove]:
 		value = -85;
 		break;
-	case $location[The Outskirts of Cobb's Knob]:
+	case $location[The Outskirts of Cobb\'s Knob]:
 		value = 20;
 		break;
 	case $location[The Typical Tavern Cellar]:
@@ -709,7 +710,7 @@ generic_t zone_combatMod(location loc)
 	case $location[The Haunted Pantry]:
 		value = 20;
 		break;
-	case $location[Cobb's Knob Treasury]:
+	case $location[Cobb\'s Knob Treasury]:
 		value = 15;
 		break;
 	case $location[The VERY Unquiet Garves]:
@@ -1112,7 +1113,10 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[8-Bit Realm]:
+	case $location[Vanya\'s Castle]:
+	case $location[The Fungus Plains]:
+	case $location[Megalo-City]:
+	case $location[Hero\'s Field]:
 		if(possessEquipment($item[Continuum Transfunctioner]) && ((internalQuestStatus("questL02Larva") >= 0) || (internalQuestStatus("questG02Whitecastle") >= 0)))
 		{
 			retval = true;
@@ -1498,7 +1502,7 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[The Naughty Sorceress' Chamber]:
+	case $location[The Naughty Sorceress\' Chamber]:
 		if(get_property("questL13Final") == "step11")
 		{
 			retval = true;
@@ -1545,16 +1549,16 @@ boolean zone_available(location loc)
 		}
 		break;
 
-	case $location[Cobb's Knob Laboratory]:
+	case $location[Cobb\'s Knob Laboratory]:
 	case $location[The Knob Shaft]:
 		if (item_amount($item[Cobb\'s Knob Lab Key]) > 0)
 		{
 			retval = true;
 		}
 		break;
-	case $location[Cobb's Knob Menagerie, Level 1]:
-	case $location[Cobb's Knob Menagerie, Level 2]:
-	case $location[Cobb's Knob Menagerie, Level 3]:
+	case $location[Cobb\'s Knob Menagerie, Level 1]:
+	case $location[Cobb\'s Knob Menagerie, Level 2]:
+	case $location[Cobb\'s Knob Menagerie, Level 3]:
 		if (item_amount($item[Cobb\'s Knob Menagerie key]) > 0)
 		{
 			retval = true;
@@ -1774,8 +1778,6 @@ generic_t zone_difficulty(location loc)
 		break;
 	case $location[The Hidden Temple]:
 		break;
-	case $location[8-Bit Realm]:
-		break;
 	case $location[The Black Forest]:
 		break;
 	case $location[The Bat Hole Entrance]:
@@ -1961,7 +1963,7 @@ generic_t zone_difficulty(location loc)
 
 boolean zone_hasLuckyAdventure(location loc)
 {
-	if ($locations[8-Bit Realm,A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
+	if ($locations[Vanya's Castle, The Fungus Plains, Megalo-City, Hero's Field, A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
 	Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
 	Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,
 	Elf Alley,Exposure Esplanade,Frat House,Frat House (Frat Disguise),Guano Junction,Hippy Camp,Hippy Camp (Hippy Disguise),Itznotyerzitz Mine,

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1083,6 +1083,7 @@ boolean needStarKey();
 boolean needDigitalKey();
 int towerKeyCount();
 int towerKeyCount(boolean effective);
+int 8BitScore();
 boolean LX_getDigitalKey();
 void LX_buyStarKeyParts();
 boolean LX_getStarKey();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -101,7 +101,6 @@ boolean handleRainDoh();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2013.ash
-void handleJar();
 void makeStartingSmiths();
 boolean didWePlantHere(location loc);
 void trickMafiaAboutFlorist();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1083,7 +1083,7 @@ boolean needStarKey();
 boolean needDigitalKey();
 int towerKeyCount();
 int towerKeyCount(boolean effective);
-int 8BitScore();
+int EightBitScore();
 boolean LX_getDigitalKey();
 void LX_buyStarKeyParts();
 boolean LX_getStarKey();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1083,7 +1083,6 @@ boolean needStarKey();
 boolean needDigitalKey();
 int towerKeyCount();
 int towerKeyCount(boolean effective);
-int whitePixelCount();
 boolean LX_getDigitalKey();
 void LX_buyStarKeyParts();
 boolean LX_getStarKey();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -215,6 +215,18 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		handleTracker(get_property("lastCopyableMonster").to_monster(), $skill[Back-Up to your Last Enemy], "auto_copies");
 		return useSkill($skill[Back-Up to your Last Enemy]);	
 	}
+
+	//saber copy (iotm) is different from other copies in that it comes with a free escape
+	//technically it is an ender. but one that should be run before duplications.
+	//2023 update: no longer saber copy blooper due to 8-bit realm changes. Leaving commented so there is an example of how to saber copy
+	//if(canUse($skill[Use the Force]) && (auto_saberChargesAvailable() > 0) && (enemy != auto_saberCurrentMonster()))
+	//{
+	//	if(enemy == $monster[Blooper] && needDigitalKey())
+	//	{
+	//		handleTracker(enemy, $skill[Use the Force], "auto_copies");
+	//		return auto_combatSaberCopy();
+	//	}
+	//}
 	
 	//[Melodramedary] familiar skill which turns monster into a group of 2. Should be done before deleveling.
 	if ($monsters[pygmy bowler, bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, red butler] contains enemy && canUse($skill[%fn\, spit on them!]))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -171,7 +171,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	if(retval != "") return retval;
 	
 	//pickpocket. do this after puzzle bosses but before escapes/instakills
-	boolean ableToPickpocket = ($classes[Accordion Thief, Avatar of Sneaky Pete, Disco Bandit, Gelatinous Noob] contains my_class() || have_effect($effect[Riboflavin']) > 0);
+	boolean ableToPickpocket = ($classes[Accordion Thief, Avatar of Sneaky Pete, Disco Bandit, Gelatinous Noob] contains my_class() || have_effect($effect[Riboflavin\']) > 0);
 	if(!combat_status_check("pickpocket") && ableToPickpocket && contains_text(text, "value=\"Pick") && canSurvive(4.0))
 	{
 		boolean tryIt = false;
@@ -214,17 +214,6 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		handleTracker(enemy, $skill[Back-Up to your Last Enemy], "auto_replaces");
 		handleTracker(get_property("lastCopyableMonster").to_monster(), $skill[Back-Up to your Last Enemy], "auto_copies");
 		return useSkill($skill[Back-Up to your Last Enemy]);	
-	}
-	
-	//saber copy (iotm) is different from other copies in that it comes with a free escape
-	//technically it is an ender. but one that should be run before duplications.
-	if(canUse($skill[Use the Force]) && (auto_saberChargesAvailable() > 0) && (enemy != auto_saberCurrentMonster()))
-	{
-		if(enemy == $monster[Blooper] && needDigitalKey())
-		{
-			handleTracker(enemy, $skill[Use the Force], "auto_copies");
-			return auto_combatSaberCopy();
-		}
 	}
 	
 	//[Melodramedary] familiar skill which turns monster into a group of 2. Should be done before deleveling.

--- a/RELEASE/scripts/autoscend/iotms/mr2012.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2012.ash
@@ -2,15 +2,15 @@
 
 void auto_reagnimatedGetPart(int choice)
 {
-	if (available_amount($item[gnomish housemaid's kgnee]) == 0) // The housemaid's kgnee is the equipment that justified using the gnome.
+	if (available_amount($item[gnomish housemaid\'s kgnee]) == 0) // The housemaid's kgnee is the equipment that justified using the gnome.
 	{
 		run_choice(4);
 	}
-	else if (available_amount($item[gnomish coal miner's lung]) == 0) // May as well get the rest of these on subsequent days.
+	else if (available_amount($item[gnomish coal miner\'s lung]) == 0) // May as well get the rest of these on subsequent days.
 	{
 		run_choice(2);
 	}
-	else if (available_amount($item[gnomish athlete's foot]) == 0)
+	else if (available_amount($item[gnomish athlete\'s foot]) == 0)
 	{
 		run_choice(5);
 	}
@@ -18,7 +18,7 @@ void auto_reagnimatedGetPart(int choice)
 	{
 		run_choice(3);
 	}
-	else if (available_amount($item[gnomish swimmer's ears]) == 0)
+	else if (available_amount($item[gnomish swimmer\'s ears]) == 0)
 	{
 		run_choice(1);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2012.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2012.ash
@@ -74,23 +74,6 @@ boolean handleRainDoh()
 		}
 		return true;
 	}
-	if(enemy == $monster[Ghost])
-	{
-		int count = whitePixelCount();
-		count += 30 * item_amount($item[digital key]);
-
-		if((count <= 20) && (get_property("_raindohCopiesMade").to_int() < 5))
-		{
-			set_property("auto_doCombatCopy", "yes");
-		}
-		handleCopiedMonster($item[Rain-Doh Box Full of Monster]);
-		validate_rainDohBox();
-		set_property("auto_doCombatCopy", "no");
-		if(count > 20)
-		{
-		}
-		return true;
-	}
 	if(enemy == $monster[Lobsterfrogman])
 	{
 		if(have_skill($skill[Rain Man]) && (item_amount($item[barrel of gunpowder]) < 4))

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -1,20 +1,5 @@
 #	This is meant for items that have a date of 2013
 
-void handleJar()
-{
-	if(item_amount($item[psychoanalytic jar]) > 0)
-	{
-		if(item_amount($item[jar of psychoses (The Crackpot Mystic)]) == 0)
-		{
-			visit_url("shop.php?whichshop=mystic&action=jung&whichperson=mystic", true);
-		}
-		else
-		{
-			put_closet(1, $item[psychoanalytic jar]);
-		}
-	}
-}
-
 void makeStartingSmiths()
 {
 	if(!auto_have_skill($skill[Summon Smithsness]))

--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -169,13 +169,7 @@ boolean auto_wantToEquipPowerfulGlove()
 
 	if(in_plumber() && !plumber_nothingToBuy()) return true;
 
-	int pixels = whitePixelCount();
-	if (contains_text(get_property("nsTowerDoorKeysUsed"), "digital key"))
-	{
-		pixels += 30;
-	}
-
-	return pixels < 30;
+	return false;
 }
 
 boolean auto_willEquipPowerfulGlove()
@@ -574,9 +568,6 @@ monster auto_monsterToMap(location loc)
 	monster enemy = $monster[none];
 	switch (loc)
 	{
-		case $location[8-Bit Realm]:
-			enemy = $monster[Blooper];
-			break;
 		case $location[The Haunted Library]:
 			enemy = $monster[writing desk];
 			break;

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -575,18 +575,5 @@ void auto_autumnatonQuest()
 		if(auto_sendAutumnaton($location[Twin Peak])) return;
 	}
 
-	if(!contains_text(get_property("nsTowerDoorKeysUsed"), "digital key") &&
-	item_amount($item[Digital Key]) == 0 &&
-	creatable_amount($item[Digital Key]) == 0 &&
-	!auto_hasPowerfulGlove())
-	{
-		if(!possessEquipment($item[continuum transfunctioner]) && my_level() >= 2)
-		{
-			// unlock 8-bit zone
-			woods_questStart();
-		}
-		if(auto_sendAutumnaton($location[8-bit realm])) return;
-	}
-
 	return;
 }

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -20,7 +20,6 @@ void ed_initializeSettings()
 {
 	if (isActuallyEd())
 	{
-		set_property("auto_crackpotjar", "done");
 		set_property("auto_day1_dna", "finished");
 		set_property("auto_getBeehive", false);
 		set_property("auto_getStarKey", false);

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -76,16 +76,6 @@ boolean routineRainManHandler()
 			return rainManSummon($monster[astronomer], false, false);
 		}
 	}
-	if(needDigitalKey())
-	{
-		if (get_property("sidequestNunsCompleted") != "none" && my_rain() > 92)
-		{
-			if(whitePixelCount() < 30 && item_amount($item[digital key]) == 0)
-			{
-				return rainManSummon($monster[ghost], false, false);
-			}
-		}
-	}
 
 	return false;
 }
@@ -306,11 +296,6 @@ boolean rainManSummon(monster target, boolean copy, boolean wink)
 	if((item_amount($item[digital key]) == 1) && target == $monster[ghost])
 	{
 		#already have the goal, don't summon
-		return false;
-	}
-	if(whitePixelCount() > 29 && target == $monster[ghost])
-	{
-		#already have the subgoal, don't summon
 		return false;
 	}
 	if ((get_property("sidequestLighthouseCompleted") != "none" || item_amount($item[barrel of gunpowder]) >= 5) && target == $monster[lobsterfrogman])

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -555,37 +555,6 @@ boolean LM_bond()
 				}
 			}
 		}
-		if(get_property("questM20Necklace") == "finished")
-		{
-			if(get_property("_sourceTerminalDigitizeMonster") == $monster[Writing Desk])
-			{
-				if((get_property("_sourceTerminalDigitizeUses").to_int() == 1) && whitePixelCount() < 30 && (item_amount($item[Richard\'s Star Key]) == 0) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Richard\'s Star Key]))
-				{
-					woods_questStart();
-					equip($slot[acc2], $item[Continuum Transfunctioner]);
-					auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
-					set_property("auto_digitizeDirective", $monster[Blooper]);
-					autoAdv(1, $location[8-bit Realm]);
-					remove_property("auto_digitizeDirective");
-					return true;
-				}
-			}
-		}
-
-		if(get_property("sidequestLighthouseCompleted") != "none")
-		{
-			if(get_property("_sourceTerminalDigitizeMonster") == $monster[Lobsterfrogman])
-			{
-				if((get_property("_sourceTerminalDigitizeUses").to_int() == 1) && (get_property("_timeSpinnerMinutesUsed").to_int() < 7) && whitePixelCount() < 30 && (item_amount($item[Richard\'s Star Key]) == 0) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Richard\'s Star Key]))
-				{
-					auto_sourceTerminalEducate($skill[Extract], $skill[Digitize]);
-					set_property("auto_combatDirective", "start;skill digitize");
-					timeSpinnerCombat($monster[Blooper]);
-					set_property("auto_combatDirective", "");
-					return true;
-				}
-			}
-		}
 
 		if((internalQuestStatus("questL12War") >= 1) && (get_property("sidequestOrchardCompleted") == "none"))
 		{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -100,7 +100,11 @@ boolean LX_getDigitalKey()
 	{
 		equip($slot[Acc3], $item[continuum transfunctioner]);
 		visit_url("place.php?whichplace=8bit&action=8treasure");
-        run_choice(1);
+		run_choice(1);
+		if(!needDigitalKey())
+		{
+			return true;
+		}
 	}
 	
 	//Spend adventures to get the digital key

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -60,9 +60,10 @@ int towerKeyCount(boolean effective)
 	return tokens;
 }
 
-int 8BitScore()
+int EightBitScore()
 {
-	return get_property("8BitScore").to_int();
+	int score = get_property("8BitScore").to_int();
+	return score;
 }
 
 boolean LX_getDigitalKey()
@@ -95,7 +96,7 @@ boolean LX_getDigitalKey()
 	}
 	
 	// buy key if you can
-	if(8BitScore() >= 10000)
+	if(EightBitScore() >= 10000)
 	{
 		equip($slot[Acc3], $item[continuum transfunctioner]);
 		visit_url("place.php?whichplace=8bit&action=8treasure");
@@ -103,37 +104,36 @@ boolean LX_getDigitalKey()
 	}
 	
 	//Spend adventures to get the digital key
+	boolean adv_spent = false;
+	woods_questStart();
+	autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
+
 	string color = get_property("8BitColor");
 	switch(color)
 	{
 		case "black":	
 			provideInitiative(600, $location[Vanya\'s Castle], true);	
 			addToMaximize("200initiative");
-			return $location[Vanya\'s Castle];
+			adv_spent = autoAdv($location[Vanya\'s Castle]);
 			break;
 		case "red":
 			addToMaximize("200meat drop");
-			return $location[The Fungus Plains];
+			adv_spent = autoAdv($location[The Fungus Plains]);
 			break;
 		case "blue":
 			addToMaximize("200DA");
-			return $location[Megalo-City];
+			adv_spent = autoAdv($location[Megalo-City]);
 			break;
 		case "green":
 			addToMaximize("200item");
-			return $location[Hero\'s Field];
+			adv_spent = autoAdv($location[Hero\'s Field]);
 			break;
 		default:
 			abort("Property 8BitColor not set to a valid value");
 			break;
 	}
-	
-	boolean adv_spent = false;
 
-	woods_questStart();
-	autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
-
-	return autoAdv(doubled8BitLocation());
+	return adv_spent;
 }
 
 void LX_buyStarKeyParts()

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -117,25 +117,30 @@ boolean LX_getDigitalKey()
 	{
 		case "black":	
 			provideInitiative(600, $location[Vanya\'s Castle], true);	
-			addToMaximize("200initiative");
+			addToMaximize("200initiative 800max");
 			adv_spent = autoAdv($location[Vanya\'s Castle]);
 			break;
 		case "red":
-			addToMaximize("200meat drop");
+			buffMaintain($effect[Polka of Plenty], 30, 1, 1);
+			addToMaximize("200meat drop 550max");
 			adv_spent = autoAdv($location[The Fungus Plains]);
 			break;
 		case "blue":
-			addToMaximize("200DA");
+			buffMaintain($effect[Ghostly Shell], 30, 1, 1);			//+80 DA. 6 MP
+			buffMaintain($effect[Astral Shell], 30, 1, 1);			//+80 DA, 10 MP
+			buffMaintain($effect[Feeling Peaceful], 0, 1, 1);
+			addToMaximize("200DA 600max");
 			adv_spent = autoAdv($location[Megalo-City]);
 			break;
 		case "green":
-			addToMaximize("200item");
+			addToMaximize("200item 500max");
 			adv_spent = autoAdv($location[Hero\'s Field]);
 			break;
 		default:
 			abort("Property 8BitColor not set to a valid value");
 			break;
 	}
+	auto_log_info("Current 8bit score: " + EightBitScore() + "/10000");
 
 	return adv_spent;
 }

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -110,7 +110,7 @@ boolean LX_getDigitalKey()
 	//Spend adventures to get the digital key
 	boolean adv_spent = false;
 	woods_questStart();
-	autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
+	autoForceEquip($slot[acc3], $item[Continuum Transfunctioner]);
 
 	string color = get_property("8BitColor");
 	switch(color)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -133,6 +133,8 @@ boolean LX_getDigitalKey()
 			adv_spent = autoAdv($location[Megalo-City]);
 			break;
 		case "green":
+			buffMaintain($effect[Fat Leon\'s Phat Loot Lyric], 30, 1, 1);
+			buffMaintain($effect[Singer\'s Faithful Ocelot], 30, 1, 1);
 			addToMaximize("200item 500max");
 			adv_spent = autoAdv($location[Hero\'s Field]);
 			break;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -21,10 +21,6 @@ boolean needDigitalKey()
 	{
 		return false;
 	}
-	if(whitePixelCount() >= 30)
-	{
-		return false;
-	}
 
 	return true;
 }
@@ -64,16 +60,39 @@ int towerKeyCount(boolean effective)
 	return tokens;
 }
 
-int whitePixelCount()
+int 8BitScore()
 {
-	return item_amount($item[White Pixel]) + creatable_amount($item[White Pixel]);
+	return get_property("8BitScore").to_int();
+}
+
+location doubled8BitLocation()
+{
+	string color = get_property("8BitColor");
+	switch(color)
+	{
+		case "black":		
+			return $location[Vanya\'s Castle];
+			break;
+		case "red":		
+			return $location[The Fungus Plains];
+			break;
+		case "blue":		
+			return $location[Megalo-City];
+			break;
+		case "green":		
+			return $location[Hero\'s Field];
+			break;
+		default:
+			abort("Property 8BitColor not set to a valid value");
+			break;
+	}
 }
 
 boolean LX_getDigitalKey()
 {
 	//Acquire the [Digital Key]
 	
-	if(contains_text(get_property("nsTowerDoorKeysUsed"), "digital key"))
+	if(!needDigitalKey())
 	{
 		return false;
 	}
@@ -98,87 +117,21 @@ boolean LX_getDigitalKey()
 		}
 	}
 	
-	//craft the key if you can
-	if(creatable_amount($item[Digital Key]) > 0 && item_amount($item[Digital Key]) == 0)
+	// buy key if you can
+	if(8BitScore() >= 10000)
 	{
-		if(create(1, $item[Digital Key]))
-		{
-			return true;
-		}
-		else
-		{
-			abort("Mysteriously failed to craft [Digital Key] even though I should be able to make one. Make it manually then run me again");
-		}
-	}
-
-	if(auto_hasAutumnaton() && !isAboutToPowerlevel() && $location[8-Bit Realm].turns_spent > 0 && internalQuestStatus("questL13Final") != 5)
-	{
-		// delay zone to allow autumnaton to grab pixels
-		// unless we have ran out of other stuff to do
-		return false;
-	}
-	
-	//if you are at the tower door and still don't have it, pull some pixels to save adv. keeping 5 pulls for later.
-	boolean needLowKeyPixels = (in_lowkeysummer() ? (lowkey_needKey($item[Digital Key]) && lowkey_keysRemaining() == 1) : true);
-	// in low-key summer, only pull pixels if we have no other keys left to get. Otherwise this wastes pulls as it starts at the door.
-	if(whitePixelCount() < 30 && (internalQuestStatus("questL13Final") == 5 && needLowKeyPixels) && canPull($item[white pixel]))
-	{
-		int pulls_needed = min((pulls_remaining()-5), 30 - whitePixelCount());
-		pullXWhenHaveY($item[white pixel], pulls_needed, item_amount($item[white pixel]));	//do not use whitePixelCount() in this line.
-	}
-	
-	//Powerful Glove drops lots of white pixels, don't spend adv on it if you have the glove
-	//But if you reach tower door without the key then continue on to spend adv to get its components.
-	if(auto_hasPowerfulGlove() && internalQuestStatus("questL13Final") < 5)
-	{
-		return false;
+		equip($slot[Acc3], $item[continuum transfunctioner]);
+		visit_url("place.php?whichplace=8bit&action=8treasure");
+        run_choice(1);
 	}
 	
 	//Spend adventures to get the digital key
 	boolean adv_spent = false;
-	if(get_property("auto_crackpotjar") == "")
-	{
-		if(item_amount($item[Jar Of Psychoses (The Crackpot Mystic)]) == 0)
-		{
-			pullXWhenHaveY($item[Jar Of Psychoses (The Crackpot Mystic)], 1, 0);
-		}
-		if(item_amount($item[Jar Of Psychoses (The Crackpot Mystic)]) == 0)
-		{
-			set_property("auto_crackpotjar", "fail");
-		}
-		else
-		{
-			woods_questStart();
-			use(1, $item[Jar Of Psychoses (The Crackpot Mystic)]);
-			set_property("auto_crackpotjar", "done");
-		}
-	}
-	auto_log_info("Getting white pixels: Have " + whitePixelCount(), "blue");
-	if(get_property("auto_crackpotjar") == "done")
-	{
-		set_property("choiceAdventure644", 3);
-		adv_spent = autoAdv(1, $location[Fear Man\'s Level]);
-		if(have_effect($effect[Consumed By Fear]) == 0)
-		{
-			auto_log_warning("Well, we don't seem to have further access to the Fear Man area so... abort that plan", "red");
-			set_property("auto_crackpotjar", "fail");
-		}
-	}
-	else if(get_property("auto_crackpotjar") == "fail")
-	{
-		woods_questStart();
-		autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
-		if(auto_saberChargesAvailable() > 0)
-		{
-			autoEquip($item[Fourth of May cosplay saber]);
-		}
-		if (canSniff($monster[Blooper], $location[8-bit Realm]) && auto_mapTheMonsters())
-		{
-			auto_log_info("Attemping to use Map the Monsters to olfact a Blooper.");
-		}
-		adv_spent = autoAdv($location[8-bit Realm]);
-	}
-	return adv_spent;
+
+	woods_questStart();
+	autoEquip($slot[acc3], $item[Continuum Transfunctioner]);
+
+	return autoAdv(doubled8BitLocation());
 }
 
 void LX_buyStarKeyParts()

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -65,29 +65,6 @@ int 8BitScore()
 	return get_property("8BitScore").to_int();
 }
 
-location doubled8BitLocation()
-{
-	string color = get_property("8BitColor");
-	switch(color)
-	{
-		case "black":		
-			return $location[Vanya\'s Castle];
-			break;
-		case "red":		
-			return $location[The Fungus Plains];
-			break;
-		case "blue":		
-			return $location[Megalo-City];
-			break;
-		case "green":		
-			return $location[Hero\'s Field];
-			break;
-		default:
-			abort("Property 8BitColor not set to a valid value");
-			break;
-	}
-}
-
 boolean LX_getDigitalKey()
 {
 	//Acquire the [Digital Key]
@@ -126,6 +103,31 @@ boolean LX_getDigitalKey()
 	}
 	
 	//Spend adventures to get the digital key
+	string color = get_property("8BitColor");
+	switch(color)
+	{
+		case "black":	
+			provideInitiative(600, $location[Vanya\'s Castle], true);	
+			addToMaximize("200initiative");
+			return $location[Vanya\'s Castle];
+			break;
+		case "red":
+			addToMaximize("200meat drop");
+			return $location[The Fungus Plains];
+			break;
+		case "blue":
+			addToMaximize("200DA");
+			return $location[Megalo-City];
+			break;
+		case "green":
+			addToMaximize("200item");
+			return $location[Hero\'s Field];
+			break;
+		default:
+			abort("Property 8BitColor not set to a valid value");
+			break;
+	}
+	
 	boolean adv_spent = false;
 
 	woods_questStart();


### PR DESCRIPTION
# Description

8-Bit realm got an overhaul. White pixels no longer needed to obtain the pixel key. Now we must adv in the 4 zones within the 8-bit realm to build points and buy the pixel key at 10k points.

This PR removes everything I could find with the old pixel key quest and replaces it with the new.

This won't result in optimal turns but I do respect which zone has double points so shouldn't be terrible. In particular providers for meat and item would be helpful. 

## How Has This Been Tested?

None yet. Only know it validates atm.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
