### PR TITLE
2002 support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1106,6 +1106,8 @@ boolean dailyEvents()
 	pickRocks();
 	auto_SITCourse();
 	auto_LegacyOfLoathingDailies();
+	auto_buyFrom2002MrStore();
+	auto_useBlackMonolith();
 	
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -571,6 +571,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Polar Express]:				useItem = $item[Cloaca Cola Polar];				break;
 	case $effect[Polka of Plenty]:				useSkill = $skill[The Polka of Plenty];			break;
 	case $effect[Polonoia]:						useItem = $item[Polo Trophy];					break;
+	case $effect[Poppy Performance]:			
+		if(auto_haveIdolMicrophone())
+		{
+			cli_execute("loathing idol pop");
+		}																						break;
 	case $effect[Power\, Man]:					useItem = $item[Power-Guy 2000 Holo-Record];	break;
 	case $effect[Power Ballad of the Arrowsmith]:useSkill = $skill[The Power Ballad of the Arrowsmith];break;
 	case $effect[Power of Heka]:				useSkill = $skill[Power of Heka];				break;
@@ -615,6 +620,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		if(auto_have_skill($skill[Reptilian Fortitude]) && acquireTotem())
 		{
 			useSkill = $skill[Reptilian Fortitude];
+		}																						break;
+	case $effect[Romantically Roused]:
+		if(auto_haveIdolMicrophone())
+		{
+			cli_execute("loathing idol ballad");
 		}																						break;
 	case $effect[A Rose by Any Other Material]:	useItem = $item[Squeaky Toy Rose];				break;
 	case $effect[Rosewater Mark]:				useItem = $item[Old Rosewater Cream];			break;
@@ -705,6 +715,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Spiritually Aware]:			useItem = $item[Spirit Beer];					break;
 	case $effect[Spiritually Awash]:			useItem = $item[Sacramental Wine];				break;
 	case $effect[Spiro Gyro]:					useItem = $item[Programmable Turtle];			break;
+	case $effect[Spitting Rhymes]:
+		if(auto_haveIdolMicrophone())
+		{
+			cli_execute("loathing idol rhyme");
+		}																						break;
 	case $effect[Spooky Hands]:					useItem = $item[Lotion of Spookiness];			break;
 	case $effect[Spooky Weapon]:				useItem = $item[Spooky Nuggets];				break;
 	case $effect[Spookypants]:					useItem = $item[Spooky Powder];					break;
@@ -761,6 +776,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Tricky Timpani]:				useSkill = $skill[Tricky Timpani];				break;
 	case $effect[Triple-Sized]:					useSkill = $skill[none];						break;
 	case $effect[Truly Gritty]:					useItem = $item[True Grit];						break;
+	case $effect[Twangy]:
+		if(auto_haveIdolMicrophone())
+		{
+			cli_execute("loathing idol country");
+		}																						break;
 	case $effect[Twen Tea]:						useItem = $item[cuppa Twen tea];				break;
 	case $effect[Twinkly Weapon]:				useItem = $item[Twinkly Nuggets];				break;
 	case $effect[Unmuffled]:

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -503,6 +503,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Merry Smithsness]:				useItem = $item[Flaskfull of Hollow];			break;
 	case $effect[Mind Vision]:					useSkill = $skill[Intracranial Eye];			break;
 	case $effect[Ministrations in the Dark]:	useItem = $item[EMD Holo-Record];				break;
+	case $effect[Minor Invulnerability]:			useItem = $item[Scroll of minor invulnerability];	break;
 	case $effect[Misplaced Rage]:				useItem = $item[angry agate];					break;
 	case $effect[The Moxie Of LOV]:				useItem = $item[LOV Elixir #9];					break;
 	case $effect[The Moxious Madrigal]:			useSkill = $skill[The Moxious Madrigal];		break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -575,7 +575,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Poppy Performance]:			
 		if(auto_haveIdolMicrophone())
 		{
-			cli_execute("loathing idol pop");
+			if(speculative)
+			{
+				return true;
+			}
+			cli_execute("loathingidol pop");
 		}																						break;
 	case $effect[Power\, Man]:					useItem = $item[Power-Guy 2000 Holo-Record];	break;
 	case $effect[Power Ballad of the Arrowsmith]:useSkill = $skill[The Power Ballad of the Arrowsmith];break;
