### PR TITLE
feat: use shadow bricks to freekill if available

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -348,6 +348,16 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 		}
 
+		if(canUse($item[shadow brick]) && (get_property("_shadowBricksUsed").to_int() < 13) && !reserveFreekills)
+		{
+			if(wantFreeKillNowEspecially || (my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))
+			{
+				handleTracker(enemy, $item[shadow brick], "auto_instakill");
+				loopHandlerDelayAll();
+				return useItem($item[shadow brick]);
+			}
+		}
+
 		if(canUse($skill[Fire the Jokester\'s Gun]) && !get_property("_firedJokestersGun").to_boolean())
 		{
 			handleTracker(enemy, $skill[Fire the Jokester\'s Gun], "auto_instakill");


### PR DESCRIPTION
# Description

Add shadow bricks to the possible instakill options.

## How Has This Been Tested?

Ran with shadow bricks. It used them in the war. It funkslung them until it only had one left, but I think that's fine, as the first one kills and then the second is unused.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
