### PR TITLE
refactor rain man to be called from summonMonster

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -54,3 +54,4 @@ auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
 auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
 auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
+auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?

--- a/BUILD/task_order/Legacy Of Loathing.dat
+++ b/BUILD/task_order/Legacy Of Loathing.dat
@@ -26,7 +26,6 @@ LX_guildUnlock
 LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 LX_unlockDesert
 handleRainDoh
-routineRainManHandler
 LX_spookyravenManorFirstFloor
 L6_friarsGetParts	LX_steelOrgan_condition_slow
 LX_steelOrgan	LX_steelOrgan_condition_slow

--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -26,7 +26,6 @@ LX_guildUnlock
 LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 LX_unlockDesert
 handleRainDoh
-routineRainManHandler
 LX_spookyravenManorFirstFloor
 L6_friarsGetParts	LX_steelOrgan_condition_slow
 LX_steelOrgan	LX_steelOrgan_condition_slow

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -92,84 +92,83 @@ Legacy of Loathing	24	LX_guildUnlock
 Legacy of Loathing	25	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 Legacy of Loathing	26	LX_unlockDesert
 Legacy of Loathing	27	handleRainDoh
-Legacy of Loathing	28	routineRainManHandler
-Legacy of Loathing	29	LX_spookyravenManorFirstFloor
-Legacy of Loathing	30	L6_friarsGetParts	LX_steelOrgan_condition_slow
-Legacy of Loathing	31	LX_steelOrgan	LX_steelOrgan_condition_slow
+Legacy of Loathing	28	LX_spookyravenManorFirstFloor
+Legacy of Loathing	29	L6_friarsGetParts	LX_steelOrgan_condition_slow
+Legacy of Loathing	30	LX_steelOrgan	LX_steelOrgan_condition_slow
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	32	L4_batCave
-Legacy of Loathing	33	L2_mosquito
-Legacy of Loathing	34	LX_unlockHiddenTemple
-Legacy of Loathing	35	L6_dakotaFanning
-Legacy of Loathing	36	LX_lockPicking
-Legacy of Loathing	37	LX_fatLootToken
+Legacy of Loathing	31	L4_batCave
+Legacy of Loathing	32	L2_mosquito
+Legacy of Loathing	33	LX_unlockHiddenTemple
+Legacy of Loathing	34	L6_dakotaFanning
+Legacy of Loathing	35	LX_lockPicking
+Legacy of Loathing	36	LX_fatLootToken
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	38	L5_slayTheGoblinKing
+Legacy of Loathing	37	L5_slayTheGoblinKing
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	39	L8_trapperQuest
+Legacy of Loathing	38	L8_trapperQuest
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	40	L7_crypt
-Legacy of Loathing	41	LX_islandAccess
-Legacy of Loathing	42	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-Legacy of Loathing	43	LX_spookyravenManorSecondFloor
-Legacy of Loathing	44	L3_tavern
-Legacy of Loathing	45	L6_friarsGetParts
-Legacy of Loathing	46	LX_steelOrgan	in_hardcore
-Legacy of Loathing	47	fancyOilPainting
-Legacy of Loathing	48	LX_steelOrgan
-Legacy of Loathing	49	L10_plantThatBean
-Legacy of Loathing	50	L12_preOutfit
-Legacy of Loathing	51	L10_airship
-Legacy of Loathing	52	L10_basement
-Legacy of Loathing	53	L10_ground
-Legacy of Loathing	54	L11_blackMarket
-Legacy of Loathing	55	L11_forgedDocuments
-Legacy of Loathing	56	L11_mcmuffinDiary
-Legacy of Loathing	57	L10_topFloor
-Legacy of Loathing	58	L10_holeInTheSkyUnlock
-Legacy of Loathing	59	L9_chasmBuild
-Legacy of Loathing	60	L9_highLandlord
-Legacy of Loathing	61	L12_flyerBackup
-Legacy of Loathing	62	Lsc_flyerSeals
+Legacy of Loathing	39	L7_crypt
+Legacy of Loathing	40	LX_islandAccess
+Legacy of Loathing	41	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
+Legacy of Loathing	42	LX_spookyravenManorSecondFloor
+Legacy of Loathing	43	L3_tavern
+Legacy of Loathing	44	L6_friarsGetParts
+Legacy of Loathing	45	LX_steelOrgan	in_hardcore
+Legacy of Loathing	46	fancyOilPainting
+Legacy of Loathing	47	LX_steelOrgan
+Legacy of Loathing	48	L10_plantThatBean
+Legacy of Loathing	49	L12_preOutfit
+Legacy of Loathing	50	L10_airship
+Legacy of Loathing	51	L10_basement
+Legacy of Loathing	52	L10_ground
+Legacy of Loathing	53	L11_blackMarket
+Legacy of Loathing	54	L11_forgedDocuments
+Legacy of Loathing	55	L11_mcmuffinDiary
+Legacy of Loathing	56	L10_topFloor
+Legacy of Loathing	57	L10_holeInTheSkyUnlock
+Legacy of Loathing	58	L9_chasmBuild
+Legacy of Loathing	59	L9_highLandlord
+Legacy of Loathing	60	L12_flyerBackup
+Legacy of Loathing	61	Lsc_flyerSeals
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	63	L11_mauriceSpookyraven
-Legacy of Loathing	64	L11_unlockHiddenCity
-Legacy of Loathing	65	L11_hiddenCityZones
-Legacy of Loathing	66	LX_ornateDowsingRod
-Legacy of Loathing	67	L11_aridDesert
+Legacy of Loathing	62	L11_mauriceSpookyraven
+Legacy of Loathing	63	L11_unlockHiddenCity
+Legacy of Loathing	64	L11_hiddenCityZones
+Legacy of Loathing	65	LX_ornateDowsingRod
+Legacy of Loathing	66	L11_aridDesert
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	68	L11_hiddenCity
-Legacy of Loathing	69	L11_talismanOfNam
+Legacy of Loathing	67	L11_hiddenCity
+Legacy of Loathing	68	L11_talismanOfNam
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	70	L11_palindome
-Legacy of Loathing	71	L11_unlockPyramid
-Legacy of Loathing	72	L11_unlockEd
-Legacy of Loathing	73	L11_defeatEd
-Legacy of Loathing	74	L12_gremlins
-Legacy of Loathing	75	L12_sonofaFinish
-Legacy of Loathing	76	L12_sonofaBeach
-Legacy of Loathing	77	L12_filthworms
-Legacy of Loathing	78	L12_orchardFinalize
-Legacy of Loathing	79	L12_themtharHills
-Legacy of Loathing	80	L12_farm
-Legacy of Loathing	81	L11_getBeehive
+Legacy of Loathing	69	L11_palindome
+Legacy of Loathing	70	L11_unlockPyramid
+Legacy of Loathing	71	L11_unlockEd
+Legacy of Loathing	72	L11_defeatEd
+Legacy of Loathing	73	L12_gremlins
+Legacy of Loathing	74	L12_sonofaFinish
+Legacy of Loathing	75	L12_sonofaBeach
+Legacy of Loathing	76	L12_filthworms
+Legacy of Loathing	77	L12_orchardFinalize
+Legacy of Loathing	78	L12_themtharHills
+Legacy of Loathing	79	L12_farm
+Legacy of Loathing	80	L11_getBeehive
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	82	L12_finalizeWar
-Legacy of Loathing	83	L12_clearBattlefield
-Legacy of Loathing	84	LX_koeInvaderHandler
-Legacy of Loathing	85	setSoftblockDelay	allowSoftblockDelay
-Legacy of Loathing	86	setSoftblockShen	allowSoftblockShen
-Legacy of Loathing	87	LX_getDigitalKey
-Legacy of Loathing	88	LX_getStarKey
-Legacy of Loathing	89	L12_lastDitchFlyer
-Legacy of Loathing	90	LX_bugbearInvasionFinale
-Legacy of Loathing	91	L13_towerNSContests
-Legacy of Loathing	92	L13_towerNSHedge
-Legacy of Loathing	93	L13_sorceressDoor
-Legacy of Loathing	94	L13_towerNSTower
-Legacy of Loathing	95	L13_towerNSNagamar
-Legacy of Loathing	96	L13_towerNSFinal
-Legacy of Loathing	97	LX_attemptPowerLevel
+Legacy of Loathing	81	L12_finalizeWar
+Legacy of Loathing	82	L12_clearBattlefield
+Legacy of Loathing	83	LX_koeInvaderHandler
+Legacy of Loathing	84	setSoftblockDelay	allowSoftblockDelay
+Legacy of Loathing	85	setSoftblockShen	allowSoftblockShen
+Legacy of Loathing	86	LX_getDigitalKey
+Legacy of Loathing	87	LX_getStarKey
+Legacy of Loathing	88	L12_lastDitchFlyer
+Legacy of Loathing	89	LX_bugbearInvasionFinale
+Legacy of Loathing	90	L13_towerNSContests
+Legacy of Loathing	91	L13_towerNSHedge
+Legacy of Loathing	92	L13_sorceressDoor
+Legacy of Loathing	93	L13_towerNSTower
+Legacy of Loathing	94	L13_towerNSNagamar
+Legacy of Loathing	95	L13_towerNSFinal
+Legacy of Loathing	96	LX_attemptPowerLevel
 
 Quantum Terrarium	0	LX_freeCombatsTask
 Quantum Terrarium	1	LX_unlockPirateRealm
