### PR TITLE
fix: also check for git installed deps

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -2,6 +2,6 @@ github Ezandora/Detective-Solver Release
 github Ezandora/Helix-Fossil Release
 github Ezandora/Far-Future Release
 github gausie/excavator
-https://github.com/Ezandora/Voting-Booth/trunk/Release/
+github midgleyc/Voting-Booth
 https://github.com/Ezandora/Comb-Beach/trunk/Release/
 https://svn.code.sf.net/p/zlib/code

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -101,7 +101,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(in_pokefam())
 	{
-		if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
+		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
 		{
 		auto_log_info("Combat via Ezandora:", "green");
 		boolean ignore = cli_execute("Pocket Familiars");

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -617,7 +617,7 @@ boolean auto_doPrecinct()
 	{
 		return false;
 	}
-	if(svn_info("Ezandora-Detective-Solver-branches-Release").last_changed_rev > 0)
+	if(svn_exists("Ezandora-Detective-Solver-branches-Release") || git_exists("Ezandora-Detective-Solver-Release"))
 	{
 		//Assume if someone has this installed that they want to use it.
 		cli_execute("ash import<Detective Solver.ash> solveAllCases(false);");
@@ -1122,7 +1122,7 @@ boolean timeSpinnerGet(string goal)
 		return false;
 	}
 
-	if(svn_info("Ezandora-Far-Future-branches-Release").last_changed_rev > 0)
+	if(svn_exists("Ezandora-Far-Future-branches-Release") || git_exists("Ezandora-Far-Future-Release"))
 	{
 		//Required by dependencies
 		cli_execute("FarFuture " + goal);

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -1171,7 +1171,7 @@ boolean auto_voteSetup(int candidate, int first, int second)
 		return false;
 	}
 
-	if(svn_info("Ezandora-Voting-Booth-trunk-Release").last_changed_rev > 0)
+	if(svn_exists("Ezandora-Voting-Booth-trunk-Release"))
 	{
 		cli_execute("VotingBooth.ash");
 		return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -1171,7 +1171,7 @@ boolean auto_voteSetup(int candidate, int first, int second)
 		return false;
 	}
 
-	if(svn_exists("Ezandora-Voting-Booth-trunk-Release"))
+	if(git_exists("midgleyc-Voting-Booth"))
 	{
 		cli_execute("VotingBooth.ash");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -36,7 +36,7 @@ boolean pokefam_makeTeam()
 	if(in_pokefam())
 	{
 		// Choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up and earn pokebucks.
-		if(svn_info("Ezandora-Helix-Fossil-branches-Release").revision > 0)
+		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
 		{
 		auto_log_info("Setting our team via Ezandora:", "green");
 		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");


### PR DESCRIPTION
# Description

Some dependencies can be installed through git or SVN. For those which can be, check whether they have been installed through either git or SVN.

## How Has This Been Tested?

I can confirm the interior of the `if` returns the appropriate result for git scripts, though I haven't run it in-run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
