### PR TITLE
don't re apply ML buff in copperhead pre_adv

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -628,6 +628,14 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
+	// monster level increases zone damage. don't re apply ML buff shrugged by level_11.ash
+	if(place == $location[The Copperhead Club])
+	{
+		doML = false;
+		removeML = true;
+		purgeML = false;
+	}
+
 	// Location Specific Conditions
 	if(lowMLZones contains place)
 	{


### PR DESCRIPTION
Fixes 
level_11.ash shrugs Ur-Kel then pre_adv applies it again, increasing ML and wasting MP every turn

## How Has This Been Tested?
in run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
