### PR TITLE
Initial cursed paw support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27299;	// feat: Perfect Embouchure spelling corrected
+since r27327;	// feat: Monkey Paw support
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1183,6 +1183,26 @@ boolean doBedtime()
 	auto_beachUseFreeCombs();
 	auto_drinkNightcap();
 	equipRollover(false);
+	
+	// Use up any cursed monkey paw wishes on Frosty (+100% item, +100% meat, +25 ML)
+	// Unless we're limiting ML, then do One Very Clear Eye
+	effect effect_to_wish = $effect[Frosty];
+	if (get_property("auto_MLSafetyLimit").to_int() < 25) // We're adding +25 ML that won't be shrugged.
+	{
+		effect_to_wish = $effect[One Very Clear Eye];
+	}
+	if (auto_haveMonkeyPaw())
+	{
+		boolean success = true;
+		while (get_property("_monkeyPawWishesUsed").to_int() < 5 && success)
+		{
+			success = auto_makeMonkeyPawWish(effect_to_wish);
+		}
+		if (!success)
+		{
+			print("Something went wrong using up monkey paw wishes.", "red");
+		}
+	}
 
 	if(in_plumber() && fullness_left() > 0)
 	{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1187,9 +1187,12 @@ boolean doBedtime()
 	// Use up any cursed monkey paw wishes on Frosty (+100% item, +100% meat, +25 ML)
 	// Unless we're limiting ML, then do One Very Clear Eye
 	effect effect_to_wish = $effect[Frosty];
-	if (get_property("auto_MLSafetyLimit").to_int() < 25) // We're adding +25 ML that won't be shrugged.
+	if (get_property("auto_MLSafetyLimit")!="")
 	{
-		effect_to_wish = $effect[One Very Clear Eye];
+		if (get_property("auto_MLSafetyLimit").to_int() < 25) // We're adding +25 ML that won't be shrugged.
+		{
+			effect_to_wish = $effect[One Very Clear Eye];
+		}
 	}
 	if (auto_haveMonkeyPaw())
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4515,7 +4515,7 @@ boolean auto_wishForEffect(effect wish)
 		if (auto_makeMonkeyPawWish(wish)) { return true; }
 	}
 	// If we're allowed to use the genie bottle, do that.
-	if(auto_shouldUseWishes() && auto_haveGenieBottle())
+	if(auto_shouldUseWishes() && auto_haveGenieBottleOrPocketWishes())
 	{
 		if(makeGenieWish(wish)) { return true; }
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4507,3 +4507,17 @@ int meatReserve()
 	
 	return reserve_gnasir + reserve_diary + reserve_zeppelin + reserve_palindome + reserve_island + reserve_extra;
 }
+
+boolean auto_wishForEffect(effect wish)
+{
+	// First try to use the monkey paw
+	if (auto_haveMonkeyPaw()) {
+		if (auto_makeMonkeyPawWish(wish)) { return true; }
+	}
+	// If we're allowed to use the genie bottle, do that.
+	if(auto_shouldUseWishes() && auto_haveGenieBottle())
+	{
+		if(makeGenieWish(wish)) { return true; }
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -230,6 +230,7 @@ void horseDark();
 void horseCrazy();
 void horsePale();
 boolean horsePreAdventure();
+boolean auto_haveGenieBottle();
 boolean auto_shouldUseWishes();
 int auto_wishesAvailable();
 boolean makeGenieWish(string wish);
@@ -490,6 +491,10 @@ void pickRocks();
 boolean wantToThrowGravel(location loc, monster enemy);
 boolean auto_haveSITCourse();
 void auto_SITCourse();
+boolean auto_haveMonkeyPaw();
+boolean auto_makeMonkeyPawWish(effect wish);
+boolean auto_makeMonkeyPawWish(item wish);
+boolean auto_makeMonkeyPawWish(string wish);
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -230,7 +230,7 @@ void horseDark();
 void horseCrazy();
 void horsePale();
 boolean horsePreAdventure();
-boolean auto_haveGenieBottle();
+boolean auto_haveGenieBottleOrPocketWishes();
 boolean auto_shouldUseWishes();
 int auto_wishesAvailable();
 boolean makeGenieWish(string wish);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1764,3 +1764,4 @@ int currentPoolSkill();
 int poolSkillPracticeGains();
 boolean hasUsefulShirt();
 int meatReserve();
+boolean auto_wishForEffect(effect wish);

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1698,6 +1698,11 @@ boolean horsePreAdventure()
 	return getHorse(desiredHorse);
 }
 
+boolean auto_haveGenieBottle()
+{
+	return (item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[Genie Bottle]));
+}
+
 boolean auto_shouldUseWishes()
 {
 	return get_property("auto_useWishes").to_boolean();

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1698,9 +1698,10 @@ boolean horsePreAdventure()
 	return getHorse(desiredHorse);
 }
 
