### PR TITLE
Fix missing escape character for parka NC detection

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4226,7 +4226,7 @@ boolean is_expectedForcedNonCombat(string encounterName)
 		// dark neck of the woods
 		How Do We Do It? Quaint and Curious Volume!,
 		Strike One!,
-		Olive My Love To You, Oh.,
+		Olive My Love To You\, Oh.,
 		The Oracle Will See You Now,
 		Dodecahedrariffic!,
 


### PR DESCRIPTION
# Description

Reported in Discord, thanks Hippo. 

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