@@ -323,74 +322,73 @@ default	24	LX_guildUnlock
 default	25	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 default	26	LX_unlockDesert
 default	27	handleRainDoh
-default	28	routineRainManHandler
-default	29	LX_spookyravenManorFirstFloor
-default	30	L6_friarsGetParts	LX_steelOrgan_condition_slow
-default	31	LX_steelOrgan	LX_steelOrgan_condition_slow
-default	32	L4_batCave
-default	33	L2_mosquito
-default	34	LX_unlockHiddenTemple
-default	35	L6_dakotaFanning
-default	36	LX_lockPicking
-default	37	LX_fatLootToken
-default	38	L5_slayTheGoblinKing
-default	39	LX_islandAccess
-default	40	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-default	41	LX_spookyravenManorSecondFloor
-default	42	L3_tavern
-default	43	L6_friarsGetParts
-default	44	LX_steelOrgan	in_hardcore
-default	45	L7_crypt
-default	46	fancyOilPainting
-default	47	L8_trapperQuest
-default	48	LX_steelOrgan
-default	49	L10_plantThatBean
-default	50	L12_preOutfit
-default	51	L10_airship
-default	52	L10_basement
-default	53	L10_ground
-default	54	L11_blackMarket
-default	55	L11_forgedDocuments
-default	56	L11_mcmuffinDiary
-default	57	L10_topFloor
-default	58	L10_holeInTheSkyUnlock
-default	59	L9_chasmBuild
-default	60	L9_highLandlord
-default	61	L12_flyerBackup
-default	62	Lsc_flyerSeals
-default	63	L11_mauriceSpookyraven
-default	64	L11_unlockHiddenCity
-default	65	L11_hiddenCityZones
-default	66	LX_ornateDowsingRod
-default	67	L11_aridDesert
-default	68	L11_hiddenCity
-default	69	L11_talismanOfNam
-default	70	L11_palindome
-default	71	L11_unlockPyramid
-default	72	L11_unlockEd
-default	73	L11_defeatEd
-default	74	L12_gremlins
-default	75	L12_sonofaFinish
-default	76	L12_sonofaBeach
-default	77	L12_filthworms
-default	78	L12_orchardFinalize
-default	79	L12_themtharHills
-default	80	L12_farm
-default	81	L11_getBeehive
-default	82	L12_finalizeWar
-default	83	L12_clearBattlefield
-default	84	LX_koeInvaderHandler
-default	85	setSoftblockDelay	allowSoftblockDelay
-default	86	setSoftblockShen	allowSoftblockShen
-default	87	LX_getDigitalKey
-default	88	LX_getStarKey
-default	89	L12_lastDitchFlyer
-default	90	LX_bugbearInvasionFinale
-default	91	L13_towerNSContests
-default	92	L13_towerNSHedge
-default	93	L13_sorceressDoor
-default	94	L13_towerNSTower
-default	95	L13_towerNSNagamar
-default	96	L13_towerNSFinal
-default	97	LX_attemptPowerLevel
+default	28	LX_spookyravenManorFirstFloor
+default	29	L6_friarsGetParts	LX_steelOrgan_condition_slow
+default	30	LX_steelOrgan	LX_steelOrgan_condition_slow
+default	31	L4_batCave
+default	32	L2_mosquito
+default	33	LX_unlockHiddenTemple
+default	34	L6_dakotaFanning
+default	35	LX_lockPicking
+default	36	LX_fatLootToken
+default	37	L5_slayTheGoblinKing
+default	38	LX_islandAccess
+default	39	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
+default	40	LX_spookyravenManorSecondFloor
+default	41	L3_tavern
+default	42	L6_friarsGetParts
+default	43	LX_steelOrgan	in_hardcore
+default	44	L7_crypt
+default	45	fancyOilPainting
+default	46	L8_trapperQuest
+default	47	LX_steelOrgan
+default	48	L10_plantThatBean
+default	49	L12_preOutfit
+default	50	L10_airship
+default	51	L10_basement
+default	52	L10_ground
+default	53	L11_blackMarket
+default	54	L11_forgedDocuments
+default	55	L11_mcmuffinDiary
+default	56	L10_topFloor
+default	57	L10_holeInTheSkyUnlock
+default	58	L9_chasmBuild
+default	59	L9_highLandlord
+default	60	L12_flyerBackup
+default	61	Lsc_flyerSeals
+default	62	L11_mauriceSpookyraven
+default	63	L11_unlockHiddenCity
+default	64	L11_hiddenCityZones
+default	65	LX_ornateDowsingRod
+default	66	L11_aridDesert
+default	67	L11_hiddenCity
+default	68	L11_talismanOfNam
+default	69	L11_palindome
+default	70	L11_unlockPyramid
+default	71	L11_unlockEd
+default	72	L11_defeatEd
+default	73	L12_gremlins
+default	74	L12_sonofaFinish
+default	75	L12_sonofaBeach
+default	76	L12_filthworms
+default	77	L12_orchardFinalize
+default	78	L12_themtharHills
+default	79	L12_farm
+default	80	L11_getBeehive
+default	81	L12_finalizeWar
+default	82	L12_clearBattlefield
+default	83	LX_koeInvaderHandler
+default	84	setSoftblockDelay	allowSoftblockDelay
+default	85	setSoftblockShen	allowSoftblockShen
+default	86	LX_getDigitalKey
+default	87	LX_getStarKey
+default	88	L12_lastDitchFlyer
+default	89	LX_bugbearInvasionFinale
+default	90	L13_towerNSContests
+default	91	L13_towerNSHedge
+default	92	L13_sorceressDoor
+default	93	L13_towerNSTower
+default	94	L13_towerNSNagamar
+default	95	L13_towerNSFinal
+default	96	LX_attemptPowerLevel
 

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -117,10 +117,6 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	if (contains_text(page, combatPage)) {
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 		run_combat(option);
-	} else if (contains_text(page, "Rainy Fax Dreams")) {
-		// Escape without spending rain
-		run_choice(2);
-		return false;
 	} else {
 		auto_log_info("autoAdvBypass has encountered a choice!", "green");
 		run_choice(-1);
@@ -147,6 +143,10 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 		return false;
 	}
 	if(get_property("lastEncounter") == "Rationing out Destruction")
