### PR TITLE
LoL dailies & basic 2002 catalog support

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -613,7 +613,8 @@ boolean chateauPainting()
 
 boolean deck_available()
 {
-	return (((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card])) || ((item_amount($item[Replica Deck of Every Card]) > 0) && (in_lol())));
+	//return (((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card])) || ((item_amount($item[Replica Deck of Every Card]) > 0) && (in_lol())));
+	return ((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card]));
 }
 
 int deck_draws_left()

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -613,7 +613,7 @@ boolean chateauPainting()
 
 boolean deck_available()
 {
-	return ((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card]));
+	return (((item_amount($item[Deck of Every Card]) > 0) && is_unrestricted($item[Deck of Every Card]) && auto_is_valid($item[Deck of Every Card])) || ((item_amount($item[Replica Deck of Every Card]) > 0) && (in_lol())));
 }
 
 int deck_draws_left()

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -263,3 +263,24 @@ boolean shouldCinchoConfetti()
 	// canSurvive checked in calling location. This function is only available to combat files
 	return true;
 }
+
+boolean auto_haveCatalog()
+{
+	// check for normal version
+	static item catalog = $item[2002 Mr. Store Catalog];
+	if(auto_is_valid(catalog) && (item_amount(catalog) > 0))
+	{
+		return true;
+	}
+
+	// check for replica in LoL path
+	static item replicaCatalog = $item[replica 2002 Mr. Store Catalog];
+	return auto_is_valid(replicaCatalog) && (item_amount(replicaCatalog) > 0);
+
+}
+
+boolean auto_useCatalog()
+{
+	//http://127.0.0.1:60080/inv_use.php?pwd=e9b6ac69c68f79351fa5dd7016617c4d&which=3&whichitem=11280
+
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -278,9 +278,3 @@ boolean auto_haveCatalog()
 	return auto_is_valid(replicaCatalog) && (item_amount(replicaCatalog) > 0);
 
 }
-
-boolean auto_useCatalog()
-{
-	//http://127.0.0.1:60080/inv_use.php?pwd=e9b6ac69c68f79351fa5dd7016617c4d&which=3&whichitem=11280
-
-}

--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -31,9 +31,13 @@ boolean lol_buyReplicas()
 		// attempt to buy 2023 IOTM first as if you one them, they are immediately available
 		// then attempt to buy sequentially year by year starting with 2004
 		// note with enough progress, can a second option up to year 2012
