### PR TITLE
Emergency bedtime when rollover's fast approaching

### DIFF
--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -65,6 +65,7 @@ any	52	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
 any	53	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
 any	54	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 any	55	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
+any	56	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -282,7 +282,6 @@ void initializeSession() {
 
 	auto_enableBackupCameraReverser();
 	set_property("_auto_organSpace", -1.0);
-	set_property("_auto_maxBonusRolloverAdv", "");
 	ed_initializeSession();
 	bat_initializeSession();
 }
@@ -1488,19 +1487,6 @@ boolean autosellCrap()
 	return true;
 }
 
-int maxBonusRolloverAdventures()
-{
-	int result = round(numeric_modifier("adventures"));
-	foreach n, rec in maximize("adventures", 0, 0, true, true)
-	{
-		if(rec.item != $item[none])
-		{
-			result += rec.score;
-		}
-	}
-	return result;
-}
-
 void print_header()
 {
 	if(my_thunder() > get_property("auto_lastthunder").to_int())
@@ -1683,9 +1669,10 @@ boolean doTasks()
 	// Check if rollover's coming up soon
 	if(almostRollover())
 	{
+		print("Rollover's coming!  Gotta consume what we can and go to bed!", "red");
 		// How much organ space left?  If none, go to bed
 		float organ_space = consumptionProgress();
-		print(`{organ_space} organ space`, '#00dddd');
+		auto_log_debug(`{organ_space} organ space`, "blue");
 		if(organ_space >= 0.999)
 		{
 		  return false;
@@ -1693,8 +1680,8 @@ boolean doTasks()
 		// How much organ space was available the last time we were here?
 		float previous_space = get_property("_auto_organSpace").to_float();
 		float organ_space_change = organ_space - previous_space;
-		print(`{previous_space} previous space`, '#00dddd');
-		print(`{organ_space_change} organ space change`, '#00dddd');
+		auto_log_debug(`{previous_space} previous space`, "blue");
+		auto_log_debug(`{organ_space_change} organ space change`, "blue");
 		set_property("_auto_organSpace", organ_space);
 		// If no space used the last time consumption was done, don't bother trying again
 		if(organ_space_change < 0.001)
@@ -1702,16 +1689,7 @@ boolean doTasks()
 		  return false;
 		}
 		// There's space left to fill, but let's continue only if we don't have enough adventures
-		if(get_property("_auto_maxBonusRolloverAdv") == "")
-		{
-		  // Let's only maximize once
-		  set_property("_auto_maxBonusRolloverAdv", maxBonusRolloverAdventures());
-		}
-		// 130 = 200 adv limit - 40 adv per day - 30 adv for nightcap
-		print(`Max bonus rollover adv: {get_property("_auto_maxBonusRolloverAdv")}`, '#00dddd');
-		int target_adv = 130 - get_property("_auto_maxBonusRolloverAdv").to_int();
-		print(`Target adventures: {target_adv}`, '#00dddd');
-		return (my_adventures() < target_adv);
+		return needToConsumeForEmergencyRollover();
 	}
 	
 	casualCheck();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -282,7 +282,7 @@ void initializeSession() {
 
 	auto_enableBackupCameraReverser();
 	set_property("_auto_organSpace", -1.0);
-	set_property("_auto_maxRolloverAdv", "");
+	set_property("_auto_maxBonusRolloverAdv", "");
 	ed_initializeSession();
 	bat_initializeSession();
 }
@@ -1488,7 +1488,7 @@ boolean autosellCrap()
 	return true;
 }
 
-int maxRolloverAdventures()
+int maxBonusRolloverAdventures()
 {
 	int result = round(numeric_modifier("adventures"));
 	foreach n, rec in maximize("adventures", 0, 0, true, true)
@@ -1702,11 +1702,11 @@ boolean doTasks()
 		  return false;
 		}
 		// There's space left to fill, but let's continue only if we don't have enough adventures
-		if(get_property("_auto_maxRolloverAdv") == "")
+		if(get_property("_auto_maxBonusRolloverAdv") == "")
 		{
-		  set_property("_auto_maxRolloverAdv", maxRolloverAdventures());
+		  set_property("_auto_maxBonusRolloverAdv", maxBonusRolloverAdventures());
 		}
