### PR TITLE
Update combo dependency to match other scripts (missing release branch)

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -3,4 +3,4 @@ github Ezandora/Helix-Fossil Release
 github Ezandora/Far-Future Release
 github gausie/excavator
 github midgleyc/Voting-Booth
-github Loathing-Associates-Scripting-Society/combo
+github Loathing-Associates-Scripting-Society/combo release


### PR DESCRIPTION
# Description

dependency.txt is missing the release branch for combo

Fixes # (issue)

## How Has This Been Tested?

git installed 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
