### PR TITLE
Use boozehounds anonymous token

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -866,18 +866,13 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	}
 
 	cli_execute("refresh inv");
-
-	if ((item_amount($item[unremarkable duffel bag]) > 0) && (pulls_remaining() != -1))
+	
+	foreach it in $items[unremarkable duffel bag,van key,Knob Goblin lunchbox,gold Boozehounds Anonymous token,booze bindle]
 	{
-		use(item_amount($item[unremarkable duffel bag]), $item[unremarkable duffel bag]);
-	}
-	if ((item_amount($item[van key]) > 0) && (pulls_remaining() != -1))
-	{
-		use(item_amount($item[van key]), $item[van key]);
-	}
-	if ((item_amount($item[Knob Goblin lunchbox]) > 0) && (pulls_remaining() != -1))
-	{
-		use(item_amount($item[Knob Goblin lunchbox]), $item[Knob Goblin lunchbox]);
+		if ((item_amount(it) > 0) && (pulls_remaining() != -1))
+		{
+			use(item_amount(it), it);
+		}
 	}
 
 	// type is "eat" or "drink"


### PR DESCRIPTION
# Description
Some items in the game generate consumables so we use them before deciding diet. This now adds two more the (nearly useless) booze bindle from Oliver's place, and the actually-probably-a-useful-nightcap Boozehounds anonymous gold token from drunk pygmies.

## How Has This Been Tested?

2 HC runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
