### PR TITLE
Let Pete use a Workshed

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -769,7 +769,7 @@ boolean LX_setWorkshed(){
 	boolean workshedChanged = get_property("_workshedItemUsed").to_boolean();
 
 	if (workshedChanged) return false; //Don't even try if the workshed has already been changed once
-	if (isActuallyEd() || in_robot() || in_nuclear() || is_pete()) return false; //Not usable in Ed, Nuclear Autumn, or You, Robot. Pete gives you a Still
+	if (isActuallyEd() || in_robot() || in_nuclear()) return false; //Not usable in Ed, Nuclear Autumn, or You, Robot
 
 	//Check to make sure we can use the workshed item and that it isn't already in the campground. If already in campground, return false also
 	//These first 2 ifs are only used if something valid other than auto is specified. Otherwise we go to the auto 


### PR DESCRIPTION
# Description

Issue reported in discord. Per Malibu, Pete gets a still but also whatever workshed you install. So no special treatment needed here

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
