### PR TITLE
Add fallback for generating Cookbookbat ingredients

### DIFF
--- a/BUILD/familiars/drop.dat
+++ b/BUILD/familiars/drop.dat
@@ -60,3 +60,5 @@ Blavious Kloop	prop:_kloopDrops<5
 Green Pixie	prop:_absintheDrops<5
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
 Galloping Grill	prop:_hotAshesDrops<5
+# If all else fails, keep generating CBB ingredients
+Cookbookbat

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -80,6 +80,8 @@ drop	26	Blavious Kloop	prop:_kloopDrops<5
 drop	27	Green Pixie	prop:_absintheDrops<5
 # Hot ashes can make a potion that gives +15 ML for 15 adv. drop limit 5/day
 drop	28	Galloping Grill	prop:_hotAshesDrops<5
+# If all else fails, keep generating CBB ingredients
+drop	29	Cookbookbat
 
 # We want to delevel, but don't want to deal damage
 gremlins	0	Nosy Nose


### PR DESCRIPTION
# Description

When I initially added Cookbookbat support, I made it conservative in terms of generating ingredients so that CBB wouldn't monopolize our familiar turns. However, in HC standard this means it generates a few ingredients and then falls back to a starfish-type familiar, which isn't very worthwhile.

After discussing a bit in Discord, we thought it'd be better to just add a final fallback if all other drop familiar conditions are met to keep generating ingredients.

## How Has This Been Tested?

TBH I haven't tested it yet, and don't plan to be in-run for a bit, but it's a simple change and I'm not concerned. The biggest reason to test would be to understand if there are loadouts/paths where this holds onto CBB too much.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