-		return (my_adventures() < (130 - get_property("_auto_maxRolloverAdv").to_int());
+		return (my_adventures() < (130 - get_property("_auto_maxBonusRolloverAdv").to_int());
 	}
 	
 	casualCheck();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1706,6 +1706,7 @@ boolean doTasks()
 		{
 		  set_property("_auto_maxBonusRolloverAdv", maxBonusRolloverAdventures());
 		}
+		// 130 = 200 adv limit - 40 adv per day - 30 adv for nightcap
 		return (my_adventures() < (130 - get_property("_auto_maxBonusRolloverAdv").to_int());
 	}
 	

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1685,7 +1685,7 @@ boolean doTasks()
 	{
 		// How much organ space left?  If none, go to bed
 		float organ_space = consumptionProgress();
-		print(`{organ_space} organ space`, 'olive');
+		print(`{organ_space} organ space`, '#00dddd');
 		if(organ_space >= 0.999)
 		{
 		  return false;
@@ -1693,8 +1693,8 @@ boolean doTasks()
 		// How much organ space was available the last time we were here?
 		float previous_space = get_property("_auto_organSpace").to_float();
 		float organ_space_change = organ_space - previous_space;
-		print(`{previous_space} previous space`, 'olive');
-		print(`{organ_space_change} organ space change`, 'olive');
+		print(`{previous_space} previous space`, '#00dddd');
+		print(`{organ_space_change} organ space change`, '#00dddd');
 		set_property("_auto_organSpace", organ_space);
 		// If no space used the last time consumption was done, don't bother trying again
 		if(organ_space_change < 0.001)
@@ -1704,10 +1704,14 @@ boolean doTasks()
 		// There's space left to fill, but let's continue only if we don't have enough adventures
 		if(get_property("_auto_maxBonusRolloverAdv") == "")
 		{
+		  // Let's only maximize once
 		  set_property("_auto_maxBonusRolloverAdv", maxBonusRolloverAdventures());
 		}
 		// 130 = 200 adv limit - 40 adv per day - 30 adv for nightcap
-		return (my_adventures() < (130 - get_property("_auto_maxBonusRolloverAdv").to_int());
+		print(`Max bonus rollover adv: {get_property("_auto_maxBonusRolloverAdv")}`, '#00dddd');
+		int target_adv = 130 - get_property("_auto_maxBonusRolloverAdv").to_int();
+		print(`Target adventures: {target_adv}`, '#00dddd');
+		return (my_adventures() < target_adv);
 	}
 	
 	casualCheck();

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -563,43 +563,49 @@ boolean doBedtime()
 
 	auto_process_kmail("auto_deleteMail");
 
-	if(my_adventures() > 4)
+	// If rollover isn't approaching, check for reasons to stop bedtime
+	boolean out_of_blood = false;
+	if(! almostRollover())
 	{
-		if(my_inebriety() <= inebriety_limit())
+		if(my_adventures() > 4)
 		{
-			if(!in_gnoob() && my_familiar() != $familiar[Stooper])
+			if(my_inebriety() <= inebriety_limit())
 			{
-				auto_log_warning("Still adventurous! Stopping bedtime.", "red");
-				return false;
+				if(!in_gnoob() && my_familiar() != $familiar[Stooper])
+				{
+					auto_log_warning("Still adventurous! Stopping bedtime.", "red");
+					return false;
+				}
 			}
 		}
+		out_of_blood = (in_darkGyffte() && item_amount($item[blood bag]) == 0);
+		if((fullness_left() > 0) && can_eat() && !out_of_blood)
+		{
+			auto_log_warning("Still hungry! Stopping bedtime.", "red");
+			return false;
+		}
+		if((inebriety_left() > 0) && can_drink() && !out_of_blood)
+		{
+			auto_log_warning("Still sober! Stopping bedtime.", "red");
+			return false;
+		}
+		int spleenlimit = spleen_limit();
+		if(!canChangeFamiliar())
+		{
+			spleenlimit -= 3;
+		}
+		if(!haveSpleenFamiliar())
+		{
+			spleenlimit = 0;
+		}
+		if((my_spleen_use() < spleenlimit) && !in_hardcore() && (inebriety_left() > 0))
+		{
+			auto_log_warning("Still spleeny! Stopping bedtime.", "red");
+			return false;
+		}
 	}
-	boolean out_of_blood = (in_darkGyffte() && item_amount($item[blood bag]) == 0);
-	if((fullness_left() > 0) && can_eat() && !out_of_blood)
-	{
-		auto_log_warning("Still hungry! Stopping bedtime.", "red");
-		return false;
-	}
-	if((inebriety_left() > 0) && can_drink() && !out_of_blood)
-	{
-		auto_log_warning("Still sober! Stopping bedtime.", "red");
-		return false;
-	}
-	int spleenlimit = spleen_limit();
-	if(!canChangeFamiliar())
-	{
-		spleenlimit -= 3;
-	}
-	if(!haveSpleenFamiliar())
-	{
-		spleenlimit = 0;
-	}
-	if((my_spleen_use() < spleenlimit) && !in_hardcore() && (inebriety_left() > 0))
-	{
-		auto_log_warning("Still spleeny! Stopping bedtime.", "red");
-		return false;
-	}
-
+	//abort("We'd proceed to bedtime if this debug abort weren't here");
+	
 	ed_terminateSession();
 	bat_terminateSession();
 

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -611,7 +611,6 @@ boolean doBedtime()
 			return false;
 		}
 	}
-	//abort("We'd proceed to bedtime if this debug abort weren't here");
 	
 	ed_terminateSession();
 	bat_terminateSession();

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -670,7 +670,8 @@ void consumeStuff()
 			autoEat(1, $item[guilty sprout]);
 		}
 	}
