### PR TITLE
Visit Grim Brother chat menu before attempting to select int buff in …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sh
 .github/kolmafia.jar
 .vs*
+*.DS_Store

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -480,7 +480,14 @@ float provideInitiative(int amt, location loc, boolean doEquips, boolean specula
 	if(doEquips && auto_have_familiar($familiar[Grim Brother]) && (have_effect($effect[Soles of Glass]) == 0) && (get_property("_grimBuff").to_boolean() == false))
 	{
 		if(!speculative)
+		{
+			// We must visit the familiar's page before we can select the choice.
+			auto_log_debug("Attempting to visit Grim brother");
+			visit_url("familiar.php?action=chatgrim&pwd", true);
+			auto_log_debug("Attempting to select Soles of Glass");
 			visit_url("choice.php?pwd&whichchoice=835&option=1", true);
+		}
+			
 		handleEffect($effect[Soles of Glass]);
 		if(pass())
 			return result();


### PR DESCRIPTION
…provideInitiative method

# Description

Please include a summary of the change. Pull requests should always be against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main).

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

When a user has Grim Brother, the provideInitiative method attempts to visit choice.php, selecting the Soles of Glass option; however, without first visiting Grim Brother (the equivalent of clicking [Talk]), attempting to select the choice errors with a message, "Whoops! You're not actually in a choice adventure".

Stack trace from the error:



## How Has This Been Tested?

Tested directly in run.



## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
