### PR TITLE
Check if we can drink Dad's Brandy specifically before choosing it

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -177,7 +177,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1469: // Beware of Alligators
 			if (my_meat() < meatReserve()) {
 				run_choice(3); // 1500 meat
-			} else if (can_drink() && my_inebriety() < inebriety_limit()) {
+			} else if (canDrink($item[Dad\'s Brandy]) && my_inebriety() < inebriety_limit()) {
 				run_choice(2); // size 1 awesome booze
 			} else {
 				run_choice(3); // 1500 meat


### PR DESCRIPTION
# Description

There is a check for if the player can drink before choosing the June Cleaver option that gives Dad's Brandy, but there isn't a check for if the player can specifically drink Dad's Brandy. This changes the check to be more specific, because several paths can drink but can't drink the brandy. 

A similar change could be made for guilty sprouts, but it's a less trivial change because the current behavior is to take guilty sprouts even if the player is too low-level to currently eat them.

## How Has This Been Tested?

Minimally tested in-run as Jarlsberg.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
