### PR TITLE
fix: use forked version of Ezandora's script broken due to modifiers change

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -1,6 +1,6 @@
 github Ezandora/Detective-Solver Release
-github Ezandora/Helix-Fossil Release
 github Ezandora/Far-Future Release
 github gausie/excavator
+github midgleyc/Helix-Fossil Release
 github midgleyc/Voting-Booth
 github Loathing-Associates-Scripting-Society/combo release

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -100,7 +100,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(in_pokefam())
 	{
-		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
+		if(git_exists("midgleyc-Helix-Fossil-Release"))
 		{
 		auto_log_info("Combat via Ezandora:", "green");
 		boolean ignore = cli_execute("Pocket Familiars");

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -36,7 +36,7 @@ boolean pokefam_makeTeam()
 	if(in_pokefam())
 	{
 		// Choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up and earn pokebucks.
-		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
+		if(git_exists("midgleyc-Helix-Fossil-Release"))
 		{
 		auto_log_info("Setting our team via Ezandora:", "green");
 		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");


### PR DESCRIPTION
# Description

Due to https://github.com/kolmafia/kolmafia/pull/1815, Helix-Fossil no longer works. Point at my fork instead until the PR is merged.

## How Has This Been Tested?

It hasn't.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