+	{
+		return false;
+	}
+	if(get_property("lastEncounter") == "Rainy Fax Dreams on your Wedding Day")
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -119,7 +119,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 		run_combat(option);
 	} else if (contains_text(page, "Rainy Fax Dreams") {
 		// Escape without spending rain
-		ash visit_url("choice.php?whichchoice=970&option=2");
+		run_choice(2);
 		return false;
 	} else {
 		auto_log_info("autoAdvBypass has encountered a choice!", "green");

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -117,6 +117,10 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	if (contains_text(page, combatPage)) {
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 		run_combat(option);
+	} else if contains_text(page, "Rainy Fax Dreams") {
+		// Escape without spending rain
+		run_choice(6);
+		return false;
 	} else {
 		auto_log_info("autoAdvBypass has encountered a choice!", "green");
 		run_choice(-1);

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -117,9 +117,9 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	if (contains_text(page, combatPage)) {
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 		run_combat(option);
-	} else if contains_text(page, "Rainy Fax Dreams") {
+	} else if (contains_text(page, "Rainy Fax Dreams") {
 		// Escape without spending rain
-		run_choice(6);
+		ash visit_url("choice.php?whichchoice=970&option=2");
 		return false;
 	} else {
 		auto_log_info("autoAdvBypass has encountered a choice!", "green");

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -117,7 +117,7 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	if (contains_text(page, combatPage)) {
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");
 		run_combat(option);
-	} else if (contains_text(page, "Rainy Fax Dreams") {
+	} else if (contains_text(page, "Rainy Fax Dreams")) {
 		// Escape without spending rain
 		run_choice(2);
 		return false;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -437,6 +437,9 @@ boolean auto_run_choice(int choice, string page)
 		case 928: // You Found Your Thrill (The Black Forest)
 			blackForestChoiceHandler(choice);
 			break;
+		case 970: // Rainy Fax Dreams on your Wedding Day
+			run_choice(2); // leave and get your rain back
+			break;
 		case 976: // Ed the Undrowning (Heavy Rains)
 			run_choice(1); // fight Ed in a Heavy Rains run
 			break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1917,7 +1917,7 @@ boolean summonMonster(monster mon, boolean speculative)
 	{
 		if(speculative && canGenieCombat(mon))
 		{
-			auto_log_debug("Can summon " + mon " via wishing", "blue");
+			auto_log_debug("Can summon " + mon + " via wishing", "blue");
 			return true;
 		}
 		else if(!speculative && makeGenieCombat(mon))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1881,48 +1881,48 @@ boolean summonMonster(monster mon, boolean speculative)
 		// calculate the universe's only summon we want, so prioritize using it
 		if(LX_calculateTheUniverse(speculative))
 		{
-			auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+			auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via calculate the universe", "blue");
 			return true;
 		}
 	}
 	// todo add support for Baa'baa'bu'ran with deck of every card sheep card
 	if(timeSpinnerCombat(mon, speculative))
 	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via time spinner", "blue");
 		return true;
 	}
 	// methods which can only summon monsters should be attempted first
 	if (rainManSummon(mon, speculative))
 	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via rain man", "blue");
 		return true;
 	}
 	if(auto_fightLocketMonster(mon, speculative))
 	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via combat lover's locket", "blue");
 		return true;
 	}
 	if(handleFaxMonster(mon, !speculative))
 	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via fax", "blue");
 		return true;
 	}
 	// methods which can do more than summon monsters
 	if(auto_cargoShortsOpenPocket(mon, speculative))
 	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via cargo shorts", "blue");
 		return true;
 	}
 	if(auto_shouldUseWishes())
 	{
 		if(speculative && canGenieCombat(mon))
 		{
-			auto_log_debug("Can summon " + mon, "blue");
+			auto_log_debug("Can summon " + mon " via wishing", "blue");
 			return true;
 		}
 		else if(!speculative && makeGenieCombat(mon))
 		{
-			auto_log_debug("Did summon " + mon, "blue");
+			auto_log_debug("Did summon " + mon + " via wishing", "blue");
 			return true;
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1826,6 +1826,29 @@ boolean LX_summonMonster()
 		if(summonMonster($monster[Astronomer])) return true;
 	}
 
+	// summon additional monsters in heavy rains with rain man when available
+	if(have_skill($skill[Rain Man]) && my_rain() >= 50)
+	{
+		// summon Family Jewels or Bush to get only stars
+		if(needStarKey() && item_amount($item[star]) < 8 && item_amount($item[line]) >= 7)
+		{
+			if(canSummonMonster($monster[Family Jewels]) && summonMonster($monster[Family Jewels])) return true;
+			if(canSummonMonster($monster[Bush]) && summonMonster($monster[Bush])) return true;
+		}
+		// summon Trouser Snake or Box to get only lines
+		if(needStarKey() && item_amount($item[star]) >= 8 && item_amount($item[line]) < 7)
+		{
+			if(canSummonMonster($monster[Trouser Snake]) && summonMonster($monster[Trouser Snake])) return true;	
+			if(canSummonMonster($monster[Box]) && summonMonster($monster[Box])) return true;
+		}
+		// summon Skinflute or Camel's Toe to get both stars and lines
+		if(needStarKey() && item_amount($item[star]) < 8 && item_amount($item[line]) < 7)
+		{
+			if(canSummonMonster($monster[Skinflute]) && summonMonster($monster[Skinflute])) return true;
+			if(canSummonMonster($monster[Camel's Toe]) && summonMonster($monster[Camel's Toe])) return true;
+		}
+	}
+
 	return false;
 }
 
@@ -1842,6 +1865,16 @@ boolean summonMonster(monster mon)
 boolean summonMonster(monster mon, boolean speculative)
 {
 	auto_log_debug((speculative ? "Checking if we can" : "Trying to") + " summon " + mon, "blue");
+
+	if (!speculative)
+	{
+		// Equip the combat lover's locket if we're missing a monster about to be summoned
+		if (auto_haveCombatLoversLocket() && mon.id > 0 && mon.copyable && !mon.boss && !auto_monsterInLocket(mon))
+		{
+			auto_log_info('We want to get the "' + mon + '" monster into the combat lover\'s locket from summoning, so we\'re bringing it along.', "blue");
+			autoEquip($item[combat lover\'s locket]);
+		}
+	}
 	// methods which require specific circumstances
 	if(mon == $monster[War Frat 151st Infantryman])
 	{	
@@ -1855,9 +1888,15 @@ boolean summonMonster(monster mon, boolean speculative)
 	// todo add support for Baa'baa'bu'ran with deck of every card sheep card
 	if(timeSpinnerCombat(mon, speculative))
 	{
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
 		return true;
 	}
 	// methods which can only summon monsters should be attempted first
+	if (rainManSummon(mon, speculative))
+	{
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
+		return true;
+	}
 	if(auto_fightLocketMonster(mon, speculative))
 	{
 		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon, "blue");
@@ -1887,9 +1926,6 @@ boolean summonMonster(monster mon, boolean speculative)
 			return true;
 		}
 	}
-
-	//todo
-	// add support for rainManSummon(). Look to routineRainManHandler()
 
 	return false;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1885,6 +1885,11 @@ boolean summonMonster(monster mon, boolean speculative)
 			return true;
 		}
 	}
+	if (rainManSummon(mon, speculative))
+	{
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via rain man", "blue");
+		return true;
+	}
 	// todo add support for Baa'baa'bu'ran with deck of every card sheep card
 	if(timeSpinnerCombat(mon, speculative))
 	{
@@ -1892,11 +1897,6 @@ boolean summonMonster(monster mon, boolean speculative)
 		return true;
 	}
 	// methods which can only summon monsters should be attempted first
-	if (rainManSummon(mon, speculative))
-	{
-		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via rain man", "blue");
-		return true;
-	}
 	if(auto_fightLocketMonster(mon, speculative))
 	{
 		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via combat lover's locket", "blue");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -728,11 +728,10 @@ boolean LA_grey_goo_tasks();
 //Defined in autoscend/paths/heavy_rains.ash
 boolean in_heavyrains();
 void heavyrains_initializeSettings();
-boolean routineRainManHandler();
 void heavyrains_initializeDay(int day);
 void heavyrains_doBedtime();
 boolean heavyrains_buySkills();
-boolean rainManSummon(monster target, boolean copy, boolean wink);
+boolean rainManSummon(monster target, boolean speculative);
 boolean L13_heavyrains_towerFinal();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -49,7 +49,7 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 		return false;
 	}
 	// don't try to fax unfaxable monsters
-	if($monsters[smut orc pervert, screambat, War Frat 151st Infantryman] contains enemy)
+	if(!can_faxbot(enemy))
 	{
 		return false;
 	}
@@ -76,7 +76,7 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 	}
 
 	auto_log_info("Faxing: " + enemy + ".", "green");
-	chat_private("cheesefax", enemy.to_string());
+	faxbot(enemy);
 	for(int i = 0; i < 3; i++)
 	{
 		//wait 10 seconds before trying to get fax

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1179,15 +1179,12 @@ boolean timeSpinnerAdventure(string option)
 boolean canTimeSpinnerMonster(monster mon)
 {
 	// Can only time spinner summon copyable monsters
-	if(!mon.copyable)
+	if(!mon.copyable || mon.id < 0)
 	{
 		return false;
 	}
-	// If adding spinner support for a new monster, ensure the monster's native zone is listed below
-	boolean[location] possibleSpinnerMonsterZones = $locations[Guano Junction, The Batrat and Ratbat Burrow, The Beanbat Chamber, The Haunted Pantry,
-		The Skeleton Store, The Secret Government Laboratory, The Goatlet, The Haunted Bedroom, Sonofa Beach, The Outskirts of Cobb's Knob];
 	
-	foreach loc in possibleSpinnerMonsterZones
+	foreach loc in $locations[]
 	{
 		if(contains_text(loc.combat_queue, to_string(mon))) return true;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1183,10 +1183,11 @@ boolean canTimeSpinnerMonster(monster mon)
 	{
 		return false;
 	}
-	
+
+	string name = mon.to_string();
 	foreach loc in $locations[]
 	{
-		if(contains_text(loc.combat_queue, to_string(mon))) return true;
+		if(contains_text(loc.combat_queue, name)) return true;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1205,7 +1205,7 @@ boolean timeSpinnerCombat(monster goal, boolean speculative)
 boolean timeSpinnerCombat(monster goal, string option, boolean speculative)
 {
 	//spend 3 minutes to Travel to a Recent Fight
-	if(timeSpinnerRemaining(true) < 3)
+	if(timeSpinnerRemaining(!speculative) < 3)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -311,6 +311,12 @@ boolean auto_backupTarget()
 		return false;
 	}
 
+	// don't backup if nextAdventure is Noob Cave as a combat was started via autoAdvBypass
+	if (get_property("nextAdventure").to_location() == $location[Noob Cave])
+	{
+		return false;
+	}
+
 	// determine if we want to backup
 	boolean wantBackupLFM = item_amount($item[barrel of gunpowder]) < 5 && get_property("sidequestLighthouseCompleted") == "none" && my_level() >= 12 && !auto_hasAutumnaton();
 	boolean wantBackupNSA = (item_amount($item[ninja rope]) < 1 || item_amount($item[ninja carabiner]) < 1 || item_amount($item[ninja crampons]) < 1) && my_level() >= 8 && !get_property("auto_L8_extremeInstead").to_boolean();

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -311,8 +311,8 @@ boolean auto_backupTarget()
 		return false;
 	}
 
-	// don't backup if nextAdventure is Noob Cave as a combat was started via autoAdvBypass
-	if (get_property("nextAdventure").to_location() == $location[Noob Cave])
+	// don't backup if nextAdventure is Noob Cave or None as a combat was started via autoAdvBypass or somewhere that is not a zone
+	if (get_property("nextAdventure").to_location() == $location[Noob Cave] || get_property("nextAdventure").to_location() == $location[None])
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -224,12 +224,7 @@ boolean canRainManSummon(monster target)
 		return true;
 	}
 
-	// If no factoids, check the page directly
-	string page = visit_url("runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1");
-	// Escape without spending rain
-	run_choice(2);
-
-	return page.contains_text("<option value=\"" + target.id + "\">");
+	return false;
 }
 
 boolean rainManSummon(monster target, boolean speculative)
@@ -249,9 +244,9 @@ boolean rainManSummon(monster target, boolean speculative)
 	auto_log_info("Rain Man will summon: " +target, "blue");
 	string[int] pages;
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";
-	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" +target.to_int()+ "&option=1&choice2=and+Fight%21";
+	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" + target.id + "&option=1&choice2=and+Fight%21";
 	// autoAdvBypass will escape from the choice and return false if the monster cannot be fought
-	if(autoAdvBypass(1, pages, $location[Noob Cave], ""))
+	if(autoAdvBypass(0, pages, $location[Noob Cave], ""))
 	{
 		handleTracker(target, $skill[Rain Man], "auto_copies");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -246,7 +246,7 @@ boolean rainManSummon(monster target, boolean speculative)
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";
 	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" + target.id + "&option=1&choice2=and+Fight%21";
 	// autoAdvBypass will escape from the choice and return false if the monster cannot be fought
-	if(autoAdvBypass(1, pages, $location[Noob Cave], ""))
+	if(autoAdvBypass(0, pages, $location[Noob Cave], ""))
 	{
 		handleTracker(target, $skill[Rain Man], "auto_copies");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -246,7 +246,7 @@ boolean rainManSummon(monster target, boolean speculative)
 	pages[0] = "runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1";
 	pages[1] = "choice.php?pwd&whichchoice=970&whichmonster=" + target.id + "&option=1&choice2=and+Fight%21";
 	// autoAdvBypass will escape from the choice and return false if the monster cannot be fought
-	if(autoAdvBypass(0, pages, $location[Noob Cave], ""))
+	if(autoAdvBypass(1, pages, $location[Noob Cave], ""))
 	{
 		handleTracker(target, $skill[Rain Man], "auto_copies");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -205,7 +205,7 @@ boolean heavyrains_buySkills()
 	return false;
 }
 
-boolean canRainManSummon(monster mon)
+boolean canRainManSummon(monster target)
 {
 	if(!have_skill($skill[Rain Man]) || my_rain() < 50)
 	{
@@ -213,13 +213,13 @@ boolean canRainManSummon(monster mon)
 	}
 
 	// Can only rain man summon copyable monsters
-	if(!mon.copyable)
+	if(!target.copyable)
 	{
 		return false;
 	}
 
 	// Can summon any monster with available factoids
-	if (mon.monster_factoidss_available(false) > 0)
+	if (target.monster_factoidss_available(false) > 0)
 	{
 		return true;
 	}
@@ -230,7 +230,7 @@ boolean canRainManSummon(monster mon)
 	run_choice(6);
 
 	// TODO
-	boolean canSummon = page.contains_text("id=" + mon.id);
+	boolean canSummon = page.contains_text("id=" + target.id);
 
 	return canSummon;
 }
@@ -242,7 +242,7 @@ boolean rainManSummon(monster target, boolean speculative)
 		return false;
 	}
 
-	boolean canSummon = canRainManSummon(mon);
+	boolean canSummon = canRainManSummon(target);
 	if (!canSummon || speculative)
 	{
 		return canSummon;
@@ -256,8 +256,8 @@ boolean rainManSummon(monster target, boolean speculative)
 	// autoAdvBypass will escape from the choice and return false if the monster cannot be fought
 	if(autoAdvBypass(1, pages, $location[Noob Cave], ""))
 	{
-		handleTracker(mon, $skill[Rain Man], "auto_copies");
-		return true
+		handleTracker(target, $skill[Rain Man], "auto_copies");
+		return true;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -224,7 +224,13 @@ boolean canRainManSummon(monster target)
 		return true;
 	}
 
-	return false;
+	// Check the page text
+	auto_log_info(target + " factoids unavailable, checking Rain Man if summon is possible", "blue");
+	buffer page = visit_url("runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1");
+	// Escape
+	run_choice(2);
+
+	return page.contains_text("<option value=" + target.id + ">");
 }
 
 boolean rainManSummon(monster target, boolean speculative)

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -219,7 +219,7 @@ boolean canRainManSummon(monster target)
 	}
 
 	// Can summon any monster with available factoids
-	if (target.monster_factoidss_available(false) > 0)
+	if (target.monster_factoids_available(false) > 0)
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -213,7 +213,7 @@ boolean canRainManSummon(monster target)
 	}
 
 	// Can only rain man summon copyable monsters
-	if(!target.copyable)
+	if(!target.copyable || target.id < 0)
 	{
 		return false;
 	}
@@ -227,12 +227,9 @@ boolean canRainManSummon(monster target)
 	// If no factoids, check the page directly
 	string page = visit_url("runskillz.php?pwd&action=Skillz&whichskill=16011&quantity=1");
 	// Escape without spending rain
-	run_choice(6);
+	run_choice(2);
 
-	// TODO
-	boolean canSummon = page.contains_text("id=" + target.id);
-
-	return canSummon;
+	return page.contains_text("<option value=\"" + target.id + "\">");
 }
 
 boolean rainManSummon(monster target, boolean speculative)

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -235,11 +235,6 @@ boolean canRainManSummon(monster target)
 
 boolean rainManSummon(monster target, boolean speculative)
 {
-	if(!have_skill($skill[Rain Man]) || my_rain() < 50)
-	{
-		return false;
-	}
-
 	boolean canSummon = canRainManSummon(target);
 	if (!canSummon || speculative)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -302,24 +302,6 @@ boolean L8_getMineOres()
 		return false;
 	}
 
-	// heavy rain copy handling.
-	if(in_heavyrains() && have_skill($skill[Rain Man]))
-	{
-		if(my_rain() < 50)
-		{
-			auto_log_info("Need Ore but not enough rain. Delaying ore for trapper", "blue");
-			return false;
-		}
-		if(have_effect($effect[Ultrahydrated]) == 0 && my_rain() < 90)
-		{
-			auto_log_info("Do not waste ultrahydrated. Delaying ore for trapper", "blue");
-			return false;
-		}
-		auto_log_info("Trying to summon a mountain man", "blue");
-		set_property("auto_mountainmen", "1");
-		return rainManSummon($monster[mountain man], false, false);
-	}
-	
 	// in softcore we want to pull an ore
 	if(canPull(oreGoal))
 	{
@@ -576,11 +558,6 @@ boolean L8_trapperSlopeSoftcore()
 	// special path or IOTM handling
 	if(!get_property("auto_L8_ninjaAssassinFail").to_boolean()) // can defeat assassins
 	{
-		if(have_skill($skill[Rain Man]))
-		{
-			auto_log_info("Delay pulling ninja climbing gear. we want to summon assassins with rain man skill", "blue");
-			return false;
-		}
 		if(get_property("_sourceTerminalDigitizeMonster") == $monster[Ninja Snowman Assassin])
 		{
 			auto_log_info("Delay pulling ninja climbing gear. we have already digitized [ninja snowman assassin]", "blue");
@@ -653,11 +630,6 @@ boolean L8_trapperNinjaLair()
 	if(get_property("_sourceTerminalDigitizeMonster") == $monster[Ninja Snowman Assassin])
 	{
 		auto_log_info("Have a digitized Ninja Snowman Assassin, let's put off the Ninja Snowmen Lair", "blue");
-		return false;
-	}
-	if(have_skill($skill[Rain Man]))
-	{
-		auto_log_info("Delay adventuring in ninja snowmen lair. we are going to be copying them instead with rain man skill", "blue");
 		return false;
 	}
 


### PR DESCRIPTION
# Description

* Remove special monster handling in heavy_rains.ash, this is unnecessary now
* Add a few extra summons in heavy rains to match old special summoning behavior, imo this could be extended to do even more summons there's a ton of rain man summons available
* Check if a monster can be summoned by first checking manual, then checking the rain man page text if no factoids are available
* Handle escaping from Rain Man if the summon fails
* Don't back up if nextLocation is Noob Cave or None, as these are used to denote monsters fought without a location (all summons for example). This was causing my rain man summoned monster to allow backing up, and of course that worked and I lost the summon.
* don't manually verify time-spinner minutes if speculating
* equip the combat lover's locket if summoning anything that could be added

## How Has This Been Tested?

* manually called summonMonster to rain man arbitrary monsters that have factoids for
* several heavy rains runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
