### PR TITLE
Updating Patriotic Eagle boolean

### DIFF
--- a/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/legacy_of_loathing.ash
@@ -39,15 +39,14 @@ boolean lol_buyReplicas()
 		{
 			buy($coinmaster[Replica Mr. Store], 1, $item[Replica 2002 Mr. Store Catalog]);
 		}
-		if(!is100FamRun()) //If this isn't a 100% familiar run, go ahead and get another familiar
-		{
-			if(contains_text(page, "patriotic eagle")) //2023
-				{	
-					buy($coinmaster[Replica Mr. Store], 1, $item[replica sleeping patriotic eagle]);
-					use(1, $item[replica sleeping patriotic eagle]); // put in terrarium
-				}
+		if(contains_text(page, "patriotic eagle") && !is100FamRun()) //If this isn't a 100% familiar run, go ahead and get another familiar
+		{	
+			buy($coinmaster[Replica Mr. Store], 1, $item[replica sleeping patriotic eagle]);
+			use(1, $item[replica sleeping patriotic eagle]); // put in terrarium
 		}
-		else if(contains_text(page, "<b>2004</b>"))
+		
+		//End of 2023 "Always Available" IoTMs and starting legacy "one at a time" IoTMs
+		if(contains_text(page, "<b>2004</b>"))
 		{
 			if(have_familiar($familiar[Jill-O-Lantern]) || have_familiar($familiar[Hand Turkey]))
 			{


### PR DESCRIPTION
Updating logic for Patriotic Eagle boolean based on feedback in Discord. Also removing the first 'else' when starting to look at legacy IoTMs

# Description

This updates the Legacy of Loathing boolean for purchasing a Patriotic Eagle hatchling

Fixes (Cleans up code to make a discord reported halt easier to diagnose)

## How Has This Been Tested?

Not tested, but thought through with HippoKing in Discord chat. Updated file passes Mafia validate command/routine.

## Checklist:

- [ x ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
