### PR TITLE
Buy the potion from CMC when consulting if you're a Gnoob

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -720,7 +720,13 @@ void auto_CMCconsult()
 	int bestOption = -1;
 	item consumableBought = $item[none];
 	string page = visit_url("campground.php?action=workshed");
-	if(contains_text(page, "Breathitin"))
+	if(in_gnoob())
+	{
+		//Gnoobs can't make effective use of the other options, so get the potion for marginal benefit
+		auto_log_info("Buying potion from CMC", "blue");
+		bestOption = 4;
+	}
+	else if(contains_text(page, "Breathitin"))
 	{
 		auto_log_info("Buying Breathitin pill from CMC", "blue");
 		bestOption = 5;


### PR DESCRIPTION
# Description

Currently, the automatic Cold Medicine Cabinet handling tries to buy anything but the potion option. In the Gelatinous Noob path, the user has no spleen, stomach, or liver, and items have no regular enchantments, so the potion option is the only potentially useful option for some extra elemental resistance and damage. This change adds a check for if the user is in Gnoob, and if they are, it buys whatever potion is available from the CMC. 
 
## How Has This Been Tested?

This has not been tested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
