### PR TITLE
Added basic usage of Hobo in Sheep's Clothing

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -25,6 +25,7 @@ Elf Operative
 Optimistic Candle
 Rockin' Robin
 God Lobster	item:God Lobster's Crown>0
+Hobo in Sheep's Clothing
 # Fairywhelps
 Pocket Professor
 Garbage Fire

--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -12,6 +12,7 @@ Crimbo Shrub
 Elf Operative
 Optimistic Candle
 Rockin' Robin
+Hobo in Sheep's Clothing
 # Volleychauns
 Ghost of Crimbo Commerce
 Golden Monkey

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -124,56 +124,57 @@ item	8	Elf Operative
 item	9	Optimistic Candle
 item	10	Rockin' Robin
 item	11	God Lobster	item:God Lobster's Crown>0
+item	12	Hobo in Sheep's Clothing
 # Fairywhelps
-item	12	Pocket Professor
-item	13	Garbage Fire
-item	14	Dandy Lion
-item	15	Choctopus
+item	13	Pocket Professor
+item	14	Garbage Fire
+item	15	Dandy Lion
+item	16	Choctopus
 # Fairychauns
-item	16	Fist Turkey
-item	17	Cat Burglar
-item	18	Angry Jung Man
-item	19	Grimstone Golem
-item	20	Adventurous Spelunker
-item	21	Blavious Kloop
-item	22	Hippo Ballerina
-item	23	Dancing Frog
-item	24	Coffee Pixie
-item	25	Attention-Deficit Demon
-item	26	Jitterbug
-item	27	Casagnova Gnome
-item	28	Psychedelic Bear
-item	29	Piano Cat
+item	17	Fist Turkey
+item	18	Cat Burglar
+item	19	Angry Jung Man
+item	20	Grimstone Golem
+item	21	Adventurous Spelunker
+item	22	Blavious Kloop
+item	23	Hippo Ballerina
+item	24	Dancing Frog
+item	25	Coffee Pixie
+item	26	Attention-Deficit Demon
+item	27	Jitterbug
+item	28	Casagnova Gnome
+item	29	Psychedelic Bear
+item	30	Piano Cat
 # Slightly special fairies
-item	30	Grey Goose
-item	31	Ghost of Crimbo Carols
-item	32	Red-Nosed Snapper
-item	33	Pair of Stomping Boots	!path:G-Lover
-item	34	Gelatinous Cubeling
-item	35	Steam-Powered Cheerleader
-item	36	Obtuse Angel
-item	37	Green Pixie
+item	31	Grey Goose
+item	32	Ghost of Crimbo Carols
+item	33	Red-Nosed Snapper
+item	34	Pair of Stomping Boots	!path:G-Lover
+item	35	Gelatinous Cubeling
+item	36	Steam-Powered Cheerleader
+item	37	Obtuse Angel
+item	38	Green Pixie
 # Elemental fairies
-item	38	Sleazy Gravy Fairy
-item	39	Stinky Gravy Fairy
-item	40	Flaming Gravy Fairy
-item	41	Frozen Gravy Fairy
-item	42	Spooky Gravy Fairy
+item	39	Sleazy Gravy Fairy
+item	40	Stinky Gravy Fairy
+item	41	Flaming Gravy Fairy
+item	42	Frozen Gravy Fairy
+item	43	Spooky Gravy Fairy
 # Physical damage fairy
-item	43	Bowlet
+item	44	Bowlet
 # Barely special fairies
-item	44	Mechanical Songbird
-item	45	Grouper Groupie
-item	46	Peppermint Rhino
+item	45	Mechanical Songbird
+item	46	Grouper Groupie
+item	47	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	47	Slimeling
+item	48	Slimeling
 # Turtles are cute
-item	48	Syncopated Turtle
+item	49	Syncopated Turtle
 # The original
-item	49	Baby Gravy Fairy
+item	50	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	50	Mutant Fire Ant
+item	51	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1
@@ -307,40 +308,41 @@ stat	4	Crimbo Shrub
 stat	5	Elf Operative
 stat	6	Optimistic Candle
 stat	7	Rockin' Robin
+stat	8	Hobo in Sheep's Clothing
 # Volleychauns
-stat	8	Ghost of Crimbo Commerce
-stat	9	Golden Monkey
-stat	10	Bloovian Groose
-stat	11	Unconscious Collective
-stat	12	Grim Brother
-stat	13	Dramatic Hedgehog
-stat	14	Chauvinist Pig
-stat	15	Uniclops
-stat	16	Hunchbacked Minion
-stat	17	Nervous Tick
-stat	18	Cymbal-Playing Monkey
-stat	19	Cheshire Bat
+stat	9	Ghost of Crimbo Commerce
+stat	10	Golden Monkey
+stat	11	Bloovian Groose
+stat	12	Unconscious Collective
+stat	13	Grim Brother
+stat	14	Dramatic Hedgehog
+stat	15	Chauvinist Pig
+stat	16	Uniclops
+stat	17	Hunchbacked Minion
+stat	18	Nervous Tick
+stat	19	Cymbal-Playing Monkey
+stat	20	Cheshire Bat
 # VolleyWhelps
-stat	20	Melodramedary
+stat	21	Melodramedary
 # Might as well build up weight for free runs, even though I'm pretty sure we don't use them...
-stat	21	Frumious Bandersnatch
+stat	22	Frumious Bandersnatch
 # Slightly special volleyballs
-stat	22	Ghost of Crimbo Cheer
-stat	23	Reanimated Reanimator
-stat	24	God Lobster
-stat	25	Party Mouse
-stat	26	Lil' Barrel Mimic
-stat	27	Piranha Plant
-stat	28	Antique Nutcracker
+stat	23	Ghost of Crimbo Cheer
+stat	24	Reanimated Reanimator
+stat	25	God Lobster
+stat	26	Party Mouse
+stat	27	Lil' Barrel Mimic
+stat	28	Piranha Plant
+stat	29	Antique Nutcracker
 # Fancy
-stat	29	Miniature Sword &amp; Martini Guy
+stat	30	Miniature Sword &amp; Martini Guy
 #Baby Mutant Rattlesnake	grimdark:2
 # Turtles are cute
-stat	30	Grinning Turtle
+stat	31	Grinning Turtle
 # His winning smile
-stat	31	Smiling Rat
+stat	32	Smiling Rat
 # The original
-stat	32	Blood-Faced Volleyball
+stat	33	Blood-Faced Volleyball
 
 yellowray	0	Crimbo Shrub
 # Nanorhino and He-Boulder would require a bit of extra doing to make work


### PR DESCRIPTION
# Description

Added Hobo in Sheep's Clothing under #Fairyballs in item.dat and stat.dat. Hobo drops have not been factored in yet.

## How Has This Been Tested?

I had a Grouper as the item drop familiar consistently. In this fork it successfully switched it over to Hobo for default item drop familiar.
