### PR TITLE
Lo l 100% fam

### DIFF
--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -41,8 +41,11 @@ boolean lol_buyReplicas()
 		}
 		if(contains_text(page, "patriotic eagle")) //2023
 		{
-			buy($coinmaster[Replica Mr. Store], 1, $item[replica sleeping patriotic eagle]);
-			use(1, $item[replica sleeping patriotic eagle]); // put in terrarium
+			if(!is100FamRun()) //If this isn't a 100% familiar run, go ahead and get another familiar
+				{	
+					buy($coinmaster[Replica Mr. Store], 1, $item[replica sleeping patriotic eagle]);
+					use(1, $item[replica sleeping patriotic eagle]); // put in terrarium
+				}
 		}
 		else if(contains_text(page, "<b>2004</b>"))
 		{

--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -39,9 +39,9 @@ boolean lol_buyReplicas()
 		{
 			buy($coinmaster[Replica Mr. Store], 1, $item[Replica 2002 Mr. Store Catalog]);
 		}
-		if(contains_text(page, "patriotic eagle")) //2023
+		if(!is100FamRun()) //If this isn't a 100% familiar run, go ahead and get another familiar
 		{
-			if(!is100FamRun()) //If this isn't a 100% familiar run, go ahead and get another familiar
+			if(contains_text(page, "patriotic eagle")) //2023
 				{	
 					buy($coinmaster[Replica Mr. Store], 1, $item[replica sleeping patriotic eagle]);
 					use(1, $item[replica sleeping patriotic eagle]); // put in terrarium


### PR DESCRIPTION
# Description

After adding support to buy the LoL Patriotic Eagle in #1318 , this adds logic to skip the Patriot Eagle if in a 100% Familiar Run (continuing the logic/idea from #1313) .

## How Has This Been Tested?
Tested in the start of a new run today. Found and fixed a bug where the is100FamRun() wasn't checked first (not having it first led to the 'else' condition from line 50 not being met, halting the script). Works fine now.

## Checklist:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
