### PR TITLE
add explicit checking for all monkey paw wishes used

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -100,6 +100,10 @@ boolean auto_haveMonkeyPaw()
 
 boolean auto_makeMonkeyPawWish(effect wish)
 {
+	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
+		auto_log_info("Out of monkey paw wishes, skipping "+wish.to_string());
+		return false;
+	}
 	boolean success = monkey_paw(wish);
 	if (success) {
 		handleTracker(to_string($item[cursed monkey\'s paw]), to_string(wish), "auto_wishes");
@@ -109,6 +113,10 @@ boolean auto_makeMonkeyPawWish(effect wish)
 
 boolean auto_makeMonkeyPawWish(item wish)
 {
+	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
+		auto_log_info("Out of monkey paw wishes, skipping "+wish.to_string());
+		return false;
+	}
 	boolean success = monkey_paw(wish);
 	if (success) {
 		handleTracker(to_string($item[cursed monkey\'s paw]), to_string(wish), "auto_wishes");
@@ -118,6 +126,10 @@ boolean auto_makeMonkeyPawWish(item wish)
 
 boolean auto_makeMonkeyPawWish(string wish)
 {
+	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
+		auto_log_info("Out of monkey paw wishes, skipping "+wish);
+		return false;
+	}
 	boolean success = monkey_paw(wish);
 	if (success) {
 		handleTracker(to_string($item[cursed monkey\'s paw]), wish, "auto_wishes");

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -100,8 +100,12 @@ boolean auto_haveMonkeyPaw()
 
 boolean auto_makeMonkeyPawWish(effect wish)
 {
+	if (!auto_haveMonkeyPaw()) {
+		auto_log_info("Requested monkey paw wish without paw available, skipping "+to_string(wish));
+		return false;
+	}
 	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
-		auto_log_info("Out of monkey paw wishes, skipping "+wish.to_string());
+		auto_log_info("Out of monkey paw wishes, skipping "+to_string(wish));
 		return false;
 	}
 	boolean success = monkey_paw(wish);
@@ -113,8 +117,12 @@ boolean auto_makeMonkeyPawWish(effect wish)
 
 boolean auto_makeMonkeyPawWish(item wish)
 {
+	if (!auto_haveMonkeyPaw()) {
+		auto_log_info("Requested monkey paw wish without paw available, skipping "+to_string(wish));
+		return false;
+	}
 	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
-		auto_log_info("Out of monkey paw wishes, skipping "+wish.to_string());
+		auto_log_info("Out of monkey paw wishes, skipping "+to_string(wish));
 		return false;
 	}
 	boolean success = monkey_paw(wish);
@@ -126,6 +134,10 @@ boolean auto_makeMonkeyPawWish(item wish)
 
 boolean auto_makeMonkeyPawWish(string wish)
 {
+	if (!auto_haveMonkeyPaw()) {
+		auto_log_info("Requested monkey paw wish without paw available, skipping "+to_string(wish));
+		return false;
+	}
 	if(get_property("_monkeyPawWishesUsed").to_int() >= 5) {
 		auto_log_info("Out of monkey paw wishes, skipping "+wish);
 		return false;


### PR DESCRIPTION
# Description

Mafia halts scripts when a monkey_paw() call returns false, so we have to avoid that. Explicitly check user hasn't maxed out their wishes before trying.

gCLI:
```
> ash import <autoscend> ; auto_makeMonkeyPawWish($effect[Frosty]);

[INFO] Out of monkey paw wishes for Frosty
Returned: false

> ash import <autoscend> ; auto_makeMonkeyPawWish("frosty");

[INFO] Out of monkey paw wishes, skipping frosty
Returned: false

> ash import <autoscend> ; auto_makeMonkeyPawWish($item[rusty hedge trimmers]);

[INFO] Out of monkey paw wishes, skipping rusty hedge trimmers
Returned: false
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
