### PR TITLE
Crystal ball minimal support

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -657,16 +657,16 @@ void addBonusToMaximize(item it, int amt)
 
 void finalizeMaximize(boolean speculative)
 {
-	if (possessEquipment($item[miniature crystal ball]))
+	if(auto_hasStillSuit() && pathHasFamiliar() && inebriety_limit() > 0)
 	{
-		// until we add support for this, we shouldn't allow the maximizer to equip it
-		// I noticed it being worn in preference to the astral pet sweater which is a waste
-		addToMaximize(`-equip {$item[miniature crystal ball].to_string()}`);
+		//always enough bonus to beat the 25 default maximizer score of miniature crystal ball's +initiative enchantment
+		//100 to 200 bonus for diminishing returns when drams already high
+		addBonusToMaximize($item[tiny stillsuit], (100 + to_int(100*min(1,(10.0 / max(1,auto_expectedStillsuitAdvs()))))));
 	}
+	//miniature crystal ball is handled along with monster goals in pre_adv
 	
 	monster nextMonster = get_property("auto_nextEncounter").to_monster();
 	boolean nextMonsterIsFree = (nextMonster != $monster[none] && isFreeMonster(nextMonster)) || (get_property("breathitinCharges").to_int() > 0 && my_location().environment == "outdoor");
-	//todo if crystal ball is supported and locked in next monster is also known. appearance_rates (with queue parameter true) also reflects this
 
 	if (auto_haveKramcoSausageOMatic())
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -663,7 +663,15 @@ void finalizeMaximize(boolean speculative)
 		//100 to 200 bonus for diminishing returns when drams already high
 		addBonusToMaximize($item[tiny stillsuit], (100 + to_int(100*min(1,(10.0 / max(1,auto_expectedStillsuitAdvs()))))));
 	}
-	//miniature crystal ball is handled along with monster goals in pre_adv
+	if(speculative && auto_haveCrystalBall())
+	{	//when doing simMaximize, in order to know if miniature crystal ball will be allowed in the simulated location, 
+		//location queue checks that would normally be done by pre_adv before maximizing equipment need to be simulated here too
+		//		TODO consider if simulating all pre_adv equipment changes needs to done in general instead of only the queue part for crystal ball, 
+		//		crystal ball directly needs this because it has an initiative bonus relevant in a zone where it can be forbidden (twin peak)
+		//		but other equipment could be wanted by simulation then replaced by something forced in pre_adv?
+		simulatePreAdvForCrystalBall(my_location());
+	}
+	//otherwise miniature crystal ball is handled along with monster goals in pre_adv
 	
 	monster nextMonster = get_property("auto_nextEncounter").to_monster();
 	boolean nextMonsterIsFree = (nextMonster != $monster[none] && isFreeMonster(nextMonster)) || (get_property("breathitinCharges").to_int() > 0 && my_location().environment == "outdoor");
@@ -828,9 +836,11 @@ boolean maximizeContains(string check)
 boolean simMaximize()
 {
 	string backup = get_property("auto_maximize_current");
+	string backupNextMonster = get_property("auto_nextEncounter");
 	finalizeMaximize(true);
 	boolean res = autoMaximize(get_property("auto_maximize_current"), true);
 	set_property("auto_maximize_current", backup);
+	set_property("auto_nextEncounter", backupNextMonster);
 	return res;
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -803,7 +803,7 @@ boolean[string] auto_banishesUsedAt(location loc)
 
 boolean auto_wantToBanish(monster enemy, location loc)
 {
-	if(appearance_rates(loc,true)[enemy] <= 0)
+	if(appearance_rates(loc)[enemy] <= 0)
 	{
 		return false;
 	}
@@ -3729,7 +3729,7 @@ boolean autoFlavour(location place)
 		}
 	}
 
-	foreach mon,chance in appearance_rates(place, true)
+	foreach mon,chance in appearance_rates(place)
 	{
 		handle_monster(mon, chance);
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -415,6 +415,7 @@ boolean auto_buyCrimboCommerceMallItem();
 boolean auto_haveCrystalBall();
 monster crystalBallMonster(location loc);
 boolean auto_forceHandleCrystalBall(location loc);
+void simulatePreAdvForCrystalBall(location place);
 boolean auto_haveEmotionChipSkills();
 boolean auto_canFeelEnvy();
 boolean auto_canFeelHatred();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -412,6 +412,9 @@ boolean auto_buyCrimboCommerceMallItem();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2021.ash
+boolean auto_haveCrystalBall();
+monster crystalBallMonster(location loc);
+boolean auto_forceHandleCrystalBall(location loc);
 boolean auto_haveEmotionChipSkills();
 boolean auto_canFeelEnvy();
 boolean auto_canFeelHatred();

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -59,7 +59,7 @@ boolean auto_allowCrystalBall(monster predicted_monster, location loc)
 	}
 
 	//if already forced by something else, no need to handle your ball
-	//pre_adv handles this as it already tracks burningDelay and forced encounters
+	//pre_adv, or simulatePreAdvForCrystalBall, handles this as it already tracks burningDelay and forced encounters
 	
 	if(is_banished(predicted_monster) || auto_wantToReplace(predicted_monster,loc) || auto_wantToBanish(predicted_monster,loc))
 	{
@@ -102,7 +102,7 @@ boolean auto_forceHandleCrystalBall(location loc)
 
 	//equipping the crystal ball can't hurt but it is neither forced nor forbidden
 	//pre_adv will consider giving it a maximizer bonus after checking if monster queue control is wanted
-	//removeFromMaximize(`-equip {$item[miniature crystal ball].to_string()}`);	//this should already get reset after every loop
+	//removeFromMaximize(`-equip {$item[miniature crystal ball].to_string()}`);	//this should already get reset after every loop or maximizer simulation
 	return false;
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2459,7 +2459,10 @@ boolean L11_ronCopperhead()
 			auto_log_info("Bringing the Camel to spit on a Red Butler for glark cables.");
 			handleFamiliar($familiar[Melodramedary]);
 		}
-		//set_property("auto_nextEncounter","Ron \"The Weasel\" Copperhead");	//this encounter is technically predictable, but mafia does not track progress?
+		if(internalQuestStatus("questL11Ron") == 4)
+		{
+			set_property("auto_nextEncounter","Ron \"The Weasel\" Copperhead");
+		}
 		boolean retval = autoAdv($location[The Red Zeppelin]);
 		// open red boxes when we get them (not sure if this is the place for this but it'll do for now)
 		if (item_amount($item[red box]) > 0)


### PR DESCRIPTION
force miniature crystal ball if it predicts a wanted monster
forbid miniature crystal ball if it predicts an unwanted monster
give miniature crystal ball a maximizer bonus if there are monsters to want or not want
give tiny stillsuit a maximizer bonus to beat the miniature crystal ball otherwise

auto_nextEncounter updated
some code needed to bypass this issue #1266 and that can't be easily disentangled from pre_adv is duplicated in simulatePreAdvForCrystalBall


## How Has This Been Tested?
worked in run when it was made, still worked after many game and mafia changes that kept this on hold
now not standard, script runs, ball to stillsuit balance and simulation changes not observed

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.