-		if(contains_text(page, "cincho")) //2023
+		if(contains_text(page, "cincho")) //May 2023
 		{
 			buy($coinmaster[Replica Mr. Store], 1, $item[replica Cincho de Mayo]);
+		}
+		else if(contains_text(page,"2002")) //June 2023
+		{
+			buy($coinmaster[Replica Mr. Store], 1, $item[Replica 2002 Mr. Store Catalog]); //no mafia support yet, but at least buy it
 		}
 		else if(contains_text(page, "<b>2004</b>"))
 		{
@@ -216,22 +220,22 @@ void auto_LegacyOfLoathingDailies()
 		use(1, $item[replica Smith\'s Tome]); // get items
 	}
 
-	pullXWhenHaveY($item[Breathitin™], 1, 0);
-	if (item_amount($item[Breathitin™]) > 0)
+	pullXWhenHaveY($item[Breathitin&trade;], 1, 0);
+	if (item_amount($item[Breathitin&trade;]) > 0)
 		{
-			use(1, $item[Breathitin™]); // get free outdoor fight charges
+			use(1, $item[Breathitin&trade;]); // get free outdoor fight charges
 		}
 		else
 		{
 			print("Failed to pull a Breathitin","red");
 		}
 
-	if (get_property(homebodylCharges).to_int() == 0) 
+	if (get_property("homebodylCharges").to_int() == 0) 
 	{
-		pullXWhenHaveY($item[Homebodyl™], 1, 0);
-		if (item_amount($item[Homebodyl™]) > 0)
+		pullXWhenHaveY($item[Homebodyl&trade;], 1, 0);
+		if (item_amount($item[Homebodyl&trade;]) > 0)
 		{
-			use(1, $item[Homebodyl™]); // get free craft charges
+			use(1, $item[Homebodyl&trade;]); // get free craft charges
 		}
 		else
 		{
@@ -239,7 +243,7 @@ void auto_LegacyOfLoathingDailies()
 		}
 	}
 
-	if (get_property(chasmBridgeProgress).to_int() < 30)
+	if (get_property("chasmBridgeProgress").to_int() < 30)
 	{
 		pullXWhenHaveY($item[smut orc keepsake box], 1, 0);
 		if (item_amount($item[smut orc keepsake box]) > 0)

--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -220,6 +220,11 @@ void auto_LegacyOfLoathingDailies()
 		use(1, $item[replica Smith\'s Tome]); // get items
 	}
 
+	if(item_amount($item[Replica 2002 Mr. Store Catalog]) > 0)
+	{
+		use(1, $item[Replica 2002 Mr. Store Catalog]); //get catalog credits
+	}
+
 	pullXWhenHaveY($item[Breathitin&trade;], 1, 0);
 	if (item_amount($item[Breathitin&trade;]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -215,4 +215,40 @@ void auto_LegacyOfLoathingDailies()
 	{
 		use(1, $item[replica Smith\'s Tome]); // get items
 	}
+
+	pullXWhenHaveY($item[Breathitin™], 1, 0);
+	if (item_amount($item[Breathitin™]) > 0)
+		{
+			use(1, $item[Breathitin™]); // get free outdoor fight charges
+		}
+		else
+		{
+			print("Failed to pull a Breathitin","red");
+		}
+
+	if (get_property(homebodylCharges).to_int() == 0) 
+	{
+		pullXWhenHaveY($item[Homebodyl™], 1, 0);
+		if (item_amount($item[Homebodyl™]) > 0)
+		{
+			use(1, $item[Homebodyl™]); // get free craft charges
+		}
+		else
+		{
+			print("Failed to pull a Homebodyl","red");
+		}
+	}
+
+	if (get_property(chasmBridgeProgress).to_int() < 30)
+	{
+		pullXWhenHaveY($item[smut orc keepsake box], 1, 0);
+		if (item_amount($item[smut orc keepsake box]) > 0)
+		{
+			use(1, $item[smut orc keepsake box]); // get bridge parts
+		}
+		else
+		{
+			print("Failed to pull a smut orc keepsake box","red");
+		}
+	}
 }


### PR DESCRIPTION
# Description

Adding pull support for breathitin, homebodyl, and keepsake boxes since LoL has pulls left over every day. Also includes basic ("it exists") support for the 2002 catalog and an attempt to see if replica Deck "just works" (it does not)

## How Has This Been Tested?

Ran it turn 0, re-entered gracefully

`use 1 infinite BACON machine
You acquire BACON (100)
Preference _baconMachineUsed changed from false to true
Preference _concoctionDatabaseRefreshes changed from 36 to 37

cast 1 That's Not a Knife
You acquire an item: boot knife
Preference _discoKnife changed from false to true
> [INFO] Trying to pull 1 of Breathitin&trade;

pull: 1 Breathitin&trade;
Preference _roninStoragePulls changed from 9025 to 9025,10830
Preference _concoctionDatabaseRefreshes changed from 37 to 38
Preference auto_pulls changed from (1:infinite BACON machine:0) to (1:infinite BACON machine:0), (1:Breathitin&trade;:0)

chew 1 Breathitin&trade;
Preference breathitinCharges changed from 0 to 5
Preference _concoctionDatabaseRefreshes changed from 38 to 39
> [INFO] Trying to pull 1 of Homebodyl&trade;

pull: 1 Homebodyl&trade;
Preference _roninStoragePulls changed from 9025,10830 to 9025,10828,10830
Preference _concoctionDatabaseRefreshes changed from 39 to 40
Preference auto_pulls changed from (1:infinite BACON machine:0), (1:Breathitin&trade;:0) to (1:infinite BACON machine:0), (1:Breathitin&trade;:0), (1:Homebodyl&trade;:0)

chew 1 Homebodyl&trade;
Preference homebodylCharges changed from 0 to 11
Preference _concoctionDatabaseRefreshes changed from 40 to 41
> [INFO] Trying to pull 1 of smut orc keepsake box

pull: 1 smut orc keepsake box
Preference _roninStoragePulls changed from 9025,10828,10830 to 9025,10828,5788,10830
Preference _concoctionDatabaseRefreshes changed from 41 to 42
Preference auto_pulls changed from (1:infinite BACON machine:0), (1:Breathitin&trade;:0), (1:Homebodyl&trade;:0) to (1:infinite BACON machine:0), (1:Breathitin&trade;:0), (1:Homebodyl&trade;:0), (1:smut orc keepsake box:0)

use 1 smut orc keepsake box
You acquire raging hardwood plank (4)
You acquire an item: morningwood plank
You acquire an item: long hard screw
You acquire messy butt joint (2)
You acquire thick caulk (2)
Preference _concoctionDatabaseRefreshes changed from 42 to 43
> [INFO] Turn(0): Starting with 40 left and 16 pulls left at Level: 1
> [INFO] Encounter: 0.0   Exp Bonus: 2.1
> [INFO] Meat Drop: 50.0	 Item Drop: 45.0
> [INFO] HP: 21/21, MP: 2/2, Meat: 1982
> [INFO] Tummy: 0/15 Liver: 0/14 Spleen: 4/15
> [INFO] ML: 0 control: 0
> [INFO] Delay between adventures... beep boop... 
Preference _auto_thisLoopHandleFamiliar changed from  to false
Preference choiceAdventure1387 changed from 3 to -1
Preference _auto_bad100Familiar changed from  to false

Visiting Replica Mr. Store`

graceful re-entry after the deck change didn't work:

`use 1 replica Libram of Resolutions

use 1 replica Smith's Tome
> Failed to pull a Breathitin
> Failed to pull a smut orc keepsake box
> [INFO] Turn(0): Starting with 40 left and 16 pulls left at Level: 1`

## Checklist:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
