### PR TITLE
Add escaped comma to forced NC name

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4250,7 +4250,7 @@ boolean is_expectedForcedNonCombat(string encounterName)
 		// The Castle in the Clouds in the Sky (Top Floor)
 		Copper Feel,
 		Melon Collie and the Infinite Lameness,
-		Yeah\, You're for Me, Punk Rock Giant,
+		Yeah\, You're for Me\, Punk Rock Giant,
 		Flavor of a Raver,
 
 		// The Haunted Billiards Room


### PR DESCRIPTION
# Description

Tracking of forced NCs needs the exact NC name, separated by commas. Commas inside NC names have to be escaped. This one wasn't.

Fixes # (issue)

## How Has This Been Tested?

Doesn't prevent it running.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
