### PR TITLE
Fist of the Mummy can damage ghosts

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -89,7 +89,7 @@ void auto_ghost_prep(location place)
 	//a few iconic spells per avatar is ok. no need to be too exhaustive
 	foreach sk in $skills[
 		Saucestorm, saucegeyser,	//base classes
-		Fist of the Mummy,		//actually ed the undying
+		Fist of the Mummy,		    //actually ed the undying
 		Boil,						//avatar of jarlsberg
 		Bilious Burst,				//zombie slayer
 		Heroic Belch				//avatar of boris

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -89,7 +89,7 @@ void auto_ghost_prep(location place)
 	//a few iconic spells per avatar is ok. no need to be too exhaustive
 	foreach sk in $skills[
 		Saucestorm, saucegeyser,	//base classes
-		Storm of the Scarab,		//actually ed the undying
+		Fist of the Mummy,		//actually ed the undying
 		Boil,						//avatar of jarlsberg
 		Bilious Burst,				//zombie slayer
 		Heroic Belch				//avatar of boris


### PR DESCRIPTION
# Description

In Actually Ed, Fist of the Mummy is sufficient to damage ghosts, so when checking to see if the player can damage ghosts, check if the player has that instead of checking for Storm of the Scarab.

## How Has This Been Tested?

Has not been tested, shouldn't need testing.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
