### PR TITLE
equip the combat lover's locket if monsters are missing from the next zone

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -324,6 +324,7 @@ boolean auto_pre_adventure()
 		{
 			if (rate > 0 && mon.id > 0 && mon.copyable && !mon.boss && !auto_monsterInLocket(mon))
 			{
+				auto_log_info('We want to get the "' + mon + '" monster into the combat lover\'s locket from ' + place + ", so we're bringing it along.", "blue");
 				autoEquip($item[combat lover\'s locket]);
 				break;
 			}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -317,6 +317,19 @@ boolean auto_pre_adventure()
 		}
 	}
 
+	// Equip the combat lover's locket if we're missing a monster in the zone
+	if (auto_haveCombatLoversLocket())
+	{
+		foreach mon,rate in appearance_rates(place)
+		{
+			if (rate > 0 && mon.id > 0 && mon.copyable && !mon.boss && !auto_monsterInLocket(mon))
+			{
+				autoEquip($item[combat lover\'s locket]);
+				break;
+			}
+		}
+	}
+
 	if(in_koe() && possessEquipment($item[low-pressure oxygen tank]))
 	{
 		autoEquip($item[low-pressure oxygen tank]);


### PR DESCRIPTION
# Description

If the next location to adventure in has monsters that could be added to the locket, equip it automatically

## How Has This Been Tested?

in progress

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
