### PR TITLE
fix: retrieve stillsuit from unusable familiars

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27182;	// Buying hat from firework shop only requires autoSatisfyWithNPCs
+since r27241;	// equipped_amount(item, boolean)
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -937,22 +937,11 @@ int equipmentAmount(item equipment)
 		return 0;
 	}
 
-	int amount = item_amount(equipment) + equipped_amount(equipment);
+	int amount = item_amount(equipment) + equipped_amount(equipment, true);
 
 	if (get_related($item[broken champagne bottle], "fold") contains equipment)
 	{
 		amount = item_amount($item[January\'s Garbage Tote]);
-	}
-
-	if(item_type(equipment) == "familiar equipment")
-	{
-		foreach fam in $familiars[]
-		{
-			if(fam != my_familiar() && familiar_equipped_equipment(fam) == equipment)
-			{
-				amount++;
-			}
-		}
 	}
 
 	return amount;

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -348,13 +348,7 @@ void utilizeStillsuit() {
 	{
 		if(item_amount($item[tiny stillsuit]) == 0)
 		{
-			foreach f in $familiars[]
-			{
-				if (have_familiar(f) && familiar_equipped_equipment(f) == $item[tiny stillsuit])
-				{	//recover the stillsuit
-					visit_url("familiar.php?action=unequip&pwd&famid=" + f.to_int(), true);
-				}
-			}
+			retrieve_item($item[tiny stillsuit]);
 		}
 		if(item_amount($item[tiny stillsuit]) > 0)
 		{


### PR DESCRIPTION
# Description

Use the new `equipped_amount(item, true)` function to check all familiars for equipped items. This means the custom loop is unnecessary. On the downside, it will now check familiars for all items; on the upside it will now find items equipped on the hand / left-hand man / hatrack / scarecrow.

Also use `retrieve_item` instead of manually going over familiars to get the stillsuit. `retrieve_item` should steal the item from any user's familiar if equipped.

## How Has This Been Tested?

Ran with it, it unequipped the stillsuit from the pet rock and stuck it on the Grinning Turtle. 

Also it drank the distillate later.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