-	if (my_adventures() < 10 && !edSpleenCheck)
+	// If adventures low 
+	if ((my_adventures() < 10 && !edSpleenCheck) || almostRollover())
 	{
 		// Stop drinking at 10 drunk if spookyraven billiards room isn't completed, unless no fullness is available
 		if (inebriety_left() > 0)
@@ -1841,7 +1842,8 @@ boolean auto_chewAdventures()
 {
 	//tries to chew a size 4 familiar spleen item that gives adventures. All are IOTM derivatives with 1.875 adv/size
 	boolean liver_check = my_inebriety() < inebriety_limit() && !in_kolhs();	//kolhs has special drinking. liver often unfilled
-	if(liver_check || my_fullness() < fullness_limit() || my_adventures() > 1+auto_advToReserve())
+	if(liver_check || my_fullness() < fullness_limit()
+		|| ((my_adventures() > 1+auto_advToReserve()) && !almostRollover()))
 	{
 		return false;	//1.875 A/S is bad. only chew if 1 adv remains
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -670,8 +670,8 @@ void consumeStuff()
 			autoEat(1, $item[guilty sprout]);
 		}
 	}
-	// If adventures low 
-	if ((my_adventures() < 10 && !edSpleenCheck) || almostRollover())
+	// If adventures low, or it's almost Rollover, we need to consume
+	if ((my_adventures() < 10 && !edSpleenCheck) || (almostRollover() && needToConsumeForEmergencyRollover()))
 	{
 		// Stop drinking at 10 drunk if spookyraven billiards room isn't completed, unless no fullness is available
 		if (inebriety_left() > 0)

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -628,6 +628,14 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
+	// monster level increases zone damage. don't re apply ML buff shrugged by level_11.ash
+	if(place == $location[The Copperhead Club])
+	{
+		doML = false;
+		removeML = true;
+		purgeML = false;
+	}
+
 	// Location Specific Conditions
 	if(lowMLZones contains place)
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4,9 +4,23 @@ boolean almostRollover()
 {
 	int warning_time = get_property("auto_stopMinutesToRollover").to_int() * 60;
 	int remaining_time = rollover() - (now_to_int()/1000);
-	print(`{warning_time} secs warning`, '#00dddd');
-	print(`{remaining_time} secs to rollover`, '#00dddd');
+	auto_log_debug(`Less than {(remaining_time/60)+1} min until rollover, bedtime at {warning_time/60} min`, "blue");
 	return (remaining_time <= warning_time);
+}
+
+boolean needToConsumeForEmergencyRollover()
+{
+	int max_bonus_adv = round(numeric_modifier("adventures"));
+	foreach n, rec in maximize("adventures", 0, 0, true, true)
+	{
+		if(rec.item != $item[none])
+		{
+			max_bonus_adv += rec.score;
+		}
+	}
+	int target_adv = 130 - max_bonus_adv;
+	auto_log_debug(`Max bonus rollover adv: {max_bonus_adv}, target adv: {target_adv}`, "blue");
+	return (my_adventures() < target_adv);
 }
 
 boolean autoMaximize(string req, boolean simulate)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1,5 +1,14 @@
 //A file full of utility functions which we import into autoscend.ash
 
+boolean almostRollover()
+{
+	int warning_time = get_property("auto_stopMinutesToRollover").to_int() * 60;
+	int remaining_time = rollover() - (now_to_int()/1000);
+	print(`{warning_time} secs warning`, 'olive');
+	print(`{remaining_time} secs to rollover`, 'olive');
+	return (remaining_time <= warning_time);
+}
+
 boolean autoMaximize(string req, boolean simulate)
 {
 	if(!simulate)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4,7 +4,11 @@ boolean almostRollover()
 {
 	int warning_time = get_property("auto_stopMinutesToRollover").to_int() * 60;
 	int remaining_time = rollover() - (now_to_int()/1000);
-	auto_log_debug(`Less than {(remaining_time/60)+1} min until rollover, bedtime at {warning_time/60} min`, "blue");
+	if ((remaining_time-300) < warning_time)
+	{
+		// Only print debug messages less than 5 minutes before emergency bedtime
+		auto_log_debug(`Less than {(remaining_time/60)+1} min until rollover, bedtime at {warning_time/60} min`, "blue");
+	}
 	return (remaining_time <= warning_time);
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4,8 +4,8 @@ boolean almostRollover()
 {
 	int warning_time = get_property("auto_stopMinutesToRollover").to_int() * 60;
 	int remaining_time = rollover() - (now_to_int()/1000);
-	print(`{warning_time} secs warning`, 'olive');
-	print(`{remaining_time} secs to rollover`, 'olive');
+	print(`{warning_time} secs warning`, '#00dddd');
+	print(`{remaining_time} secs to rollover`, '#00dddd');
 	return (remaining_time <= warning_time);
 }
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1278,10 +1278,12 @@ boolean canDrink(item toDrink);
 boolean canEat(item toEat);
 boolean canChew(item toChew);
 float consumptionProgress();
-void consumeStuff();
 boolean consumeFortune();
 void auto_printNightcap();
 void auto_drinkNightcap();
+ConsumeAction auto_findBestConsumeAction(string type);
+ConsumeAction auto_findBestConsumeAction();
+boolean auto_autoConsumeOne(ConsumeAction action);
 boolean auto_autoConsumeOne(string type);
 item auto_autoConsumeOneSimulation(string type);
 boolean auto_knapsackAutoConsume(string type, boolean simulate);
@@ -1292,6 +1294,7 @@ item still_targetToOrigin(item target);
 boolean stillReachable();
 boolean distill(item target);
 boolean prepare_food_xp_multi();
+void consumeStuff();
 
 ########################################################################################################
 //Defined in autoscend/auto_settings.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1457,7 +1457,6 @@ boolean hasTorso(monster enemy);
 
 ########################################################################################################
 //Defined in autoscend/auto_path_util.ash
-boolean almostRollover();
 boolean auto_buySkills();
 void pathDroppedCheck();
 
@@ -1573,6 +1572,8 @@ boolean[location] monster_to_location(monster target);
 //Defined in autoscend/auto_util.ash
 //Other files are placed alphabetically. But due to its sheer size auto_util.ash goes last
 
+boolean almostRollover();
+boolean needToConsumeForEmergencyRollover();
 boolean autoMaximize(string req, boolean simulate);
 boolean autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate);
 aggregate autoMaximize(string req, int maxPrice, int priceLevel, boolean simulate, boolean includeEquip);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1457,6 +1457,7 @@ boolean hasTorso(monster enemy);
 
 ########################################################################################################
 //Defined in autoscend/auto_path_util.ash
+boolean almostRollover();
 boolean auto_buySkills();
 void pathDroppedCheck();
 

--- a/RELEASE/scripts/autoscend/autoscend_record.ash
+++ b/RELEASE/scripts/autoscend/autoscend_record.ash
@@ -49,3 +49,20 @@ record generic_t
 	element _element;
 	phylum _phylum;
 };
+
+//used in auto_consume.ash
+record ConsumeAction
+{
+	// exactly one of these is non-none
+	item it;
+	int cafeId;
+
+	int size;           // how much of organ is used
+	float adventures;   // expected adv from (thing)
+
+	float desirability; // adv count that will be used for optimization
+	                    // (lower for pulls, higher for buffs/tower keys)
+
+	int organ;          // AUTO_ORGAN_*
+	int howToGet;       // AUTO_OBTAIN_*
+};


### PR DESCRIPTION
# Description

This PR is to add emergency bedtime handling when rollover is fast approaching.  The time setting auto_stopMinutesToRollover (default 5) determines when autoscend will stop its normal run, consume as much as it can (without wasting too much adv to the rollover limit), and do bedtime.  This is to prevent autoscend terminating without proper bedtime processing due to rollover.  This feature can also be used just to stop the day's run early; for example, if you have somewhere to be 2 hours before rollover, set auto_stopMinutesToRollover to 125 or so.

## How Has This Been Tested?

Before testing, I put an abort() statement in doBedtime() just after the if block that tests (! almostRollover()).  This prevents bedtime from being done so I could resume my run for another test.

In the GUI, I set auto_stopMinutesToRollover to some point in the near future.  For example, if it's 10 hours until rollover, I set it to 595 (5 minutes from now).  If necessary, I could limit how much is going to be consumed by changing the 130 in needToConsumeForEmergencyRollover() (auto_util.ash) to a lower number.  Then I ran autoscend.  When the timer expired, I saw the message (possibly more than once) that rollover's coming, items being consumed until past the adv limit, and then hitting the abort, indicating that bedtime would have been done.

To do one final test for the day, I removed the abort, set auto_stopMinutesToRollover again to some point in the future shortly before I expected to finish the day anyway, and reran autoscend.  That time, everything was as in the previous test except that bedtime was done at the end.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
