### PR TITLE
Avatar fax

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -36,6 +36,10 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 	{
 		return false;
 	}
+	if(is_boris() || is_jarlsberg || is_pete())
+	{
+		return false;
+	}
 	if(item_amount($item[Clan VIP Lounge Key]) == 0)
 	{
 		return false;


### PR DESCRIPTION
# Description
Avatars of Boris, Jarlsberg, and Pete can't fax, so now handleFax returns "false" if you're in any of those paths.

Fixes #1255 

## How Has This Been Tested?

Tested in-run with Avatar of Jarlsberg, works.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