@@ -625,7 +629,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Romantically Roused]:
 		if(auto_haveIdolMicrophone())
 		{
-			cli_execute("loathing idol ballad");
+			if(speculative)
+			{
+				return true;
+			}
+			cli_execute("loathingidol ballad");
 		}																						break;
 	case $effect[A Rose by Any Other Material]:	useItem = $item[Squeaky Toy Rose];				break;
 	case $effect[Rosewater Mark]:				useItem = $item[Old Rosewater Cream];			break;
@@ -719,7 +727,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Spitting Rhymes]:
 		if(auto_haveIdolMicrophone())
 		{
-			cli_execute("loathing idol rhyme");
+			if(speculative)
+			{
+				return true;
+			}
+			cli_execute("loathingidol rhyme");
 		}																						break;
 	case $effect[Spooky Hands]:					useItem = $item[Lotion of Spookiness];			break;
 	case $effect[Spooky Weapon]:				useItem = $item[Spooky Nuggets];				break;
@@ -780,7 +792,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Twangy]:
 		if(auto_haveIdolMicrophone())
 		{
-			cli_execute("loathing idol country");
+			if(speculative)
+			{
+				return true;
+			}
+			cli_execute("loathingidol country");
 		}																						break;
 	case $effect[Twen Tea]:						useItem = $item[cuppa Twen tea];				break;
 	case $effect[Twinkly Weapon]:				useItem = $item[Twinkly Nuggets];				break;

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -903,6 +903,14 @@ boolean auto_post_adventure()
 		// items which give stats
 		buffMaintain($effect[Scorched Earth]);
 		buffMaintain($effect[Wisdom of Others]);
+		foreach it in $items[azurite, eye agate, lapis lazuli]
+		{
+			if(item_amount(it) > 0 && auto_is_valid(it))
+			{
+				use(it, item_amount(it));
+			}
+		}
+		
 	}
 
 

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -799,7 +799,8 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 			Temporarily Filtered,
 			Gritty,
 			Too Shamed,
-			Twangy
+			Twangy,
+			minor invulnerability
 		]))
 			return result();
 	}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -114,7 +114,8 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 		High Colognic,
 		Celestial Saltiness,
 		Simply Irresistible,
-		Crunching Leaves
+		Crunching Leaves,
+		Romantically Roused
 	])) {
 		return result();
 	}
@@ -507,6 +508,7 @@ float provideInitiative(int amt, location loc, boolean doEquips, boolean specula
 		Sugar Rush,
 		Ticking Clock,
 		Well-Swabbed Ear,
+		Poppy Performance
 	]))
 		return result();
 
@@ -797,6 +799,7 @@ int [element] provideResistances(int [element] amt, location loc, boolean doEqui
 			Temporarily Filtered,
 			Gritty,
 			Too Shamed,
+			Twangy
 		]))
 			return result();
 	}
@@ -1062,6 +1065,7 @@ float [stat] provideStats(int [stat] amt, location loc, boolean doEquips, boolea
 			Superhuman Sarcasm,
 			Unrunnable Face,
 			Gaffe Free,
+			Poppy Performance,
 
 			// all-stat effects
 			Confidence of the Votive,

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3111,6 +3111,24 @@ int [item] auto_get_campground()
 	return campItems;
 }
 
