### PR TITLE
refactor: use combo over Comb-Beach

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -3,4 +3,4 @@ github Ezandora/Helix-Fossil Release
 github Ezandora/Far-Future Release
 github gausie/excavator
 github midgleyc/Voting-Booth
-https://github.com/Ezandora/Comb-Beach/trunk/Release/
+github Loathing-Associates-Scripting-Society/combo

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -807,9 +807,9 @@ int auto_beachCombFreeUsesLeft(){
 }
 
 boolean auto_beachUseFreeCombs() {
-	if(!auto_beachCombAvailable()) { return false; }
-	if(get_property("_freeBeachWalksUsed").to_int() >= 11) { return false; }
-	cli_execute("CombBeach free");
+	int freeCombs = auto_beachCombFreeUsesLeft();
+	if(freeCombs <= 0) { return false; }
+	cli_execute(`combo {freeCombs}`);
 	return true;
 }
 


### PR DESCRIPTION
# Description

Follow-up to #1242.

Comb-Beach cannot be installed using git and so will stop being installable at the end of 2023.

## How Has This Been Tested?

I ran the function manually. From looking at the code, `CombBeach free` and `combo {advCount}` (and also plain `combo`, but that one might fail if you have no combs left) should do the same thing.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