-boolean auto_haveGenieBottle()
+boolean auto_haveGenieBottleOrPocketWishes()
 {
-	return (item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[Genie Bottle]));
+	return (item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[Genie Bottle]) ||
+	        item_amount($item[Pocket Wish] ) > 0 && auto_is_valid($item[Pocket Wish] ) );
 }
 
 boolean auto_shouldUseWishes()

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -91,3 +91,36 @@ void auto_SITCourse()
 		return;
 	}
 }
+
+boolean auto_haveMonkeyPaw()
+{
+	static item paw = $item[cursed monkey\'s paw];
+	return auto_is_valid(paw) && item_amount(paw) > 0;
+}
+
+boolean auto_makeMonkeyPawWish(effect wish)
+{
+	boolean success = monkey_paw(wish);
+	if (success) {
+		handleTracker(to_string($item[cursed monkey\'s paw]), to_string(wish), "auto_wishes");
+	}
+	return success;
+}
+
+boolean auto_makeMonkeyPawWish(item wish)
+{
+	boolean success = monkey_paw(wish);
+	if (success) {
+		handleTracker(to_string($item[cursed monkey\'s paw]), to_string(wish), "auto_wishes");
+	}
+	return success;
+}
+
+boolean auto_makeMonkeyPawWish(string wish)
+{
+	boolean success = monkey_paw(wish);
+	if (success) {
+		handleTracker(to_string($item[cursed monkey\'s paw]), wish, "auto_wishes");
+	}
+	return success;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -95,7 +95,7 @@ void auto_SITCourse()
 boolean auto_haveMonkeyPaw()
 {
 	static item paw = $item[cursed monkey\'s paw];
-	return auto_is_valid(paw) && item_amount(paw) > 0;
+	return auto_is_valid(paw) && (item_amount(paw) > 0 || have_equipped(paw));
 }
 
 boolean auto_makeMonkeyPawWish(effect wish)

--- a/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
@@ -154,7 +154,7 @@ boolean awol_buySkills()
 		return false;
 	}
 
-	if(item_amount($item[Tales of the West: Cow Punching]) > 0)
+	if(item_amount($item[Tales of the West: \ Cow Punching]) > 0)
 	{
 		string page = visit_url("inv_use.php?pwd=&which=3&whichitem=8955");
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2355,9 +2355,22 @@ boolean L11_redZeppelin()
 	{
 		if(cloversAvailable() >= 3 && auto_shouldUseWishes())
 		{
-			makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
-			makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
-		}
+			if (auto_haveGenieBottle()) {
+				makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
+				makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
+			}
+			if (auto_haveMonkeyPaw())
+			{
+				if(have_effect($effect[Fifty Ways to Bereave Your Lover])==0)
+				{
+					monkey_paw($effect[Fifty Ways to Bereave Your Lover]);
+				}
+				if(have_effect($effect[Dirty Pear])==0)
+				{
+					monkey_paw($effect[Dirty Pear]);
+				}
+			} // monkey paw
+		} // use wishes
 		if(in_tcrs())
 		{
 			if(my_class() == $class[Sauceror] && my_sign() == "Blender")

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2353,24 +2353,16 @@ boolean L11_redZeppelin()
 
 	if(get_property("zeppelinProtestors").to_int() < 75 && cloversAvailable() > 0)
 	{
-		if(cloversAvailable() >= 3 && auto_shouldUseWishes())
+		if(cloversAvailable() >= 3)
 		{
-			if (auto_haveGenieBottle()) {
-				makeGenieWish($effect[Fifty Ways to Bereave Your Lover]); // +100 sleaze dmg
-				makeGenieWish($effect[Dirty Pear]); // double sleaze dmg
-			}
-			if (auto_haveMonkeyPaw())
+			foreach ef in $effects[Fifty Ways to Bereave Your Lover,Dirty Pear] //+100 sleaze dmg, double sleaze dmg
 			{
-				if(have_effect($effect[Fifty Ways to Bereave Your Lover])==0)
+				if (have_effect(ef)==0)
 				{
-					auto_makeMonkeyPawWish($effect[Fifty Ways to Bereave Your Lover]);
+					auto_wishForEffect(ef);
 				}
-				if(have_effect($effect[Dirty Pear])==0)
-				{
-					auto_makeMonkeyPawWish($effect[Dirty Pear]);
-				}
-			} // monkey paw
-		} // use wishes
+			} // effects
+		} // have clovers
 		if(in_tcrs())
 		{
 			if(my_class() == $class[Sauceror] && my_sign() == "Blender")

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2363,11 +2363,11 @@ boolean L11_redZeppelin()
 			{
 				if(have_effect($effect[Fifty Ways to Bereave Your Lover])==0)
 				{
-					monkey_paw($effect[Fifty Ways to Bereave Your Lover]);
+					auto_makeMonkeyPawWish($effect[Fifty Ways to Bereave Your Lover]);
 				}
 				if(have_effect($effect[Dirty Pear])==0)
 				{
-					monkey_paw($effect[Dirty Pear]);
+					auto_makeMonkeyPawWish($effect[Dirty Pear]);
 				}
 			} // monkey paw
 		} // use wishes

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1390,9 +1390,9 @@ boolean L11_unlockHiddenCity()
 	}
 	else if(in_glover())
 	{
-		if(auto_shouldUseWishes() && have_effect($effect[Stone-Faced]) == 0)
+		if(have_effect($effect[Stone-Faced]) == 0)
 		{
-			makeGenieWish($effect[Stone-Faced]);
+			auto_wishForEffect($effect[Stone-Faced]);
 		}
 		else return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2355,11 +2355,14 @@ boolean L11_redZeppelin()
 	{
 		if(cloversAvailable() >= 3)
 		{
-			foreach ef in $effects[Fifty Ways to Bereave Your Lover,Dirty Pear] //+100 sleaze dmg, double sleaze dmg
+			foreach ef in $effects[Dirty Pear, Fifty Ways to Bereave Your Lover] // double sleaze dmg, +100 sleaze dmg, 
 			{
-				if (have_effect(ef)==0)
+				if (numeric_modifier("sleaze_damage")+numeric_modifier("sleaze spell damage") < 400)
 				{
-					auto_wishForEffect(ef);
+					if (have_effect(ef)==0)
+					{
+						auto_wishForEffect(ef);
+					}
 				}
 			} // effects
 		} // have clovers

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1742,9 +1742,9 @@ boolean L12_themtharHills()
 	handleFamiliar("meat");
 	addToMaximize("200meat drop");
 
-	if(auto_shouldUseWishes())
+	if(have_effect($effect[Frosty])==0)
 	{
-		makeGenieWish($effect[Frosty]);
+		auto_wishForEffect($effect[Frosty]);
 	}
 	buffMaintain($effect[Greedy Resolve]);
 	buffMaintain($effect[Disco Leer], 10, 1, 1);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -409,6 +409,14 @@ boolean L13_towerNSContests()
 					cli_execute("concert White-boy Angst");
 				}
 
+			if(crowd1Insufficient())
+			{
+				if (have_effect($effect[New and Improved])==0)
+				{
+					auto_wishForEffect($effect[New and Improved]);
+				}
+			}
+
 				if(crowd1Insufficient())
 				{
 					if(get_property("auto_secondPlaceOrBust").to_boolean())
@@ -478,6 +486,14 @@ boolean L13_towerNSContests()
 					if(crowd2Insufficient()) fightClubSpa($effect[Uncucumbered]);
 				}
 				break;
+			}
+			
+			if(crowd2Insufficient())
+			{
+				if (have_effect($effect[New and Improved])==0)
+				{
+					auto_wishForEffect($effect[New and Improved]);
+				}
 			}
 
 			if(crowd2Insufficient())
@@ -563,24 +579,24 @@ boolean L13_towerNSContests()
 
 			score = numeric_modifier(challenge + " damage");
 			score += numeric_modifier(challenge + " spell damage");
-			if((score < 80) && auto_shouldUseWishes())
+			if((score < 80))
 			{
 				switch(challenge)
 				{
 				case $element[cold]:
-					makeGenieWish($effect[Staying Frosty]);
+					auto_wishForEffect($effect[Staying Frosty]);
 					break;
 				case $element[hot]:
-					makeGenieWish($effect[Dragged Through the Coals]);
+					auto_wishForEffect($effect[Dragged Through the Coals]);
 					break;
 				case $element[sleaze]:
-					makeGenieWish($effect[Fifty Ways to Bereave your Lover]);
+					auto_wishForEffect($effect[Fifty Ways to Bereave your Lover]);
 					break;
 				case $element[stench]:
-					makeGenieWish($effect[Sewer-Drenched]);
+					auto_wishForEffect($effect[Sewer-Drenched]);
 					break;
 				case $element[spooky]:
-					makeGenieWish($effect[You\'re Back...]);
+					auto_wishForEffect($effect[You\'re Back...]);
 					break;
 				}
 			}


### PR DESCRIPTION
# Description

This adds helper functions for the cursed paw, with wish tracking and one initial use (sleaze damage for the zeppelin). More can be added later.

At the moment, I left the use protected behind the auto_useWishes preference being true. I'm not sure if that's appropriate, and I'm more than happy to change it before merging.

## How Has This Been Tested?

3 HC Standard runs worked fine.

However, the zeppelin code also interacts with the Genie Bottle code, and I don't have a Genie bottle. Can someone else test this please? 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
