### PR TITLE
Ensure 8bit prefs are refreshed prior to using them

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -95,6 +95,10 @@ boolean LX_getDigitalKey()
 		}
 	}
 	
+	// start quest and equip to refresh mafia's prefs
+	woods_questStart();
+	autoForceEquip($slot[acc3], $item[Continuum Transfunctioner]);
+
 	// buy key if you can
 	if(EightBitScore() >= 10000)
 	{
@@ -109,8 +113,6 @@ boolean LX_getDigitalKey()
 	
 	//Spend adventures to get the digital key
 	boolean adv_spent = false;
-	woods_questStart();
-	autoForceEquip($slot[acc3], $item[Continuum Transfunctioner]);
 
 	string color = get_property("8BitColor");
 	switch(color)


### PR DESCRIPTION
# Description

Currently mafia (r27115) doesn't reset the 8bit prefs on ascension. This change ensures the asc is equipped, which refreshes the prefs, prior to using them

## How Has This Been Tested?

In run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
