### PR TITLE
Don't use worksheds in some paths

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -769,7 +769,7 @@ boolean LX_setWorkshed(){
 	boolean workshedChanged = get_property("_workshedItemUsed").to_boolean();
 
 	if (workshedChanged) return false; //Don't even try if the workshed has already been changed once
-	if (isActuallyEd()) return false; //Not usable in Ed
+	if (isActuallyEd() || in_robot() || in_nuclear() || is_pete()) return false; //Not usable in Ed, Nuclear Autumn, or You, Robot. Pete gives you a Still
 
 	//Check to make sure we can use the workshed item and that it isn't already in the campground. If already in campground, return false also
 	//These first 2 ifs are only used if something valid other than auto is specified. Otherwise we go to the auto 

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -769,6 +769,7 @@ boolean LX_setWorkshed(){
 	boolean workshedChanged = get_property("_workshedItemUsed").to_boolean();
 
 	if (workshedChanged) return false; //Don't even try if the workshed has already been changed once
+	if (isActuallyEd()) return false; //Not usable in Ed
 
 	//Check to make sure we can use the workshed item and that it isn't already in the campground. If already in campground, return false also
 	//These first 2 ifs are only used if something valid other than auto is specified. Otherwise we go to the auto 


### PR DESCRIPTION
# Description

Some paths can't use worksheds so force setWorkshed to return false

## How Has This Been Tested?

There wasn't any

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
