### PR TITLE
Zombie Slayer Update For Spookyraven

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -528,7 +528,7 @@ void hauntedBedroomChoiceHandler(int choice, string[int] options)
 	else if(choice == 878) // One Ornate Nightstand (The Haunted Bedroom)
 	{
 		boolean needSpectacles = !possessEquipment($item[Lord Spookyraven\'s Spectacles]) && internalQuestStatus("questL11Manor") < 2;
-		if(is_boris() || in_wotsf() || (in_nuclear() && in_hardcore()))
+		if(is_boris() || in_wotsf() || (in_zombieSlayer() && in_hardcore()) || (in_nuclear() && in_hardcore()))
 		{
 			needSpectacles = false;
 		}
@@ -598,7 +598,7 @@ boolean LX_getLadySpookyravensFinestGown() {
 	// Might not be worth it since we need to fight ornate nightstands for the spectacles and camera
 	boolean needSpectacles = !possessEquipment($item[Lord Spookyraven\'s Spectacles]) && internalQuestStatus("questL11Manor") < 2;
 	boolean needCamera = (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1);
-	if (is_boris() || in_wotsf() || (in_nuclear() && in_hardcore())) {
+	if (is_boris() || in_wotsf() || (in_zombieSlayer() && in_hardcore()) || (in_nuclear() && in_hardcore())) {
 		needSpectacles = false;
 	}
 	else if(needCamera && needSpectacles) {
@@ -2162,7 +2162,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_wotsf() || in_bhy() || in_robot() || (in_nuclear() && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_zombieSlayer() || in_wotsf() || in_bhy() || in_robot() || (in_nuclear() && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.


### PR DESCRIPTION
Basically, Spookyraven cannot be done the traditional way so we need to ensure that the script doesn't try to get the wine bomb in Hardcore and that it gets the ingredients. Checked manually earlier today

# Description

Please include a summary of the change. Pull requests should always be against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main).

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
