### PR TITLE
G-Lover can't use faxes so don't try to acquire

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -36,7 +36,7 @@ boolean handleFaxMonster(monster enemy, boolean fightIt, string option)
 	{
 		return false;
 	}
-	if(is_boris() || is_jarlsberg() || is_pete())
+	if(is_boris() || is_jarlsberg() || is_pete() || in_glover())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Reported in Discord.
G-Lover can't use the photocopy to fight the faxed monster so don't bother trying to use the fax in the first place.

## How Has This Been Tested?

Validates. I ain't getting into a G-Lover run just to try this.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