+boolean haveCampgroundMaid()
+{
+	int [item] campItems = auto_get_campground();
+	if(campItems contains $item[meat maid])
+	{
+		return true;
+	}
+	if(campItems contains $item[clockwork maid])
+	{
+		return true;
+	}
+	if(campItems contains $item[meat butler])
+	{
+		return true;
+	}
+	return false;
+}
+
 location solveDelayZone()
 {
 	int[location] delayableZones = zone_delayable();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -509,6 +509,12 @@ int auto_cinchAfterNextRest();
 boolean auto_nextRestOverCinch();
 boolean auto_getCinch(int goal);
 boolean shouldCinchoConfetti();
+boolean auto_have2002Catalog();
+int remainingCatalogCredits();
+int remainingCatalogCredits();
+boolean auto_haveIdolMicrophone();
+void auto_buyFrom2002MrStore();
+void auto_useBlackMonolith();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -320,7 +320,7 @@ void auto_buyFrom2002MrStore()
 	{
 		return;
 	}
-	auto_log_debug("Have credits to buy from Mr. Store 2002");
+	auto_log_debug("Have " + remainingCatalogCredits() + " credit(s) to buy from Mr. Store 2002. Let's spend them!");
 	// meat butler on day 1 of run
 	item itemConsidering = $item[meat butler];
 	if(remainingCatalogCredits() > 0 && my_daycount() == 1 && !haveCampgroundMaid() && auto_is_valid(itemConsidering))

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -151,16 +151,13 @@ boolean auto_makeMonkeyPawWish(string wish)
 
 boolean auto_haveCincho()
 {
-	// check for normal version
-	static item cincho = $item[Cincho de Mayo];
+	static item cincho = wrap_item($item[Cincho de Mayo]);
 	if(auto_is_valid(cincho) && (item_amount(cincho) > 0 || have_equipped(cincho)))
 	{
 		return true;
 	}
 
-	// check for replica in LoL path
-	static item replicaCincho = $item[replica Cincho de Mayo];
-	return auto_is_valid(replicaCincho) && (item_amount(replicaCincho) > 0 || have_equipped(replicaCincho));
+	return false;
 }
 
 int auto_currentCinch()
@@ -275,16 +272,12 @@ boolean shouldCinchoConfetti()
 
 boolean auto_have2002Catalog()
 {
-	// check for normal version
-	static item catalog = $item[2002 Mr. Store Catalog];
+	static item catalog = wrap_item($item[2002 Mr. Store Catalog]);
 	if(auto_is_valid(catalog) && (item_amount(catalog) > 0 || have_equipped(catalog)))
 	{
 		return true;
 	}
-
-	// check for replica in LoL path
-	static item replicaCatalog = $item[replica 2002 Mr. Store Catalog];
-	return auto_is_valid(replicaCatalog) && (item_amount(replicaCatalog) > 0 || have_equipped(replicaCatalog));
+	return false;
 }
 
 int remainingCatalogCredits()

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -272,3 +272,114 @@ boolean shouldCinchoConfetti()
 	// canSurvive checked in calling location. This function is only available to combat files
 	return true;
 }
