### PR TITLE
Allow makeGeniePocket() to use replica bottle

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1866,7 +1866,7 @@ boolean makeGeniePocket()
 	int count = item_amount($item[Pocket Wish]);
 
 	string wish = "for more wishes";
-	string page = visit_url("inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=9529", false);
+	string page = visit_url("inv_use.php?pwd=" + my_hash() + "&which=3&whichitem=" + bottle.to_int(), false);
 	page = visit_url("choice.php?pwd=" + my_hash() + "&whichchoice=1267&option=1&wish=" + wish);
 
 	if(count == item_amount($item[Pocket Wish]))


### PR DESCRIPTION
# Description

makeGeniePocket() now uses the replica genie bottle if that's what the user has, not just the genie bottle

## How Has This Been Tested?

I changed the line in my Mafia's scripts/autoscend/iotms/mr2017.ash that I changed here, and ran autoscend (again).  I observed that my LoL bedtime was able to complete, when it wasn't before.

## Checklist:

- [ x] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
