### PR TITLE
Hot Fix - Modifier now a type, can't bee variable name

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -883,9 +883,9 @@ boolean simMaximizeWith(string add)
 	return simMaximizeWith(my_location(), add);
 }
 
-float simValue(string modifier)
+float simValue(string mod)
 {
-	return numeric_modifier("Generated:_spec", modifier);
+	return numeric_modifier("Generated:_spec", mod);
 }
 
 void equipMaximizedGear()

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1339,7 +1339,7 @@ boolean simMaximize();
 boolean simMaximize(location loc);
 boolean simMaximizeWith(location loc, string add);
 boolean simMaximizeWith(string add);
-float simValue(string modifier);
+float simValue(string mod);
 void equipMaximizedGear();
 void equipOverrides();
 int equipmentAmount(item equipment);


### PR DESCRIPTION
# Description

Mafia now has `modifier` as a type. Can not be a variable name

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
