### PR TITLE
use visit_url to buy fireworks hats if retrieve_item fails

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -500,7 +500,11 @@ boolean auto_buyFireworksHat()
 		float simNonCombat = providePlusNonCombat(25, $location[noob cave], true, true);
 		if(simNonCombat < 25.0)
 		{
-			retrieve_item(1, $item[porkpie-mounted popper]);
+			if (!retrieve_item(1, $item[porkpie-mounted popper]))
+			{
+				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
+				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1249&pwd", true, true);
+			}
 			return true;
 		}
 	}
@@ -511,7 +515,11 @@ boolean auto_buyFireworksHat()
 		float simCombat = providePlusCombat(25, $location[noob cave], true, true);
 		if(simCombat < 25.0)
 		{
-			retrieve_item(1, $item[sombrero-mounted sparkler]);
+			if (!retrieve_item(1, $item[sombrero-mounted sparkler]))
+			{
+				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
+				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1248&pwd", true, true);
+			}
 			return true;
 		}
 	}
@@ -522,7 +530,11 @@ boolean auto_buyFireworksHat()
 	{
 		if(monster_level_adjustment() < get_property("auto_MLSafetyLimit").to_int())
 		{
-			retrieve_item(1, $item[fedora-mounted fountain]);
+			if (!retrieve_item(1, $item[fedora-mounted fountain]))
+			{
+				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
+				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1247&pwd", true, true);
+			}
 			return true;
 		}
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -494,6 +494,11 @@ boolean auto_buyFireworksHat()
 		return false;
 	}
 
+	// there is a long-standing issue where mafia may fail to purchase a fireworks hat for unknown reasons, and it is not
+	// currently known whether it is a kol issue or a mafia issue.  Testing suggests that using visit_url instead of
+	// retrieve_item resolves at least one reason this failure occurs.  See thread on mafia forums for more details:
+	// https://kolmafia.us/threads/sometimes-unable-to-buy-limited-items-from-underground-fireworks-shop.27277/
+
 	// noncombat is most valuable hat but has no effect in LAR
 	if(auto_can_equip($item[porkpie-mounted popper]) && !in_lar())
 	{


### PR DESCRIPTION
# Description

Automated purchase of the 1/day fireworks hats from the underground fireworks shop has been known to simply fail under unknown conditions for some time.  It is not clear if this is a mafia issue or a KoL issue, see https://kolmafia.us/threads/sometimes-unable-to-buy-limited-items-from-underground-fireworks-shop.27277/

This changes auto_buyFireworksHat() in mr2021.ash to, if retrieve_item() fails to acquire the specified hat, use visit_url() calls to get the hat instead.

Code primarily attributed to Zdrvst (#3286685) from their personal scripting; I only put it in this file and added support for the other two hats.

## How Has This Been Tested?

Prior to making these changes to my local copy, autoscend would consistently fail out when attempting to buy a fireworks hat at the start of the day/run, for a total of about 20 aborts.  After making these changes, autoscend has successfully purchased the sombrero and porkpie a combined 16 times, with no failures.  It has not attempted to purchase the fedora, presumably because it has not at any point deemed the fedora the best available choice.

I am not certain what the result would be if it attempts to purchase a hat when it already has one, but since this would require a user to manually purchase a hat (due to the existing _fireworksShopHatBought property preventing the script from asking for more than one naturally) this seems out of scope.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
