### PR TITLE
Revert "use visit_url to buy fireworks hats if retrieve_item fails (#1245)"

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27108;	// new 8-bit realm
+since r27182;	// Buying hat from firework shop only requires autoSatisfyWithNPCs
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -498,22 +498,13 @@ boolean auto_buyFireworksHat()
 		return false;
 	}
 
-	// there is a long-standing issue where mafia may fail to purchase a fireworks hat for unknown reasons, and it is not
-	// currently known whether it is a kol issue or a mafia issue.  Testing suggests that using visit_url instead of
-	// retrieve_item resolves at least one reason this failure occurs.  See thread on mafia forums for more details:
-	// https://kolmafia.us/threads/sometimes-unable-to-buy-limited-items-from-underground-fireworks-shop.27277/
-
 	// noncombat is most valuable hat but has no effect in LAR
 	if(auto_can_equip($item[porkpie-mounted popper]) && !in_lar())
 	{
 		float simNonCombat = providePlusNonCombat(25, $location[noob cave], true, true);
 		if(simNonCombat < 25.0)
 		{
-			if (!retrieve_item(1, $item[porkpie-mounted popper]))
-			{
-				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
-				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1249&pwd", true, true);
-			}
+			retrieve_item(1, $item[porkpie-mounted popper]);
 			return true;
 		}
 	}
@@ -524,11 +515,7 @@ boolean auto_buyFireworksHat()
 		float simCombat = providePlusCombat(25, $location[noob cave], true, true);
 		if(simCombat < 25.0)
 		{
-			if (!retrieve_item(1, $item[sombrero-mounted sparkler]))
-			{
-				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
-				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1248&pwd", true, true);
-			}
+			retrieve_item(1, $item[sombrero-mounted sparkler]);
 			return true;
 		}
 	}
@@ -539,11 +526,7 @@ boolean auto_buyFireworksHat()
 	{
 		if(monster_level_adjustment() < get_property("auto_MLSafetyLimit").to_int())
 		{
-			if (!retrieve_item(1, $item[fedora-mounted fountain]))
-			{
-				visit_url("clan_viplounge.php?action=fwshop&whichfloor=2", false, true);
-				visit_url("shop.php?whichshop=fwshop&action=buyitem&quantity=1&whichrow=1247&pwd", true, true);
-			}
+			retrieve_item(1, $item[fedora-mounted fountain]);
 			return true;
 		}
 	}


### PR DESCRIPTION
This reverts commit 742c0e5ecee4ff387ffd03869160fe0b3b9098a0.

# Description

Should be no longer required as it looks like the mafia issue has been fixed. Also updated min mafia version.

## How Has This Been Tested?

Ran day 1 & started day 2 in Normal Standard SC run. Seems to work fine but it wasn't always reproducible and I don't recall if my test account hit the issue in the first place.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
