### PR TITLE
Use Jumpsuited Hound Dog if we want +item and don't mind +combat

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -404,7 +404,16 @@ boolean autoChooseFamiliar(location place)
 	Frat House, Hippy Camp, The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Hatching Chamber,
 	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, Hero's Field, The Degrassi Knoll Garage, The Old Landfill,
 	The Laugh Floor, Infernal Rackets Backstage] contains place) {
-		famChoice = lookupFamiliarDatafile("item");
+		// if we don't care about having some + combat rate and don't have a better fairy, JHD is a 1.25x fairy
+		if(zone_combatMod(place)._int > -1 && canChangeToFamiliar($familiar[Jumpsuited Hound Dog])
+		&& (!canChangeToFamiliar($familiar[Steam-Powered Cheerleader]) || get_property("_cheerleaderSteam").to_int() <= 100))
+		{
+			famChoice = $familiar[Jumpsuited Hound Dog];
+		}
+		else
+		{
+			famChoice = lookupFamiliarDatafile("item");
+		}
 	}
 	if (place == $location[Inside the Palindome] && item_amount($item[Stunt Nuts]) == 0 && item_amount($item[Wet Stunt Nut Stew]) == 0) {
 		famChoice = lookupFamiliarDatafile("item");


### PR DESCRIPTION
# Description

When automatically choosing familiar by place and an +item familiar is needed, this chooses Jumpsuited Hound Dog as an item familiar if the place doesn't want 0 or less combat rate (as according to zone_CombatMod). It also checks if the user has a Steam-Powered Cheerleader with enough steam to be better than JHD, and if so falls back to the normal method of selecting a familiar, which should select SPC.

This currently only affects the main list of places that need +item unconditionally

Addresses part of #1200

## How Has This Been Tested?

Has not been tested, I do not currently own JHD. A potential reason this behavior might not be better than default is the potential loss in +item from having a lower weight non-JHD +item familiar in a place where +combat is not wanted.
## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
