### PR TITLE
Fix Chateau in LoL

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -294,11 +294,11 @@ boolean auto_mayoItems()
 boolean chateaumantegna_available()
 {
 	item chateau_key = wrap_item($item[Chateau Mantegna Room Key]);
-	if(get_property("chateauAvailable").to_boolean() && is_unrestricted(chateau_key))
+	if(!in_lol() && get_property("chateauAvailable").to_boolean() && is_unrestricted(chateau_key))
 	{
 		return true;
 	}
-	if(contains_text(visit_url("mountains.php"),"whichplace=chateau") && is_unrestricted(chateau_key))
+	if(in_lol() && get_property("replicaChateauAvailable").to_boolean() && is_unrestricted(chateau_key))
 	{
 		return true;
 	}


### PR DESCRIPTION
# Description

Issue reported in discord of autoscend looping and not doing anything. Cause was we think we have chateau but actually don't.

Not sure why we had a visit_url to see if chateau was in the mountains. Removed as the chateau is in the mountians in LoL, even if you haven't bought it yet. Cause of loop. 

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