+
+boolean auto_have2002Catalog()
+{
+	// check for normal version
+	static item catalog = $item[2002 Mr. Store Catalog];
+	if(auto_is_valid(catalog) && (item_amount(catalog) > 0 || have_equipped(catalog)))
+	{
+		return true;
+	}
+
+	// check for replica in LoL path
+	static item replicaCatalog = $item[replica 2002 Mr. Store Catalog];
+	return auto_is_valid(replicaCatalog) && (item_amount(replicaCatalog) > 0 || have_equipped(replicaCatalog));
+}
+
+int remainingCatalogCredits()
+{
+	if(!auto_have2002Catalog())
+	{
+		return 0;
+	}
+	if(!get_property("_2002MrStoreCreditsCollected").to_boolean())
+	{
+		//todo - collect credits
+	}
+	return get_property("availableMrStore2002Credits").to_int();
+}
+
+boolean auto_haveIdolMicrophone()
+{
+	if(item_amount($item[Loathing Idol Microphone]) > 0)
+	{
+		return true;
+	}
+	if(item_amount($item[Loathing Idol Microphone (75% charged)]) > 0)
+	{
+		return true;
+	}
+	if(item_amount($item[Loathing Idol Microphone (50% charged)]) > 0)
+	{
+		return true;
+	}
+	if(item_amount($item[Loathing Idol Microphone (25% charged)]) > 0)
+	{
+		return true;
+	}
+	return false;
+}
+
+void auto_buyFrom2002MrStore()
+{
+	if(remainingCatalogCredits() == 0)
+	{
+		return;
+	}
+	// meat butler on day 1 of run
+	item itemConsidering = $item[meat butler];
+	if(remainingCatalogCredits() > 0 && my_daycount() == 1 && !haveCampgroundMaid() && auto_is_valid(itemConsidering))
+	{
+		buy($coinmaster[Mr. Store 2002], 1, itemConsidering);
+		use(itemConsidering);
+	}
+	// manual of secret door detection. skill: Secret door awareness
+	itemConsidering = $item[manual of secret door detection];
+	if(remainingCatalogCredits() > 0 && !auto_have_skill($skill[Secret door awareness]) && auto_is_valid(itemConsidering))
+	{
+		buy($coinmaster[Mr. Store 2002], 1, itemConsidering);
+		use(itemConsidering);
+	}
+	// giant black monlith. Mostly useful at low level for stats
+	itemConsidering = $item[giant black monolith];
+	if(remainingCatalogCredits() > 0 && !(auto_get_campground() contains itemConsidering) && auto_is_valid(itemConsidering))
+	{
+		buy($coinmaster[Mr. Store 2002], 1, itemConsidering);
+		use(itemConsidering);
+		visit_url("campground.php?action=monolith");
+	}
+	// crimbo cookie. Should we expand to buy more or use in more paths beyond HC LoL?
+	itemConsidering = $item[Crimbo cookie sheet];
+	if(remainingCatalogCredits() > 0 && in_hardcore() && my_daycount() == 1 && in_lol())
+	{
+		buy($coinmaster[Mr. Store 2002], remainingCatalogCredits(), itemConsidering);
+	}
+	// loathing idol microphone. Use remaining credits
+	itemConsidering = $item[loathing idol microphone];
+	if(remainingCatalogCredits() > 0 && !auto_haveIdolMicrophone() && auto_is_valid(itemConsidering))
+	{
+		buy($coinmaster[Mr. Store 2002], remainingCatalogCredits(), itemConsidering);
+	}
+}
+
+void auto_useBlackMonolith()
+{
+	// done if already used it today
+	if(get_property("_blackMonolithUsed").to_boolean())
+	{
+		return;
+	}
+	// done if we don't want stats
+	if(!disregardInstantKarma())
+	{
+		return;
+	}
+	// done if we don't have monolith
+	if(!(auto_get_campground() contains $item[giant black monolith]))
+	{
+		return;
+	}
+	// use monolith
+	visit_url("campground.php?action=monolith");
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -320,6 +320,7 @@ void auto_buyFrom2002MrStore()
 	{
 		return;
 	}
+	auto_log_debug("Have credits to buy from Mr. Store 2002");
 	// meat butler on day 1 of run
 	item itemConsidering = $item[meat butler];
 	if(remainingCatalogCredits() > 0 && my_daycount() == 1 && !haveCampgroundMaid() && auto_is_valid(itemConsidering))
@@ -350,7 +351,7 @@ void auto_buyFrom2002MrStore()
 	}
 	// loathing idol microphone. Use remaining credits
 	itemConsidering = $item[loathing idol microphone];
-	if(remainingCatalogCredits() > 0 && !auto_haveIdolMicrophone() && auto_is_valid(itemConsidering))
+	if(remainingCatalogCredits() > 0 && auto_is_valid(itemConsidering))
 	{
 		buy($coinmaster[Mr. Store 2002], remainingCatalogCredits(), itemConsidering);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -696,7 +696,7 @@ boolean LX_dolphinKingMap()
 
 boolean LX_meatMaid()
 {
-	if(auto_get_campground() contains $item[Meat Maid])
+	if(!haveCampgroundMaid())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Uses the 2002 Mr. Store
Buys:
Meat Bulter for RO Adv
Detect Secret Doors as it is a good skill
Black Monolith for stats
Crimbo cookies for HC LoL runs... should we expend this to more options?
Idol Microphone for buffs

## How Has This Been Tested?

Doing a normal standard run and it is working well. Buys butler, monolith, and mic. Saw it use the mic properly as well for modern zombie init

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
